### PR TITLE
Update JasperFx and Weasel NuGet packages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
 
     <ItemGroup>
         <!-- Core dependencies -->
-        <PackageVersion Include="JasperFx" Version="1.21.3" />
+        <PackageVersion Include="JasperFx" Version="1.21.4" />
         <PackageVersion Include="JasperFx.Events" Version="1.24.1" />
         <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.4" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
@@ -28,8 +28,8 @@
         <PackageVersion Include="Shouldly" Version="4.3.0" />
         <PackageVersion Include="xunit" Version="2.9.3" />
         <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.4" />
-        <PackageVersion Include="Weasel.EntityFrameworkCore" Version="8.10.1" />
-        <PackageVersion Include="Weasel.SqlServer" Version="8.10.1" />
+        <PackageVersion Include="Weasel.EntityFrameworkCore" Version="8.10.2" />
+        <PackageVersion Include="Weasel.SqlServer" Version="8.10.2" />
 
         <!-- Strongly typed IDs -->
         <PackageVersion Include="StronglyTypedId" Version="1.0.0-beta08" />


### PR DESCRIPTION
## Summary
- JasperFx 1.21.3 → 1.21.4 (includes fix for unix socket DatabaseUri, JasperFx/jasperfx#170)
- Weasel.SqlServer 8.10.1 → 8.10.2
- Weasel.EntityFrameworkCore 8.10.1 → 8.10.2

## Test plan
- [x] Polecat compiles successfully with updated packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)