### PR TITLE
Default to SQL Server 2025 native json column type

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>1.6.1</Version>
+        <Version>2.0.0</Version>
         <LangVersion>latest</LangVersion>
         <Authors>Jeremy D. Miller</Authors>
         <PackageIcon>logo.png</PackageIcon>

--- a/docs/configuration/json.md
+++ b/docs/configuration/json.md
@@ -61,7 +61,7 @@ opts.UseSystemTextJsonSerializerOptions(o =>
 
 ## SQL Server 2025 JSON Type
 
-Polecat stores all document bodies and event data using SQL Server 2025's native `json` data type. This provides:
+Polecat stores all document bodies and event data using SQL Server 2025's native `json` data type by default. This provides:
 
 - Native JSON validation at the database level
 - Efficient JSON path queries via `JSON_VALUE()` and `JSON_QUERY()`
@@ -71,3 +71,13 @@ Polecat stores all document bodies and event data using SQL Server 2025's native
 ::: tip
 The `json` type in SQL Server 2025 is analogous to PostgreSQL's `jsonb` type used by Marten, but without the binary storage optimization.
 :::
+
+### Falling Back to nvarchar(max)
+
+If you are running against a pre-2025 SQL Server instance that does not support the native `json` data type, disable it with:
+
+```cs
+opts.UseNativeJsonType = false;
+```
+
+When set to `false`, Polecat uses `nvarchar(max)` for all JSON columns instead. All JSON querying, patching, and projection features continue to work identically with either column type.

--- a/docs/configuration/storeoptions.md
+++ b/docs/configuration/storeoptions.md
@@ -48,6 +48,16 @@ All Polecat tables use the `pc_` prefix:
 - `pc_hilo` -- HiLo sequence storage
 - `pc_doc_{typename}` -- Document tables
 
+## Native JSON Column Type
+
+By default, Polecat uses SQL Server 2025's native `json` data type for document bodies, event data, headers, and snapshots. To fall back to `nvarchar(max)` for pre-2025 SQL Server instances:
+
+```cs
+opts.UseNativeJsonType = false;
+```
+
+See [JSON Serialization](/configuration/json#falling-back-to-nvarcharmax) for more details.
+
 ## Store Policies
 
 Apply policies across all document types:

--- a/src/Polecat.Tests/DependencyInjection/service_registration_tests.cs
+++ b/src/Polecat.Tests/DependencyInjection/service_registration_tests.cs
@@ -13,6 +13,7 @@ public class service_registration_tests
         var expression = services.AddPolecat(opts =>
         {
             opts.ConnectionString = ConnectionSource.ConnectionString;
+            opts.UseNativeJsonType = ConnectionSource.SupportsNativeJson;
         });
         configure?.Invoke(expression);
         return services.BuildServiceProvider();
@@ -129,7 +130,8 @@ public class service_registration_tests
         var options = new StoreOptions
         {
             ConnectionString = ConnectionSource.ConnectionString,
-            DatabaseSchemaName = "custom"
+            DatabaseSchemaName = "custom",
+            UseNativeJsonType = ConnectionSource.SupportsNativeJson
         };
 
         var services = new ServiceCollection();
@@ -152,7 +154,8 @@ public class service_registration_tests
             sp.GetRequiredService<string>().ShouldBe("test-connection-marker");
             return new StoreOptions
             {
-                ConnectionString = ConnectionSource.ConnectionString
+                ConnectionString = ConnectionSource.ConnectionString,
+                UseNativeJsonType = ConnectionSource.SupportsNativeJson
             };
         });
 

--- a/src/Polecat.Tests/Events/use_identity_map_for_aggregates.cs
+++ b/src/Polecat.Tests/Events/use_identity_map_for_aggregates.cs
@@ -52,7 +52,8 @@ public class use_identity_map_for_aggregates : IntegrationContext
         var options = new StoreOptions
         {
             ConnectionString = ConnectionSource.ConnectionString,
-            DatabaseSchemaName = "idmap_disabled"
+            DatabaseSchemaName = "idmap_disabled",
+            UseNativeJsonType = ConnectionSource.SupportsNativeJson
         };
 
         await using var store = new DocumentStore(options);

--- a/src/Polecat.Tests/Harness/ConnectionSource.cs
+++ b/src/Polecat.Tests/Harness/ConnectionSource.cs
@@ -1,3 +1,5 @@
+using Microsoft.Data.SqlClient;
+
 namespace Polecat.Tests.Harness;
 
 /// <summary>
@@ -10,4 +12,37 @@ public static class ConnectionSource
     public static readonly string ConnectionString =
         Environment.GetEnvironmentVariable("POLECAT_TESTING_DATABASE")
         ?? "Server=localhost,11433;User Id=sa;Password=P@55w0rd;Timeout=5;MultipleActiveResultSets=True;Initial Catalog=master;Encrypt=False";
