### PR TITLE
Add string-key ProjectLatest tests

### DIFF
--- a/docs/events/projections/project-latest.md
+++ b/docs/events/projections/project-latest.md
@@ -2,7 +2,30 @@
 
 `ProjectLatest<T>()` returns the projected state of an aggregate including any events that have been
 appended in the current session but not yet committed. This eliminates the need for a forced
-`SaveChangesAsync()` + `FetchLatest()` round-trip.
+`SaveChangesAsync()` + `FetchLatest()` round-trip when you need the projected result immediately
+after appending events.
+
+## Motivation
+
+A common pattern in command handlers looks like this:
+
+```csharp
+// Today's pattern: forced flush + re-read
+session.Events.StartStream<Report>(id, new ReportCreated("Q1"));
+await session.SaveChangesAsync(ct);  // forced flush
+var report = await session.Events.FetchLatest<Report>(id, ct);  // re-read
+return report;
+```
+
+With `ProjectLatest`, this becomes:
+
+```csharp
+// Better: project locally including pending events
+session.Events.StartStream<Report>(id, new ReportCreated("Q1"));
+var report = await session.Events.ProjectLatest<Report>(id, ct);
+// SaveChangesAsync happens later (e.g., Wolverine AutoApplyTransactions)
+return report;
+```
 
 ## API
 
