### PR TITLE
Register Lazy<T> for ancillary stores in projections

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -121,6 +121,7 @@ const config: UserConfig<DefaultTheme.Config> = {
                 { text: 'Asynchronous Projections', link: '/events/projections/async-daemon' },
                 { text: 'EF Core Projections', link: '/events/projections/efcore' },
                 { text: 'Ancillary Stores in Projections', link: '/events/projections/ancillary-stores' },
+                { text: 'ProjectLatest — Include Pending Events', link: '/events/projections/project-latest' },
               ]
             },
             {

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -120,6 +120,7 @@ const config: UserConfig<DefaultTheme.Config> = {
                 { text: 'Composite Projections', link: '/events/projections/composite' },
                 { text: 'Asynchronous Projections', link: '/events/projections/async-daemon' },
                 { text: 'EF Core Projections', link: '/events/projections/efcore' },
+                { text: 'Ancillary Stores in Projections', link: '/events/projections/ancillary-stores' },
               ]
             },
             {

--- a/docs/events/projections/ancillary-stores.md
+++ b/docs/events/projections/ancillary-stores.md
@@ -1,0 +1,103 @@
+# Using Ancillary Stores in Projections
+
+## The Problem
+
+When building systems with multiple Polecat stores (using `AddPolecatStore<T>()`), it's common to
+need projections in one store that reference data from another. For example, a billing projection
+in your primary store might need to look up tariff data from a separate `ITarievenStore`.
+
+Directly injecting an ancillary store via constructor can cause startup deadlocks because the
+DI container may attempt to resolve the ancillary store while the primary store is still being
+constructed.
+
+## Solution: Inject `Lazy<T>`
+
+`AddPolecatStore<T>()` automatically registers `Lazy<T>` in the DI container alongside the
+store itself. This lets you inject a lazy reference that defers resolution until the store is
+actually needed — safely past the startup phase:
+
+```csharp
+public interface ITarievenStore : IDocumentStore;
+
+public class InvoiceProjection : SingleStreamProjection<Invoice, Guid>
+{
+    private readonly Lazy<ITarievenStore> _tarievenStore;
+
+    public InvoiceProjection(Lazy<ITarievenStore> tarievenStore)
+    {
+        _tarievenStore = tarievenStore;
+    }
+
+    public override async Task EnrichEventsAsync(
+        SliceGroup<Invoice, Guid> group,
+        IQuerySession querySession,
+        CancellationToken cancellation)
+    {
+        // Safe - the store is fully constructed by the time
+        // EnrichEventsAsync runs
+        await using var session = _tarievenStore.Value.QuerySession();
+
+        var ids = group.Slices
+            .SelectMany(s => s.Events().OfType<IEvent<ServicePerformed>>())
+            .Select(e => e.Data.TariefId)
+            .Distinct().ToArray();
+
+        var tarieven = await session.LoadManyAsync<Tarief>(cancellation, ids);
+
+        foreach (var slice in group.Slices)
+        {
+            foreach (var e in slice.Events().OfType<IEvent<ServicePerformed>>())
+            {
+                if (tarieven.TryGetValue(e.Data.TariefId, out var tarief))
+                {
+                    e.Data.ResolvedPrice = tarief.Price;
+                }
+            }
+        }
+    }
+}
+```
+
+Register the stores and projection:
+
+```csharp
+services.AddPolecat(opts =>
+{
+    opts.ConnectionString = "primary connection string";
+});
+
+services.AddPolecatStore<ITarievenStore>(opts =>
+{
+    opts.ConnectionString = "tarieven connection string";
+});
+```
+
+### Why `Lazy<T>` Works
+
+The `Lazy<T>` wrapper is constructed immediately (it's just a thin wrapper), but the inner
+`IDocumentStore` isn't resolved until `.Value` is accessed. By the time your projection's
+methods execute, all stores are fully constructed and the lazy resolution succeeds without
+deadlock.
+
+### Multiple Ancillary Stores
+
+You can inject multiple lazy store references. Each `AddPolecatStore<T>()` call automatically
+registers its own `Lazy<T>`:
+
+```csharp
+public class CrossStoreProjection : SingleStreamProjection<Summary, Guid>
+{
+    private readonly Lazy<ITarievenStore> _tarieven;
+    private readonly Lazy<IDebtorsStore> _debtors;
+
+    public CrossStoreProjection(
+        Lazy<ITarievenStore> tarieven,
+        Lazy<IDebtorsStore> debtors)
+    {
+        _tarieven = tarieven;
+        _debtors = debtors;
+    }
+
+    // Use _tarieven.Value and _debtors.Value in your projection methods
+}
+```

--- a/docs/events/projections/project-latest.md
+++ b/docs/events/projections/project-latest.md
@@ -1,0 +1,42 @@
+# ProjectLatest — Include Pending Events
+
+`ProjectLatest<T>()` returns the projected state of an aggregate including any events that have been
+appended in the current session but not yet committed. This eliminates the need for a forced
+`SaveChangesAsync()` + `FetchLatest()` round-trip.
+
+## API
+
+```csharp
+// On IDocumentSession.Events (IEventOperations)
+ValueTask<T?> ProjectLatest<T>(Guid id, CancellationToken cancellation = default);
+ValueTask<T?> ProjectLatest<T>(string key, CancellationToken cancellation = default);
+```
+
+## Example
+
+```csharp
+await using var session = store.LightweightSession();
+
+session.Events.StartStream(streamId,
+    new ReportCreated("Q1 Report"),
+    new SectionAdded("Revenue"),
+    new SectionAdded("Costs")
+);
+
+// Get the projected state WITHOUT saving first
+var report = await session.Events.ProjectLatest<Report>(streamId);
+// report.Title == "Q1 Report"
+// report.SectionCount == 2
+
+// SaveChangesAsync happens later
+await session.SaveChangesAsync();
+```
+
+## Behavior
+
+1. Fetches the current committed aggregate state from the database
+2. Finds any pending (uncommitted) events for that stream in the current session
+3. Applies the pending events on top using the aggregate's Apply/Create methods
+4. Returns the result
+
+When no pending events exist, `ProjectLatest` behaves identically to `FetchLatest`.

--- a/src/Polecat.Tests/DependencyInjection/lazy_ancillary_store_registration_tests.cs
+++ b/src/Polecat.Tests/DependencyInjection/lazy_ancillary_store_registration_tests.cs
@@ -1,0 +1,64 @@
+using Microsoft.Extensions.DependencyInjection;
+using Polecat.Tests.Harness;
+
+namespace Polecat.Tests.DependencyInjection;
+
+public interface ILazyTestStore : IDocumentStore;
+
+public class lazy_ancillary_store_registration_tests
+{
+    [Fact]
+    public void add_polecat_store_registers_lazy_of_T()
+    {
+        var services = new ServiceCollection();
+        services.AddPolecat(opts =>
+        {
+            opts.ConnectionString = ConnectionSource.ConnectionString;
+            opts.UseNativeJsonType = ConnectionSource.SupportsNativeJson;
+        });
+
+        services.AddPolecatStore<ILazyTestStore>(opts =>
+        {
+            opts.ConnectionString = ConnectionSource.ConnectionString;
+            opts.DatabaseSchemaName = "lazy_test_ancillary";
+            opts.UseNativeJsonType = ConnectionSource.SupportsNativeJson;
+        });
+
+        // Verify the Lazy<T> service descriptor is registered
+        var descriptor = services.FirstOrDefault(d =>
+            d.ServiceType == typeof(Lazy<ILazyTestStore>));
+
+        descriptor.ShouldNotBeNull();
+        descriptor.Lifetime.ShouldBe(ServiceLifetime.Singleton);
+    }
+
+    [Fact]
+    public void add_polecat_store_registers_lazy_for_each_ancillary_store()
+    {
+        var services = new ServiceCollection();
+        services.AddPolecat(opts =>
+        {
+            opts.ConnectionString = ConnectionSource.ConnectionString;
+            opts.UseNativeJsonType = ConnectionSource.SupportsNativeJson;
+        });
+
+        services.AddPolecatStore<ILazyTestStore>(opts =>
+        {
+            opts.ConnectionString = ConnectionSource.ConnectionString;
+            opts.DatabaseSchemaName = "lazy_test_store1";
+            opts.UseNativeJsonType = ConnectionSource.SupportsNativeJson;
+        });
+
+        services.AddPolecatStore<IAnotherTestStore>(opts =>
+        {
+            opts.ConnectionString = ConnectionSource.ConnectionString;
+            opts.DatabaseSchemaName = "lazy_test_store2";
+            opts.UseNativeJsonType = ConnectionSource.SupportsNativeJson;
+        });
+
+        services.Any(d => d.ServiceType == typeof(Lazy<ILazyTestStore>)).ShouldBeTrue();
+        services.Any(d => d.ServiceType == typeof(Lazy<IAnotherTestStore>)).ShouldBeTrue();
+    }
+}
+
+public interface IAnotherTestStore : IDocumentStore;

--- a/src/Polecat.Tests/Events/project_latest_tests.cs
+++ b/src/Polecat.Tests/Events/project_latest_tests.cs
@@ -1,0 +1,113 @@
+using JasperFx.Events;
+using Polecat.Tests.Harness;
+
+namespace Polecat.Tests.Events;
+
+public record ReportCreated(string Title);
+public record SectionAdded(string SectionName);
+public record ReportPublished;
+
+public class Report
+{
+    public Guid Id { get; set; }
+    public string Title { get; set; } = "";
+    public int SectionCount { get; set; }
+    public bool IsPublished { get; set; }
+
+    public static Report Create(ReportCreated e) => new Report { Title = e.Title };
+    public void Apply(SectionAdded e) => SectionCount++;
+    public void Apply(ReportPublished e) => IsPublished = true;
+}
+
+[Collection("integration")]
+public class project_latest_tests : IntegrationContext
+{
+    public project_latest_tests(DefaultStoreFixture fixture) : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task includes_pending_events_from_start_stream()
+    {
+        var streamId = Guid.NewGuid();
+
+        await using var session = theStore.LightweightSession();
+
+        session.Events.StartStream(streamId,
+            new ReportCreated("Q1 Report"),
+            new SectionAdded("Revenue"),
+            new SectionAdded("Costs")
+        );
+
+        var report = await session.Events.ProjectLatest<Report>(streamId);
+
+        report.ShouldNotBeNull();
+        report.Title.ShouldBe("Q1 Report");
+        report.SectionCount.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task includes_pending_events_after_committed_events()
+    {
+        var streamId = Guid.NewGuid();
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Events.StartStream(streamId,
+                new ReportCreated("Q1 Report"),
+                new SectionAdded("Revenue")
+            );
+            await session.SaveChangesAsync();
+        }
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Events.Append(streamId,
+                new SectionAdded("Costs"),
+                new SectionAdded("Outlook"),
+                new ReportPublished()
+            );
+
+            var report = await session.Events.ProjectLatest<Report>(streamId);
+
+            report.ShouldNotBeNull();
+            report.Title.ShouldBe("Q1 Report");
+            report.SectionCount.ShouldBe(3);
+            report.IsPublished.ShouldBeTrue();
+        }
+    }
+
+    [Fact]
+    public async Task no_pending_events_behaves_like_fetch_latest()
+    {
+        var streamId = Guid.NewGuid();
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Events.StartStream(streamId,
+                new ReportCreated("Q1 Report"),
+                new SectionAdded("Revenue")
+            );
+            await session.SaveChangesAsync();
+        }
+
+        await using (var session = theStore.LightweightSession())
+        {
+            var fromProjectLatest = await session.Events.ProjectLatest<Report>(streamId);
+            var fromFetchLatest = await session.Events.FetchLatest<Report>(streamId);
+
+            fromProjectLatest.ShouldNotBeNull();
+            fromFetchLatest.ShouldNotBeNull();
+            fromProjectLatest.Title.ShouldBe(fromFetchLatest.Title);
+            fromProjectLatest.SectionCount.ShouldBe(fromFetchLatest.SectionCount);
+        }
+    }
+
+    [Fact]
+    public async Task returns_null_for_nonexistent_stream()
+    {
+        await using var session = theStore.LightweightSession();
+        var report = await session.Events.ProjectLatest<Report>(Guid.NewGuid());
+        report.ShouldBeNull();
+    }
+}

