### PR TITLE
1.6.1: Fix test failures and Azure SQL Edge compatibility

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>1.6.0</Version>
+        <Version>1.6.1</Version>
         <LangVersion>latest</LangVersion>
         <Authors>Jeremy D. Miller</Authors>
         <PackageIcon>logo.png</PackageIcon>

--- a/src/Polecat.Tests/MultiTenancy/separate_database_tenancy_tests.cs
+++ b/src/Polecat.Tests/MultiTenancy/separate_database_tenancy_tests.cs
@@ -15,10 +15,10 @@ public class separate_database_tenancy_tests : IAsyncLifetime
     private const string DbB = "polecat_tenant_b";
 
     private static readonly string MasterConnectionString =
-        "Server=localhost,11433;Database=master;User Id=sa;Password=Polecat#Dev2025;TrustServerCertificate=true";
+        ConnectionSource.ConnectionString.Replace("Initial Catalog=master", "Database=master");
 
     private static string TenantConnectionString(string dbName) =>
-        $"Server=localhost,11433;Database={dbName};User Id=sa;Password=Polecat#Dev2025;TrustServerCertificate=true";
+        ConnectionSource.ConnectionString.Replace("Initial Catalog=master", $"Database={dbName}");
 
     public async Task InitializeAsync()
     {

--- a/src/Polecat.Tests/Reading/advanced_sql_query.cs
+++ b/src/Polecat.Tests/Reading/advanced_sql_query.cs
@@ -182,7 +182,7 @@ public class advanced_sql_query : IntegrationContext
         await using var query = theStore.QuerySession();
         var results = new List<(int, string)>();
         await foreach (var item in query.AdvancedSql.StreamAsync<int, string>(
-            "SELECT value, CONCAT('item_', CAST(value AS varchar)) FROM GENERATE_SERIES(1, 3)",
+            "SELECT value, CONCAT('item_', CAST(value AS varchar)) FROM (VALUES (1),(2),(3)) AS s(value)",
             CancellationToken.None))
         {
             results.Add(item);

--- a/src/Polecat/Linq/Parsing/GroupBySelectBuilder.cs
+++ b/src/Polecat/Linq/Parsing/GroupBySelectBuilder.cs
@@ -8,8 +8,10 @@ using Weasel.SqlServer;
 namespace Polecat.Linq.Parsing;
 
 /// <summary>
-///     Builds JSON_OBJECT SELECT clause, GROUP BY columns, and HAVING fragments
+///     Builds SELECT clause (using CONCAT-based JSON), GROUP BY columns, and HAVING fragments
 ///     from a GroupBy key selector and result projection.
+///     Uses CONCAT with manual JSON encoding for broad SQL Server compatibility
+///     (works on Azure SQL Edge and SQL Server 2022+).
 /// </summary>
 internal class GroupBySelectBuilder
 {
@@ -17,8 +19,9 @@ internal class GroupBySelectBuilder
     private readonly JsonNamingPolicy? _namingPolicy;
 
     // Key members for GROUP BY (maps anonymous type member name to SQL locator)
-    private readonly Dictionary<string, string> _keyLocators = new();
+    private readonly Dictionary<string, (string locator, bool isString)> _keyLocators = new();
     private string? _simpleKeyLocator;
+    private bool _simpleKeyIsString;
     private bool _isCompositeKey;
 
     public List<string> GroupByColumns { get; } = [];
@@ -65,7 +68,8 @@ internal class GroupBySelectBuilder
                     ?? throw new NotSupportedException(
                         $"GroupBy composite key member must be a property, got: {newExpr.Arguments[i]}");
                 var member = _memberFactory.ResolveMember(memberExpr);
-                _keyLocators[parameters[i].Name!] = member.TypedLocator;
+                var isString = IsStringType(memberExpr.Type);
+                _keyLocators[parameters[i].Name!] = (member.TypedLocator, isString);
                 GroupByColumns.Add(member.TypedLocator);
             }
         }
@@ -74,6 +78,7 @@ internal class GroupBySelectBuilder
             _isCompositeKey = false;
             var member = _memberFactory.ResolveMember(memberBody);
             _simpleKeyLocator = member.TypedLocator;
+            _simpleKeyIsString = IsStringType(memberBody.Type);
             GroupByColumns.Add(member.TypedLocator);
         }
         else
