### PR TITLE
Add time-based multi-stream projection sample and async daemon test

### DIFF
--- a/docs/events/projections/multi-stream-projections.md
+++ b/docs/events/projections/multi-stream-projections.md
@@ -87,6 +87,16 @@ The key technique is using a composite identity that combines the stream ID with
 <!-- snippet: sample_polecat_monthly_account_activity_projection -->
 <!-- endSnippet -->
 
+Register the projection as inline (for immediate consistency) or async (for eventual consistency):
+
+```cs
+// Inline — projected immediately during SaveChangesAsync
+opts.Projections.Add<MonthlyAccountActivityProjection>(ProjectionLifecycle.Inline);
+
+// Async — projected by the async daemon in the background
+opts.Projections.Add<MonthlyAccountActivityProjection>(ProjectionLifecycle.Async);
+```
+
 Each account stream's events are routed to monthly documents automatically. Querying is straightforward:
 
 ```cs
@@ -99,6 +109,10 @@ var monthlies = await session.Query<MonthlyAccountActivity>()
 // Get a specific month
 var jan = await session.LoadAsync<MonthlyAccountActivity>($"{accountId}:2026-01");
 ```
+
+::: tip
+When using async projections, make sure to start the async daemon — see [Asynchronous Projections](/events/projections/async-daemon) for details.
+:::
 
 ## ID Types
 

--- a/src/Polecat.Tests/Projections/time_based_multi_stream_projection_tests.cs
+++ b/src/Polecat.Tests/Projections/time_based_multi_stream_projection_tests.cs
@@ -125,6 +125,47 @@ public class time_based_multi_stream_projection_tests : IntegrationContext
     }
 
     [Fact]
+    public async Task monthly_projection_works_with_async_daemon()
+    {
+        await StoreOptions(opts =>
+        {
+            opts.Projections.Add<MonthlyAccountActivityProjection>(ProjectionLifecycle.Async);
+        });
+
+        var accountId = Guid.NewGuid();
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Events.StartStream(accountId, new AccountOpened("Checking"));
+            await session.SaveChangesAsync();
+        }
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Events.Append(accountId,
+                new AccountDebited(75m, "Gas"),
+                new AccountCredited(3000m, "Paycheck"));
+            await session.SaveChangesAsync();
+        }
+
+        // Run the async daemon to catch up
+        using var daemon = (IProjectionDaemon)await theStore.BuildProjectionDaemonAsync();
+        await daemon.StartAllAsync();
+        await daemon.CatchUpAsync(TimeSpan.FromSeconds(30), CancellationToken.None);
+        await daemon.StopAllAsync();
+
+        var currentMonth = DateTime.UtcNow.ToString("yyyy-MM");
+
+        await using var query = theStore.QuerySession();
+        var activity = await query.LoadAsync<MonthlyAccountActivity>($"{accountId}:{currentMonth}");
+
+        activity.ShouldNotBeNull();
+        activity.TotalDebits.ShouldBe(75m);
+        activity.TotalCredits.ShouldBe(3000m);
+        activity.TransactionCount.ShouldBe(2);
+    }
+
+    [Fact]
     public async Task separate_accounts_get_separate_monthly_documents()
     {
         var store = await CreateStoreWithMonthlyProjection();


### PR DESCRIPTION
Closes #27

## Summary

- Add `monthly_projection_works_with_async_daemon` test demonstrating the time-based multi-stream projection with the async daemon
- Enhance multi-stream projections docs with inline/async registration examples and tip linking to async daemon docs

The code snippets (events, document, projection) were already wired via mdsnippets region markers in the test file. All 3 time-based projection tests pass.

## Test plan
- [x] `segments_single_stream_into_monthly_documents` passes
- [x] `separate_accounts_get_separate_monthly_documents` passes
- [x] `monthly_projection_works_with_async_daemon` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)