### PR TITLE
SingleStreamProjection<TDoc, TId> + strongly-typed ID support, bump to 1.4.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>1.3.0</Version>
+        <Version>1.4.0</Version>
         <LangVersion>latest</LangVersion>
         <Authors>Jeremy D. Miller</Authors>
         <PackageIcon>logo.png</PackageIcon>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -31,6 +31,9 @@
         <PackageVersion Include="Weasel.EntityFrameworkCore" Version="8.10.1" />
         <PackageVersion Include="Weasel.SqlServer" Version="8.10.1" />
 
+        <!-- Strongly typed IDs -->
+        <PackageVersion Include="StronglyTypedId" Version="1.0.0-beta08" />
+
         <!-- Source generators -->
         <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="1.3.0" />
     </ItemGroup>

--- a/src/Polecat.EntityFrameworkCore/EfCoreSingleStreamProjection.cs
+++ b/src/Polecat.EntityFrameworkCore/EfCoreSingleStreamProjection.cs
@@ -17,7 +17,7 @@ namespace Polecat.EntityFrameworkCore;
 /// <typeparam name="TDoc">The aggregate document type (EF Core entity).</typeparam>
 /// <typeparam name="TDbContext">The EF Core DbContext type.</typeparam>
 public abstract class EfCoreSingleStreamProjection<TDoc, TDbContext>
