### PR TITLE
Bump Weasel.* to 9.0.0-alpha.3

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -25,8 +25,8 @@
         <PackageVersion Include="Shouldly" Version="4.3.0" />
         <PackageVersion Include="xunit" Version="2.9.3" />
         <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.4" />
-        <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.0.0-alpha.2" />
-        <PackageVersion Include="Weasel.SqlServer" Version="9.0.0-alpha.2" />
+        <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.0.0-alpha.3" />
+        <PackageVersion Include="Weasel.SqlServer" Version="9.0.0-alpha.3" />
 
         <!-- Strongly typed IDs -->
         <PackageVersion Include="StronglyTypedId" Version="1.0.0-beta08" />


### PR DESCRIPTION
Follow-up to [#67](https://github.com/JasperFx/polecat/pull/67) (foundation bump to JasperFx 2.0.0-alpha.11 + JasperFx.Events 2.0.0-alpha.4 + \`IsAotCompatible=true\`). Weasel.* 9.0.0-alpha.3 was published from [weasel#273](https://github.com/JasperFx/weasel/pull/273) shortly after #67 landed; this picks it up across both pinned Weasel packages.

## Bumps

| Package | Old | New |
|---|---|---|
| \`Weasel.SqlServer\` | 9.0.0-alpha.2 | **9.0.0-alpha.3** |
| \`Weasel.EntityFrameworkCore\` | 9.0.0-alpha.2 | **9.0.0-alpha.3** |

## What alpha.3 carries

- The Weasel-side AOT cleanups from [weasel#265](https://github.com/JasperFx/weasel/issues/265) + [weasel#266](https://github.com/JasperFx/weasel/issues/266) (\`AssertCommand\` Spectre suppression, \`CommandBuilderBase.GetType()\` DAM annotation)
- First Weasel release built against the AOT-pillar JasperFx alphas (alpha.11 / alpha.4) that #67 also adopted

## Verification

- \`Polecat.csproj\` build clean (0 errors) against the new pins
- No other changes in \`Directory.Packages.props\`

## Critter Stack 2026 status after this lands

The foundation-alpha consumption chain is fully aligned end-to-end:

| Layer | Version |
|---|---|
| JasperFx | 2.0.0-alpha.11 |
| JasperFx.Events | 2.0.0-alpha.4 |
| Weasel.* | 9.0.0-alpha.3 |
| Polecat | (consumes all three) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)