+
+    private static bool? _supportsNativeJson;
+
+    /// <summary>
+    ///     Detects whether the connected SQL Server instance supports the native json data type
+    ///     (SQL Server 2025+). Returns false for Azure SQL Edge and older versions.
+    /// </summary>
+    public static bool SupportsNativeJson
+    {
+        get
+        {
+            if (_supportsNativeJson.HasValue) return _supportsNativeJson.Value;
+            _supportsNativeJson = DetectNativeJsonSupport();
+            return _supportsNativeJson.Value;
+        }
+    }
+
+    private static bool DetectNativeJsonSupport()
+    {
+        try
+        {
+            using var conn = new SqlConnection(ConnectionString);
+            conn.Open();
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = "DECLARE @x json = '{}'; SELECT 1;";
+            cmd.ExecuteScalar();
+            return true;
+        }
+        catch (SqlException)
+        {
+            return false;
+        }
+    }
 }

--- a/src/Polecat.Tests/Harness/DefaultStoreFixture.cs
+++ b/src/Polecat.Tests/Harness/DefaultStoreFixture.cs
@@ -19,7 +19,8 @@ public class DefaultStoreFixture : IAsyncLifetime
         Options = new StoreOptions
         {
             ConnectionString = ConnectionSource.ConnectionString,
-            AutoCreateSchemaObjects = AutoCreate.All
+            AutoCreateSchemaObjects = AutoCreate.All,
+            UseNativeJsonType = ConnectionSource.SupportsNativeJson
         };
 
         Store = new DocumentStore(Options);

--- a/src/Polecat.Tests/Harness/IntegrationContext.cs
+++ b/src/Polecat.Tests/Harness/IntegrationContext.cs
@@ -59,7 +59,8 @@ public abstract class IntegrationContext : IAsyncLifetime
         var options = new StoreOptions
         {
             ConnectionString = ConnectionSource.ConnectionString,
-            AutoCreateSchemaObjects = AutoCreate.All
+            AutoCreateSchemaObjects = AutoCreate.All,
+            UseNativeJsonType = ConnectionSource.SupportsNativeJson
         };
 
         configure(options);

--- a/src/Polecat.Tests/Harness/OneOffConfigurationsContext.cs
+++ b/src/Polecat.Tests/Harness/OneOffConfigurationsContext.cs
@@ -57,7 +57,8 @@ public abstract class OneOffConfigurationsContext : IAsyncLifetime
         {
             ConnectionString = ConnectionSource.ConnectionString,
             AutoCreateSchemaObjects = AutoCreate.All,
-            DatabaseSchemaName = _schemaName
+            DatabaseSchemaName = _schemaName,
+            UseNativeJsonType = ConnectionSource.SupportsNativeJson
         };
 
         configure(options);

