### PR TITLE
Share pc_streams reader between FetchStreamStateAsync and IEventStore explorer (#57 pc_streams half)

### DIFF
--- a/src/Polecat/DocumentStore.EventStoreExplorer.cs
+++ b/src/Polecat/DocumentStore.EventStoreExplorer.cs
@@ -7,6 +7,7 @@ using JasperFx.Events.Daemon;
 using JasperFx.Events.Projections;
 using Microsoft.Data.SqlClient;
 using Polecat.Events;
+using Polecat.Events.Internal;
 using Polecat.Storage;
 
 namespace Polecat;
@@ -28,8 +29,11 @@ public partial class DocumentStore
         await using var conn = new SqlConnection(Options.ConnectionString);
         await conn.OpenAsync(ct);
         await using var cmd = conn.CreateCommand();
+        // #57: share the column projection + row read with FetchStreamStateAsync
+        // and GetStreamMetadataAsync via PcStreamsRowReader so all three sites
+        // stay aligned when pc_streams' shape evolves.
         cmd.CommandText = $"""
-            SELECT TOP (@count) id, type, version, created, timestamp, tenant_id
+            SELECT TOP (@count) {PcStreamsRowReader.SelectColumns}
             FROM {Events.StreamsTableName}
             ORDER BY timestamp DESC;
             """;
@@ -38,19 +42,7 @@ public partial class DocumentStore
         await using var reader = await cmd.ExecuteReaderAsync(ct);
         while (await reader.ReadAsync(ct))
         {
-            var streamIdValue = reader.GetValue(0);
-            var streamId = streamIdValue switch
-            {
-                Guid g => g.ToString(),
-                _ => streamIdValue.ToString() ?? string.Empty
-            };
-            var streamType = reader.IsDBNull(1) ? null : reader.GetString(1);
-            var version = reader.GetInt64(2);
-            var created = reader.GetDateTimeOffset(3);
-            var lastUpdated = reader.GetDateTimeOffset(4);
-            var tenantId = reader.IsDBNull(5) ? Tenancy.DefaultTenantId : reader.GetString(5);
-
-            results.Add(new StreamSummary(streamId, streamType!, version, created, lastUpdated, tenantId));
+            results.Add(PcStreamsRowReader.ReadStreamSummary(reader, Tenancy.DefaultTenantId));
         }
 
         return results;
@@ -135,8 +127,12 @@ public partial class DocumentStore
         await using var conn = new SqlConnection(Options.ConnectionString);
         await conn.OpenAsync(ct);
         await using var cmd = conn.CreateCommand();
+        // #57: share the pc_streams column projection + row read with the
+        // other two stream-reading sites via PcStreamsRowReader. The JOIN'd
+        // first_event_at column is appended after the canonical projection
+        // (index 7) and threaded into ReadStreamMetadata explicitly.
         cmd.CommandText = $"""
-            SELECT s.id, s.type, s.version, s.created, s.timestamp, s.tenant_id, s.is_archived,
+            SELECT {PcStreamsRowReader.SelectColumnsWithAlias("s")},
                    MIN(e.timestamp) AS first_event_at
             FROM {Events.StreamsTableName} s
             LEFT JOIN {Events.EventsTableName} e ON e.stream_id = s.id AND e.tenant_id = s.tenant_id
@@ -151,31 +147,11 @@ public partial class DocumentStore
             return null;
         }
 
-        var rawId = reader.GetValue(0);
-        var streamIdString = rawId switch
-        {
-            Guid g => g.ToString(),
-            _ => rawId.ToString() ?? string.Empty
-        };
-        var streamType = reader.IsDBNull(1) ? null : reader.GetString(1);
-        var version = reader.GetInt64(2);
-        var created = reader.GetDateTimeOffset(3);
-        var lastUpdated = reader.GetDateTimeOffset(4);
-        var tenantId = reader.IsDBNull(5) ? Tenancy.DefaultTenantId : reader.GetString(5);
-        var isArchived = reader.GetBoolean(6);
-        var firstEventAt = reader.IsDBNull(7) ? created : reader.GetDateTimeOffset(7);
+        var firstEventAt = reader.IsDBNull(7)
+            ? (DateTimeOffset?)null
+            : reader.GetFieldValue<DateTimeOffset>(7);
 
-        return new StreamMetadata(
-            streamIdString,
-            streamType!,
-            version,
-            firstEventAt,
-            lastUpdated,
-            LastSnapshotAt: null,
-            LastSnapshotVersion: null,
-            IsArchived: isArchived,
-            TenantId: tenantId,
-            Tags: null!);
+        return PcStreamsRowReader.ReadStreamMetadata(reader, Tenancy.DefaultTenantId, firstEventAt);
     }
 
     IAsyncEnumerable<EventRecord> IEventStore.QueryByTagsAsync(

--- a/src/Polecat/Events/Internal/PcStreamsRowReader.cs
+++ b/src/Polecat/Events/Internal/PcStreamsRowReader.cs
@@ -1,0 +1,126 @@
+using System.Data.Common;
+using JasperFx.Descriptors;
+using JasperFx.Events;
+using Polecat.Metadata;
+
+namespace Polecat.Events.Internal;
+
+/// <summary>
+///     Canonical SQL fragment + row reader for the <c>pc_streams</c> table.
+///     Shared between <see cref="QueryEventStore.FetchStreamStateAsync(System.Guid, System.Threading.CancellationToken)"/>
+///     and the <see cref="JasperFx.Events.IEventStore"/> explorer surface so the
+///     column shape stays in sync across schema migrations. Closes the audit
+///     row tracked at
+///     <see href="https://github.com/JasperFx/polecat/issues/57">polecat#57</see>
+///     (mirrors the Marten 9 <c>ISelector&lt;StreamState&gt;</c> consolidation).
+/// </summary>
+/// <remarks>
+///     The canonical column order is locked here. Call sites compose
+///     <c>SELECT {<see cref="SelectColumns"/>} FROM {streamsTable} ...</c> and
+///     pass the resulting reader into one of the typed read methods rather
+///     than hand-rolling positional <c>GetInt64</c> / <c>GetGuid</c> ladders.
+///     Adding or renaming a <c>pc_streams</c> column means updating this file
+///     and exactly this file.
+/// </remarks>
+internal static class PcStreamsRowReader
+{
+    /// <summary>
+    ///     Canonical column projection for any read from <c>pc_streams</c>. The
+    ///     order is fixed so the typed read methods below can use positional
+    ///     reads. When this changes, every call site that composes its SELECT
+    ///     from this constant adjusts automatically.
+    /// </summary>
+    internal const string SelectColumns = "id, type, version, created, timestamp, tenant_id, is_archived";
+
+    /// <summary>
+    ///     Same column list with a table alias prefix, for queries that join
+    ///     <c>pc_streams</c> against other tables.
+    /// </summary>
+    internal static string SelectColumnsWithAlias(string alias) =>
+        $"{alias}.id, {alias}.type, {alias}.version, {alias}.created, {alias}.timestamp, {alias}.tenant_id, {alias}.is_archived";
+
+    /// <summary>
+    ///     Read the row the reader is positioned on into a
+    ///     <see cref="StreamState"/>. The caller is responsible for
+    ///     <c>await reader.ReadAsync(...)</c> beforehand.
+    /// </summary>
+    internal static StreamState ReadStreamState(DbDataReader reader, StreamIdentity streamIdentity)
+    {
+        var state = new StreamState
+        {
+            Version = reader.GetInt64(2),
+            Created = reader.GetFieldValue<DateTimeOffset>(3),
+            LastTimestamp = reader.GetFieldValue<DateTimeOffset>(4),
+            IsArchived = reader.GetBoolean(6)
+        };
+
+        if (streamIdentity == StreamIdentity.AsGuid)
+        {
+            state.Id = reader.GetGuid(0);
+        }
+        else
+        {
+            state.Key = reader.GetString(0);
+        }
+
+        return state;
+    }
+
+    /// <summary>
+    ///     Read the row the reader is positioned on into a
+    ///     <see cref="StreamSummary"/>. <paramref name="defaultTenantId"/> is
+    ///     substituted when the row's <c>tenant_id</c> column is NULL (matches
+    ///     Polecat's single-tenant fall-back behavior).
+    /// </summary>
+    internal static StreamSummary ReadStreamSummary(DbDataReader reader, string defaultTenantId)
+    {
+        var streamId = StreamIdToString(reader.GetValue(0));
+        var streamType = reader.IsDBNull(1) ? null : reader.GetString(1);
+        var version = reader.GetInt64(2);
+        var created = reader.GetFieldValue<DateTimeOffset>(3);
+        var lastUpdated = reader.GetFieldValue<DateTimeOffset>(4);
+        var tenantId = reader.IsDBNull(5) ? defaultTenantId : reader.GetString(5);
+
+        return new StreamSummary(streamId, streamType!, version, created, lastUpdated, tenantId);
+    }
+
+    /// <summary>
+    ///     Read the row the reader is positioned on into a
+    ///     <see cref="StreamMetadata"/>. <paramref name="firstEventAt"/> comes
+    ///     from a JOIN against <c>pc_events</c> (not part of <c>pc_streams</c>
+    ///     itself); when it's <see langword="null"/> the row's own <c>created</c>
+    ///     column is used as the fallback, mirroring the pre-consolidation
+    ///     behavior in <c>DocumentStore.GetStreamMetadataAsync</c>.
+    /// </summary>
+    internal static StreamMetadata ReadStreamMetadata(
+        DbDataReader reader,
+        string defaultTenantId,
+        DateTimeOffset? firstEventAt)
+    {
+        var streamId = StreamIdToString(reader.GetValue(0));
+        var streamType = reader.IsDBNull(1) ? null : reader.GetString(1);
+        var version = reader.GetInt64(2);
+        var created = reader.GetFieldValue<DateTimeOffset>(3);
+        var lastUpdated = reader.GetFieldValue<DateTimeOffset>(4);
+        var tenantId = reader.IsDBNull(5) ? defaultTenantId : reader.GetString(5);
+        var isArchived = reader.GetBoolean(6);
+
+        return new StreamMetadata(
+            streamId,
+            streamType!,
+            version,
+            firstEventAt ?? created,
+            lastUpdated,
+            LastSnapshotAt: null,
+            LastSnapshotVersion: null,
+            IsArchived: isArchived,
+            TenantId: tenantId,
+            Tags: null!);
+    }
+
+    private static string StreamIdToString(object value) => value switch
+    {
+        System.Guid g => g.ToString(),
+        _ => value.ToString() ?? string.Empty
+    };
+}

--- a/src/Polecat/Events/Operations/AssignTagWhereOperation.cs
+++ b/src/Polecat/Events/Operations/AssignTagWhereOperation.cs
@@ -16,7 +16,7 @@ namespace Polecat.Events.Operations;
 ///   AND NOT EXISTS (SELECT 1 FROM [schema].[pc_event_tag_{suffix}] x WHERE x.value = @value AND x.seq_id = e.seq_id)
 /// For conjoined tenancy, includes tenant_id in INSERT and NOT EXISTS check.
 /// </summary>
-internal class AssignTagWhereOperation : Internal.IStorageOperation
+internal class AssignTagWhereOperation : Polecat.Internal.IStorageOperation
 {
     private readonly string _schemaName;
     private readonly ITagTypeRegistration _registration;

--- a/src/Polecat/Events/QueryEventStore.cs
+++ b/src/Polecat/Events/QueryEventStore.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using System.Reflection;
 using JasperFx.Events;
 using Microsoft.Data.SqlClient;
+using Polecat.Events.Internal;
 using Polecat.Events.Linq;
 using Polecat.Internal;
 using Polecat.Linq;
@@ -181,42 +182,24 @@ internal class QueryEventStore : IQueryEventStore
 
     private async Task<StreamState?> FetchStreamStateInternalAsync(object streamId, CancellationToken token)
     {
+        // #57: column projection + row read live in PcStreamsRowReader so this
+        // method, GetRecentStreamsAsync, and GetStreamMetadataAsync all read
+        // pc_streams with the same shape. Note the canonical column order
+        // (created before timestamp) differs from the historical order this
+        // method used (timestamp before created) — the typed reader normalizes.
         await using var cmd = new SqlCommand();
         cmd.CommandText = $"""
-            SELECT id, type, version, timestamp, created, tenant_id, is_archived
+            SELECT {PcStreamsRowReader.SelectColumns}
             FROM {_events.StreamsTableName}
             WHERE id = @id AND tenant_id = @tenant_id;
             """;
         cmd.Parameters.AddWithValue("@id", streamId);
         cmd.Parameters.AddWithValue("@tenant_id", _session.TenantId);
 
-        await using var dbReader = await _session.ExecuteReaderAsync(cmd, token);
-        var reader = (SqlDataReader)dbReader;
+        await using var reader = await _session.ExecuteReaderAsync(cmd, token);
         if (await reader.ReadAsync(token))
         {
-            var version = reader.GetInt64(2);
-            var lastTimestamp = reader.GetDateTimeOffset(3);
-            var created = reader.GetDateTimeOffset(4);
-            var isArchived = reader.GetBoolean(6);
-
-            var state = new StreamState
-            {
-                Version = version,
-                LastTimestamp = lastTimestamp,
-                Created = created,
-                IsArchived = isArchived
-            };
-
-            if (_events.StreamIdentity == StreamIdentity.AsGuid)
-            {
-                state.Id = reader.GetGuid(0);
-            }
-            else
-            {
-                state.Key = reader.GetString(0);
-            }
-
-            return state;
+            return PcStreamsRowReader.ReadStreamState(reader, _events.StreamIdentity);
         }
 
         return null;


### PR DESCRIPTION
## Summary

Closes the **pc_streams** half of #57. Three sites were reading from \`pc_streams\` with three different column orderings and three hand-rolled positional-read ladders:

| Site | Output | Old column order |
|---|---|---|
| \`QueryEventStore.FetchStreamStateInternalAsync\` | \`StreamState\` | id, type, version, **timestamp, created**, tenant_id, is_archived |
| \`DocumentStore.GetRecentStreamsAsync\` | \`StreamSummary\` | id, type, version, **created, timestamp**, tenant_id (no is_archived) |
| \`DocumentStore.GetStreamMetadataAsync\` | \`StreamMetadata\` | id, type, version, created, timestamp, tenant_id, is_archived + JOIN'd first_event_at |

All three now share a single \`Polecat.Events.Internal.PcStreamsRowReader\` static helper that owns:

- A canonical \`SelectColumns\` const projecting all seven pc_streams columns in a fixed order. Adding or renaming a pc_streams column now updates exactly one file.
- A \`SelectColumnsWithAlias\` helper for queries that join pc_streams against pc_events.
- Typed \`ReadStreamState\` / \`ReadStreamSummary\` / \`ReadStreamMetadata\` methods that take a \`DbDataReader\` (portable, no SqlDataReader cast) and produce the appropriate output type. JOIN'd \`first_event_at\` is threaded into ReadStreamMetadata as an explicit parameter (preserves the nullable-fallback behavior where it falls back to the row's \`created\` when the LEFT JOIN returned no events).

**Net `-41 lines` across the three call sites** beyond the new file.

## Column-order normalization

The canonical order is \`id, type, version, created, timestamp, tenant_id, is_archived\` — matching two of three pre-existing sites. \`FetchStreamStateInternalAsync\` historically had \`timestamp\` and \`created\` swapped; both the SELECT projection and the read indices change in lockstep so observed behavior is identical.

## Namespace shadowing fix

Introducing \`Polecat.Events.Internal\` shadowed an unqualified \`Internal.IStorageOperation\` reference in \`AssignTagWhereOperation.cs:19\` — the unqualified \`Internal.\` no longer resolves to \`Polecat.Internal\` because the closer \`Polecat.Events.Internal\` now exists. Fixed by switching that file to the fully-qualified \`Polecat.Internal.IStorageOperation\`, matching the convention used everywhere else in the codebase (verified via grep — this was the only outlier).

## Out of scope — pc_events half

#57 also mentions consolidating the \`pc_events\` row reads between \`FetchStreamInternalAsync\` and \`ReadStreamAsync\`. Those have:
- Divergent column orders.
- Divergent column *sets* (FetchStream consumes \`dotnet_type\` + \`is_archived\` + optional correlation/causation/headers triple; ReadStream consumes only optional headers).
- Divergent output types (\`IEvent\` with serializer + mapping + \`Wrap()\` vs raw \`EventRecord\` for diagnostics).

A clean consolidation there needs a design call on canonical column ordering plus the optional-metadata convention. **#57 stays open** with the pc_events half noted as the next slice.

## Test plan
- [x] \`dotnet build polecat.slnx -c Debug\` — clean, 0 errors
- [ ] CI runs the SQL Server integration suite covering the three affected methods

🤖 Generated with [Claude Code](https://claude.com/claude-code)