### PR TITLE
Share pc_events row reader between FetchStreamAsync and ReadStreamAsync (closes #57)

### DIFF
--- a/src/Polecat/DocumentStore.EventStoreExplorer.cs
+++ b/src/Polecat/DocumentStore.EventStoreExplorer.cs
@@ -83,10 +83,14 @@ public partial class DocumentStore
             resolvedStreamId,
             defaultTenantId: Tenancy.DefaultTenantId);
 
+        // Per-batch hoist: optional-metadata column ordinals computed once.
+        // Explorer path doesn't need EventTypeCache (no EventMappingFor call).
+        var slots = MetadataSlots.Compute(Events.EventOptions);
+
         await using var reader = await cmd.ExecuteReaderAsync(ct);
         while (await reader.ReadAsync(ct))
         {
-            yield return PcEventsRowReader.ReadEventRecord(reader, ctx);
+            yield return PcEventsRowReader.ReadEventRecord(reader, ctx, slots);
         }
     }
 

--- a/src/Polecat/DocumentStore.EventStoreExplorer.cs
+++ b/src/Polecat/DocumentStore.EventStoreExplorer.cs
@@ -62,56 +62,31 @@ public partial class DocumentStore
         await conn.OpenAsync(ct);
         await using var cmd = conn.CreateCommand();
 
-        var eventOptions = Events.EventOptions;
-        var selectColumns = "id, seq_id, version, stream_id, type, data, timestamp, tenant_id";
-        if (eventOptions.EnableHeaders) selectColumns += ", headers";
-
+        // #57 pc_events half: share the column projection + row hydration
+        // with QueryEventStore.FetchStreamAsync via PcEventsRowReader. The
+        // canonical SELECT projects all enabled metadata columns; the
+        // explorer's EventRecord shape ignores the columns it doesn't surface
+        // (dotnet_type, is_archived, correlation_id, causation_id) per the
+        // polecat#57 Q2 design note — wire cost is negligible against the
+        // readability of one canonical projection.
         cmd.CommandText = $"""
-            SELECT {selectColumns}
+            SELECT {PcEventsRowReader.ComposeSelectColumns(Events.EventOptions)}
             FROM {Events.EventsTableName}
             WHERE stream_id = @stream_id
             ORDER BY version;
             """;
         cmd.Parameters.AddWithValue("@stream_id", resolvedStreamId);
 
+        var ctx = new EventHydrationContext(
+            Events,
+            Options.Serializer,
+            resolvedStreamId,
+            defaultTenantId: Tenancy.DefaultTenantId);
+
         await using var reader = await cmd.ExecuteReaderAsync(ct);
         while (await reader.ReadAsync(ct))
         {
-            var eventId = reader.GetGuid(0);
-            var sequence = reader.GetInt64(1);
-            var version = reader.GetInt64(2);
-            var streamIdRaw = reader.GetValue(3);
-            var streamIdString = streamIdRaw switch
-            {
-                Guid g => g.ToString(),
-                _ => streamIdRaw.ToString() ?? string.Empty
-            };
-            var typeName = reader.GetString(4);
-            var rawData = reader.GetString(5);
-            var timestamp = reader.GetDateTimeOffset(6);
-            var tenantId = reader.IsDBNull(7) ? Tenancy.DefaultTenantId : reader.GetString(7);
-
-            JsonElement? metadata = null;
-            if (eventOptions.EnableHeaders && !reader.IsDBNull(8))
-            {
-                using var headerDoc = JsonDocument.Parse(reader.GetString(8));
-                metadata = headerDoc.RootElement.Clone();
-            }
-
-            using var doc = JsonDocument.Parse(rawData);
-            var data = doc.RootElement.Clone();
-
-            yield return new EventRecord(
-                eventId,
-                sequence,
-                version,
-                streamIdString,
-                typeName,
-                data,
-                metadata,
-                timestamp,
-                tenantId,
-                Tags: null!);
+            yield return PcEventsRowReader.ReadEventRecord(reader, ctx);
         }
     }
 

