### PR TITLE
Upgrade Weasel to 8.11.1 and JasperFx to latest

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,8 +5,8 @@
 
     <ItemGroup>
         <!-- Core dependencies -->
-        <PackageVersion Include="JasperFx" Version="1.21.4" />
-        <PackageVersion Include="JasperFx.Events" Version="1.24.1" />
+        <PackageVersion Include="JasperFx" Version="1.22.0" />
+        <PackageVersion Include="JasperFx.Events" Version="1.24.2" />
         <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.4" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
@@ -28,13 +28,13 @@
         <PackageVersion Include="Shouldly" Version="4.3.0" />
         <PackageVersion Include="xunit" Version="2.9.3" />
         <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.4" />
-        <PackageVersion Include="Weasel.EntityFrameworkCore" Version="8.10.2" />
-        <PackageVersion Include="Weasel.SqlServer" Version="8.10.2" />
+        <PackageVersion Include="Weasel.EntityFrameworkCore" Version="8.11.1" />
+        <PackageVersion Include="Weasel.SqlServer" Version="8.11.1" />
 
         <!-- Strongly typed IDs -->
         <PackageVersion Include="StronglyTypedId" Version="1.0.0-beta08" />
 
         <!-- Source generators -->
-        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="1.3.0" />
+        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="1.4.0" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- Upgrades Weasel packages (SqlServer, EntityFrameworkCore) from 8.10.2 → 8.11.1
- Upgrades JasperFx from 1.21.4 → 1.22.0
- Upgrades JasperFx.Events from 1.24.1 → 1.24.2
- Upgrades JasperFx.Events.SourceGenerator from 1.3.0 → 1.4.0

Notable in Weasel 8.11.1: support for EF Core `OwnsOne().ToJson()` JSON column mapping in schema migrations ([JasperFx/weasel#232](https://github.com/JasperFx/weasel/pull/233)).

## Test plan
- [x] Solution builds cleanly (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)