### PR TITLE
Bump JasperFx to 2.0.0-alpha.6 / Events 2.0.0-alpha.3

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,8 +5,8 @@
 
     <ItemGroup>
         <!-- Core dependencies -->
-        <PackageVersion Include="JasperFx" Version="2.0.0-alpha.4" />
-        <PackageVersion Include="JasperFx.Events" Version="2.0.0-alpha.2" />
+        <PackageVersion Include="JasperFx" Version="2.0.0-alpha.6" />
+        <PackageVersion Include="JasperFx.Events" Version="2.0.0-alpha.3" />
         <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
@@ -32,7 +32,7 @@
         <PackageVersion Include="StronglyTypedId" Version="1.0.0-beta08" />
 
         <!-- Source generators -->
-        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.0.0-alpha.1" />
+        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.0.0-alpha.2" />
 
         <!-- Build automation -->
         <PackageVersion Include="Nuke.Common" Version="9.0.4" />


### PR DESCRIPTION
## Summary
- Bump JasperFx 2.0.0-alpha.4 → alpha.6 (4 bug fixes + 1 metadata refresh).
- Bump JasperFx.Events 2.0.0-alpha.2 → alpha.3 (#201 breaking change — verified zero Polecat call-site impact).
- Bump JasperFx.Events.SourceGenerator alpha.1 → alpha.2 (package metadata refresh).

## What's in the bumps

JasperFx alpha.6:
- jasperfx#234 (closes #231) — RecentlyUsedCache deterministic LRU via Interlocked counter (relevant to Polecat's composite-projection upstream-cache, polecat#53)
- jasperfx#236 (closes #203) — OptionsDescription Children + Sets as properties
- jasperfx#238 (closes #228) — ScopedContainerCreation: gate await-using on AsyncMode.AsyncTask
- jasperfx#239 (closes #227) — Codegen CLI enforces ServiceLocationPolicy per file

JasperFx.Events alpha.3:
- jasperfx#202 (closes #201) — \`IJasperFxAggregateGrouper.Group\` takes \`IReadOnlyList<IEvent>\`. **Verified zero Polecat impact** via \`grep -rn "IAggregateGrouper|IJasperFxAggregateGrouper|CustomGrouping|IEnumerable<IEvent>" src/\` — no implementations or callers.

## Test plan
- [x] \`dotnet build polecat.slnx -c Debug\` — 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)