### PR TITLE
Improve Wolverine integration support

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>1.0.0</Version>
+        <Version>1.1.0</Version>
         <LangVersion>latest</LangVersion>
         <Authors>Jeremy D. Miller</Authors>
         <PackageIcon>logo.png</PackageIcon>

--- a/polecat.slnx
+++ b/polecat.slnx
@@ -1,12 +1,15 @@
 <Solution>
+  <Folder Name="/SolutionItems/">
+    <File Path="Directory.Build.props" />
+  </Folder>
   <Folder Name="/src/">
-    <Project Path="src/Polecat/Polecat.csproj" />
-    <Project Path="src/Polecat.Tests/Polecat.Tests.csproj" />
-    <Project Path="src/Polecat.CodeGeneration/Polecat.CodeGeneration.csproj" />
-    <Project Path="src/Polecat.EntityFrameworkCore/Polecat.EntityFrameworkCore.csproj" />
-    <Project Path="src/Polecat.EntityFrameworkCore.Tests/Polecat.EntityFrameworkCore.Tests.csproj" />
-    <Project Path="src/Polecat.AspNetCore/Polecat.AspNetCore.csproj" />
-    <Project Path="src/Polecat.AspNetCore.Testing/Polecat.AspNetCore.Testing.csproj" />
     <Project Path="src/DcbLoadTest/DcbLoadTest.csproj" />
+    <Project Path="src/Polecat.AspNetCore.Testing/Polecat.AspNetCore.Testing.csproj" />
+    <Project Path="src/Polecat.AspNetCore/Polecat.AspNetCore.csproj" />
+    <Project Path="src/Polecat.CodeGeneration/Polecat.CodeGeneration.csproj" />
+    <Project Path="src/Polecat.EntityFrameworkCore.Tests/Polecat.EntityFrameworkCore.Tests.csproj" />
+    <Project Path="src/Polecat.EntityFrameworkCore/Polecat.EntityFrameworkCore.csproj" />
+    <Project Path="src/Polecat.Tests/Polecat.Tests.csproj" />
+    <Project Path="src/Polecat/Polecat.csproj" />
   </Folder>
 </Solution>

--- a/src/Polecat/DocumentStore.EventStore.cs
+++ b/src/Polecat/DocumentStore.EventStore.cs
@@ -82,7 +82,7 @@ public partial class DocumentStore : IEventStore<IDocumentSession, IQuerySession
         AsyncOptions shardOptions)
     {
         var connStr = database is PolecatDatabase pdb ? pdb.ConnectionString : Options.ConnectionString;
-        return new PolecatEventLoader(Events, Options, connStr);
+        return new PolecatEventLoader(Events, Options, connStr, filtering);
     }
 
     async ValueTask<IProjectionBatch<IDocumentSession, IQuerySession>>
@@ -262,8 +262,11 @@ public partial class DocumentStore : IEventStore<IDocumentSession, IQuerySession
         var batch = new PolecatProjectionBatch(this, Events, connStr);
         await batch.RecordProgress(range);
 
-        // Create a session the subscription can use for reads/writes
+        // Create a session the subscription can use for reads/writes,
+        // and register it with the batch so its pending operations are included
+        // in the batch's transaction.
         await using var session = LightweightSession();
+        batch.RegisterSession(session);
         var listener = await subscription.ProcessEventsAsync(range, range.Agent, session, token);
 
         await batch.ExecuteAsync(token);

