### PR TITLE
Fix markdown lint errors in documentation

### DIFF
--- a/docs/documents/identity.md
+++ b/docs/documents/identity.md
@@ -82,7 +82,7 @@ These patterns are compatible with libraries like [Vogen](https://github.com/Ste
 ### Supported Inner Types
 
 | Wrapper Pattern | ID Generation |
-|---|---|
+| --- | --- |
 | `record struct InvoiceId(Guid Value)` | Auto-assigned sequential Guid |
 | `record struct OrderItemId(int Value)` | HiLo sequence |
 | `record struct IssueId(long Value)` | HiLo sequence |

--- a/docs/events/projections/async-daemon.md
+++ b/docs/events/projections/async-daemon.md
@@ -84,7 +84,7 @@ The daemon uses Polly resilience pipelines for error handling. See [Resiliency P
 
 ## Architecture
 
-```
+```text
 pc_events
   │ (Polling)
   ▼


### PR DESCRIPTION
## Summary
- Add spaces around table separator pipes in `docs/documents/identity.md` (MD060)
- Add `text` language specifier to fenced code block in `docs/events/projections/async-daemon.md` (MD040)

🤖 Generated with [Claude Code](https://claude.com/claude-code)