### PR TITLE
Port typed streaming IResult types from Marten.AspNetCore

### DIFF
--- a/src/Polecat.AspNetCore.Testing/Polecat.AspNetCore.Testing.csproj
+++ b/src/Polecat.AspNetCore.Testing/Polecat.AspNetCore.Testing.csproj
@@ -19,6 +19,7 @@
 
     <ItemGroup>
         <ProjectReference Include="..\Polecat.AspNetCore\Polecat.AspNetCore.csproj" />
+        <ProjectReference Include="..\Polecat.TestUtils\Polecat.TestUtils.csproj" />
     </ItemGroup>
 
 </Project>

--- a/src/Polecat.AspNetCore.Testing/Program.cs
+++ b/src/Polecat.AspNetCore.Testing/Program.cs
@@ -17,6 +17,8 @@ builder.Services.AddPolecat(opts =>
     opts.UseNativeJsonType = ConnectionSource.SupportsNativeJson;
     opts.AutoCreateSchemaObjects = AutoCreate.All;
     opts.Events.StreamIdentity = StreamIdentity.AsGuid;
+    opts.Events.EnableCorrelationId = true;
+    opts.Events.EnableCausationId = true;
 });
 
 var app = builder.Build();

--- a/src/Polecat.AspNetCore.Testing/Program.cs
+++ b/src/Polecat.AspNetCore.Testing/Program.cs
@@ -1,6 +1,9 @@
+using JasperFx;
 using JasperFx.Events;
 using Polecat;
 using Polecat.AspNetCore;