--- a/src/Polecat/Events/Daemon/Coordination/IProjectionCoordinator.cs
+++ b/src/Polecat/Events/Daemon/Coordination/IProjectionCoordinator.cs
@@ -1,0 +1,45 @@
+using JasperFx.Events.Daemon;
+using Microsoft.Extensions.Hosting;
+
+namespace Polecat.Events.Daemon.Coordination;
+
+/// <summary>
+///     Coordinates the lifecycle of asynchronous projection and subscription daemons.
+///     Used by Wolverine's agent framework for distributed event processing.
+/// </summary>
+public interface IProjectionCoordinator : IHostedService
+{
+    /// <summary>
+    ///     Get the projection daemon for the main database
+    /// </summary>
+    IProjectionDaemon DaemonForMainDatabase();
+
+    /// <summary>
+    ///     Get the projection daemon for a specific database by its identifier
+    /// </summary>
+    ValueTask<IProjectionDaemon> DaemonForDatabase(string databaseIdentifier);
+
+    /// <summary>
+    ///     Get all active projection daemons across all databases
+    /// </summary>
+    ValueTask<IReadOnlyList<IProjectionDaemon>> AllDaemonsAsync();
+
+    /// <summary>
+    ///     Stops the projection coordinator's automatic restart logic and stops all running agents
+    ///     across all daemons. Does not release any held locks.
+    /// </summary>
+    Task PauseAsync();
+
+    /// <summary>
+    ///     Resumes the projection coordinator's automatic restart logic and starts all running agents
+    ///     across all daemons. Intended to be used after <see cref="PauseAsync" />
+    /// </summary>
+    Task ResumeAsync();
+}
+
+/// <summary>
+///     Typed projection coordinator for use with specific document store types
+/// </summary>
+public interface IProjectionCoordinator<T> : IProjectionCoordinator where T : IDocumentStore
+{
+}

--- a/src/Polecat/Events/Daemon/PolecatEventLoader.cs
+++ b/src/Polecat/Events/Daemon/PolecatEventLoader.cs
@@ -17,13 +17,26 @@ internal class PolecatEventLoader : IEventLoader
     private readonly StoreOptions _options;
     private readonly string _connectionString;
     private readonly ResiliencePipeline _resilience;
+    private readonly HashSet<string>? _allowedDotNetTypes;
 
-    public PolecatEventLoader(EventGraph events, StoreOptions options, string connectionString)
+    public PolecatEventLoader(EventGraph events, StoreOptions options, string connectionString,
+        EventFilterable? filtering = null)
     {
         _events = events;
         _options = options;
         _connectionString = connectionString;
         _resilience = options.ResiliencePipeline;
+
+        // Build an allow list of dotnet_type names from the included event types
+        if (filtering?.IncludedEventTypes is { Count: > 0 } includedTypes)
+        {
+            _allowedDotNetTypes = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var type in includedTypes)
+            {
+                var mapping = events.EventMappingFor(type);
+                _allowedDotNetTypes.Add(mapping.DotNetTypeName);
+            }
+        }
     }
 
     public async Task<EventPage> LoadAsync(EventRequest request, CancellationToken token)
@@ -63,6 +76,13 @@ internal class PolecatEventLoader : IEventLoader
                 var tenantId = reader.GetString(7);
                 var dotNetTypeName = reader.IsDBNull(8) ? null : reader.GetString(8);
                 var isArchived = reader.GetBoolean(9);
+
+                // Apply event type allow-list filter (skip events not in the subscription's filter)
+                if (_allowedDotNetTypes != null && dotNetTypeName != null &&
+                    !_allowedDotNetTypes.Contains(dotNetTypeName))
+                {
+                    continue;
+                }
 
                 var resolvedType = _events.ResolveEventType(dotNetTypeName);
                 if (resolvedType == null)

--- a/src/Polecat/Events/Daemon/PolecatProjectionBatch.cs
+++ b/src/Polecat/Events/Daemon/PolecatProjectionBatch.cs
@@ -40,6 +40,15 @@ internal class PolecatProjectionBatch : IProjectionBatch<IDocumentSession, IQuer
         return session;
     }
 