--- a/src/Polecat/Events/EventOperations.cs
+++ b/src/Polecat/Events/EventOperations.cs
@@ -186,6 +186,34 @@ internal class EventOperations : QueryEventStore, IEventOperations
         return await FetchForWritingInternal<T>(key, true, null, cancellation);
     }
 
+    public async ValueTask<T?> ProjectLatest<T>(Guid id, CancellationToken cancellation = default)
+        where T : class, new()
+    {
+        var snapshot = await _sessionBase.Events.FetchLatest<T>(id, cancellation);
+
+        if (_workTracker.TryFindStream(id, out var stream) && stream!.Events.Count > 0)
+        {
+            var aggregator = _sessionBase.Options.Projections.AggregatorFor<T>();
+            snapshot = await aggregator.BuildAsync(stream.Events, _sessionBase, snapshot, cancellation);
+        }
+
+        return snapshot;
+    }
+
+    public async ValueTask<T?> ProjectLatest<T>(string key, CancellationToken cancellation = default)
+        where T : class, new()
+    {
+        var snapshot = await _sessionBase.Events.FetchLatest<T>(key, cancellation);
+
+        if (_workTracker.TryFindStream(key, out var stream) && stream!.Events.Count > 0)
+        {
+            var aggregator = _sessionBase.Options.Projections.AggregatorFor<T>();
+            snapshot = await aggregator.BuildAsync(stream.Events, _sessionBase, snapshot, cancellation);
+        }
+
+        return snapshot;
+    }
+
     public async Task WriteToAggregate<T>(Guid id, Action<IEventStream<T>> writing, CancellationToken cancellation = default)
         where T : class, new()
     {

--- a/src/Polecat/Events/IEventOperations.cs
+++ b/src/Polecat/Events/IEventOperations.cs
@@ -93,6 +93,18 @@ public interface IEventOperations : IQueryEventStore
     Task<IEventStream<T>> FetchForExclusiveWriting<T>(string key, CancellationToken cancellation = default) where T : class, new();
 
     /// <summary>
+    ///     Fetch the projected aggregate T by id, including any events appended
+    ///     in this session that have not yet been committed.
+    /// </summary>
+    ValueTask<T?> ProjectLatest<T>(Guid id, CancellationToken cancellation = default) where T : class, new();
+
+    /// <summary>
+    ///     Fetch the projected aggregate T by id, including any events appended
+    ///     in this session that have not yet been committed.
+    /// </summary>
+    ValueTask<T?> ProjectLatest<T>(string key, CancellationToken cancellation = default) where T : class, new();
+
+    /// <summary>
     ///     Fetch the aggregate, apply events via callback, and save changes in one step.
     /// </summary>
     Task WriteToAggregate<T>(Guid id, Action<IEventStream<T>> writing, CancellationToken cancellation = default) where T : class, new();

--- a/src/Polecat/PolecatStoreServiceCollectionExtensions.cs
+++ b/src/Polecat/PolecatStoreServiceCollectionExtensions.cs
@@ -47,6 +47,8 @@ public static class PolecatStoreServiceCollectionExtensions
             return (T)(IDocumentStore)store;
         });
 
+        services.AddSingleton<Lazy<T>>(sp => new Lazy<T>(() => sp.GetRequiredService<T>()));
+
         return new PolecatStoreExpression<T>(services);
     }
 


### PR DESCRIPTION
## Summary

- `AddPolecatStore<T>()` now automatically registers `Lazy<T>` as a singleton in the DI container
- This enables safe injection of ancillary store references into projections without the startup deadlock caused by direct constructor injection
- Added documentation page explaining the pattern and cross-store enrichment scenarios
- Added tests verifying the `Lazy<T>` service registration

## Test plan

- [x] `add_polecat_store_registers_lazy_of_T` — verifies `Lazy<T>` service descriptor is registered as singleton
- [x] `add_polecat_store_registers_lazy_for_each_ancillary_store` — verifies each `AddPolecatStore<T>()` call registers its own `Lazy<T>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)