@@ -12,31 +35,46 @@ ValueTask<T?> ProjectLatest<T>(Guid id, CancellationToken cancellation = default
 ValueTask<T?> ProjectLatest<T>(string key, CancellationToken cancellation = default);
 ```
 
-## Example
-
-```csharp
-await using var session = store.LightweightSession();
-
-session.Events.StartStream(streamId,
-    new ReportCreated("Q1 Report"),
-    new SectionAdded("Revenue"),
-    new SectionAdded("Costs")
-);
-
-// Get the projected state WITHOUT saving first
-var report = await session.Events.ProjectLatest<Report>(streamId);
-// report.Title == "Q1 Report"
-// report.SectionCount == 2
-
-// SaveChangesAsync happens later
-await session.SaveChangesAsync();
-```
-
 ## Behavior
 
-1. Fetches the current committed aggregate state from the database
+1. Fetches the current committed aggregate state from the database via `FetchLatest<T>()`
 2. Finds any pending (uncommitted) events for that stream in the current session
 3. Applies the pending events on top using the aggregate's Apply/Create methods
 4. Returns the result
 
-When no pending events exist, `ProjectLatest` behaves identically to `FetchLatest`.
+### When No Pending Events Exist
+
+If there are no uncommitted events for the given stream in the session, `ProjectLatest` behaves
+identically to `FetchLatest` — it returns the current committed state.
+
+## Example
+
+<!-- snippet: sample_polecat_project_latest_example -->
+<!-- endSnippet -->
+
+## Merging Committed and Pending Events
+
+`ProjectLatest` also works when the stream has previously committed events and new events
+are appended in the current session:
+
+<!-- snippet: sample_polecat_project_latest_merge_example -->
+<!-- endSnippet -->
+
+## String-Keyed Streams
+
+`ProjectLatest` supports string-keyed streams as well:
+
+```csharp
+// For stores configured with StreamIdentity.AsString
+session.Events.StartStream("report-123",
+    new ReportCreated("Annual Report"),
+    new SectionAdded("Overview")
+);
+
+var report = await session.Events.ProjectLatest<Report>("report-123");
+```
+
+## Limitations
+
+- **Read-only sessions**: `ProjectLatest` is only available on `IDocumentSession.Events`
+  (not `IQuerySession.Events`) because it needs access to the session's pending work tracker.

--- a/src/Polecat.Tests/Events/project_latest_tests.cs
+++ b/src/Polecat.Tests/Events/project_latest_tests.cs
@@ -26,6 +26,8 @@ public class project_latest_tests : IntegrationContext
     {
     }
 
+    #region sample_polecat_project_latest_example
+
     [Fact]
     public async Task includes_pending_events_from_start_stream()
     {
@@ -33,24 +35,34 @@ public class project_latest_tests : IntegrationContext
 
         await using var session = theStore.LightweightSession();
 
+        // Append events without committing
         session.Events.StartStream(streamId,
             new ReportCreated("Q1 Report"),
             new SectionAdded("Revenue"),
             new SectionAdded("Costs")
         );
 
+        // ProjectLatest includes the pending events above
         var report = await session.Events.ProjectLatest<Report>(streamId);
 
         report.ShouldNotBeNull();
         report.Title.ShouldBe("Q1 Report");
         report.SectionCount.ShouldBe(2);
+
+        // SaveChangesAsync can happen later
+        await session.SaveChangesAsync();
     }
+
+    #endregion
+
+    #region sample_polecat_project_latest_merge_example
 
     [Fact]
     public async Task includes_pending_events_after_committed_events()
     {
         var streamId = Guid.NewGuid();
 
+        // First, commit some events
         await using (var session = theStore.LightweightSession())
         {
             session.Events.StartStream(streamId,
@@ -60,6 +72,7 @@ public class project_latest_tests : IntegrationContext
             await session.SaveChangesAsync();
         }
 
+        // In a new session, append more events without committing
         await using (var session = theStore.LightweightSession())
         {
             session.Events.Append(streamId,
@@ -68,14 +81,17 @@ public class project_latest_tests : IntegrationContext
                 new ReportPublished()
             );
 
+            // ProjectLatest merges the committed state with pending events
             var report = await session.Events.ProjectLatest<Report>(streamId);
 
             report.ShouldNotBeNull();
             report.Title.ShouldBe("Q1 Report");
-            report.SectionCount.ShouldBe(3);
-            report.IsPublished.ShouldBeTrue();
+            report.SectionCount.ShouldBe(3);       // 1 committed + 2 pending
+            report.IsPublished.ShouldBeTrue();      // from pending ReportPublished
         }
     }
+
+    #endregion
 
     [Fact]
     public async Task no_pending_events_behaves_like_fetch_latest()

--- a/src/Polecat.Tests/Events/project_latest_tests.cs
+++ b/src/Polecat.Tests/Events/project_latest_tests.cs
@@ -110,4 +110,70 @@ public class project_latest_tests : IntegrationContext
         var report = await session.Events.ProjectLatest<Report>(Guid.NewGuid());
         report.ShouldBeNull();
     }
+
+    [Fact]
+    public async Task project_latest_with_string_key_includes_pending_events()
+    {
+        // Reconfigure for string-keyed streams with isolated schema
+        await StoreOptions(opts =>
+        {
+            opts.DatabaseSchemaName = "project_latest_str";
+            opts.Events.StreamIdentity = StreamIdentity.AsString;
+        });
+
+        var key = "report-" + Guid.NewGuid().ToString("N");
+
+        await using var session = theStore.LightweightSession();
+        session.Events.StartStream(key,
+            new ReportCreated("Quarterly Report"),
+            new SectionAdded("Revenue"),
+            new SectionAdded("Costs"),
+            new ReportPublished()
+        );
+
+        var report = await session.Events.ProjectLatest<Report>(key);
+
+        report.ShouldNotBeNull();
+        report.Title.ShouldBe("Quarterly Report");
+        report.SectionCount.ShouldBe(2);
+        report.IsPublished.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task project_latest_merges_committed_and_pending_for_string_key()
+    {
+        await StoreOptions(opts =>
+        {
+            opts.DatabaseSchemaName = "project_latest_str2";
+            opts.Events.StreamIdentity = StreamIdentity.AsString;
+        });
+
+        var key = "report-" + Guid.NewGuid().ToString("N");
+
+        // Commit initial events
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Events.StartStream(key,
+                new ReportCreated("Annual Report"),
+                new SectionAdded("Overview")
+            );
+            await session.SaveChangesAsync();
+        }
+
+        // Append more events without committing, then project
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Events.Append(key,
+                new SectionAdded("Financials"),
+                new ReportPublished()
+            );
+
+            var report = await session.Events.ProjectLatest<Report>(key);
+
+            report.ShouldNotBeNull();
+            report.Title.ShouldBe("Annual Report");
+            report.SectionCount.ShouldBe(2);
+            report.IsPublished.ShouldBeTrue();
+        }
+    }
 }


### PR DESCRIPTION
Closes #29

## Summary

The `ProjectLatest<T>()` feature was already fully implemented (both Guid and string-key overloads) with 4 passing tests. This PR adds 2 additional tests covering string-key streams:

- `project_latest_with_string_key_includes_pending_events` — verifies in-flight events from `StartStream` are projected without committing
- `project_latest_merges_committed_and_pending_for_string_key` — verifies committed + uncommitted events are merged in the projection

Both tests confirm that the forced `SaveChangesAsync()` flush is unnecessary when using `ProjectLatest<T>()` — exactly the pattern described in the issue.

## Test plan
- [x] All 6 ProjectLatest tests pass (4 existing + 2 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)