+    /// <summary>
+    ///     Register an externally-created session with this batch so its pending
+    ///     operations are included in the batch's transaction.
+    /// </summary>
+    internal void RegisterSession(IDocumentSession session)
+    {
+        _sessions.Add(session);
+    }
+
     public ValueTask RecordProgress(EventRange range)
     {
         var progressionTable = _events.ProgressionTableName;

--- a/src/Polecat/Internal/PolecatDaemonHostedService.cs
+++ b/src/Polecat/Internal/PolecatDaemonHostedService.cs
@@ -9,11 +9,10 @@ namespace Polecat.Internal;
 ///     Hosted service that starts and stops the async projection daemon.
 ///     Registered by AddAsyncDaemon().
 /// </summary>
-internal class PolecatDaemonHostedService : IHostedService, IAsyncDisposable
+public class PolecatDaemonHostedService : IHostedService, IAsyncDisposable
 {
     private readonly DocumentStore _store;
     private readonly ILoggerFactory _loggerFactory;
-    private IProjectionDaemon? _daemon;
 
     public PolecatDaemonHostedService(DocumentStore store, ILoggerFactory loggerFactory)
     {
@@ -21,23 +20,28 @@ internal class PolecatDaemonHostedService : IHostedService, IAsyncDisposable
         _loggerFactory = loggerFactory;
     }
 
+    /// <summary>
+    ///     The running projection daemon, if started.
+    /// </summary>
+    public IProjectionDaemon? Daemon { get; private set; }
+
     public async Task StartAsync(CancellationToken token)
     {
         var logger = _loggerFactory.CreateLogger<PolecatDaemonHostedService>();
-        _daemon = await _store.BuildProjectionDaemonAsync(logger: logger);
-        await _daemon.StartAllAsync();
+        Daemon = await _store.BuildProjectionDaemonAsync(logger: logger);
+        await Daemon.StartAllAsync();
     }
 
     public async Task StopAsync(CancellationToken token)
     {
-        if (_daemon != null)
+        if (Daemon != null)
         {
-            await _daemon.StopAllAsync();
+            await Daemon.StopAllAsync();
         }
     }
 
     public async ValueTask DisposeAsync()
     {
-        _daemon?.Dispose();
+        Daemon?.Dispose();
     }
 }

--- a/src/Polecat/PolecatConfigurationExpression.cs
+++ b/src/Polecat/PolecatConfigurationExpression.cs
@@ -54,11 +54,12 @@ public class PolecatConfigurationExpression
     {
         Services.ConfigurePolecat(opts => opts.DaemonSettings.AsyncMode = mode);
         EnsureActivatorIsRegistered();
-        Services.AddSingleton<IHostedService>(sp =>
+        Services.AddSingleton<PolecatDaemonHostedService>(sp =>
         {
             var store = (DocumentStore)sp.GetRequiredService<IDocumentStore>();
             return new PolecatDaemonHostedService(store, sp.GetRequiredService<ILoggerFactory>());
         });
+        Services.AddSingleton<IHostedService>(sp => sp.GetRequiredService<PolecatDaemonHostedService>());
         return this;
     }
 


### PR DESCRIPTION
## Summary
- Pass `EventFilterable` through to `PolecatEventLoader` so subscription event type filters are correctly applied during event loading
- Make `PolecatDaemonHostedService` public with an exposed `Daemon` property, enabling test access to the running projection daemon
- Register `PolecatDaemonHostedService` as a resolvable singleton in DI (in addition to `IHostedService`)
- Add `RegisterSession` to `PolecatProjectionBatch` so externally-created sessions have their pending operations included in the batch transaction
- Add `IProjectionCoordinator` interface for future distribution support
- Bump version to 1.1.0

## Test plan
- [x] All 183 PolecatTests pass (185 total, 2 skipped for known TrackActivity race condition)
- [x] Event type filtering verified via `use_inline_subscription_filtered` and `use_filtered_batch_subscription` tests
- [x] Daemon singleton resolution verified via inline and service-scoped subscription tests
- [x] Batch session registration verified via batch subscription tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)