### PR TITLE
Add EventProjection alternative to flat table projection docs

### DIFF
--- a/docs/events/projections/flat.md
+++ b/docs/events/projections/flat.md
@@ -70,3 +70,65 @@ Flat table projections use SQL Server `MERGE` statements for upsert behavior, en
 ::: tip
 Flat table projections bypass the document storage layer entirely, writing directly to user-defined SQL tables. This makes the data accessible to any SQL tool without understanding JSON document structure.
 :::
+
+## Using EventProjection for Flat Tables
+
+::: tip
+The `EventProjection` approach shown below is more explicit code than `FlatTableProjection`, but it is also
+more flexible. Use `EventProjection` when you need full control over the SQL being generated, need to access
+event metadata through the `IEvent<T>` envelope, or when the declarative `FlatTableProjection` API does not
+support your use case. The tradeoff is that you are writing raw SQL yourself, so you are responsible for
+getting the SQL correct and handling upsert logic on your own.
+:::
+
+As an alternative to the more rigid `FlatTableProjection` approach, you can use Polecat's `EventProjection` as a
+base class and write explicit SQL to project events into a flat table. This gives you complete control over the
+SQL operations and full access to event metadata:
+
+<!-- snippet: sample_polecat_import_sql_event_projection -->
+<a id='snippet-sample_polecat_import_sql_event_projection'></a>
+```cs
+public partial class ImportSqlProjection: EventProjection
+{
+    // Use the IEvent<T> envelope to access event metadata
+    // like stream identity and timestamps
+    public void Project(IEvent<ImportStarted> e, IDocumentSession ops)
+    {
+        ops.QueueSqlCommand(
+            "insert into import_history (id, activity_type, customer_id, started) values (?, ?, ?, ?)",
+            e.StreamId, e.Data.ActivityType, e.Data.CustomerId, e.Data.Started
+        );
+    }
+
+    public void Project(IEvent<ImportFinished> e, IDocumentSession ops)
+    {
+        ops.QueueSqlCommand(
+            "update import_history set finished = ? where id = ?",
+            e.Data.Finished, e.StreamId
+        );
+    }
+
+    // You can use any SQL operation, including deletes
+    public void Project(IEvent<ImportFailed> e, IDocumentSession ops)
+    {
+        ops.QueueSqlCommand(
+            "delete from import_history where id = ?",
+            e.StreamId
+        );
+    }
+}
+```
+<sup><a href='https://github.com/JasperFx/polecat/blob/main/src/Polecat.Tests/Projections/using_event_projection_for_flat_tables.cs#L26-L57' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_polecat_import_sql_event_projection' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+A couple notes about the `EventProjection` approach:
+
+* **Batched execution** -- The `QueueSqlCommand()` method doesn't execute inline. Instead, it adds the SQL to be executed
+  in a batch when you call `IDocumentSession.SaveChangesAsync()`. This batching reduces network round trips to the
+  database and is a consistent performance win.
+* **Event metadata access** -- The `Project()` methods use `IEvent<T>` envelope types, giving you access to event metadata
+  like timestamps, version information, and stream identity. This is something the declarative `FlatTableProjection`
+  cannot currently provide.
+* **Full SQL control** -- You can write any SQL you need: inserts, updates, deletes, or even complex statements with
+  subqueries. This is useful when your projection logic doesn't fit the `Map`/`Increment`/`SetValue` patterns of
+  `FlatTableProjection`.

--- a/src/Polecat.Tests/Projections/using_event_projection_for_flat_tables.cs
+++ b/src/Polecat.Tests/Projections/using_event_projection_for_flat_tables.cs
@@ -1,0 +1,57 @@
+using JasperFx.Events;
+using Polecat.Projections;
+
+namespace Polecat.Tests.Projections;
+
+#region sample_polecat_event_projection_flat_table_events
+
+public record ImportStarted(
+    DateTimeOffset Started,
+    string ActivityType,
+    string CustomerId,
+    int PlannedSteps);
+
+public record ImportProgress(
+    string StepName,
+    int Records,
+    int Invalids);
+
+public record ImportFinished(DateTimeOffset Finished);
+
+public record ImportFailed;
+
+#endregion
+
+#region sample_polecat_import_sql_event_projection
+
+public partial class ImportSqlProjection: EventProjection
+{
+    // Use the IEvent<T> envelope to access event metadata
+    // like stream identity and timestamps
+    public void Project(IEvent<ImportStarted> e, IDocumentSession ops)
+    {
+        ops.QueueSqlCommand(
+            "insert into import_history (id, activity_type, customer_id, started) values (?, ?, ?, ?)",
+            e.StreamId, e.Data.ActivityType, e.Data.CustomerId, e.Data.Started
+        );
+    }
+
+    public void Project(IEvent<ImportFinished> e, IDocumentSession ops)
+    {
+        ops.QueueSqlCommand(
+            "update import_history set finished = ? where id = ?",
+            e.Data.Finished, e.StreamId
+        );
+    }
+
+    // You can use any SQL operation, including deletes
+    public void Project(IEvent<ImportFailed> e, IDocumentSession ops)
+    {
+        ops.QueueSqlCommand(
+            "delete from import_history where id = ?",
+            e.StreamId
+        );
+    }
+}
+
+#endregion