+using Polecat.AspNetCore.Testing;
+using Polecat.TestUtils;
 
 var builder = WebApplication.CreateBuilder(new WebApplicationOptions
 {
@@ -10,14 +13,53 @@ var builder = WebApplication.CreateBuilder(new WebApplicationOptions
 
 builder.Services.AddPolecat(opts =>
 {
-    opts.ConnectionString = "Server=localhost,11433;Database=polecat_mcp_test;User Id=sa;Password=Polecat#Dev2025;TrustServerCertificate=true";
+    opts.ConnectionString = ConnectionSource.ConnectionString;
+    opts.UseNativeJsonType = ConnectionSource.SupportsNativeJson;
+    opts.AutoCreateSchemaObjects = AutoCreate.All;
     opts.Events.StreamIdentity = StreamIdentity.AsGuid;
-    opts.Events.EnableCorrelationId = true;
-    opts.Events.EnableCausationId = true;
 });
 
 var app = builder.Build();
 
 app.MapPolecatMcp();
 
+// StreamOne endpoint — returns first matching document or 404
+app.MapGet("/api/issues/{id:guid}", async (Guid id, IQuerySession session) =>
+    new StreamOne<StreamingIssue>(session.Query<StreamingIssue>().Where(x => x.Id == id)));
+
+// StreamMany endpoint — returns JSON array of all documents
+app.MapGet("/api/issues", async (IQuerySession session) =>
+    new StreamMany<StreamingIssue>(session.Query<StreamingIssue>()));
+
+// StreamAggregate endpoint — returns latest aggregate state or 404
+app.MapGet("/api/aggregates/{id:guid}", async (Guid id, IQuerySession session) =>
+    new StreamAggregate<StreamingQuestParty>(session, id));
+
 app.Run();
+
+namespace Polecat.AspNetCore.Testing
+{
+    // Test document types
+    public class StreamingIssue
+    {
+        public Guid Id { get; set; }
+        public string Title { get; set; } = "";
+        public bool IsOpen { get; set; } = true;
+    }
+
+    // Aggregate type for StreamAggregate tests
+    public class StreamingQuestParty
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; } = "";
+        public int MemberCount { get; set; }
+
+        public static StreamingQuestParty Create(StreamingQuestStarted e) =>
+            new() { Name = e.Name, MemberCount = 0 };
+
+        public void Apply(StreamingMembersJoined e) => MemberCount += e.Members.Length;
+    }
+
+    public record StreamingQuestStarted(string Name);
+    public record StreamingMembersJoined(string[] Members);
+}

--- a/src/Polecat.AspNetCore.Testing/streaming_result_types_tests.cs
+++ b/src/Polecat.AspNetCore.Testing/streaming_result_types_tests.cs
@@ -13,8 +13,9 @@ public class streaming_result_types_tests : IAsyncLifetime
     {
         _host = await AlbaHost.For<Program>();
 
-        // Apply schema
-        var store = _host.Services.GetRequiredService<IDocumentStore>();
+        // Ensure schema is created and clean documents for a fresh start
+        var store = (DocumentStore)_host.Services.GetRequiredService<IDocumentStore>();
+        await store.Database.ApplyAllConfiguredChangesToDatabaseAsync();
         await store.Advanced.CleanAllDocumentsAsync();
     }
 

--- a/src/Polecat.AspNetCore.Testing/streaming_result_types_tests.cs
+++ b/src/Polecat.AspNetCore.Testing/streaming_result_types_tests.cs
@@ -1,0 +1,135 @@
+using Alba;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Xunit;
+
+namespace Polecat.AspNetCore.Testing;
+
+public class streaming_result_types_tests : IAsyncLifetime
+{
+    private IAlbaHost _host = null!;
+
+    public async Task InitializeAsync()
+    {
+        _host = await AlbaHost.For<Program>();
+
+        // Apply schema
+        var store = _host.Services.GetRequiredService<IDocumentStore>();
+        await store.Advanced.CleanAllDocumentsAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _host.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task stream_one_returns_200_with_document()
+    {
+        var store = _host.Services.GetRequiredService<IDocumentStore>();
+
+        var issue = new StreamingIssue { Id = Guid.NewGuid(), Title = "Bug #1", IsOpen = true };
+        await using (var session = store.LightweightSession())
+        {
+            session.Store(issue);
+            await session.SaveChangesAsync();
+        }
+
+        var result = await _host.Scenario(s =>
+        {
+            s.Get.Url($"/api/issues/{issue.Id}");
+            s.StatusCodeShouldBe(200);
+            s.ContentTypeShouldBe("application/json");
+        });
+
+        var body = result.ReadAsText();
+        body.ShouldContain("Bug #1");
+    }
+
+    [Fact]
+    public async Task stream_one_returns_404_when_not_found()
+    {
+        await _host.Scenario(s =>
+        {
+            s.Get.Url($"/api/issues/{Guid.NewGuid()}");
+            s.StatusCodeShouldBe(404);
+        });
+    }
+
+    [Fact]
+    public async Task stream_many_returns_200_with_json_array()
+    {
+        var store = _host.Services.GetRequiredService<IDocumentStore>();
+
+        await using (var session = store.LightweightSession())
+        {
+            session.Store(new StreamingIssue { Id = Guid.NewGuid(), Title = "Issue A" });
+            session.Store(new StreamingIssue { Id = Guid.NewGuid(), Title = "Issue B" });
+            await session.SaveChangesAsync();
+        }
+
+        var result = await _host.Scenario(s =>
+        {
+            s.Get.Url("/api/issues");
+            s.StatusCodeShouldBe(200);
+            s.ContentTypeShouldBe("application/json");
+        });
+
+        var body = result.ReadAsText();
+        body.ShouldStartWith("[");
+        body.ShouldContain("Issue A");
+        body.ShouldContain("Issue B");
+    }
+
+    [Fact]
+    public async Task stream_many_returns_empty_array_when_no_results()
+    {
+        var store = _host.Services.GetRequiredService<IDocumentStore>();
+        await store.Advanced.CleanAllDocumentsAsync();
+
+        var result = await _host.Scenario(s =>
+        {
+            s.Get.Url("/api/issues");
+            s.StatusCodeShouldBe(200);
+            s.ContentTypeShouldBe("application/json");
+        });
+
+        var body = result.ReadAsText();
+        body.ShouldBe("[]");
+    }
+
+    [Fact]
+    public async Task stream_aggregate_returns_200_with_aggregate()
+    {
+        var store = _host.Services.GetRequiredService<IDocumentStore>();
+        var streamId = Guid.NewGuid();
+
+        await using (var session = store.LightweightSession())
+        {
+            session.Events.StartStream(streamId,
+                new StreamingQuestStarted("Fellowship"),
+                new StreamingMembersJoined(["Frodo", "Sam", "Gandalf"]));
+            await session.SaveChangesAsync();
+        }
+
+        var result = await _host.Scenario(s =>
+        {
+            s.Get.Url($"/api/aggregates/{streamId}");
+            s.StatusCodeShouldBe(200);
+            s.ContentTypeShouldBe("application/json");
+        });
+
+        var body = result.ReadAsText();
+        body.ShouldContain("Fellowship");
+    }
+
+    [Fact]
+    public async Task stream_aggregate_returns_404_for_unknown_id()
+    {
+        await _host.Scenario(s =>
+        {
+            s.Get.Url($"/api/aggregates/{Guid.NewGuid()}");
+            s.StatusCodeShouldBe(404);
+        });
+    }
+}

--- a/src/Polecat.AspNetCore/StreamAggregate.cs
+++ b/src/Polecat.AspNetCore/StreamAggregate.cs
@@ -1,0 +1,101 @@
+using System.Reflection;
+using System.Text.Json;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Metadata;
+
+namespace Polecat.AspNetCore;
+
+/// <summary>
+/// Minimal-API endpoint return value that streams the latest projected state of an
+/// event-sourced aggregate as JSON to the HTTP response.
+/// <para>
+/// Returns HTTP <c>404</c> if no aggregate exists for the supplied id,
+/// <see cref="OnFoundStatus"/> (default 200) if it does.
+/// </para>
+/// <para>
+/// <b>StreamAggregate vs StreamOne.</b> Use <see cref="StreamAggregate{T}"/>
+/// for event-sourced aggregates — Polecat rebuilds (or reads the snapshot of) the
+/// latest aggregate state from events before streaming. Use <see cref="StreamOne{T}"/>
+/// for regular documents that are stored directly (not event-sourced).
+/// </para>
+/// </summary>
+/// <typeparam name="T">The aggregate type.</typeparam>
+public sealed class StreamAggregate<T> : IResult, IEndpointMetadataProvider where T : class, new()
+{
+    private readonly IQuerySession _session;
+    private readonly Guid _guidId;
+    private readonly string? _stringId;
+    private readonly bool _useGuid;
+
+    /// <summary>
+    /// Stream the latest aggregate state of type <typeparamref name="T"/> for
+    /// the aggregate whose stream is identified by <paramref name="id"/>.
+    /// </summary>
+    public StreamAggregate(IQuerySession session, Guid id)
+    {
+        _session = session ?? throw new ArgumentNullException(nameof(session));
+        _guidId = id;
+        _stringId = null;
+        _useGuid = true;
+    }
+
+    /// <summary>
+    /// Stream the latest aggregate state of type <typeparamref name="T"/> for
+    /// the aggregate whose stream is identified by string <paramref name="id"/>
+    /// (for stores configured with string-keyed streams).
+    /// </summary>
+    public StreamAggregate(IQuerySession session, string id)
+    {
+        _session = session ?? throw new ArgumentNullException(nameof(session));
+        _stringId = id ?? throw new ArgumentNullException(nameof(id));
+        _guidId = Guid.Empty;
+        _useGuid = false;
+    }
+
+    /// <summary>
+    /// Status code written when the aggregate is found. Defaults to 200.
+    /// </summary>
+    public int OnFoundStatus { get; init; } = StatusCodes.Status200OK;
+
+    /// <summary>
+    /// Response content type. Defaults to <c>application/json</c>.
+    /// </summary>
+    public string ContentType { get; init; } = "application/json";
+
+    /// <inheritdoc />
+    public async Task ExecuteAsync(HttpContext httpContext)
+    {
+        ArgumentNullException.ThrowIfNull(httpContext);
+
+        var aggregate = _useGuid
+            ? await _session.Events.FetchLatest<T>(_guidId)
+            : await _session.Events.FetchLatest<T>(_stringId!);
+
+        if (aggregate is null)
+        {
+            httpContext.Response.StatusCode = StatusCodes.Status404NotFound;
+            return;
+        }
+
+        httpContext.Response.StatusCode = OnFoundStatus;
+        httpContext.Response.ContentType = ContentType;
+        var json = JsonSerializer.SerializeToUtf8Bytes(aggregate);
+        httpContext.Response.ContentLength = json.Length;
+        await httpContext.Response.Body.WriteAsync(json);
+    }
+
+    /// <summary>
+    /// Populates endpoint metadata so OpenAPI correctly advertises a
+    /// <c>200: T</c> and <c>404</c> response for this endpoint.
+    /// </summary>
+    public static void PopulateMetadata(MethodInfo method, EndpointBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.Metadata.Add(new ProducesResponseTypeMetadata(
+            StatusCodes.Status200OK, typeof(T), ["application/json"]));
+        builder.Metadata.Add(new ProducesResponseTypeMetadata(
+            StatusCodes.Status404NotFound, typeof(void), []));
+    }
+}

--- a/src/Polecat.AspNetCore/StreamMany.cs
+++ b/src/Polecat.AspNetCore/StreamMany.cs
@@ -1,0 +1,69 @@
+using System.Reflection;
+using System.Text.Json;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Metadata;
+using Polecat.Linq;
+
+namespace Polecat.AspNetCore;
+
+/// <summary>
+/// Minimal-API endpoint return value that streams a JSON array of Polecat documents
+/// to the HTTP response.
+/// <para>
+/// Unlike <see cref="StreamOne{T}"/>, this type never returns 404: an empty result
+/// set yields an empty JSON array (<c>[]</c>) with status <see cref="OnFoundStatus"/>
+/// (default 200).
+/// </para>
+/// </summary>
+/// <typeparam name="T">The document type contained in the array.</typeparam>
+public sealed class StreamMany<T> : IResult, IEndpointMetadataProvider
+{
+    private readonly IQueryable<T> _queryable;
+
+    /// <summary>
+    /// Create a <see cref="StreamMany{T}"/> wrapping a Polecat <see cref="IQueryable{T}"/>.
+    /// All matching documents are streamed as a JSON array.
+    /// </summary>
+    public StreamMany(IQueryable<T> queryable)
+    {
+        _queryable = queryable ?? throw new ArgumentNullException(nameof(queryable));
+    }
+
+    /// <summary>
+    /// Status code written with the response. Defaults to 200.
+    /// </summary>
+    public int OnFoundStatus { get; init; } = StatusCodes.Status200OK;
+
+    /// <summary>
+    /// Response content type. Defaults to <c>application/json</c>.
+    /// </summary>
+    public string ContentType { get; init; } = "application/json";
+
+    /// <inheritdoc />
+    public async Task ExecuteAsync(HttpContext httpContext)
+    {
+        ArgumentNullException.ThrowIfNull(httpContext);
+
+        var results = await _queryable.ToListAsync();
+
+        httpContext.Response.StatusCode = OnFoundStatus;
+        httpContext.Response.ContentType = ContentType;
+        var json = JsonSerializer.SerializeToUtf8Bytes(results);
+        httpContext.Response.ContentLength = json.Length;
+        await httpContext.Response.Body.WriteAsync(json);
+    }
+
+    /// <summary>
+    /// Populates endpoint metadata so OpenAPI correctly advertises a
+    /// <c>200: T[]</c> response for this endpoint. No 404 is advertised
+    /// because an empty array is a valid response.
+    /// </summary>
+    public static void PopulateMetadata(MethodInfo method, EndpointBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.Metadata.Add(new ProducesResponseTypeMetadata(
+            StatusCodes.Status200OK, typeof(IReadOnlyList<T>), ["application/json"]));
+    }
+}

--- a/src/Polecat.AspNetCore/StreamOne.cs
+++ b/src/Polecat.AspNetCore/StreamOne.cs
@@ -1,0 +1,80 @@
+using System.Reflection;
+using System.Text.Json;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Metadata;
+using Polecat.Linq;
+
+namespace Polecat.AspNetCore;
+
+/// <summary>
+/// Minimal-API endpoint return value that streams the first matching Polecat document
+/// as JSON to the HTTP response.
+/// <para>
+/// Returns HTTP <c>404</c> if the query produces no result, <see cref="OnFoundStatus"/>
+/// (default 200) if it does.
+/// </para>
+/// <para>
+/// <b>StreamOne vs StreamAggregate.</b> Use <see cref="StreamOne{T}"/> for regular
+/// documents queried with <c>session.Query&lt;T&gt;()</c>. Use <see cref="StreamAggregate{T}"/>
+/// for event-sourced aggregates projected live from the event stream.
+/// </para>
+/// </summary>
+/// <typeparam name="T">The document type to stream.</typeparam>
+public sealed class StreamOne<T> : IResult, IEndpointMetadataProvider
+{
+    private readonly IQueryable<T> _queryable;
+
+    /// <summary>
+    /// Create a <see cref="StreamOne{T}"/> wrapping a Polecat <see cref="IQueryable{T}"/>.
+    /// The query's first matching document is streamed as JSON; 404 if none.
+    /// </summary>
+    public StreamOne(IQueryable<T> queryable)
+    {
+        _queryable = queryable ?? throw new ArgumentNullException(nameof(queryable));
+    }
+
+    /// <summary>
+    /// Status code written when the query produces a result. Defaults to 200.
+    /// </summary>
+    public int OnFoundStatus { get; init; } = StatusCodes.Status200OK;
+
+    /// <summary>
+    /// Response content type. Defaults to <c>application/json</c>.
+    /// </summary>
+    public string ContentType { get; init; } = "application/json";
+
+    /// <inheritdoc />
+    public async Task ExecuteAsync(HttpContext httpContext)
+    {
+        ArgumentNullException.ThrowIfNull(httpContext);
+
+        var result = await _queryable.FirstOrDefaultAsync();
+
+        if (result is null)
+        {
+            httpContext.Response.StatusCode = StatusCodes.Status404NotFound;
+            return;
+        }
+
+        httpContext.Response.StatusCode = OnFoundStatus;
+        httpContext.Response.ContentType = ContentType;
+        var json = JsonSerializer.SerializeToUtf8Bytes(result);
+        httpContext.Response.ContentLength = json.Length;
+        await httpContext.Response.Body.WriteAsync(json);
+    }
+
+    /// <summary>
+    /// Populates endpoint metadata so OpenAPI correctly advertises a
+    /// <c>200: T</c> and <c>404</c> response for this endpoint.
+    /// </summary>
+    public static void PopulateMetadata(MethodInfo method, EndpointBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.Metadata.Add(new ProducesResponseTypeMetadata(
+            StatusCodes.Status200OK, typeof(T), ["application/json"]));
+        builder.Metadata.Add(new ProducesResponseTypeMetadata(
+            StatusCodes.Status404NotFound, typeof(void), []));
+    }
+}


### PR DESCRIPTION
Closes #32

## Summary

Port the three typed streaming `IResult` types from Marten.AspNetCore to Polecat.AspNetCore:

- **`StreamOne<T>`** — streams first matching document as JSON (200/404)
- **`StreamMany<T>`** — streams JSON array of all matching documents (always 200, empty `[]` if none)
- **`StreamAggregate<T>`** — streams latest event-sourced aggregate state (200/404)

All types implement `IResult` (for Minimal API dispatch) and `IEndpointMetadataProvider` (for OpenAPI metadata). Each exposes `OnFoundStatus` and `ContentType` as `init`-only properties.

Since Polecat doesn't have Marten's raw-JSON streaming path yet, these materialize documents via the regular query path then serialize with `System.Text.Json`. A later enhancement can swap to a true deserialize-free streaming path.

## Test plan
- [x] `stream_one_returns_200_with_document` — hit case
- [x] `stream_one_returns_404_when_not_found` — miss case
- [x] `stream_many_returns_200_with_json_array` — multiple docs
- [x] `stream_many_returns_empty_array_when_no_results` — empty set
- [x] `stream_aggregate_returns_200_with_aggregate` — event-sourced hit
- [x] `stream_aggregate_returns_404_for_unknown_id` — event-sourced miss

🤖 Generated with [Claude Code](https://claude.com/claude-code)