### PR TITLE
Bump JasperFx → 2.0.0-alpha.11 + JasperFx.Events → 2.0.0-alpha.4; IsAotCompatible=true (#46)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,8 +5,8 @@
 
     <ItemGroup>
         <!-- Core dependencies -->
-        <PackageVersion Include="JasperFx" Version="2.0.0-alpha.8" />
-        <PackageVersion Include="JasperFx.Events" Version="2.0.0-alpha.3" />
+        <PackageVersion Include="JasperFx" Version="2.0.0-alpha.11" />
+        <PackageVersion Include="JasperFx.Events" Version="2.0.0-alpha.4" />
         <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />

--- a/src/Polecat/Polecat.csproj
+++ b/src/Polecat/Polecat.csproj
@@ -4,6 +4,12 @@
         <Description>SQL Server backed Event Store for the Critter Stack</Description>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <RootNamespace>Polecat</RootNamespace>
+        <!-- AOT pillar (Critter Stack 2026 — JasperFx#213). Surfaces IL2026 / IL2070 /
+             IL2075 / IL3050 warnings against Polecat itself so the AOT punch list shows
+             up in our own CI rather than downstream consumers'. Aligns with
+             JasperFx + JasperFx.Events 2.0.0-alpha.11 / 2.0.0-alpha.4 and Weasel.Core
+             9.0.0-alpha.2 (refresh to alpha.3 lands in a follow-up bump). -->
+        <IsAotCompatible>true</IsAotCompatible>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Tier 2 E of the Critter Stack 2026 AOT pillar (JasperFx/jasperfx#213) consumer-side rollout. Picks up the JasperFx-side flag flip + CommandLine annotation pass that shipped today via [JasperFx/jasperfx#247](https://github.com/JasperFx/jasperfx/pull/247) / [#250](https://github.com/JasperFx/jasperfx/pull/250) / [#251](https://github.com/JasperFx/jasperfx/pull/251).

## Bumps

| Package | Old | New |
|---|---|---|
| `JasperFx` | 2.0.0-alpha.8 | **2.0.0-alpha.11** |
| `JasperFx.Events` | 2.0.0-alpha.3 | **2.0.0-alpha.4** |

`Weasel.*` stays on `9.0.0-alpha.2` for now — the alpha.3 refresh is queued via [weasel#273](https://github.com/JasperFx/weasel/pull/273) (refreshed today). I'll follow up with a Polecat bump to Weasel.* 9.0.0-alpha.3 once Weasel publishes from its dispatch workflow.

## Polecat.csproj — IsAotCompatible=true

\`\`\`xml
<IsAotCompatible>true</IsAotCompatible>
\`\`\`

Enables IL2026 / IL2070 / IL2075 / IL3050 analyzers against Polecat's own build, so the punch list of reflective surfaces that need [RequiresDynamicCode] / [RequiresUnreferencedCode] / [DynamicallyAccessedMembers] annotations surfaces in Polecat's own CI rather than downstream consumers'. Mirrors what jasperfx#247 did for JasperFx + JasperFx.Events.

## Initial fallout (per TFM; net9.0 + net10.0 mirror)

**270 IL warnings**, broken down by area:

| Warnings | Area |
|---|---|
| 88 | DocumentStore.ProjectionReplay.cs — STJ deserialize + reflection |
| 72 | Serialization/Serializer.cs — STJ deserialize / serialize |
| 64 | Linq/PolecatQueryableExtensions.cs — generic Queryable construction |
| 56 | Linq/PolecatLinqQueryProvider.cs — same |
| 32 | Linq/SoftDeletes/SoftDeletedExtensions.cs |
| 24 | Linq/NonStaleDataExtensions.cs |
| 20 | Events/Linq/EventLinqQueryProvider.cs |
| 16 each | Storage/DocumentMapping.cs, LinqExtensions.cs, Linq/Metadata/MetadataExtensions.cs, Linq/Metadata/CreatedAtExtensions.cs, Internal/DocumentProviderRegistry.cs, DocumentStore.EventStoreExplorer.cs |

These are the input punch list for the Polecat-side AOT pillar work. The shape mirrors what's queued for JasperFx (Core/Reflection, Core/IoC, etc.) — each area becomes a follow-up issue against the AOT pillar.

## Verification

- Polecat.csproj build — 0 errors against alpha.11 / alpha.4
- Polecat.Tests build — 0 errors
- 90 non-DB tests pass locally; the ~978 DB-dependent tests will run in CI against the SQL Server matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)