--- a/src/Polecat/IDocumentOperations.cs
+++ b/src/Polecat/IDocumentOperations.cs
@@ -111,4 +111,10 @@ public interface IDocumentOperations : IQuerySession
     ///     for optimistic concurrency checking.
     /// </summary>
     void UpdateRevision<T>(T document, int revision) where T : notnull;
+
+    /// <summary>
+    ///     Registers a SQL command to be executed with the underlying unit of work as part of the batched command.
+    ///     The '?' character is used as a placeholder for positional parameters.
+    /// </summary>
+    void QueueSqlCommand(string sql, params object[] parameterValues);
 }

--- a/src/Polecat/Internal/DocumentSessionBase.cs
+++ b/src/Polecat/Internal/DocumentSessionBase.cs
@@ -267,6 +267,12 @@ internal abstract class DocumentSessionBase : QuerySession, IDocumentSession
         Store(document);
     }
 
+    public void QueueSqlCommand(string sql, params object[] parameterValues)
+    {
+        var operation = new Operations.ExecuteSqlStorageOperation(sql, parameterValues);
+        _workTracker.Add(operation);
+    }
+
     public async Task SaveChangesAsync(CancellationToken token = default)
     {
         if (!_workTracker.HasOutstandingWork()) return;

--- a/src/Polecat/Internal/NestedTenantSession.cs
+++ b/src/Polecat/Internal/NestedTenantSession.cs
@@ -213,6 +213,9 @@ internal class NestedTenantSession : ITenantOperations
     public void UpdateRevision<T>(T document, int revision) where T : notnull
         => _parent.UpdateRevision(document, revision);
 
+    public void QueueSqlCommand(string sql, params object[] parameterValues)
+        => _parent.QueueSqlCommand(sql, parameterValues);
+
     public ValueTask DisposeAsync()
     {
         // No-op: parent owns the connection

--- a/src/Polecat/Internal/Operations/ExecuteSqlStorageOperation.cs
+++ b/src/Polecat/Internal/Operations/ExecuteSqlStorageOperation.cs
@@ -1,0 +1,46 @@
+using System.Data.Common;
+using Microsoft.Data.SqlClient;
+using Weasel.Core;
+using Weasel.SqlServer;
+
+namespace Polecat.Internal.Operations;
+
+internal class ExecuteSqlStorageOperation : IStorageOperation
+{
+    private readonly string _commandText;
+    private readonly object[] _parameterValues;
+
+    public ExecuteSqlStorageOperation(string commandText, params object[] parameterValues)
+    {
+        _commandText = commandText.TrimEnd(';');
+        _parameterValues = parameterValues;
+    }
+
+    public Type DocumentType => typeof(object);
+    public OperationRole Role() => OperationRole.Upsert;
+
+    public void ConfigureCommand(ICommandBuilder builder)
+    {
+        var parameters = builder.AppendWithParameters(_commandText);
+        if (parameters.Length != _parameterValues.Length)
+        {
+            throw new InvalidOperationException(
+                $"Wrong number of parameter values to SQL '{_commandText}', got {_parameterValues.Length} parameters");
+        }
+
+        for (var i = 0; i < parameters.Length; i++)
+        {
+            if (_parameterValues[i] == null)
+            {
+                parameters[i].Value = DBNull.Value;
+            }
+            else
+            {
+                parameters[i].Value = _parameterValues[i];
+            }
+        }
+    }
+
+    public Task PostprocessAsync(DbDataReader reader, IList<Exception> exceptions, CancellationToken token) =>
+        Task.CompletedTask;
+}


### PR DESCRIPTION
## Summary
- Add `QueueSqlCommand` to `IDocumentOperations` and `DocumentSessionBase` for queuing raw SQL in the unit of work batch
- Add `ExecuteSqlStorageOperation` to support batched raw SQL execution
- Add new code sample in `Polecat.Tests` demonstrating `EventProjection` with `QueueSqlCommand` for flat table projections
- Update flat table projection docs with `EventProjection` as a more flexible alternative to `FlatTableProjection`

## Test plan
- [ ] Verify `Polecat` and `Polecat.Tests` projects compile with the new code
- [ ] Review documentation renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)