### PR TITLE
Bump JasperFx to 2.0.0-alpha.7 + dedup CascadeAction onto Weasel.Core (#47)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,8 +5,8 @@
 
     <ItemGroup>
         <!-- Core dependencies -->
-        <PackageVersion Include="JasperFx" Version="2.0.0-alpha.4" />
-        <PackageVersion Include="JasperFx.Events" Version="2.0.0-alpha.2" />
+        <PackageVersion Include="JasperFx" Version="2.0.0-alpha.7" />
+        <PackageVersion Include="JasperFx.Events" Version="2.0.0-alpha.3" />
         <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
@@ -32,7 +32,7 @@
         <PackageVersion Include="StronglyTypedId" Version="1.0.0-beta08" />
 
         <!-- Source generators -->
-        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.0.0-alpha.1" />
+        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.0.0-alpha.2" />
 
         <!-- Build automation -->
         <PackageVersion Include="Nuke.Common" Version="9.0.4" />

--- a/src/Polecat.Tests/Storage/document_foreign_key_tests.cs
+++ b/src/Polecat.Tests/Storage/document_foreign_key_tests.cs
@@ -1,5 +1,6 @@
 using Polecat.Storage;
 using Polecat.Tests.Harness;
+using Weasel.Core;
 
 namespace Polecat.Tests.Storage;
 

--- a/src/Polecat/Storage/DocumentForeignKey.cs
+++ b/src/Polecat/Storage/DocumentForeignKey.cs
@@ -1,5 +1,6 @@
 using System.Linq.Expressions;
 using System.Reflection;
+using Weasel.Core;
 
 namespace Polecat.Storage;
 
@@ -127,15 +128,4 @@ public class DocumentForeignKey
             $"Expression '{expression}' is not a supported foreign key expression. " +
             "Use a single property (x => x.Prop).");
     }
-}
-
-/// <summary>
-///     Cascade action for foreign key constraints.
-/// </summary>
-public enum CascadeAction
-{
-    NoAction,
-    Cascade,
-    SetNull,
-    SetDefault
 }


### PR DESCRIPTION
## Summary

- **Bump JasperFx pins** straight to the current published alphas:
  - JasperFx 2.0.0-alpha.4 → 2.0.0-alpha.7
  - JasperFx.Events 2.0.0-alpha.2 → 2.0.0-alpha.3
  - JasperFx.Events.SourceGenerator 2.0.0-alpha.1 → 2.0.0-alpha.2
- **Closes #47** (dedup audit, db-manipulation slice Row 2): drop the local \`Polecat.Storage.CascadeAction\` enum; \`DocumentForeignKey\` and its test import \`Weasel.Core.CascadeAction\` instead.

**Supersedes #60** (its alpha.4→alpha.6 bump rolled into this further-reaching alpha.7 bump). Will close #60 after this one merges.

## What's in JasperFx since alpha.4
- jasperfx#229 (closes #226) — RecentlyUsedCache thread-safety
- jasperfx#230 (closes marten#4354) — StaticTypeLoader codegen-write fallback
- jasperfx#234 (closes #231) — RecentlyUsedCache deterministic LRU
- jasperfx#235 (closes #188) — AssemblyGenerator tolerates missing references (Oracle EF Core satellites)
- jasperfx#236 (closes #203) — OptionsDescription Children + Sets as properties
- jasperfx#238 (closes #228) — ScopedContainerCreation: gate \`await using\` on \`AsyncMode.AsyncTask\`
- jasperfx#239 (closes #227) — Codegen CLI enforces ServiceLocationPolicy per file
- jasperfx#240 (closes Row 1 + 2 + companion of jasperfx#224 multi-tenancy slice) — \`UnknownTenantIdException.TenantId\` exposed as a property

## JasperFx.Events alpha.3
- jasperfx#202 (closes #201) — \`IJasperFxAggregateGrouper.Group\` parameter promoted to \`IReadOnlyList<IEvent>\`. **Verified zero Polecat call-site impact** via \`grep -rn \"IAggregateGrouper|IJasperFxAggregateGrouper|CustomGrouping|IEnumerable<IEvent>\" src/\` — no grouper implementations or callers in Polecat.

## Why this CascadeAction migration is safe
Per the audit at jasperfx#218, \`Weasel.Core.CascadeAction\` has been the canonical enum all along; Marten was already using it. Polecat is the last consumer to catch up. Other Polecat files (\`EventsTable\`, \`NaturalKeyTable\`, \`EventTagTable\`) reference \`CascadeAction\` via \`using Weasel.SqlServer;\` — those resolve to Weasel.SqlServer's deprecated copy (already wrapped in a \`#pragma warning disable CS0618\`) and are out of scope for this row.

## Test plan
- [x] \`dotnet build polecat.slnx -c Debug\` — 0 errors
- [x] \`grep -rn \"CascadeAction\" src/\` — \`DocumentForeignKey\` + its test now resolve to \`Weasel.Core.CascadeAction\`; the three Weasel.SqlServer.Tables.ForeignKey usages are untouched (their deprecation is tracked separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)