### PR TITLE
Un-skip tiny_upstream_cache_limit test (JasperFx 2.0.0-alpha.4)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
 
     <ItemGroup>
         <!-- Core dependencies -->
-        <PackageVersion Include="JasperFx" Version="2.0.0-alpha.3" />
+        <PackageVersion Include="JasperFx" Version="2.0.0-alpha.4" />
         <PackageVersion Include="JasperFx.Events" Version="2.0.0-alpha.2" />
         <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />

--- a/src/Polecat.Tests/Projections/composite_try_find_upstream_cache_tests.cs
+++ b/src/Polecat.Tests/Projections/composite_try_find_upstream_cache_tests.cs
@@ -167,13 +167,7 @@ public class composite_try_find_upstream_cache_tests : IntegrationContext
         notification.Carrier.ShouldBe("UPS");
     }
 
-    [Fact(Skip = "Tracks JasperFx/jasperfx#226 — RecentlyUsedCache.Store is not thread-safe; "
-                + "concurrent Store() calls under the daemon's 10-way Block parallelism lose entries "
-                + "via a field-level lost-update race. Independent of the deferred-compaction fix this "
-                + "test was originally written for (#206). Un-skip once Polecat consumes the JasperFx "
-                + "version that fixes the cache race — likely arrives with the Polecat 4 cutover onto "
-                + "JasperFx 2.x. See JasperFx/polecat#53 for the original CI failure and "
-                + "JasperFx/jasperfx#226 for the root-cause analysis.")]
+    [Fact]
     public async Task tiny_upstream_cache_limit_does_not_starve_downstream_stage()
     {
         // Regression coverage from JasperFx/jasperfx#206. Before that fix,
@@ -183,8 +177,10 @@ public class composite_try_find_upstream_cache_tests : IntegrationContext
         // write succeeded. With JasperFx.Events 1.35.0 in place, the upstream
         // cache is held until *all* composite stages have run.
         //
-        // Currently skipped — see [Fact(Skip = ...)] above for the JasperFx-side
-        // race that prevents this test from running reliably on Polecat 3.x.
+        // Also exercises the RecentlyUsedCache thread-safety fix from
+        // JasperFx/jasperfx#226 (shipped in JasperFx 2.0.0-alpha.4) — the
+        // daemon's 10-way Block parallelism on Store() previously raced and
+        // dropped entries, surfacing as flaky failures on SQL Server CI.
         await StoreOptions(opts =>
         {
             opts.DatabaseSchemaName = "composite_tiny_cache";


### PR DESCRIPTION
Closes **[#53](https://github.com/JasperFx/polecat/issues/53)**. JasperFx 2.0.0-alpha.4 ships the `RecentlyUsedCache` thread-safety fix from [jasperfx#226](https://github.com/JasperFx/jasperfx/issues/226), which was the underlying race behind the flaky `tiny_upstream_cache_limit_does_not_starve_downstream_stage` test.

## Changes

- Bumps `JasperFx` package version `2.0.0-alpha.3` → `2.0.0-alpha.4`.
- Removes the `[Fact(Skip = ...)]` attribute that #56 added pending this fix.
- Updates the test's inline comment to mention both the JasperFx.Events 1.35.0 deferred-compaction fix (the original regression coverage) AND the JasperFx 2.0.0-alpha.4 cache race fix (now also exercised).

## Test plan

- [ ] CI green on `polecat` workflow's `test (default)` + `test (edge)` tiers.
- [ ] Test runs reliably across 5 consecutive CI runs (the original flake threshold).

🤖 Generated with [Claude Code](https://claude.com/claude-code)