### PR TITLE
Replace retired azure-sql-edge image with mssql/server:2022-latest

### DIFF
--- a/docker-compose.azure-sql-edge.yml
+++ b/docker-compose.azure-sql-edge.yml
@@ -1,5 +1,23 @@
+# Compose override for the `edge` matrix axis in the GitHub Actions test
+# workflows (polecat.yml / aspnetcore.yml / efcore.yml).
+#
+# Historically this pulled `mcr.microsoft.com/azure-sql-edge:latest` to
+# exercise Polecat against the smaller / Azure-shaped SQL surface. Azure
+# SQL Edge has been retired by Microsoft and the image is no longer
+# publicly available — pulls now return "The request is blocked" /
+# "pull access denied" from mcr.microsoft.com.
+#
+# Replacement: `mssql/server:2022-latest`. Keeps the `edge` matrix axis
+# meaningful as a *different SQL Server version* than the base compose's
+# `mssql/server:2025-latest`, exercising cross-version compatibility.
+# Both 2022+ images carry mssql-tools18 at /opt/mssql-tools18/bin/sqlcmd
+# and support the `-C` (Trust Server Certificate) flag, so the base
+# compose's healthcheck definition works without any override beyond
+# the image swap.
+#
+# Matrix-axis name stays `edge` to avoid renaming the cascading status
+# checks across three workflow files (polecat.yml, aspnetcore.yml,
+# efcore.yml) and any branch-protection rules that reference them.
 services:
   sqlserver:
-    image: mcr.microsoft.com/azure-sql-edge:latest
-    environment:
-      SQLCMD_PATH: "/opt/mssql-tools/bin/sqlcmd"
+    image: mcr.microsoft.com/mssql/server:2022-latest


### PR DESCRIPTION
## Symptom

Every Polecat PR's \`test (edge)\` matrix job has been failing with:

\`\`\`
sqlserver Error pull access denied for mcr.microsoft.com/azure-sql-edge,
repository does not exist or may require 'docker login': denied:
... The request is blocked.

Error response from daemon: pull access denied for
mcr.microsoft.com/azure-sql-edge, repository does not exist or may
require 'docker login'

##[error]Process completed with exit code 1.
\`\`\`

Caught while diagnosing CI on polecat#67. Azure SQL Edge has been [retired by Microsoft](https://learn.microsoft.com/en-us/azure/azure-sql-edge/disconnected-deployment) and the public image \`mcr.microsoft.com/azure-sql-edge:latest\` is no longer publishable.

## Fix

\`docker-compose.azure-sql-edge.yml\` now overrides to \`mcr.microsoft.com/mssql/server:2022-latest\` instead. This keeps the \`edge\` matrix axis meaningful as a *different SQL Server version* than the base compose's \`2025-latest\`, preserving cross-version compatibility coverage. Both images ship with mssql-tools18 + support the \`-C\` flag, so the base compose's healthcheck works without further override beyond the image swap.

The matrix-axis name stays \`edge\` so the cascading status checks across \`polecat.yml\` / \`aspnetcore.yml\` / \`efcore.yml\` (and any branch-protection rules referencing them) don't need renaming.

## Unblocks

- polecat#67 (the AOT-pillar bump that surfaced the failure)
- every subsequent Polecat PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)