--- a/src/Polecat/Events/Internal/EventHydrationContext.cs
+++ b/src/Polecat/Events/Internal/EventHydrationContext.cs
@@ -1,0 +1,63 @@
+using JasperFx.Events;
+using Polecat.Serialization;
+
+namespace Polecat.Events.Internal;
+
+/// <summary>
+///     Per-call context for hydrating <c>pc_events</c> rows into either
+///     a fully-resolved <see cref="IEvent"/> (via <c>FetchStreamAsync</c>)
+///     or a raw <see cref="JasperFx.Descriptors.EventRecord"/> (via the
+///     <see cref="IEventStore"/> explorer's <c>ReadStreamAsync</c>).
+///     Packages the dependencies the two read paths share so the shared
+///     <see cref="PcEventsRowReader"/> doesn't grow a long parameter list.
+/// </summary>
+/// <remarks>
+///     <para>
+///     <see cref="StreamId"/> is per-call (each <c>FetchStreamAsync</c>
+///     invocation supplies its own); the rest are session- or store-
+///     scoped. <see cref="StreamId"/> is unused by the
+///     <see cref="JasperFx.Descriptors.EventRecord"/> path, which reads
+///     each row's <c>stream_id</c> column directly.
+///     </para>
+///     <para>
+///     <see cref="DefaultTenantId"/> is the fallback when the row's
+///     <c>tenant_id</c> column is NULL — only reachable from the explorer
+///     path; the <see cref="IEvent"/> path's <c>WHERE</c> clause filters
+///     by tenant and guarantees the column is non-null.
+///     </para>
+/// </remarks>
+internal sealed class EventHydrationContext
+{
+    public EventHydrationContext(
+        EventGraph eventGraph,
+        ISerializer serializer,
+        object streamId,
+        string defaultTenantId)
+    {
+        EventGraph = eventGraph;
+        Serializer = serializer;
+        StreamId = streamId;
+        DefaultTenantId = defaultTenantId;
+    }
+
+    public EventGraph EventGraph { get; }
+    public ISerializer Serializer { get; }
+    public EventStoreOptions Options => EventGraph.EventOptions;
+    public StreamIdentity StreamIdentity => EventGraph.StreamIdentity;
+
+    /// <summary>
+    ///     The stream id the caller is reading (<see cref="System.Guid"/> or
+    ///     <see cref="string"/> depending on <see cref="StreamIdentity"/>).
+    ///     Used by <see cref="PcEventsRowReader.ReadEvent"/> to set
+    ///     <see cref="IEvent.StreamId"/> / <see cref="IEvent.StreamKey"/>;
+    ///     unused by <see cref="PcEventsRowReader.ReadEventRecord"/>.
+    /// </summary>
+    public object StreamId { get; }
+
+    /// <summary>
+    ///     Tenant id substituted when a row's <c>tenant_id</c> column is
+    ///     NULL. Only reachable from the explorer path; the IEvent path's
+    ///     WHERE clause filters by tenant.
+    /// </summary>
+    public string DefaultTenantId { get; }
+}

--- a/src/Polecat/Events/Internal/EventHydrationContext.cs
+++ b/src/Polecat/Events/Internal/EventHydrationContext.cs
@@ -25,6 +25,16 @@ namespace Polecat.Events.Internal;
 ///     path; the <see cref="IEvent"/> path's <c>WHERE</c> clause filters
 ///     by tenant and guarantees the column is non-null.
 ///     </para>
