### PR TITLE
Add Nuke build project with Attach/Detach targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -406,3 +406,7 @@ FodyWeavers.xsd
 # VitePress build output
 docs/.vitepress/dist/
 docs/.vitepress/cache/
+
+# Nuke build
+.nuke/temp/
+results/

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -1,0 +1,146 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "definitions": {
+    "Host": {
+      "type": "string",
+      "enum": [
+        "AppVeyor",
+        "AzurePipelines",
+        "Bamboo",
+        "Bitbucket",
+        "Bitrise",
+        "GitHubActions",
+        "GitLab",
+        "Jenkins",
+        "Rider",
+        "SpaceAutomation",
+        "TeamCity",
+        "Terminal",
+        "TravisCI",
+        "VisualStudio",
+        "VSCode"
+      ]
+    },
+    "ExecutableTarget": {
+      "type": "string",
+      "enum": [
+        "Attach",
+        "Compile",
+        "CompileProject",
+        "Detach",
+        "Docs",
+        "DocsBuild",
+        "Init",
+        "InitDb",
+        "InstallMdSnippets",
+        "NpmInstall",
+        "Pack",
+        "PublishDocs",
+        "RebuildDb",
+        "Restore",
+        "Test",
+        "TestAspnetcore",
+        "TestEfCore",
+        "TestPolecat"
+      ]
+    },
+    "Verbosity": {
+      "type": "string",
+      "description": "",
+      "enum": [
+        "Verbose",
+        "Normal",
+        "Minimal",
+        "Quiet"
+      ]
+    },
+    "NukeBuild": {
+      "properties": {
+        "Continue": {
+          "type": "boolean",
+          "description": "Indicates to continue a previously failed build attempt"
+        },
+        "Help": {
+          "type": "boolean",
+          "description": "Shows the help text for this build assembly"
+        },
+        "Host": {
+          "description": "Host for execution. Default is 'automatic'",
+          "$ref": "#/definitions/Host"
+        },
+        "NoLogo": {
+          "type": "boolean",
+          "description": "Disables displaying the NUKE logo"
+        },
+        "Partition": {
+          "type": "string",
+          "description": "Partition to use on CI"
+        },
+        "Plan": {
+          "type": "boolean",
+          "description": "Shows the execution plan (HTML)"
+        },
+        "Profile": {
+          "type": "array",
+          "description": "Defines the profiles to load",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Root": {
+          "type": "string",
+          "description": "Root directory during build execution"
+        },
+        "Skip": {
+          "type": "array",
+          "description": "List of targets to be skipped. Empty list skips all dependencies",
+          "items": {
+            "$ref": "#/definitions/ExecutableTarget"
+          }
+        },
+        "Target": {
+          "type": "array",
+          "description": "List of targets to be invoked. Default is '{default_target}'",
+          "items": {
+            "$ref": "#/definitions/ExecutableTarget"
+          }
+        },
+        "Verbosity": {
+          "description": "Logging verbosity during build execution. Default is 'Normal'",
+          "$ref": "#/definitions/Verbosity"
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "properties": {
+        "Configuration": {
+          "type": "string",
+          "description": "Configuration to build - Default is 'Debug' (local) or 'Release' (server)",
+          "enum": [
+            "Debug",
+            "Release"
+          ]
+        },
+        "ConnectionString": {
+          "type": "string",
+          "description": "SQL Server connection string used for integration tests"
+        },
+        "Framework": {
+          "type": "string"
+        },
+        "Project": {
+          "type": "string"
+        },
+        "Solution": {
+          "type": "string",
+          "description": "Path to a solution file that is automatically loaded"
+        }
+      }
+    },
+    {
+      "$ref": "#/definitions/NukeBuild"
+    }
+  ]
+}

--- a/.nuke/parameters.json
+++ b/.nuke/parameters.json
@@ -1,0 +1,3 @@
+{
+  "Solution": "polecat.slnx"
+}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -33,6 +33,9 @@
 
         <!-- Source generators -->
         <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="1.4.0" />
+
+        <!-- Build automation -->
+        <PackageVersion Include="Nuke.Common" Version="9.0.4" />
     </ItemGroup>
 
     <!-- EF Core -->

--- a/build.cmd
+++ b/build.cmd
@@ -1,0 +1,7 @@
+:; set -eo pipefail
+:; SCRIPT_DIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)
+:; ${SCRIPT_DIR}/build.sh "$@"
+:; exit $?
+
+@ECHO OFF
+powershell -ExecutionPolicy ByPass -NoProfile -File "%~dp0build.ps1" %*

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,74 @@
+[CmdletBinding()]
+Param(
+    [Parameter(Position=0,Mandatory=$false,ValueFromRemainingArguments=$true)]
+    [string[]]$BuildArguments
+)
+
+Write-Output "PowerShell $($PSVersionTable.PSEdition) version $($PSVersionTable.PSVersion)"
+
+Set-StrictMode -Version 2.0; $ErrorActionPreference = "Stop"; $ConfirmPreference = "None"; trap { Write-Error $_ -ErrorAction Continue; exit 1 }
+$PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
+
+###########################################################################
+# CONFIGURATION
+###########################################################################
+
+$BuildProjectFile = "$PSScriptRoot\build\build.csproj"
+$TempDirectory = "$PSScriptRoot\..\.nuke\temp"
+
+$DotNetGlobalFile = "$PSScriptRoot\..\global.json"
+$DotNetInstallUrl = "https://dot.net/v1/dotnet-install.ps1"
+$DotNetChannel = "STS"
+
+$env:DOTNET_CLI_TELEMETRY_OPTOUT = 1
+$env:DOTNET_NOLOGO = 1
+
+###########################################################################
+# EXECUTION
+###########################################################################
+
+function ExecSafe([scriptblock] $cmd) {
+    & $cmd
+    if ($LASTEXITCODE) { exit $LASTEXITCODE }
+}
+
+# If dotnet CLI is installed globally and it matches requested version, use for execution
+if ($null -ne (Get-Command "dotnet" -ErrorAction SilentlyContinue) -and `
+     $(dotnet --version) -and $LASTEXITCODE -eq 0) {
+    $env:DOTNET_EXE = (Get-Command "dotnet").Path
+}
+else {
+    # Download install script
+    $DotNetInstallFile = "$TempDirectory\dotnet-install.ps1"
+    New-Item -ItemType Directory -Path $TempDirectory -Force | Out-Null
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+    (New-Object System.Net.WebClient).DownloadFile($DotNetInstallUrl, $DotNetInstallFile)
+
+    # If global.json exists, load expected version
+    if (Test-Path $DotNetGlobalFile) {
+        $DotNetGlobal = $(Get-Content $DotNetGlobalFile | Out-String | ConvertFrom-Json)
+        if ($DotNetGlobal.PSObject.Properties["sdk"] -and $DotNetGlobal.sdk.PSObject.Properties["version"]) {
+            $DotNetVersion = $DotNetGlobal.sdk.version
+        }
+    }
+
+    # Install by channel or version
+    $DotNetDirectory = "$TempDirectory\dotnet-win"
+    if (!(Test-Path variable:DotNetVersion)) {
+        ExecSafe { & powershell $DotNetInstallFile -InstallDir $DotNetDirectory -Channel $DotNetChannel -NoPath }
+    } else {
+        ExecSafe { & powershell $DotNetInstallFile -InstallDir $DotNetDirectory -Version $DotNetVersion -NoPath }
+    }
+    $env:DOTNET_EXE = "$DotNetDirectory\dotnet.exe"
+    $env:PATH = "$DotNetDirectory;$env:PATH"
+}
+
+Write-Output "Microsoft (R) .NET SDK version $(& $env:DOTNET_EXE --version)"
+
+if (Test-Path env:NUKE_ENTERPRISE_TOKEN) {
+    & $env:DOTNET_EXE nuget remove source "nuke-enterprise" > $null
+    & $env:DOTNET_EXE nuget add source "https://f.feedz.io/nuke/enterprise/nuget" --name "nuke-enterprise" --username "PAT" --password $env:NUKE_ENTERPRISE_TOKEN > $null
+}
+
+ExecSafe { & $env:DOTNET_EXE build $BuildProjectFile /nodeReuse:false /p:UseSharedCompilation=false -nologo -clp:NoSummary --verbosity quiet }
+ExecSafe { & $env:DOTNET_EXE run --project $BuildProjectFile --no-build -- $BuildArguments }

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+bash --version 2>&1 | head -n 1
+
+set -eo pipefail
+SCRIPT_DIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)
+
+###########################################################################
+# CONFIGURATION
+###########################################################################
+
+BUILD_PROJECT_FILE="$SCRIPT_DIR/build/build.csproj"
+TEMP_DIRECTORY="$SCRIPT_DIR/../.nuke/temp"
+
+DOTNET_GLOBAL_FILE="$SCRIPT_DIR/../global.json"
+DOTNET_INSTALL_URL="https://dot.net/v1/dotnet-install.sh"
+DOTNET_CHANNEL="STS"
+
+export DOTNET_CLI_TELEMETRY_OPTOUT=1
+export DOTNET_NOLOGO=1
+
+###########################################################################
+# EXECUTION
+###########################################################################
+
+function FirstJsonValue {
+    perl -nle 'print $1 if m{"'"$1"'": "([^"]+)",?}' <<< "${@:2}"
+}
+
+# If dotnet CLI is installed globally and it matches requested version, use for execution
+if [ -x "$(command -v dotnet)" ] && dotnet --version &>/dev/null; then
+    export DOTNET_EXE="$(command -v dotnet)"
+else
+    # Download install script
+    DOTNET_INSTALL_FILE="$TEMP_DIRECTORY/dotnet-install.sh"
+    mkdir -p "$TEMP_DIRECTORY"
+    curl -Lsfo "$DOTNET_INSTALL_FILE" "$DOTNET_INSTALL_URL"
+    chmod +x "$DOTNET_INSTALL_FILE"
+
+    # If global.json exists, load expected version
+    if [[ -f "$DOTNET_GLOBAL_FILE" ]]; then
+        DOTNET_VERSION=$(FirstJsonValue "version" "$(cat "$DOTNET_GLOBAL_FILE")")
+        if [[ "$DOTNET_VERSION" == ""  ]]; then
+            unset DOTNET_VERSION
+        fi
+    fi
+
+    # Install by channel or version
+    DOTNET_DIRECTORY="$TEMP_DIRECTORY/dotnet-unix"
+    if [[ -z ${DOTNET_VERSION+x} ]]; then
+        "$DOTNET_INSTALL_FILE" --install-dir "$DOTNET_DIRECTORY" --channel "$DOTNET_CHANNEL" --no-path
+    else
+        "$DOTNET_INSTALL_FILE" --install-dir "$DOTNET_DIRECTORY" --version "$DOTNET_VERSION" --no-path
+    fi
+    export DOTNET_EXE="$DOTNET_DIRECTORY/dotnet"
+    export PATH="$DOTNET_DIRECTORY:$PATH"
+fi
+
+echo "Microsoft (R) .NET SDK version $("$DOTNET_EXE" --version)"
+
+if [[ ! -z ${NUKE_ENTERPRISE_TOKEN+x} && "$NUKE_ENTERPRISE_TOKEN" != "" ]]; then
+    "$DOTNET_EXE" nuget remove source "nuke-enterprise" &>/dev/null || true
+    "$DOTNET_EXE" nuget add source "https://f.feedz.io/nuke/enterprise/nuget" --name "nuke-enterprise" --username "PAT" --password "$NUKE_ENTERPRISE_TOKEN" --store-password-in-clear-text &>/dev/null || true
+fi
+
+"$DOTNET_EXE" build "$BUILD_PROJECT_FILE" /nodeReuse:false /p:UseSharedCompilation=false -nologo -clp:NoSummary --verbosity quiet
+"$DOTNET_EXE" run --project "$BUILD_PROJECT_FILE" --no-build -- "$@"

--- a/build/Configuration.cs
+++ b/build/Configuration.cs
@@ -1,0 +1,14 @@
+using System.ComponentModel;
+using Nuke.Common.Tooling;
+
+[TypeConverter(typeof(TypeConverter<Configuration>))]
+public class Configuration : Enumeration
+{
+    public static Configuration Debug = new Configuration { Value = nameof(Debug) };
+    public static Configuration Release = new Configuration { Value = nameof(Release) };
+
+    public static implicit operator string(Configuration configuration)
+    {
+        return configuration.Value;
+    }
+}

--- a/build/build.cs
+++ b/build/build.cs
@@ -1,0 +1,331 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
+using Nuke.Common;
+using Nuke.Common.IO;
+using Nuke.Common.ProjectModel;
+using Nuke.Common.Tooling;
+using Nuke.Common.Tools.DotNet;
+using Nuke.Common.Tools.Npm;
+using Serilog;
+using static Nuke.Common.Tools.DotNet.DotNetTasks;
+
+class Build : NukeBuild
+{
+    public static int Main() => Execute<Build>(x => x.Compile);
+
+    [Parameter("Configuration to build - Default is 'Debug' (local) or 'Release' (server)")]
+    readonly Configuration Configuration = IsLocalBuild ? Configuration.Debug : Configuration.Release;
+
+    [Solution(GenerateProjects = true)] readonly Solution Solution;
+
+    [Parameter] readonly string Framework;
+
+    [Parameter("SQL Server connection string used for integration tests.")]
+    readonly string ConnectionString =
+        "Server=localhost,11433;User Id=sa;Password=P@55w0rd;Timeout=5;MultipleActiveResultSets=True;Initial Catalog=master;Encrypt=False";
+
+    [Parameter] readonly string Project;
+
+    // Project references for Attach/Detach. Map sibling repository folder name -> project names.
+    private Dictionary<string, string[]> ReferencedProjects = new()
+    {
+        { "jasperfx", ["JasperFx", "JasperFx.Events"] },
+        { "weasel", ["Weasel.Core", "Weasel.SqlServer", "Weasel.EntityFrameworkCore"] }
+    };
+
+    // Subset of projects above that are also referenced as NuGet packages from src projects.
+    string[] Nugets = ["JasperFx", "JasperFx.Events", "Weasel.SqlServer", "Weasel.EntityFrameworkCore"];
+
+    // Map a NuGet package name -> the Polecat csproj(s) that reference it. Used by Attach/Detach.
+    private Dictionary<string, string[]> NugetConsumers = new()
+    {
+        { "JasperFx", ["src/Polecat/Polecat.csproj"] },
+        { "JasperFx.Events", ["src/Polecat/Polecat.csproj"] },
+        { "Weasel.SqlServer", ["src/Polecat/Polecat.csproj", "src/Polecat.EntityFrameworkCore.Tests/Polecat.EntityFrameworkCore.Tests.csproj"] },
+        { "Weasel.EntityFrameworkCore", ["src/Polecat.EntityFrameworkCore/Polecat.EntityFrameworkCore.csproj"] }
+    };
+
+    Target Test => _ => _
+        .DependsOn(TestPolecat)
+        .DependsOn(TestAspnetcore)
+        .DependsOn(TestEfCore);
+
+    Target Init => _ => _
+        .Executes(() =>
+        {
+            Clean();
+        });
+
+    Target NpmInstall => _ => _
+        .Executes(() => NpmTasks.NpmInstall(c => c
+            .AddProcessAdditionalArguments("--loglevel=error")));
+
+    Target Compile => _ => _
+        .DependsOn(Restore)
+        .Executes(() =>
+        {
+            DotNetBuild(s => s
+                .SetProjectFile(Solution)
+                .SetConfiguration(Configuration)
+                .EnableNoRestore());
+        });
+
+    Target Restore => _ => _
+        .DependsOn(Init)
+        .Executes(() =>
+        {
+            DotNetRestore(s => s
+                .SetProjectFile(Solution));
+        });
+
+    Target CompileProject => _ => _
+        .DependsOn(Init)
+        .Executes(() =>
+        {
+            if (string.IsNullOrEmpty(Project))
+            {
+                Log.Error("Project parameter is required. Usage: --project <path-to-project>");
+                throw new ArgumentException("Project parameter must be specified");
+            }
+
+            Log.Information($"Restoring project: {Project}");
+            DotNetRestore(s => s
+                .SetProjectFile(Project));
+
+            Log.Information($"Compiling project: {Project}");
+            DotNetBuild(s => s
+                .SetProjectFile(Project)
+                .SetConfiguration(Configuration)
+                .SetFramework(Framework)
+                .EnableNoRestore());
+        });
+
+    Target TestPolecat => _ => _
+        .ProceedAfterFailure()
+        .Executes(() =>
+        {
+            DotNetTest(c => c
+                .SetProjectFile("src/Polecat.Tests")
+                .SetConfiguration(Configuration)
+                .EnableNoBuild()
+                .EnableNoRestore()
+                .SetFramework(Framework));
+        });
+
+    Target TestAspnetcore => _ => _
+        .ProceedAfterFailure()
+        .Executes(() =>
+        {
+            DotNetTest(c => c
+                .SetProjectFile("src/Polecat.AspNetCore.Testing")
+                .SetConfiguration(Configuration)
+                .EnableNoBuild()
+                .EnableNoRestore()
+                .SetFramework(Framework));
+        });
+
+    Target TestEfCore => _ => _
+        .ProceedAfterFailure()
+        .Executes(() =>
+        {
+            DotNetTest(c => c
+                .SetProjectFile("src/Polecat.EntityFrameworkCore.Tests")
+                .SetConfiguration(Configuration)
+                .EnableNoBuild()
+                .EnableNoRestore()
+                .SetFramework(Framework));
+        });
+
+    Target RebuildDb => _ => _
+        .Executes(() =>
+        {
+            ProcessTasks.StartProcess("docker", "compose down");
+            ProcessTasks.StartProcess("docker", "compose up -d");
+        });
+
+    Target InitDb => _ => _
+        .Executes(async () =>
+        {
+            ProcessTasks.StartProcess("docker", "compose up -d");
+            await WaitForDatabaseToBeReady();
+        });
+
+    Target InstallMdSnippets => _ => _
+        .ProceedAfterFailure()
+        .Executes(() =>
+        {
+            const string toolName = "markdownSnippets.tool";
+
+            if (IsDotNetToolInstalled(toolName))
+            {
+                Log.Information($"{toolName} is already installed, skipping this step.");
+                return;
+            }
+
+            DotNetToolInstall(c => c
+                .SetPackageName(toolName)
+                .EnableGlobal());
+        });
+
+    Target Docs => _ => _
+        .DependsOn(NpmInstall, InstallMdSnippets)
+        .Executes(() => NpmTasks.NpmRun(s => s.SetCommand("docs")));
+
+    Target DocsBuild => _ => _
+        .DependsOn(NpmInstall, InstallMdSnippets)
+        .Executes(() => NpmTasks.NpmRun(s => s.SetCommand("docs-build")));
+
+    Target PublishDocs => _ => _
+        .DependsOn(NpmInstall, InstallMdSnippets, DocsBuild)
+        .Executes(() => NpmTasks.NpmRun(s => s.SetCommand("deploy")));
+
+    Target Pack => _ => _
+        .DependsOn(Compile)
+        .Executes(() =>
+        {
+            var projects = new[]
+            {
+                "./src/Polecat",
+                "./src/Polecat.AspNetCore",
+                "./src/Polecat.CodeGeneration",
+                "./src/Polecat.EntityFrameworkCore"
+            };
+
+            foreach (var project in projects)
+            {
+                DotNetPack(s => s
+                    .SetProject(project)
+                    .SetOutputDirectory("./artifacts")
+                    .SetConfiguration(Configuration.Release));
+            }
+        });
+
+    /// <summary>
+    /// Switch Polecat from NuGet PackageReferences for JasperFx and Weasel
+    /// to local ProjectReferences pointing at sibling repositories
+    /// (~/code/jasperfx and ~/code/weasel). Used for cross-repo development.
+    /// </summary>
+    Target Attach => _ => _.Executes(() =>
+    {
+        foreach (var pair in ReferencedProjects)
+        {
+            foreach (var projectName in pair.Value)
+            {
+                addProject(pair.Key, projectName);
+            }
+        }
+
+        foreach (var nuget in Nugets)
+        {
+            if (!NugetConsumers.TryGetValue(nuget, out var consumers)) continue;
+            foreach (var consumer in consumers)
+            {
+                DotNet($"remove {consumer} package {nuget}");
+            }
+        }
+    });
+
+    /// <summary>
+    /// Inverse of Attach. Restore Polecat to using NuGet PackageReferences for
+    /// JasperFx and Weasel (latest prerelease) and remove the local sibling
+    /// repository ProjectReferences.
+    /// </summary>
+    Target Detach => _ => _.Executes(() =>
+    {
+        foreach (var pair in ReferencedProjects)
+        {
+            foreach (var projectName in pair.Value)
+            {
+                removeProject(pair.Key, projectName);
+            }
+        }
+
+        foreach (var nuget in Nugets)
+        {
+            if (!NugetConsumers.TryGetValue(nuget, out var consumers)) continue;
+            foreach (var consumer in consumers)
+            {
+                DotNet($"add {consumer} package {nuget} --prerelease");
+            }
+        }
+    });
+
+    private void addProject(string repository, string projectName)
+    {
+        var path = Path.GetFullPath($"../{repository}/src/{projectName}/{projectName}.csproj");
+        var slnPath = Solution.Path;
+        DotNet($"sln {slnPath} add {path} --solution-folder Attached");
+
+        if (Nugets.Contains(projectName) && NugetConsumers.TryGetValue(projectName, out var consumers))
+        {
+            foreach (var consumer in consumers)
+            {
+                DotNet($"add {consumer} reference {path}");
+            }
+        }
+    }
+
+    private void removeProject(string repository, string projectName)
+    {
+        var path = Path.GetFullPath($"../{repository}/src/{projectName}/{projectName}.csproj");
+
+        if (Nugets.Contains(projectName) && NugetConsumers.TryGetValue(projectName, out var consumers))
+        {
+            foreach (var consumer in consumers)
+            {
+                DotNet($"remove {consumer} reference {path}");
+            }
+        }
+
+        var slnPath = Solution.Path;
+        DotNet($"sln {slnPath} remove {path}");
+    }
+
+    private async Task WaitForDatabaseToBeReady()
+    {
+        var attempt = 0;
+        while (attempt < 10)
+        {
+            try
+            {
+                await using var conn = new SqlConnection(ConnectionString);
+                await conn.OpenAsync();
+
+                var cmd = conn.CreateCommand();
+                cmd.CommandText = "SELECT 1";
+                await cmd.ExecuteNonQueryAsync();
+
+                Log.Information("SQL Server is up and ready!");
+                break;
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Error while waiting for the database to be ready");
+                Thread.Sleep(250);
+                attempt++;
+            }
+        }
+    }
+
+    bool IsDotNetToolInstalled(string toolName)
+    {
+        var process = ProcessTasks.StartProcess("dotnet", "tool list -g", logOutput: false);
+        process.AssertZeroExitCode();
+        var output = process.Output.Select(x => x.Text).ToList();
+
+        return output.Any(line => line.Contains(toolName, StringComparison.OrdinalIgnoreCase));
+    }
+
+    static void Clean()
+    {
+        var results = AbsolutePath.Create("results");
+        var artifacts = AbsolutePath.Create("artifacts");
+        results.CreateOrCleanDirectory();
+        artifacts.CreateOrCleanDirectory();
+    }
+}

--- a/build/build.csproj
+++ b/build/build.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <RootNamespace></RootNamespace>
+    <NoWarn>CS0649;CS0169;CA1050;CA1822;CA2211;IDE1006</NoWarn>
+    <NukeRootDirectory>..</NukeRootDirectory>
+    <NukeScriptDirectory></NukeScriptDirectory>
+    <NukeTelemetryVersion>1</NukeTelemetryVersion>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="JasperFx" />
+    <PackageReference Include="Microsoft.Data.SqlClient" />
+    <PackageReference Include="Nuke.Common" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary

Mirrors the Marten Nuke build setup at `~/code/marten/build/`.

### Build infrastructure
- `build/build.csproj` — Nuke build project (net10.0)
- `build/build.cs` — All targets
- `build/Configuration.cs` — Debug/Release enumeration
- `build.sh` / `build.cmd` / `build.ps1` — Wrapper scripts
- `.nuke/parameters.json` — Solution path
- Updated `.gitignore` and `Directory.Packages.props` (added `Nuke.Common 9.0.4`)

### Available targets
- `Compile`, `Restore`, `Test`, `TestPolecat`, `TestAspnetcore`, `TestEfCore`
- `Pack` — packs all 4 NuGet packages (Polecat, AspNetCore, CodeGeneration, EntityFrameworkCore)
- `Docs`, `DocsBuild`, `PublishDocs`, `InstallMdSnippets`
- `RebuildDb`, `InitDb`
- **`Attach`** / **`Detach`** — see below

### Attach / Detach

Cross-repo dev workflow that mirrors Marten exactly:

**`./build.sh --target Attach`**
1. Adds `JasperFx`, `JasperFx.Events`, `Weasel.Core`, `Weasel.SqlServer`, `Weasel.EntityFrameworkCore` from sibling repos (`../jasperfx`, `../weasel`) to `polecat.slnx` under an `Attached` solution folder
2. Removes the corresponding NuGet `PackageReference`s from `Polecat`, `Polecat.EntityFrameworkCore`, and `Polecat.EntityFrameworkCore.Tests`
3. Adds `ProjectReference`s to those sibling projects in their place

**`./build.sh --target Detach`**
1. Removes the sibling `ProjectReference`s
2. Removes the projects from `polecat.slnx`
3. Restores `--prerelease` NuGet `PackageReference`s

This makes it trivial to develop JasperFx or Weasel changes alongside Polecat without manually editing csproj files.

## Test plan
- [x] `dotnet build build/build.csproj` succeeds
- [x] `./build.sh --target Help` lists all targets including `Attach` and `Detach`
- [x] `Attach` invokes the right `dotnet sln add` / `dotnet remove package` sequence (verified via dry run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)