@@ -97,7 +102,7 @@ internal class GroupBySelectBuilder
 
         if (body is MethodCallExpression scalarMethod)
         {
-            var sql = ResolveAggregate(scalarMethod, groupingParam);
+            var (sql, _) = ResolveProjectionMember(scalarMethod, groupingParam);
             if (sql != null)
             {
                 SelectColumns = sql;
@@ -105,7 +110,7 @@ internal class GroupBySelectBuilder
             }
         }
 
-        // Complex projection: build JSON_OBJECT
+        // Complex projection: build JSON via CONCAT
         if (body is NewExpression newExpr)
         {
             SelectColumns = BuildJsonObject(newExpr, groupingParam);
@@ -124,43 +129,46 @@ internal class GroupBySelectBuilder
     private string BuildJsonObject(NewExpression newExpr, ParameterExpression groupingParam)
     {
         var parameters = newExpr.Constructor!.GetParameters();
-        var parts = new List<string>();
+        var parts = new List<(string key, string valueSql, bool isString)>();
 
         for (var i = 0; i < parameters.Length; i++)
         {
             var name = FormatKey(parameters[i].Name!);
-            var sql = ResolveProjectionMember(newExpr.Arguments[i], groupingParam);
-            parts.Add($"'{name}': {sql}");
+            var (sql, isString) = ResolveProjectionMember(newExpr.Arguments[i], groupingParam);
+            parts.Add((name, sql, isString));
         }
 
-        return $"JSON_OBJECT({string.Join(", ", parts)}) as data";
+        return BuildConcatJson(parts);
     }
 
     private string BuildJsonObjectFromMemberInit(MemberInitExpression memberInit, ParameterExpression groupingParam)
     {
-        var parts = new List<string>();
+        var parts = new List<(string key, string valueSql, bool isString)>();
 
         // Handle constructor parameters
         var ctorParams = memberInit.NewExpression.Constructor!.GetParameters();
         for (var i = 0; i < ctorParams.Length; i++)
         {
             var name = FormatKey(ctorParams[i].Name!);
-            var sql = ResolveProjectionMember(memberInit.NewExpression.Arguments[i], groupingParam);
-            parts.Add($"'{name}': {sql}");
+            var (sql, isString) = ResolveProjectionMember(memberInit.NewExpression.Arguments[i], groupingParam);
+            parts.Add((name, sql, isString));
         }
 
         // Handle member bindings
         foreach (var binding in memberInit.Bindings.OfType<MemberAssignment>())
         {
             var name = FormatKey(binding.Member.Name);
-            var sql = ResolveProjectionMember(binding.Expression, groupingParam);
-            parts.Add($"'{name}': {sql}");
+            var (sql, isString) = ResolveProjectionMember(binding.Expression, groupingParam);
+            parts.Add((name, sql, isString));
         }
 
-        return $"JSON_OBJECT({string.Join(", ", parts)}) as data";
+        return BuildConcatJson(parts);
     }
 
-    private string ResolveProjectionMember(Expression expr, ParameterExpression groupingParam)
+    /// <summary>
+    ///     Returns (sql, isStringType) for a projection member.
+    /// </summary>
+    private (string sql, bool isString) ResolveProjectionMember(Expression expr, ParameterExpression groupingParam)
     {
         // g.Key
         if (expr is MemberExpression memberAccess && memberAccess.Member.Name == "Key"
@@ -172,7 +180,7 @@ internal class GroupBySelectBuilder
                     "Cannot select the entire composite GroupBy key directly. Access individual key members like g.Key.Color instead.");
             }
 
-            return _simpleKeyLocator!;
+            return (_simpleKeyLocator!, _simpleKeyIsString);
         }
 
         // g.Key.PropertyName (composite key)