+///     <para>
+///     <c>EventStoreOptions</c> and <c>StreamIdentity</c> are deliberately
+///     NOT exposed here. Both are stable across a batch, so per-row reads
+///     would re-evaluate them needlessly; instead the caller hoists those
+///     decisions: <c>EventStoreOptions</c> flows through
+///     <see cref="MetadataSlots"/> (computed once), and
+///     <c>StreamIdentity</c> is dispatched once via
+///     <see cref="PcEventsRowReader.ReadEventAsGuid"/> vs
+///     <see cref="PcEventsRowReader.ReadEventAsString"/>.
+///     </para>
 /// </remarks>
 internal sealed class EventHydrationContext
 {
@@ -42,13 +52,12 @@ internal sealed class EventHydrationContext
 
     public EventGraph EventGraph { get; }
     public ISerializer Serializer { get; }
-    public EventStoreOptions Options => EventGraph.EventOptions;
-    public StreamIdentity StreamIdentity => EventGraph.StreamIdentity;
 
     /// <summary>
     ///     The stream id the caller is reading (<see cref="System.Guid"/> or
-    ///     <see cref="string"/> depending on <see cref="StreamIdentity"/>).
-    ///     Used by <see cref="PcEventsRowReader.ReadEvent"/> to set
+    ///     <see cref="string"/> depending on the active
+    ///     <see cref="JasperFx.Events.StreamIdentity"/>). Used by the
+    ///     <see cref="IEvent"/> read methods to set
     ///     <see cref="IEvent.StreamId"/> / <see cref="IEvent.StreamKey"/>;
     ///     unused by <see cref="PcEventsRowReader.ReadEventRecord"/>.
     /// </summary>

--- a/src/Polecat/Events/Internal/PcEventsRowReader.cs
+++ b/src/Polecat/Events/Internal/PcEventsRowReader.cs
@@ -32,6 +32,26 @@ namespace Polecat.Events.Internal;
 ///     negligible against the readability of one canonical projection. See
 ///     polecat#57 Q2 design note.
 ///     </para>
+///     <para>
+///     <b>Per-row hot-path discipline.</b> The read methods are entered
+///     once per row in <see cref="QueryEventStore.FetchStreamAsync(System.Guid, long, System.DateTimeOffset?, long, System.Threading.CancellationToken)"/>;
+///     two flavors of state that are stable across a single read batch are
+///     hoisted into structs the caller builds once and passes in:
+///     <see cref="MetadataSlots"/> (pre-computed column ordinals for the
+///     optional metadata triple) and <see cref="EventTypeCache"/> (last-seen
+///     event-type → mapping, so streams with repeated event types don't
+///     re-dictionary-lookup per row). The per-row <c>if</c>-on-options
+///     ladder and per-row <c>EventMappingFor</c> dictionary lookup both go
+///     away in the common case.
+///     </para>
+///     <para>
+///     <b>StreamIdentity specialization.</b> <c>StreamIdentity</c> is fixed
+///     at store-construction time but the pre-#57-Q2 code branched on it
+///     per row. <see cref="ReadEventAsGuid"/> / <see cref="ReadEventAsString"/>
+///     are specializations the caller picks once at the top of its read
+///     loop — see <see cref="QueryEventStore"/>. Both delegate to
+///     <see cref="ReadEventCore"/> for the shared 95% of the work.
+///     </para>
 /// </remarks>
 internal static class PcEventsRowReader
 {
@@ -58,12 +78,54 @@ internal static class PcEventsRowReader
 
     /// <summary>
     ///     Read the row the reader is positioned on into a fully-hydrated
-    ///     <see cref="IEvent"/>. Returns <see langword="null"/> when the
-    ///     row's <c>dotnet_type</c> doesn't resolve to a known event type
-    ///     so callers can filter unresolvable rows with a single
+    ///     <see cref="IEvent"/>, assuming the active store uses
+    ///     <see cref="StreamIdentity.AsGuid"/>. Caller selects between this
+    ///     and <see cref="ReadEventAsString"/> once at the top of its read
+    ///     loop, eliminating the per-row branch on <c>StreamIdentity</c>.
+    ///     Returns <see langword="null"/> when <c>dotnet_type</c> doesn't
+    ///     resolve to a known type so callers can skip with a single
     ///     <c>continue</c>.
     /// </summary>
-    internal static IEvent? ReadEvent(DbDataReader reader, EventHydrationContext ctx)
+    internal static IEvent? ReadEventAsGuid(
+        DbDataReader reader,
+        EventHydrationContext ctx,
+        MetadataSlots slots,
+        ref EventTypeCache cache)
+    {
+        var @event = ReadEventCore(reader, ctx, slots, ref cache);
+        if (@event == null) return null;
+        @event.StreamId = ctx.StreamId is Guid g ? g : Guid.Empty;
+        return @event;
+    }
+
+    /// <summary>
+    ///     Read the row the reader is positioned on into a fully-hydrated
+    ///     <see cref="IEvent"/>, assuming the active store uses
+    ///     <see cref="StreamIdentity.AsString"/>. See <see cref="ReadEventAsGuid"/>.
+    /// </summary>
+    internal static IEvent? ReadEventAsString(
+        DbDataReader reader,
+        EventHydrationContext ctx,
+        MetadataSlots slots,
+        ref EventTypeCache cache)
+    {
+        var @event = ReadEventCore(reader, ctx, slots, ref cache);
+        if (@event == null) return null;
+        @event.StreamKey = ctx.StreamId.ToString();
+        return @event;
+    }
+
+    /// <summary>
+    ///     Shared body of <see cref="ReadEventAsGuid"/> /
+    ///     <see cref="ReadEventAsString"/>. Reads every field EXCEPT
+    ///     <c>StreamId</c> / <c>StreamKey</c>; the specialized wrappers
+    ///     pick the right id-assignment.
+    /// </summary>
+    private static IEvent? ReadEventCore(
+        DbDataReader reader,
+        EventHydrationContext ctx,
+        MetadataSlots slots,
+        ref EventTypeCache cache)
     {
         var seqId = reader.GetInt64(0);
         var eventId = reader.GetGuid(1);
@@ -79,8 +141,12 @@ internal static class PcEventsRowReader
         var resolvedType = ctx.EventGraph.ResolveEventType(dotNetTypeName);
         if (resolvedType == null) return null;
 
+        // Per-batch single-slot type→mapping cache. For streams with
+        // repeated event types (the common shape of an aggregate stream)
+        // this collapses N dictionary lookups into 1 per distinct type.
+        var mapping = cache.LookupOrAdd(ctx.EventGraph, resolvedType);
+
         var data = ctx.Serializer.FromJson(resolvedType, json);
-        var mapping = ctx.EventGraph.EventMappingFor(resolvedType);
         var @event = mapping.Wrap(data);
 
         @event.Id = eventId;
@@ -92,30 +158,25 @@ internal static class PcEventsRowReader
         @event.DotNetTypeName = dotNetTypeName!;
         @event.IsArchived = isArchived;
 
-        var metaIndex = 10;
-        if (ctx.Options.EnableCorrelationId)
+        // Per-batch pre-computed slots. Each branch tests a sentinel and is
+        // taken/not-taken the same way for every row in this batch — branch
+        // predictor pegged. The per-row metaIndex++ chain is gone.
+        if (slots.CorrelationIdx >= 0)
         {
-            @event.CorrelationId = reader.IsDBNull(metaIndex) ? null : reader.GetString(metaIndex);
-            metaIndex++;
+            @event.CorrelationId = reader.IsDBNull(slots.CorrelationIdx)
+                ? null
+                : reader.GetString(slots.CorrelationIdx);
         }
-        if (ctx.Options.EnableCausationId)
+        if (slots.CausationIdx >= 0)
         {
-            @event.CausationId = reader.IsDBNull(metaIndex) ? null : reader.GetString(metaIndex);
-            metaIndex++;
+            @event.CausationId = reader.IsDBNull(slots.CausationIdx)
+                ? null
+                : reader.GetString(slots.CausationIdx);
         }
-        if (ctx.Options.EnableHeaders && !reader.IsDBNull(metaIndex))
+        if (slots.HeadersIdx >= 0 && !reader.IsDBNull(slots.HeadersIdx))
         {
-            var headersJson = reader.GetString(metaIndex);
+            var headersJson = reader.GetString(slots.HeadersIdx);
             @event.Headers = ctx.Serializer.FromJson<Dictionary<string, object>>(headersJson);
-        }
-
-        if (ctx.StreamIdentity == StreamIdentity.AsGuid)
-        {
-            @event.StreamId = ctx.StreamId is Guid g ? g : Guid.Empty;
-        }
-        else
-        {
-            @event.StreamKey = ctx.StreamId.ToString();
         }
 
         return @event;
@@ -124,11 +185,21 @@ internal static class PcEventsRowReader
     /// <summary>
     ///     Read the row the reader is positioned on into a raw
     ///     <see cref="EventRecord"/> for the explorer surface. Unlike
-    ///     <see cref="ReadEvent"/> this returns a self-contained record
-    ///     (no <see cref="ISerializer"/> deserialization; <c>data</c> and
-    ///     <c>headers</c> are surfaced as cloned <see cref="JsonElement"/>s).
+    ///     <see cref="ReadEventAsGuid"/> / <see cref="ReadEventAsString"/>
+    ///     this returns a self-contained record (no <see cref="ISerializer"/>
+    ///     deserialization; <c>data</c> and <c>headers</c> are surfaced as
+    ///     cloned <see cref="JsonElement"/>s).
     /// </summary>
-    internal static EventRecord ReadEventRecord(DbDataReader reader, EventHydrationContext ctx)
+    /// <remarks>
+    ///     Same per-batch <see cref="MetadataSlots"/> hoisting as the
+    ///     <see cref="IEvent"/> path. The explorer doesn't need the
+    ///     <see cref="EventTypeCache"/> because it doesn't call
+    ///     <c>EventMappingFor</c>.
+    /// </remarks>
+    internal static EventRecord ReadEventRecord(
+        DbDataReader reader,
+        EventHydrationContext ctx,
+        MetadataSlots slots)
     {
         var seqId = reader.GetInt64(0);
         var eventId = reader.GetGuid(1);
@@ -144,16 +215,10 @@ internal static class PcEventsRowReader
         // SELECT because the canonical projection is shared; the diagnostic
         // path just ignores them.
 
-        // Advance metaIndex past correlation_id / causation_id when they're
-        // projected, since the explorer doesn't surface them either.
-        var metaIndex = 10;
-        if (ctx.Options.EnableCorrelationId) metaIndex++;
-        if (ctx.Options.EnableCausationId) metaIndex++;
-
         JsonElement? metadata = null;
-        if (ctx.Options.EnableHeaders && !reader.IsDBNull(metaIndex))
+        if (slots.HeadersIdx >= 0 && !reader.IsDBNull(slots.HeadersIdx))
         {
-            using var headerDoc = JsonDocument.Parse(reader.GetString(metaIndex));
+            using var headerDoc = JsonDocument.Parse(reader.GetString(slots.HeadersIdx));
             metadata = headerDoc.RootElement.Clone();
         }
 
@@ -178,4 +243,57 @@ internal static class PcEventsRowReader
         Guid g => g.ToString(),
         _ => value.ToString() ?? string.Empty
     };
+}
+
+/// <summary>
+///     Pre-computed column ordinals for the optional metadata triple
+///     (<c>correlation_id</c>, <c>causation_id</c>, <c>headers</c>). Built
+///     once at the top of a read loop from <see cref="EventStoreOptions"/>
+///     and passed by value into every <see cref="PcEventsRowReader"/> call
+///     in the batch. <c>-1</c> means the column is not projected; the
+///     reader skips it without checking the underlying flag.
+/// </summary>
+internal readonly record struct MetadataSlots(int CorrelationIdx, int CausationIdx, int HeadersIdx)
+{
+    /// <summary>
+    ///     Sentinel indicating the column is not in the projected SELECT.
+    /// </summary>
+    public const int Disabled = -1;
+
+    public static MetadataSlots Compute(EventStoreOptions options)
+    {
+        var ordinal = 10;
+        var correlation = options.EnableCorrelationId ? ordinal++ : Disabled;
+        var causation = options.EnableCausationId ? ordinal++ : Disabled;
+        var headers = options.EnableHeaders ? ordinal : Disabled;
+        return new MetadataSlots(correlation, causation, headers);
+    }
+}
+
+/// <summary>
+///     Per-batch single-slot LRU for the <c>resolved-Type → IEventType
+///     mapping</c> lookup performed inside <see cref="PcEventsRowReader.ReadEventAsGuid"/>
+///     / <see cref="PcEventsRowReader.ReadEventAsString"/>. Streams of
+///     events typically have a small set of distinct event types repeated
+///     many times — caching the last seen type and its mapping turns N
+///     dictionary lookups into 1 per distinct type in the common case.
+/// </summary>
+/// <remarks>
+///     Mutable struct, passed by <c>ref</c>. Live for the lifetime of a
+///     single batch read; never crosses thread boundaries.
+/// </remarks>
+internal struct EventTypeCache
+{
+    private Type? _lastType;
+    private IEventType? _lastMapping;
+
+    public IEventType LookupOrAdd(EventGraph eventGraph, Type resolvedType)
+    {
+        if (!ReferenceEquals(resolvedType, _lastType))
+        {
+            _lastMapping = eventGraph.EventMappingFor(resolvedType);
+            _lastType = resolvedType;
+        }
+        return _lastMapping!;
+    }
 }

--- a/src/Polecat/Events/Internal/PcEventsRowReader.cs
+++ b/src/Polecat/Events/Internal/PcEventsRowReader.cs
@@ -1,0 +1,181 @@
+using System.Data.Common;
+using System.Text;
+using System.Text.Json;
+using JasperFx.Descriptors;
+using JasperFx.Events;
+using Polecat.Metadata;
+
+namespace Polecat.Events.Internal;
+
+/// <summary>
+///     Canonical SQL fragment + row reader for the <c>pc_events</c> table.
+///     Shared between <see cref="QueryEventStore.FetchStreamAsync(System.Guid, long, System.DateTimeOffset?, long, System.Threading.CancellationToken)"/>
+///     (full <see cref="IEvent"/> hydration) and the
+///     <see cref="IEventStore"/> explorer's <c>ReadStreamAsync</c> (raw
+///     <see cref="EventRecord"/> for diagnostics). Closes the pc_events
+///     half of <see href="https://github.com/JasperFx/polecat/issues/57">polecat#57</see>
+///     (mirrors the Marten 9 <c>ISelector&lt;IEvent&gt;</c> consolidation).
+/// </summary>
+/// <remarks>
+///     <para>
+///     <b>Canonical column order is locked here.</b> The pre-consolidation
+///     <see cref="QueryEventStore"/> order (the workhorse path) is preserved
+///     as the canonical order; the explorer's <c>ReadStreamAsync</c> renumbered
+///     to match. Adding or renaming a <c>pc_events</c> column means updating
+///     this file and exactly this file.
+///     </para>
+///     <para>
+///     <b>Optional metadata columns</b> (<c>correlation_id</c>, <c>causation_id</c>,
+///     <c>headers</c>) are projected when their <see cref="EventStoreOptions"/>
+///     flag is on. Readers that don't surface a particular metadata field
+///     skip it on read — the column is still on the wire but the cost is
+///     negligible against the readability of one canonical projection. See
+///     polecat#57 Q2 design note.
+///     </para>
+/// </remarks>
+internal static class PcEventsRowReader
+{
+    /// <summary>
+    ///     Mandatory columns, always projected. Ordinals 0–9.
+    /// </summary>
+    internal const string CoreSelectColumns =
+        "seq_id, id, stream_id, version, data, type, timestamp, tenant_id, dotnet_type, is_archived";
+
+    /// <summary>
+    ///     Compose <see cref="CoreSelectColumns"/> plus any optional metadata
+    ///     columns the active <see cref="EventStoreOptions"/> enables. Both readers
+    ///     consume this so the SELECT shape stays in lockstep regardless of
+    ///     which output type the caller is producing.
+    /// </summary>
+    internal static string ComposeSelectColumns(EventStoreOptions options)
+    {
+        var sb = new StringBuilder(CoreSelectColumns);
+        if (options.EnableCorrelationId) sb.Append(", correlation_id");
+        if (options.EnableCausationId) sb.Append(", causation_id");
+        if (options.EnableHeaders) sb.Append(", headers");
+        return sb.ToString();
+    }
+
+    /// <summary>
+    ///     Read the row the reader is positioned on into a fully-hydrated
+    ///     <see cref="IEvent"/>. Returns <see langword="null"/> when the
+    ///     row's <c>dotnet_type</c> doesn't resolve to a known event type
+    ///     so callers can filter unresolvable rows with a single
+    ///     <c>continue</c>.
+    /// </summary>
+    internal static IEvent? ReadEvent(DbDataReader reader, EventHydrationContext ctx)
+    {
+        var seqId = reader.GetInt64(0);
+        var eventId = reader.GetGuid(1);
+        // stream_id at ordinal 2 — known by the caller; not read here
+        var eventVersion = reader.GetInt64(3);
+        var json = reader.GetString(4);
+        var typeName = reader.GetString(5);
+        var eventTimestamp = reader.GetFieldValue<DateTimeOffset>(6);
+        var tenantId = reader.IsDBNull(7) ? ctx.DefaultTenantId : reader.GetString(7);
+        var dotNetTypeName = reader.IsDBNull(8) ? null : reader.GetString(8);
+        var isArchived = reader.GetBoolean(9);
+
+        var resolvedType = ctx.EventGraph.ResolveEventType(dotNetTypeName);
+        if (resolvedType == null) return null;
+
+        var data = ctx.Serializer.FromJson(resolvedType, json);
+        var mapping = ctx.EventGraph.EventMappingFor(resolvedType);
+        var @event = mapping.Wrap(data);
+
+        @event.Id = eventId;
+        @event.Sequence = seqId;
+        @event.Version = eventVersion;
+        @event.Timestamp = eventTimestamp;
+        @event.TenantId = tenantId;
+        @event.EventTypeName = typeName;
+        @event.DotNetTypeName = dotNetTypeName!;
+        @event.IsArchived = isArchived;
+
+        var metaIndex = 10;
+        if (ctx.Options.EnableCorrelationId)
+        {
+            @event.CorrelationId = reader.IsDBNull(metaIndex) ? null : reader.GetString(metaIndex);
+            metaIndex++;
+        }
+        if (ctx.Options.EnableCausationId)
+        {
+            @event.CausationId = reader.IsDBNull(metaIndex) ? null : reader.GetString(metaIndex);
+            metaIndex++;
+        }
+        if (ctx.Options.EnableHeaders && !reader.IsDBNull(metaIndex))
+        {
+            var headersJson = reader.GetString(metaIndex);
+            @event.Headers = ctx.Serializer.FromJson<Dictionary<string, object>>(headersJson);
+        }
+
+        if (ctx.StreamIdentity == StreamIdentity.AsGuid)
+        {
+            @event.StreamId = ctx.StreamId is Guid g ? g : Guid.Empty;
+        }
+        else
+        {
+            @event.StreamKey = ctx.StreamId.ToString();
+        }
+
+        return @event;
+    }
+
+    /// <summary>
+    ///     Read the row the reader is positioned on into a raw
+    ///     <see cref="EventRecord"/> for the explorer surface. Unlike
+    ///     <see cref="ReadEvent"/> this returns a self-contained record
+    ///     (no <see cref="ISerializer"/> deserialization; <c>data</c> and
+    ///     <c>headers</c> are surfaced as cloned <see cref="JsonElement"/>s).
+    /// </summary>
+    internal static EventRecord ReadEventRecord(DbDataReader reader, EventHydrationContext ctx)
+    {
+        var seqId = reader.GetInt64(0);
+        var eventId = reader.GetGuid(1);
+        var streamIdRaw = reader.GetValue(2);
+        var streamIdString = StreamIdToString(streamIdRaw);
+        var eventVersion = reader.GetInt64(3);
+        var rawData = reader.GetString(4);
+        var typeName = reader.GetString(5);
+        var eventTimestamp = reader.GetFieldValue<DateTimeOffset>(6);
+        var tenantId = reader.IsDBNull(7) ? ctx.DefaultTenantId : reader.GetString(7);
+        // dotnet_type (8) + is_archived (9) intentionally not surfaced — the
+        // explorer's EventRecord shape doesn't include them. They're in the
+        // SELECT because the canonical projection is shared; the diagnostic
+        // path just ignores them.
+
+        // Advance metaIndex past correlation_id / causation_id when they're
+        // projected, since the explorer doesn't surface them either.
+        var metaIndex = 10;
+        if (ctx.Options.EnableCorrelationId) metaIndex++;
+        if (ctx.Options.EnableCausationId) metaIndex++;
+
+        JsonElement? metadata = null;
+        if (ctx.Options.EnableHeaders && !reader.IsDBNull(metaIndex))
+        {
+            using var headerDoc = JsonDocument.Parse(reader.GetString(metaIndex));
+            metadata = headerDoc.RootElement.Clone();
+        }
+
+        using var doc = JsonDocument.Parse(rawData);
+        var data = doc.RootElement.Clone();
+
+        return new EventRecord(
+            eventId,
+            seqId,
+            eventVersion,
+            streamIdString,
+            typeName,
+            data,
+            metadata,
+            eventTimestamp,
+            tenantId,
+            Tags: null!);
+    }
+
+    private static string StreamIdToString(object value) => value switch
+    {
+        Guid g => g.ToString(),
+        _ => value.ToString() ?? string.Empty
+    };
+}

--- a/src/Polecat/Events/QueryEventStore.cs
+++ b/src/Polecat/Events/QueryEventStore.cs
@@ -100,13 +100,32 @@ internal class QueryEventStore : IQueryEventStore
             streamId,
             defaultTenantId: _session.TenantId);
 
+        // Per-batch hoists: compute the optional-metadata column ordinals
+        // once, declare a single-slot type→mapping cache, pick the
+        // StreamIdentity specialization once. Per-row reads have zero
+        // option-flag branches and ~1 EventMappingFor lookup per distinct
+        // event-type-in-stream.
+        var slots = MetadataSlots.Compute(_events.EventOptions);
+        var cache = new EventTypeCache();
+
         var results = new List<IEvent>();
         await using var reader = await _session.ExecuteReaderAsync(cmd, token);
 
-        while (await reader.ReadAsync(token))
+        if (_events.StreamIdentity == StreamIdentity.AsGuid)
         {
-            var @event = PcEventsRowReader.ReadEvent(reader, ctx);
-            if (@event != null) results.Add(@event);
+            while (await reader.ReadAsync(token))
+            {
+                var @event = PcEventsRowReader.ReadEventAsGuid(reader, ctx, slots, ref cache);
+                if (@event != null) results.Add(@event);
+            }
+        }
+        else
+        {
+            while (await reader.ReadAsync(token))
+            {
+                var @event = PcEventsRowReader.ReadEventAsString(reader, ctx, slots, ref cache);
+                if (@event != null) results.Add(@event);
+            }
         }
 
         return results;

--- a/src/Polecat/Events/QueryEventStore.cs
+++ b/src/Polecat/Events/QueryEventStore.cs
@@ -59,18 +59,13 @@ internal class QueryEventStore : IQueryEventStore
     private async Task<IReadOnlyList<IEvent>> FetchStreamInternalAsync(object streamId, long version,
         DateTimeOffset? timestamp, long fromVersion, CancellationToken token)
     {
+        // #57 pc_events half: column projection + per-row hydration live in
+        // PcEventsRowReader, shared with the IEventStore explorer's
+        // ReadStreamAsync path. This method only composes WHERE / ORDER BY.
         await using var cmd = new SqlCommand();
 
-        var eventOptions = _events.EventOptions;
-
-        // Build SELECT columns dynamically for optional metadata
-        var selectColumns = "seq_id, id, stream_id, version, data, type, timestamp, tenant_id, dotnet_type, is_archived";
-        if (eventOptions.EnableCorrelationId) selectColumns += ", correlation_id";
-        if (eventOptions.EnableCausationId) selectColumns += ", causation_id";
-        if (eventOptions.EnableHeaders) selectColumns += ", headers";
-
         var sql = $"""
-            SELECT {selectColumns}
+            SELECT {PcEventsRowReader.ComposeSelectColumns(_events.EventOptions)}
             FROM {_events.EventsTableName}
             WHERE stream_id = @stream_id AND tenant_id = @tenant_id AND is_archived = 0
             """;
@@ -99,72 +94,19 @@ internal class QueryEventStore : IQueryEventStore
         sql += " ORDER BY version;";
         cmd.CommandText = sql;
 
+        var ctx = new EventHydrationContext(
+            _events,
+            _session.Serializer,
+            streamId,
+            defaultTenantId: _session.TenantId);
+
         var results = new List<IEvent>();
-        await using var dbReader = await _session.ExecuteReaderAsync(cmd, token);
-        var reader = (SqlDataReader)dbReader;
+        await using var reader = await _session.ExecuteReaderAsync(cmd, token);
 
         while (await reader.ReadAsync(token))
         {
-            var seqId = reader.GetInt64(0);
-            var eventId = reader.GetGuid(1);
-            // stream_id at index 2
-            var eventVersion = reader.GetInt64(3);
-            var json = reader.GetString(4);
-            var typeName = reader.GetString(5);
-            var eventTimestamp = reader.GetDateTimeOffset(6);
-            var tenantId = reader.GetString(7);
-            var dotNetTypeName = reader.IsDBNull(8) ? null : reader.GetString(8);
-            var isArchived = reader.GetBoolean(9);
-
-            var resolvedType = _events.ResolveEventType(dotNetTypeName);
-            if (resolvedType == null) continue; // Skip events we can't resolve
-
-            var data = _session.Serializer.FromJson(resolvedType, json);
-            var mapping = _events.EventMappingFor(resolvedType);
-            var @event = mapping.Wrap(data);
-
-            @event.Id = eventId;
-            @event.Sequence = seqId;
-            @event.Version = eventVersion;
-            @event.Timestamp = eventTimestamp;
-            @event.TenantId = tenantId;
-            @event.EventTypeName = typeName;
-            @event.DotNetTypeName = dotNetTypeName!;
-            @event.IsArchived = isArchived;
-
-            // Read optional metadata columns (indices 10+ based on what's enabled)
-            var metaIndex = 10;
-            if (eventOptions.EnableCorrelationId)
-            {
-                @event.CorrelationId = reader.IsDBNull(metaIndex) ? null : reader.GetString(metaIndex);
-                metaIndex++;
-            }
-
-            if (eventOptions.EnableCausationId)
-            {
-                @event.CausationId = reader.IsDBNull(metaIndex) ? null : reader.GetString(metaIndex);
-                metaIndex++;
-            }
-
-            if (eventOptions.EnableHeaders)
-            {
-                if (!reader.IsDBNull(metaIndex))
-                {
-                    var headersJson = reader.GetString(metaIndex);
-                    @event.Headers = _session.Serializer.FromJson<Dictionary<string, object>>(headersJson);
-                }
-            }
-
-            if (_events.StreamIdentity == StreamIdentity.AsGuid)
-            {
-                @event.StreamId = streamId is Guid g ? g : Guid.Empty;
-            }
-            else
-            {
-                @event.StreamKey = streamId.ToString();
-            }
-
-            results.Add(@event);
+            var @event = PcEventsRowReader.ReadEvent(reader, ctx);
+            if (@event != null) results.Add(@event);
         }
 
         return results;


### PR DESCRIPTION
## Summary

**Closes #57.** The pc_streams half shipped in #64; this PR is the pc_events half, mirroring the same consolidation pattern.

Two sites were reading from \`pc_events\` with different column orders, divergent column sets, and per-call hand-rolled hydration:

| Site | Output | Old column order |
|---|---|---|
| \`QueryEventStore.FetchStreamInternalAsync\` | \`IEvent\` (serializer + \`EventMapping.Wrap()\`) | \`seq_id, id, stream_id, version, data, type, timestamp, tenant_id, dotnet_type, is_archived\` + optional metadata triple |
| \`DocumentStore.ReadStreamAsync\` | \`EventRecord\` (raw, for explorer) | \`id, seq_id, version, stream_id, type, data, timestamp, tenant_id\` + optional headers |

Both now share \`Polecat.Events.Internal.PcEventsRowReader\` + \`Polecat.Events.Internal.EventHydrationContext\`. **Net \`-83\` lines** across the two call sites.

## Design

Decided in interview before implementing — each option's letter maps back to the interview prompt:

| Q | Choice | What it means |
|---|---|---|
| **Q1** | a | Canonical column order = FetchStream's existing order verbatim (the workhorse path). Explorer renumbers. |
| **Q2** | a | Optional metadata gated by \`EventStoreOptions\` flags; both readers project the same SELECT. Explorer ignores \`correlation_id\` / \`causation_id\` / \`dotnet_type\` / \`is_archived\` on read. Tiny extra wire bytes, one canonical projection. |
| **Q3** | a | Two typed read methods. \`ReadEvent\` returns \`IEvent?\` (null signals \`dotnet_type\` didn't resolve, matches the existing \`continue\` pattern). \`ReadEventRecord\` returns \`EventRecord\` with cloned \`JsonElement\` data + headers. |
| **Q4** | b | \`EventHydrationContext\` wraps \`EventGraph\` + \`ISerializer\` + per-call \`streamId\` + fallback \`defaultTenantId\`. Avoids a five-arg method signature; future hydration deps have one place to land. |
| **Q5** | a | File name \`PcEventsRowReader.cs\` parallel to the \`PcStreamsRowReader.cs\` that #64 added. |

## Behavior preservation

- **FetchStream path**: identical column reads (same order, same indices, same optional-metadata logic). Only semantic shift is a defensive widening — \`tenantId\` now falls back to \`ctx.DefaultTenantId\` if the column were ever NULL, where the old code would have thrown \`InvalidCastException\`. The WHERE clause prevents NULL so this branch is unreachable in practice.
- **ReadStream path**: column read indices shift (canonical order differs from explorer's old order); the projected SELECT now always includes \`dotnet_type\` + \`is_archived\` + any enabled correlation/causation columns, which the explorer just doesn't read. \`EventRecord\` output shape unchanged.

## Out of scope

- DCB tag-set query path (\`QueryByTagsAsync\` / \`GetProjectedStateForTagsAsync\`) still throws \`NotSupportedException\` in the explorer — separate roadmap, doesn't read pc_events through the same column shape.
- \`OverwriteEventOperation\` / \`ReplaceEventOperation\` / \`DeleteEventsOperation\` write to pc_events but don't read it for projection; out of scope.

## Test plan
- [x] \`dotnet build polecat.slnx -c Debug\` — 0 errors
- [ ] CI runs the SQL Server integration suite covering both affected methods

🤖 Generated with [Claude Code](https://claude.com/claude-code)