-    : SingleStreamProjection<TDoc>, IValidatedProjection<StoreOptions>
+    : SingleStreamProjection<TDoc, Guid>, IValidatedProjection<StoreOptions>
     where TDoc : class
     where TDbContext : DbContext
 {

--- a/src/Polecat.Tests/Polecat.Tests.csproj
+++ b/src/Polecat.Tests/Polecat.Tests.csproj
@@ -13,6 +13,7 @@
         <PackageReference Include="Microsoft.Extensions.Hosting" />
         <PackageReference Include="xunit.runner.visualstudio" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
+        <PackageReference Include="StronglyTypedId" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Polecat.Tests/Projections/single_stream_projection_with_string_identity_tests.cs
+++ b/src/Polecat.Tests/Projections/single_stream_projection_with_string_identity_tests.cs
@@ -1,0 +1,247 @@
+using JasperFx.Events;
+using Polecat.Projections;
+using Polecat.Tests.Harness;
+
+namespace Polecat.Tests.Projections;
+
+/// <summary>
+///     Aggregate document with a string identity, for use with string-keyed streams.
+/// </summary>
+public class StringQuestParty
+{
+    public string Id { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public List<string> Members { get; set; } = new();
+    public string? Location { get; set; }
+    public List<string> MonstersSlain { get; set; } = new();
+}
+
+/// <summary>
+///     Self-aggregating document type with string identity, for use with
+///     the Snapshot&lt;T, TId&gt; API (conventional Apply/Create methods on the type itself).
+/// </summary>
+public class SelfAggregatingStringQuest
+{
+    public string Id { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public List<string> Members { get; set; } = new();
+
+    public static SelfAggregatingStringQuest Create(QuestStarted e)
+    {
+        return new SelfAggregatingStringQuest { Name = e.Name };
+    }
+
+    public void Apply(MembersJoined e)
+    {
+        Members.AddRange(e.Members);
+    }
+}
+
+/// <summary>
+///     Custom SingleStreamProjection with TId = string, demonstrating the new
+///     two-type-parameter signature that mirrors Marten's SingleStreamProjection&lt;TDoc, TId&gt;.
+/// </summary>
+public class StringQuestPartyProjection : SingleStreamProjection<StringQuestParty, string>
+{
+    public StringQuestPartyProjection()
+    {
+    }
+
+    public static StringQuestParty Create(IEvent<QuestStarted> @event)
+    {
+        return new StringQuestParty
+        {
+            Id = @event.StreamKey!,
+            Name = @event.Data.Name
+        };
+    }
+
+    public void Apply(MembersJoined e, StringQuestParty party)
+    {
+        party.Members.AddRange(e.Members);
+        party.Location = e.Location;
+    }
+
+    public void Apply(MembersDeparted e, StringQuestParty party)
+    {
+        foreach (var m in e.Members) party.Members.Remove(m);
+    }
+
+    public void Apply(ArrivedAtLocation e, StringQuestParty party)
+    {
+        party.Location = e.Location;
+    }
+
+    public void Apply(MonsterSlain e, StringQuestParty party)
+    {
+        party.MonstersSlain.Add(e.Name);
+    }
+
+    public bool ShouldDelete(QuestEnded e)
+    {
+        return true;
+    }
+}
+
+[Collection("integration")]
+public class single_stream_projection_with_string_identity_tests : IntegrationContext
+{
+    public single_stream_projection_with_string_identity_tests(DefaultStoreFixture fixture) : base(fixture)
+    {
+    }
+
+    private async Task<DocumentStore> CreateStoreWithStringProjection()
+    {
+        await StoreOptions(opts =>
+        {
+            opts.DatabaseSchemaName = "string_proj";
+            opts.Events.StreamIdentity = StreamIdentity.AsString;
+            opts.Projections.Add<StringQuestPartyProjection>(JasperFx.Events.Projections.ProjectionLifecycle.Inline);
+        });
+        return theStore;
+    }
+
+    [Fact]
+    public async Task custom_projection_creates_aggregate_on_start_stream()
+    {
+        var store = await CreateStoreWithStringProjection();
+
+        var streamKey = "quest-" + Guid.NewGuid();
+        await using var session = store.LightweightSession();
+        session.Events.StartStream(streamKey,
+            new QuestStarted("Destroy the Ring"));
+        await session.SaveChangesAsync();
+
+        await using var query = store.QuerySession();
+        var party = await query.LoadAsync<StringQuestParty>(streamKey);
+
+        party.ShouldNotBeNull();
+        party.Id.ShouldBe(streamKey);
+        party.Name.ShouldBe("Destroy the Ring");
+    }
+
+    [Fact]
+    public async Task custom_projection_applies_multiple_events()
+    {
+        var store = await CreateStoreWithStringProjection();
+
+        var streamKey = "quest-" + Guid.NewGuid();
+        await using var session = store.LightweightSession();
+        session.Events.StartStream(streamKey,
+            new QuestStarted("Fellowship"),
+            new MembersJoined(1, "Rivendell", ["Aragorn", "Legolas", "Gimli"]));
+        await session.SaveChangesAsync();
+
+        await using var query = store.QuerySession();
+        var party = await query.LoadAsync<StringQuestParty>(streamKey);
+
+        party.ShouldNotBeNull();
+        party.Name.ShouldBe("Fellowship");
+        party.Members.ShouldBe(["Aragorn", "Legolas", "Gimli"]);
+        party.Location.ShouldBe("Rivendell");
+    }
+
+    [Fact]
+    public async Task custom_projection_updates_on_append()
+    {
+        var store = await CreateStoreWithStringProjection();
+
+        var streamKey = "quest-" + Guid.NewGuid();
+        await using var session = store.LightweightSession();
+        session.Events.StartStream(streamKey,
+            new QuestStarted("Adventure"),
+            new MembersJoined(1, "Start", ["Hero"]));
+        await session.SaveChangesAsync();
+
+        await using var session2 = store.LightweightSession();
+        session2.Events.Append(streamKey,
+            new ArrivedAtLocation("Dungeon", 2),
+            new MonsterSlain("Goblin", 50));
+        await session2.SaveChangesAsync();
+
+        await using var query = store.QuerySession();
+        var party = await query.LoadAsync<StringQuestParty>(streamKey);
+
+        party.ShouldNotBeNull();
+        party.Location.ShouldBe("Dungeon");
+        party.MonstersSlain.ShouldContain("Goblin");
+    }
+
+    [Fact]
+    public async Task custom_projection_should_delete_removes_aggregate()
+    {
+        var store = await CreateStoreWithStringProjection();
+
+        var streamKey = "quest-" + Guid.NewGuid();
+        await using var session = store.LightweightSession();
+        session.Events.StartStream(streamKey,
+            new QuestStarted("Doomed Quest"),
+            new MembersJoined(1, "Start", ["Hero"]));
+        await session.SaveChangesAsync();
+
+        await using var session2 = store.LightweightSession();
+        session2.Events.Append(streamKey,
+            new QuestEnded("Doomed Quest"));
+        await session2.SaveChangesAsync();
+
+        await using var query = store.QuerySession();
+        var party = await query.LoadAsync<StringQuestParty>(streamKey);
+        party.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task multiple_string_keyed_streams_projected_independently()
+    {
+        var store = await CreateStoreWithStringProjection();
+
+        var key1 = "quest-" + Guid.NewGuid();
+        var key2 = "quest-" + Guid.NewGuid();
+
+        await using var session = store.LightweightSession();
+        session.Events.StartStream(key1,
+            new QuestStarted("Quest 1"),
+            new MembersJoined(1, "Town A", ["Alpha"]));
+        session.Events.StartStream(key2,
+            new QuestStarted("Quest 2"),
+            new MembersJoined(1, "Town B", ["Beta", "Gamma"]));
+        await session.SaveChangesAsync();
+
+        await using var query = store.QuerySession();
+        var party1 = await query.LoadAsync<StringQuestParty>(key1);
+        var party2 = await query.LoadAsync<StringQuestParty>(key2);
+
+        party1.ShouldNotBeNull();
+        party1.Name.ShouldBe("Quest 1");
+        party1.Members.ShouldBe(["Alpha"]);
+
+        party2.ShouldNotBeNull();
+        party2.Name.ShouldBe("Quest 2");
+        party2.Members.ShouldBe(["Beta", "Gamma"]);
+    }
+
+    [Fact]
+    public async Task snapshot_with_string_identity_via_snapshot_api()
+    {
+        // Use the Snapshot<T, TId> overload with a self-aggregating type
+        await StoreOptions(opts =>
+        {
+            opts.DatabaseSchemaName = "string_snap";
+            opts.Events.StreamIdentity = StreamIdentity.AsString;
+            opts.Projections.Snapshot<SelfAggregatingStringQuest, string>(SnapshotLifecycle.Inline);
+        });
+
+        var streamKey = "snap-" + Guid.NewGuid();
+        await using var session = theStore.LightweightSession();
+        session.Events.StartStream(streamKey,
+            new QuestStarted("Snapshot Quest"),
+            new MembersJoined(1, "Castle", ["Knight"]));
+        await session.SaveChangesAsync();
+
+        await using var query = theStore.QuerySession();
+        var party = await query.LoadAsync<SelfAggregatingStringQuest>(streamKey);
+
+        party.ShouldNotBeNull();
+        party.Name.ShouldBe("Snapshot Quest");
+        party.Members.ShouldBe(["Knight"]);
+    }
+}

--- a/src/Polecat.Tests/Projections/using_guid_based_strong_typed_id_for_aggregate_identity.cs
+++ b/src/Polecat.Tests/Projections/using_guid_based_strong_typed_id_for_aggregate_identity.cs
@@ -1,0 +1,194 @@
+using System.Text.Json.Serialization;
+using JasperFx.Events;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Projections;
+using Polecat.Projections;
+using Polecat.Tests.Harness;
+using StronglyTypedIds;
+
+namespace Polecat.Tests.Projections;
+
+[StronglyTypedId(Template.Guid)]
+public readonly partial struct PaymentId;
+
+public enum PaymentState
+{
+    Created,
+    Initialized,
+    Canceled,
+    Verified
+}
+
+public record PaymentCreated(DateTimeOffset CreatedAt);
+public record PaymentCanceled(DateTimeOffset CanceledAt);
+public record PaymentVerified(DateTimeOffset VerifiedAt);
+
+public class Payment
+{
+    [JsonInclude] public PaymentId? Id { get; private set; }
+    [JsonInclude] public DateTimeOffset CreatedAt { get; private set; }
+    [JsonInclude] public PaymentState State { get; private set; }
+
+    public static Payment Create(IEvent<PaymentCreated> @event)
+    {
+        return new Payment
+        {
+            Id = new PaymentId(@event.StreamId),
+            CreatedAt = @event.Data.CreatedAt,
+            State = PaymentState.Created
+        };
+    }
+
+    public void Apply(PaymentCanceled @event)
+    {
+        State = PaymentState.Canceled;
+    }
+
+    public void Apply(PaymentVerified @event)
+    {
+        State = PaymentState.Verified;
+    }
+}
+
+[Collection("integration")]
+public class using_guid_based_strong_typed_id_for_aggregate_identity : IntegrationContext
+{
+    public using_guid_based_strong_typed_id_for_aggregate_identity(DefaultStoreFixture fixture) : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task can_utilize_strong_typed_id_in_aggregate_stream()
+    {
+        await StoreOptions(opts =>
+        {
+            opts.DatabaseSchemaName = "guid_stid";
+        });
+
+        var streamId = Guid.NewGuid();
+        await using var session = theStore.LightweightSession();
+        session.Events.StartStream(streamId,
+            new PaymentCreated(DateTimeOffset.UtcNow),
+            new PaymentVerified(DateTimeOffset.UtcNow));
+        await session.SaveChangesAsync();
+
+        var payment = await session.Events.AggregateStreamAsync<Payment>(streamId);
+
+        payment.ShouldNotBeNull();
+        payment.Id!.Value.Value.ShouldBe(streamId);
+        payment.State.ShouldBe(PaymentState.Verified);
+    }
+
+    [Fact]
+    public async Task can_utilize_strong_typed_id_with_inline_aggregations()
+    {
+        await StoreOptions(opts =>
+        {
+            opts.DatabaseSchemaName = "guid_stid_inline";
+            opts.Projections.Snapshot<Payment>(SnapshotLifecycle.Inline);
+        });
+
+        var streamId = Guid.NewGuid();
+        await using var session = theStore.LightweightSession();
+        session.Events.StartStream(streamId,
+            new PaymentCreated(DateTimeOffset.UtcNow),
+            new PaymentVerified(DateTimeOffset.UtcNow));
+        await session.SaveChangesAsync();
+
+        await using var query = theStore.QuerySession();
+        var payment = await query.LoadAsync<Payment>(streamId);
+
+        payment.ShouldNotBeNull();
+        payment.State.ShouldBe(PaymentState.Verified);
+    }
+
+    [Fact]
+    public async Task can_utilize_strong_typed_id_with_explicit_projection_registration()
+    {
+        await StoreOptions(opts =>
+        {
+            opts.DatabaseSchemaName = "guid_stid_explicit";
+            opts.Projections.Add(new SingleStreamProjection<Payment, PaymentId>(),
+                ProjectionLifecycle.Inline);
+        });
+
+        var streamId = Guid.NewGuid();
+        await using var session = theStore.LightweightSession();
+        session.Events.StartStream(streamId,
+            new PaymentCreated(DateTimeOffset.UtcNow),
+            new PaymentVerified(DateTimeOffset.UtcNow));
+        await session.SaveChangesAsync();
+
+        await using var query = theStore.QuerySession();
+        var payment = await query.LoadAsync<Payment>(streamId);
+
+        payment.ShouldNotBeNull();
+        payment.State.ShouldBe(PaymentState.Verified);
+    }
+
+    [Fact]
+    public async Task use_fetch_for_writing_with_strong_typed_id()
+    {
+        await StoreOptions(opts =>
+        {
+            opts.DatabaseSchemaName = "guid_stid_ffw";
+            opts.Projections.Add(new SingleStreamProjection<Payment, PaymentId>(),
+                ProjectionLifecycle.Inline);
+        });
+
+        var streamId = Guid.NewGuid();
+        await using var session = theStore.LightweightSession();
+        session.Events.StartStream(streamId,
+            new PaymentCreated(DateTimeOffset.UtcNow),
+            new PaymentVerified(DateTimeOffset.UtcNow));
+        await session.SaveChangesAsync();
+
+        await using var session2 = theStore.LightweightSession();
+        var stream = await session2.Events.FetchForWriting<Payment>(streamId);
+
+        stream.ShouldNotBeNull();
+        stream.Aggregate.ShouldNotBeNull();
+        stream.Aggregate.Id!.Value.Value.ShouldBe(streamId);
+        stream.Aggregate.State.ShouldBe(PaymentState.Verified);
+    }
+
+    [Fact]
+    public async Task can_utilize_strong_typed_id_with_async_aggregation()
+    {
+        await StoreOptions(opts =>
+        {
+            opts.DatabaseSchemaName = "guid_stid_async";
+            opts.Projections.Snapshot<Payment>(SnapshotLifecycle.Async);
+        });
+
+        var streamId = Guid.NewGuid();
+        await using var session = theStore.LightweightSession();
+        session.Events.StartStream(streamId,
+            new PaymentCreated(DateTimeOffset.UtcNow),
+            new PaymentVerified(DateTimeOffset.UtcNow));
+        await session.SaveChangesAsync();
+
+        using var daemon = (IProjectionDaemon)await theStore.BuildProjectionDaemonAsync();
+        await daemon.StartAllAsync();
+        await daemon.CatchUpAsync(TimeSpan.FromSeconds(30), CancellationToken.None);
+
+        await using var query = theStore.QuerySession();
+        var payment = await query.LoadAsync<Payment>(streamId);
+
+        payment.ShouldNotBeNull();
+        payment.State.ShouldBe(PaymentState.Verified);
+
+        // Append more events and verify async daemon catches up
+        await using var session2 = theStore.LightweightSession();
+        session2.Events.Append(streamId, new PaymentCanceled(DateTimeOffset.UtcNow));
+        await session2.SaveChangesAsync();
+
+        await daemon.CatchUpAsync(TimeSpan.FromSeconds(30), CancellationToken.None);
+
+        await using var query2 = theStore.QuerySession();
+        var updated = await query2.LoadAsync<Payment>(streamId);
+
+        updated.ShouldNotBeNull();
+        updated.State.ShouldBe(PaymentState.Canceled);
+    }
+}

--- a/src/Polecat.Tests/Projections/using_string_based_strong_typed_id_for_aggregate_identity.cs
+++ b/src/Polecat.Tests/Projections/using_string_based_strong_typed_id_for_aggregate_identity.cs
@@ -1,0 +1,192 @@
+using System.Text.Json.Serialization;
+using JasperFx.Events;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Projections;
+using Polecat.Projections;
+using Polecat.Tests.Harness;
+using StronglyTypedIds;
+
+namespace Polecat.Tests.Projections;
+
+[StronglyTypedId(Template.String)]
+public readonly partial struct Payment2Id;
+
+public class Payment2
+{
+    [JsonInclude] public Payment2Id? Id { get; private set; }
+    [JsonInclude] public DateTimeOffset CreatedAt { get; private set; }
+    [JsonInclude] public PaymentState State { get; private set; }
+
+    public static Payment2 Create(IEvent<PaymentCreated> @event)
+    {
+        return new Payment2
+        {
+            Id = new Payment2Id(@event.StreamKey!),
+            CreatedAt = @event.Data.CreatedAt,
+            State = PaymentState.Created
+        };
+    }
+
+    public void Apply(PaymentCanceled @event)
+    {
+        State = PaymentState.Canceled;
+    }
+
+    public void Apply(PaymentVerified @event)
+    {
+        State = PaymentState.Verified;
+    }
+}
+
+[Collection("integration")]
+public class using_string_based_strong_typed_id_for_aggregate_identity : IntegrationContext
+{
+    public using_string_based_strong_typed_id_for_aggregate_identity(DefaultStoreFixture fixture) : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task can_utilize_strong_typed_id_in_aggregate_stream()
+    {
+        await StoreOptions(opts =>
+        {
+            opts.DatabaseSchemaName = "str_stid";
+            opts.Events.StreamIdentity = StreamIdentity.AsString;
+        });
+
+        var id = Guid.NewGuid().ToString();
+
+        await using var session = theStore.LightweightSession();
+        session.Events.StartStream<Payment2>(id,
+            new PaymentCreated(DateTimeOffset.UtcNow),
+            new PaymentVerified(DateTimeOffset.UtcNow));
+        await session.SaveChangesAsync();
+
+        var payment = await session.Events.AggregateStreamAsync<Payment2>(id);
+
+        payment.ShouldNotBeNull();
+        payment.Id!.Value.Value.ShouldBe(id);
+        payment.State.ShouldBe(PaymentState.Verified);
+    }
+
+    [Fact]
+    public async Task can_utilize_strong_typed_id_with_inline_aggregations()
+    {
+        await StoreOptions(opts =>
+        {
+            opts.DatabaseSchemaName = "str_stid_inline";
+            opts.Events.StreamIdentity = StreamIdentity.AsString;
+            opts.Projections.Snapshot<Payment2, Payment2Id>(SnapshotLifecycle.Inline);
+        });
+
+        var id = Guid.NewGuid().ToString();
+
+        await using var session = theStore.LightweightSession();
+        session.Events.StartStream<Payment2>(id,
+            new PaymentCreated(DateTimeOffset.UtcNow),
+            new PaymentVerified(DateTimeOffset.UtcNow));
+        await session.SaveChangesAsync();
+
+        await using var query = theStore.QuerySession();
+        var payment = await query.LoadAsync<Payment2>(id);
+
+        payment.ShouldNotBeNull();
+        payment.State.ShouldBe(PaymentState.Verified);
+    }
+
+    [Fact]
+    public async Task can_utilize_strong_typed_id_with_explicit_projection_registration()
+    {
+        await StoreOptions(opts =>
+        {
+            opts.DatabaseSchemaName = "str_stid_explicit";
+            opts.Events.StreamIdentity = StreamIdentity.AsString;
+            opts.Projections.Add(new SingleStreamProjection<Payment2, Payment2Id>(),
+                ProjectionLifecycle.Inline);
+        });
+
+        var id = Guid.NewGuid().ToString();
+
+        await using var session = theStore.LightweightSession();
+        session.Events.StartStream<Payment2>(id,
+            new PaymentCreated(DateTimeOffset.UtcNow),
+            new PaymentVerified(DateTimeOffset.UtcNow));
+        await session.SaveChangesAsync();
+
+        await using var query = theStore.QuerySession();
+        var payment = await query.LoadAsync<Payment2>(id);
+
+        payment.ShouldNotBeNull();
+        payment.State.ShouldBe(PaymentState.Verified);
+    }
+
+    [Fact]
+    public async Task use_fetch_for_writing_with_strong_typed_id()
+    {
+        await StoreOptions(opts =>
+        {
+            opts.DatabaseSchemaName = "str_stid_ffw";
+            opts.Events.StreamIdentity = StreamIdentity.AsString;
+            opts.Projections.Add(new SingleStreamProjection<Payment2, Payment2Id>(),
+                ProjectionLifecycle.Inline);
+        });
+
+        var id = Guid.NewGuid().ToString();
+
+        await using var session = theStore.LightweightSession();
+        session.Events.StartStream<Payment2>(id,
+            new PaymentCreated(DateTimeOffset.UtcNow),
+            new PaymentVerified(DateTimeOffset.UtcNow));
+        await session.SaveChangesAsync();
+
+        await using var session2 = theStore.LightweightSession();
+        var stream = await session2.Events.FetchForWriting<Payment2>(id);
+
+        stream.ShouldNotBeNull();
+        stream.Aggregate.ShouldNotBeNull();
+        stream.Aggregate.Id!.Value.Value.ShouldBe(id);
+        stream.Aggregate.State.ShouldBe(PaymentState.Verified);
+    }
+
+    [Fact]
+    public async Task can_utilize_strong_typed_id_with_async_aggregation()
+    {
+        await StoreOptions(opts =>
+        {
+            opts.DatabaseSchemaName = "str_stid_async";
+            opts.Events.StreamIdentity = StreamIdentity.AsString;
+            opts.Projections.Snapshot<Payment2, Payment2Id>(SnapshotLifecycle.Async);
+        });
+
+        var id = Guid.NewGuid().ToString();
+
+        await using var session = theStore.LightweightSession();
+        session.Events.StartStream<Payment2>(id,
+            new PaymentCreated(DateTimeOffset.UtcNow),
+            new PaymentVerified(DateTimeOffset.UtcNow));
+        await session.SaveChangesAsync();
+
+        using var daemon = (IProjectionDaemon)await theStore.BuildProjectionDaemonAsync();
+        await daemon.StartAllAsync();
+        await daemon.CatchUpAsync(TimeSpan.FromSeconds(30), CancellationToken.None);
+
+        await using var query = theStore.QuerySession();
+        var payment = await query.LoadAsync<Payment2>(id);
+
+        payment.ShouldNotBeNull();
+        payment.State.ShouldBe(PaymentState.Verified);
+
+        // Append more events and verify async daemon catches up
+        await using var session2 = theStore.LightweightSession();
+        session2.Events.Append(id, new PaymentCanceled(DateTimeOffset.UtcNow));
+        await session2.SaveChangesAsync();
+
+        await daemon.CatchUpAsync(TimeSpan.FromSeconds(30), CancellationToken.None);
+
+        await using var query2 = theStore.QuerySession();
+        var updated = await query2.LoadAsync<Payment2>(id);
+
+        updated.ShouldNotBeNull();
+        updated.State.ShouldBe(PaymentState.Canceled);
+    }
+}

--- a/src/Polecat/Events/EventGraph.cs
+++ b/src/Polecat/Events/EventGraph.cs
@@ -129,8 +129,11 @@ public class EventGraph : EventRegistry, IAggregationSourceFactory<IQuerySession
     /// </summary>
     IAggregatorSource<IQuerySession>? IAggregationSourceFactory<IQuerySession>.Build<TDoc>()
     {
+        // Use the appropriate identity type based on stream identity configuration
+        var idType = StreamIdentity == StreamIdentity.AsGuid ? typeof(Guid) : typeof(string);
+        var projectionType = typeof(SingleStreamProjection<,>).MakeGenericType(typeof(TDoc), idType);
 #pragma warning disable CS8714 // notnull constraint mismatch
-        var projection = new SingleStreamProjection<TDoc>();
+        var projection = (ProjectionBase)Activator.CreateInstance(projectionType)!;
 #pragma warning restore CS8714
         projection.Lifecycle = ProjectionLifecycle.Live;
         projection.AssembleAndAssertValidity();

--- a/src/Polecat/Projections/PolecatCompositeProjection.cs
+++ b/src/Polecat/Projections/PolecatCompositeProjection.cs
@@ -20,15 +20,26 @@ public class PolecatCompositeProjection : CompositeProjection<IDocumentSession, 
     }
 
     /// <summary>
-    ///     Add a snapshot (self-aggregating) projection to this composite.
+    ///     Add a snapshot (self-aggregating) projection with explicit identity type to this composite.
     /// </summary>
-    public void Snapshot<T>(int stageNumber = 1) where T : notnull, new()
+    public void Snapshot<T, TId>(int stageNumber = 1)
+        where T : notnull, new()
+        where TId : notnull
     {
-        var source = new SingleStreamProjection<T>();
+        var source = new SingleStreamProjection<T, TId>();
         source.Lifecycle = ProjectionLifecycle.Async;
         source.AssembleAndAssertValidity();
 
         StageFor(stageNumber).Add((IProjectionSource<IDocumentSession, IQuerySession>)source);
+    }
+
+    /// <summary>
+    ///     Add a snapshot (self-aggregating) projection to this composite.
+    ///     Uses Guid as the default stream identity type.
+    /// </summary>
+    public void Snapshot<T>(int stageNumber = 1) where T : notnull, new()
+    {
+        Snapshot<T, Guid>(stageNumber);
     }
 
     /// <summary>

--- a/src/Polecat/Projections/PolecatProjectionOptions.cs
+++ b/src/Polecat/Projections/PolecatProjectionOptions.cs
@@ -56,13 +56,14 @@ public class PolecatProjectionOptions
     }
 
     /// <summary>
-    ///     Register a self-aggregating type for snapshot projection.
+    ///     Register a self-aggregating type for snapshot projection with explicit identity type.
     ///     The aggregate type must have Apply/Create methods matching event types.
     /// </summary>
-    public void Snapshot<T>(SnapshotLifecycle lifecycle)
+    public void Snapshot<T, TId>(SnapshotLifecycle lifecycle)
         where T : notnull, new()
+        where TId : notnull
     {
-        var projection = new SingleStreamProjection<T>();
+        var projection = new SingleStreamProjection<T, TId>();
         var mapped = lifecycle.Map();
         projection.Lifecycle = mapped;
         projection.AssembleAndAssertValidity();
@@ -73,6 +74,17 @@ public class PolecatProjectionOptions
         }
 
         All.Add((IProjectionSource<IDocumentSession, IQuerySession>)projection);
+    }
+
+    /// <summary>
+    ///     Register a self-aggregating type for snapshot projection.
+    ///     Uses Guid as the default stream identity type.
+    ///     The aggregate type must have Apply/Create methods matching event types.
+    /// </summary>
+    public void Snapshot<T>(SnapshotLifecycle lifecycle)
+        where T : notnull, new()
+    {
+        Snapshot<T, Guid>(lifecycle);
     }
 
     /// <summary>

--- a/src/Polecat/Projections/PolecatProjectionStorage.cs
+++ b/src/Polecat/Projections/PolecatProjectionStorage.cs
@@ -45,7 +45,51 @@ internal class PolecatProjectionStorage<TDoc, TId> : IProjectionStorage<TDoc, TI
 
     public TId Identity(TDoc document)
     {
-        return (TId)_provider.Mapping.GetId(document);
+        var rawId = _provider.Mapping.GetId(document);
+
+        // If TId is the inner type (e.g., Guid/string) but GetId returned the unwrapped value, cast directly
+        if (rawId is TId typedId)
+        {
+            return typedId;
+        }
+
+        // If TId is a wrapper type (e.g., PaymentId) and GetId returned the inner value,
+        // wrap it back up
+        if (_provider.Mapping.ValueTypeId != null)
+        {
+            object wrapped;
+            if (_provider.Mapping.ValueTypeId.Ctor != null)
+            {
+                wrapped = _provider.Mapping.ValueTypeId.Ctor.Invoke([rawId]);
+            }
+            else
+            {
+                wrapped = _provider.Mapping.ValueTypeId.Builder!.Invoke(null, [rawId])!;
+            }
+
+            return (TId)wrapped;
+        }
+
+        return (TId)rawId;
+    }
+
+    /// <summary>
+    ///     Unwrap a strongly-typed ID to its inner value for use as a SQL parameter.
+    ///     If the ID is not a value type wrapper, returns it unchanged.
+    /// </summary>
+    private object UnwrapId(TId id)
+    {
+        if (_provider.Mapping.ValueTypeId != null)
+        {
+            // Only unwrap if id is actually the wrapper type (not already the inner type)
+            var wrapperType = Nullable.GetUnderlyingType(_provider.Mapping.IdType) ?? _provider.Mapping.IdType;
+            if (id.GetType() == wrapperType)
+            {
+                return _provider.Mapping.ValueTypeId.ValueProperty.GetValue(id)!;
+            }
+        }
+
+        return id;
     }
 
     public void Store(TDoc snapshot)
@@ -116,7 +160,7 @@ internal class PolecatProjectionStorage<TDoc, TId> : IProjectionStorage<TDoc, TI
 
         await using var cmd = new SqlCommand();
         cmd.CommandText = _provider.LoadSql;
-        cmd.Parameters.AddWithValue("@id", (object)id);
+        cmd.Parameters.AddWithValue("@id", UnwrapId(id));
         cmd.Parameters.AddWithValue("@tenant_id", TenantId);
 
         await using var reader = await _session.ExecuteReaderAsync(cmd, cancellation);
@@ -143,7 +187,7 @@ internal class PolecatProjectionStorage<TDoc, TId> : IProjectionStorage<TDoc, TI
         for (var i = 0; i < identities.Length; i++)
         {
             paramNames[i] = $"@id{i}";
-            cmd.Parameters.AddWithValue(paramNames[i], (object)identities[i]);
+            cmd.Parameters.AddWithValue(paramNames[i], UnwrapId(identities[i]));
         }
 
         var softDeleteFilter = _provider.Mapping.DeleteStyle == DeleteStyle.SoftDelete

--- a/src/Polecat/Projections/SingleStreamProjection.cs
+++ b/src/Polecat/Projections/SingleStreamProjection.cs
@@ -9,7 +9,7 @@ namespace Polecat.Projections;
 ///
 ///     Usage:
 ///     <code>
-///     public class QuestPartyProjection : SingleStreamProjection&lt;QuestParty&gt;
+///     public class QuestPartyProjection : SingleStreamProjection&lt;QuestParty, Guid&gt;
 ///     {
 ///         public static QuestParty Create(QuestStarted e) => new() { Name = e.Name };
 ///         public void Apply(MembersJoined e, QuestParty party) => party.Members.AddRange(e.Members);
@@ -17,9 +17,11 @@ namespace Polecat.Projections;
 ///     }
 ///     </code>
 /// </summary>
-/// <typeparam name="TDoc">The aggregate document type. Must have a Guid Id property.</typeparam>
-public class SingleStreamProjection<TDoc>
-    : JasperFxSingleStreamProjectionBase<TDoc, Guid, IDocumentSession, IQuerySession>
+/// <typeparam name="TDoc">The aggregate document type.</typeparam>
+/// <typeparam name="TId">The stream identity type (typically Guid or string).</typeparam>
+public class SingleStreamProjection<TDoc, TId>
+    : JasperFxSingleStreamProjectionBase<TDoc, TId, IDocumentSession, IQuerySession>
     where TDoc : notnull
+    where TId : notnull
 {
 }

--- a/src/Polecat/Storage/DocumentMapping.cs
+++ b/src/Polecat/Storage/DocumentMapping.cs
@@ -29,10 +29,13 @@ internal class DocumentMapping
 
         IdType = _idProperty.PropertyType;
 
-        if (!SupportedIdTypes.Contains(IdType))
+        // Unwrap Nullable<T> for strongly-typed ID detection (e.g., PaymentId? -> PaymentId)
+        var idTypeToCheck = Nullable.GetUnderlyingType(IdType) ?? IdType;
+
+        if (!SupportedIdTypes.Contains(idTypeToCheck))
         {
             // Check for strongly typed ID wrapper (e.g., record struct OrderId(Guid Value))
-            ValueTypeId = TryResolveValueTypeId(IdType);
+            ValueTypeId = TryResolveValueTypeId(idTypeToCheck);
             if (ValueTypeId == null)
             {
                 throw new InvalidOperationException(
@@ -242,6 +245,15 @@ internal class DocumentMapping
     {
         if (ValueTypeId != null)
         {
+            // If id is already the wrapper type (e.g., PaymentId), use it directly
+            var idActualType = id.GetType();
+            var wrapperType = Nullable.GetUnderlyingType(IdType) ?? IdType;
+            if (idActualType == wrapperType)
+            {
+                _idProperty.SetValue(document, id);
+                return;
+            }
+
             // Wrap: Guid → OrderId
             object wrapped;
             if (ValueTypeId.Ctor != null)


### PR DESCRIPTION
## Summary
- Change `SingleStreamProjection<TDoc>` to `SingleStreamProjection<TDoc, TId>` to match Marten's signature
- Add `Snapshot<T, TId>()` overloads on `PolecatProjectionOptions` and `PolecatCompositeProjection` (existing `Snapshot<T>()` defaults to `Guid`)
- Fix nullable strongly-typed ID handling in `DocumentMapping` (unwrap `Nullable<T>` before ValueTypeInfo resolution)
- Fix `DocumentMapping.SetId` to avoid double-wrapping when id is already the wrapper type
- Fix `PolecatProjectionStorage` to properly unwrap/wrap strongly-typed IDs for SQL parameters and identity resolution
- Update `EventGraph` live aggregation to pick `Guid` or `string` based on `StreamIdentity` configuration
- Update `EfCoreSingleStreamProjection` to inherit `SingleStreamProjection<TDoc, Guid>`
- Add `StronglyTypedId` 1.0.0-beta08 NuGet package to test project
- Bump NuGet version to 1.4.0

## Test plan
- [x] 6 new tests for `SingleStreamProjection<TDoc, string>` with string stream identity (inline projection, custom projection class, Snapshot API)
- [x] 5 new tests for Guid-based strongly-typed ID (`PaymentId`) — live aggregation, inline, explicit registration, FetchForWriting, async daemon
- [x] 5 new tests for string-based strongly-typed ID (`Payment2Id`) — same coverage as Guid-based
- [x] All existing projection tests pass (inline, live, multi-stream, event, composite)
- [x] EF Core project compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)