--- a/src/Polecat.Tests/MultiTenancy/separate_database_tenancy_tests.cs
+++ b/src/Polecat.Tests/MultiTenancy/separate_database_tenancy_tests.cs
@@ -60,6 +60,7 @@ public class separate_database_tenancy_tests : IAsyncLifetime
         {
             opts.ConnectionString = TenantConnectionString(DbA); // default connection
             opts.AutoCreateSchemaObjects = AutoCreate.All;
+            opts.UseNativeJsonType = ConnectionSource.SupportsNativeJson;
 
             opts.MultiTenantedDatabases(tenancy =>
             {
@@ -204,6 +205,7 @@ public class separate_database_tenancy_tests : IAsyncLifetime
         using var store = DocumentStore.For(opts =>
         {
             opts.ConnectionString = ConnectionSource.ConnectionString;
+            opts.UseNativeJsonType = ConnectionSource.SupportsNativeJson;
         });
 
         store.Options.Tenancy.ShouldNotBeNull();

--- a/src/Polecat.Tests/Schema/SchemaCreationTests.cs
+++ b/src/Polecat.Tests/Schema/SchemaCreationTests.cs
@@ -17,7 +17,11 @@ public class SchemaCreationTests : IAsyncLifetime
 
     private static PolecatDatabase CreateDatabase(Action<StoreOptions>? configure = null)
     {
-        var options = new StoreOptions { ConnectionString = ConnectionSource.ConnectionString };
+        var options = new StoreOptions
+        {
+            ConnectionString = ConnectionSource.ConnectionString,
+            UseNativeJsonType = ConnectionSource.SupportsNativeJson
+        };
         configure?.Invoke(options);
         return new PolecatDatabase(options);
     }

--- a/src/Polecat/Events/EventGraph.cs
+++ b/src/Polecat/Events/EventGraph.cs
@@ -58,6 +58,8 @@ public class EventGraph : EventRegistry, IAggregationSourceFactory<IQuerySession
 
     internal EventStoreOptions EventOptions => _options.Events;
 
+    internal string JsonColumnType => _options.JsonColumnType;
+
     /// <summary>
     ///     Whether extended progression tracking columns are enabled.
     /// </summary>

--- a/src/Polecat/Events/Schema/EventsTable.cs
+++ b/src/Polecat/Events/Schema/EventsTable.cs
@@ -30,8 +30,8 @@ internal class EventsTable : Table
         // Version within the stream
         AddColumn("version", "bigint").NotNull();
 
-        // Event data — SQL Server 2025 JSON type
-        AddColumn("data", "nvarchar(max)").NotNull();
+        // Event data — SQL Server 2025 native JSON type by default
+        AddColumn("data", events.JsonColumnType).NotNull();
 
         // Event type name for deserialization
         AddColumn("type", "varchar(500)").NotNull();
@@ -62,7 +62,7 @@ internal class EventsTable : Table
 
         if (events.EventOptions.EnableHeaders)
         {
-            AddColumn("headers", "nvarchar(max)").AllowNulls();
+            AddColumn("headers", events.JsonColumnType).AllowNulls();
         }
 
         // Archive flag

--- a/src/Polecat/Events/Schema/StreamsTable.cs
+++ b/src/Polecat/Events/Schema/StreamsTable.cs
@@ -35,7 +35,7 @@ internal class StreamsTable : Table
             .NotNull()
             .DefaultValueByExpression("SYSDATETIMEOFFSET()");
 
-        AddColumn("snapshot", "nvarchar(max)").AllowNulls();
+        AddColumn("snapshot", events.JsonColumnType).AllowNulls();
         AddColumn("snapshot_version", "int").AllowNulls();
 
         if (events.TenancyStyle != TenancyStyle.Conjoined)

--- a/src/Polecat/Storage/DocumentMapping.cs
+++ b/src/Polecat/Storage/DocumentMapping.cs
@@ -64,6 +64,7 @@ internal class DocumentMapping
         DatabaseSchemaName = options.DatabaseSchemaName;
         DotNetTypeName = $"{documentType.FullName}, {documentType.Assembly.GetName().Name}";
         TenancyStyle = options.Events.TenancyStyle;
+        JsonColumnType = options.JsonColumnType;
 
         // Discover and register attribute-based indexes
         DiscoverIndexAttributes(documentType);
@@ -114,6 +115,7 @@ internal class DocumentMapping
     public string DatabaseSchemaName { get; }
     public string DotNetTypeName { get; }
     public TenancyStyle TenancyStyle { get; }
+    public string JsonColumnType { get; }
     public DeleteStyle DeleteStyle { get; } = DeleteStyle.Remove;
 
     /// <summary>

--- a/src/Polecat/Storage/DocumentTable.cs
+++ b/src/Polecat/Storage/DocumentTable.cs
@@ -24,7 +24,7 @@ internal class DocumentTable : Table
 
         AddColumn("id", idColumnType).AsPrimaryKey().NotNull();
 
-        AddColumn("data", "nvarchar(max)").NotNull();
+        AddColumn("data", mapping.JsonColumnType).NotNull();
 
         AddColumn("version", "int").NotNull().DefaultValue(1);
 

--- a/src/Polecat/StoreOptions.cs
+++ b/src/Polecat/StoreOptions.cs
@@ -168,6 +168,18 @@ public class StoreOptions
     internal Dictionary<Type, Func<Internal.DocumentSessionBase, string, object>> CustomProjectionStorageProviders { get; } = new();
 
     /// <summary>
+    ///     When true (the default), Polecat uses the SQL Server 2025 native <c>json</c>
+    ///     data type for document bodies, event data, headers, and snapshots.
+    ///     Set to false to fall back to <c>nvarchar(max)</c> for pre-2025 SQL Server instances.
+    /// </summary>
+    public bool UseNativeJsonType { get; set; } = true;
+
+    /// <summary>
+    ///     Resolved SQL column type for JSON storage based on <see cref="UseNativeJsonType"/>.
+    /// </summary>
+    internal string JsonColumnType => UseNativeJsonType ? "json" : "nvarchar(max)";
+
+    /// <summary>
     ///     Additional SQL Server tables to be managed by this DocumentStore alongside
     ///     Polecat's own schema objects. Used by extensions like EF Core integration
     ///     to register entity tables for Weasel schema migration.


### PR DESCRIPTION
## Summary

- **Add `StoreOptions.UseNativeJsonType`** (default: `true`) — switches all JSON data columns from `nvarchar(max)` to the SQL Server 2025 native `json` type
- **Schema columns affected**: `pc_doc_*.data`, `pc_events.data`, `pc_events.headers`, `pc_streams.snapshot`
- **Fallback**: Set `UseNativeJsonType = false` for pre-2025 SQL Server instances
- **Test auto-detection**: `ConnectionSource.SupportsNativeJson` probes the server at startup so tests work against both SQL Server 2025 and Azure SQL Edge

## Implementation

The option flows through `StoreOptions.JsonColumnType` → `DocumentMapping.JsonColumnType` / `EventGraph.JsonColumnType` → table constructors (`DocumentTable`, `EventsTable`, `StreamsTable`).

All existing SQL operations (`JSON_VALUE`, `JSON_MODIFY`, `JSON_QUERY`, `OPENJSON`, string parameter binding) are compatible with both column types — no query changes needed.

## Test plan
- [x] Full suite: 982/983 pass on net10.0 (1 pre-existing flaky async daemon test)
- [x] Builds clean with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)