### PR TITLE
Bump JasperFx 2.0.0-alpha.7 → 2.0.0-alpha.8

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
 
     <ItemGroup>
         <!-- Core dependencies -->
-        <PackageVersion Include="JasperFx" Version="2.0.0-alpha.7" />
+        <PackageVersion Include="JasperFx" Version="2.0.0-alpha.8" />
         <PackageVersion Include="JasperFx.Events" Version="2.0.0-alpha.3" />
         <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />


### PR DESCRIPTION
## Summary

Pin bump only. Picks up [jasperfx#241](https://github.com/JasperFx/jasperfx/pull/241): bumps FastExpressionCompiler 5.3.0 → 5.4.1 transitively. Polecat doesn't reference FastExpressionCompiler directly; the bump propagates through the JasperFx dependency.

## Test plan
- [x] \`dotnet build polecat.slnx -c Debug\` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)