@@ -182,20 +190,20 @@ internal class GroupBySelectBuilder
             && innerMember.Expression == groupingParam)
         {
             var propName = compositeAccess.Member.Name;
-            if (_keyLocators.TryGetValue(propName, out var locator))
+            if (_keyLocators.TryGetValue(propName, out var info))
             {
-                return locator;
+                return (info.locator, info.isString);
             }
 
             throw new NotSupportedException(
                 $"Unknown composite key member '{propName}' in GroupBy projection");
         }
 
-        // Aggregate method calls
+        // Aggregate method calls (always numeric)
         if (expr is MethodCallExpression methodCall)
         {
             var sql = ResolveAggregate(methodCall, groupingParam);
-            if (sql != null) return sql;
+            if (sql != null) return (sql, false);
         }
 
         throw new NotSupportedException(
@@ -316,6 +324,47 @@ internal class GroupBySelectBuilder
             throw new NotSupportedException(
                 $"Unsupported HAVING operand: {expr}");
         }
+    }
+
+    /// <summary>
+    ///     Combines key-value fragments into a JSON object using CONCAT.
+    ///     Numeric values are emitted bare; string values are quoted and escaped.
+    /// </summary>
+    private static string BuildConcatJson(List<(string key, string valueSql, bool isString)> fragments)
+    {
+        var concatParts = new List<string>();
+        concatParts.Add("'{'");
+
+        for (var i = 0; i < fragments.Count; i++)
+        {
+            if (i > 0) concatParts.Add("','");
+            var (key, valueSql, isString) = fragments[i];
+            concatParts.Add($"'\"' + '{EscapeJsonKey(key)}' + '\":'");
+            if (isString)
+            {
+                // String values: quote and escape embedded double-quotes
+                concatParts.Add($"'\"' + REPLACE(CAST({valueSql} AS nvarchar(max)), '\"', '\\\"') + '\"'");
+            }
+            else
+            {
+                // Numeric values: emit raw
+                concatParts.Add($"CAST({valueSql} AS nvarchar(max))");
+            }
+        }
+
+        concatParts.Add("'}'");
+        return $"CONCAT({string.Join(", ", concatParts)}) as data";
+    }
+
+    private static string EscapeJsonKey(string key)
+    {
+        return key.Replace("'", "''");
+    }
+
+    private static bool IsStringType(Type type)
+    {
+        var underlying = Nullable.GetUnderlyingType(type) ?? type;
+        return underlying == typeof(string);
     }
 
     private string FormatKey(string name)

--- a/src/Polecat/Linq/PolecatLinqQueryProvider.cs
+++ b/src/Polecat/Linq/PolecatLinqQueryProvider.cs
@@ -339,8 +339,8 @@ internal class PolecatLinqQueryProvider : IPolecatAsyncQueryProvider
 
         await using var reader = await _session.ExecuteReaderAsync(batch, token);
 
-        // Check if the select is JSON_OBJECT (complex projection) or scalar
-        if (builder2.SelectColumns.StartsWith("JSON_OBJECT("))
+        // Check if the select is a complex JSON projection or scalar
+        if (builder2.SelectColumns.EndsWith(" as data"))
         {
             // Deserialize JSON results
             return await InvokeGroupByListHandlerAsync<TResult>(reader, parser.SelectExpression!, token);


### PR DESCRIPTION
## Summary

- **Fix separate database tenancy tests** — connection strings now derive from `ConnectionSource` instead of hard-coded wrong password (`Polecat#Dev2025` vs actual `P@55w0rd`)
- **Fix GROUP BY LINQ operator** — replace `JSON_OBJECT('key': value)` (SQL Server 2022+ only) with `CONCAT`-based JSON construction for Azure SQL Edge compatibility (9 tests)
- **Fix GENERATE_SERIES test** — replace with `VALUES` clause compatible with Azure SQL Edge
- **Bump patch version** to 1.6.1

## Test plan
- [x] All 6 separate database tenancy tests pass
- [x] All 10 GROUP BY operator tests pass
- [x] `can_stream_tuple_results` test passes
- [x] Full suite: 983 tests, 976 pass, 7 flaky async daemon tests (pass individually)

🤖 Generated with [Claude Code](https://claude.com/claude-code)