### PR TITLE
Skip flaky tiny_upstream_cache_limit test pending JasperFx fix (#53)

### DIFF
--- a/src/Polecat.Tests/Projections/composite_try_find_upstream_cache_tests.cs
+++ b/src/Polecat.Tests/Projections/composite_try_find_upstream_cache_tests.cs
@@ -167,7 +167,13 @@ public class composite_try_find_upstream_cache_tests : IntegrationContext
         notification.Carrier.ShouldBe("UPS");
     }
 
-    [Fact]
+    [Fact(Skip = "Tracks JasperFx/jasperfx#226 — RecentlyUsedCache.Store is not thread-safe; "
+                + "concurrent Store() calls under the daemon's 10-way Block parallelism lose entries "
+                + "via a field-level lost-update race. Independent of the deferred-compaction fix this "
+                + "test was originally written for (#206). Un-skip once Polecat consumes the JasperFx "
+                + "version that fixes the cache race — likely arrives with the Polecat 4 cutover onto "
+                + "JasperFx 2.x. See JasperFx/polecat#53 for the original CI failure and "
+                + "JasperFx/jasperfx#226 for the root-cause analysis.")]
     public async Task tiny_upstream_cache_limit_does_not_starve_downstream_stage()
     {
         // Regression coverage from JasperFx/jasperfx#206. Before that fix,
@@ -176,6 +182,9 @@ public class composite_try_find_upstream_cache_tests : IntegrationContext
         // producing zero-data downstream notifications even though every upstream
         // write succeeded. With JasperFx.Events 1.35.0 in place, the upstream
         // cache is held until *all* composite stages have run.
+        //
+        // Currently skipped — see [Fact(Skip = ...)] above for the JasperFx-side
+        // race that prevents this test from running reliably on Polecat 3.x.
         await StoreOptions(opts =>
         {
             opts.DatabaseSchemaName = "composite_tiny_cache";


### PR DESCRIPTION
## Summary

Addresses #53 by quarantining the flaky test pending an upstream JasperFx fix. **Leaving open for review — please do not merge until the strategy is acknowledged.**

## Root cause

The test fails because `JasperFx.Core.RecentlyUsedCache.Store()` is not thread-safe and the async daemon's slice-processing `Block` runs `ApplyChangesAsync` with **10-way parallelism**. Concurrent `Store()` calls lose entries via a field-level lost-update race on:

```csharp
public void Store(TKey key, TItem item)
{
    _items = _items.AddOrUpdate(key, item);      // racy
    _times = _times.AddOrUpdate(key, ...);       // racy
}
```

The race is independent of `CacheLimitPerTenant` — raising the limit doesn't help because the bug is in the field write, not in compaction. The deferred-compaction fix this test was originally written for ([jasperfx#206](https://github.com/JasperFx/jasperfx/issues/206) / JasperFx.Events 1.35.0) remains in place and works as intended; this is a separate, pre-existing thread-safety bug in the cache itself.

Root-cause analysis filed as [**JasperFx/jasperfx#226**](https://github.com/JasperFx/jasperfx/issues/226).

## Why this surfaces on Polecat but not Marten

Postgres latency on Marten's CI runners is low enough that the parallel-Block race window is narrow and rarely triggers. SQL Server's per-call overhead on Polecat's CI widens the window so the race lands almost every run.

## What this PR does

Single change: marks the test with `[Fact(Skip = "...")]` and a comment linking to jasperfx#226. No other code changes.

## Why skip rather than fix in Polecat

The fix lives in `JasperFx.Core.RecentlyUsedCache`. Polecat 3.x consumes JasperFx 1.x, so the fix doesn't backport without a JasperFx 1.x maintenance release.

**Polecat 4 cutover onto JasperFx 2.x picks the fix up automatically** once JasperFx ships the alpha.4 (or later) with the race closed. Un-skip then.

## Test plan

- [x] `dotnet build src/Polecat.Tests/Polecat.Tests.csproj` succeeds.
- [ ] CI tier `test (default) / test` on the `polecat` workflow is now reliably green for the upstream-cache test class (the skipped test no longer runs; the other test in the file continues to run).
- [ ] When JasperFx 2.0.0-alpha.4 (or later) ships with [JasperFx/jasperfx#226](https://github.com/JasperFx/jasperfx/issues/226) fixed, file a follow-up to un-skip — likely as part of the Polecat 4 cutover work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)