### PR TITLE
Annotate DocumentStore.ProjectionReplay.cs reflective surface for AOT (closes #71)

### DIFF
--- a/src/Polecat/DocumentStore.ProjectionReplay.cs
+++ b/src/Polecat/DocumentStore.ProjectionReplay.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Text.Json;
 using JasperFx.Descriptors;
@@ -15,6 +16,14 @@ namespace Polecat;
 /// </summary>
 public partial class DocumentStore
 {
+    [UnconditionalSuppressMessage("Trimming", "IL2091:DynamicallyAccessedMembers",
+        Justification = "Forwards to RunProjectionForReferenceTypeAsync<TState> via MakeGenericMethod. Projection step-through is a dev-time / diagnostic IEventStore surface (CritterWatch / projection replay); AOT-publishing apps either avoid the surface entirely or supply a source-generated dispatcher.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+        Justification = "MakeGenericMethod is required to satisfy the aggregator's `class, new()` constraint without changing the public IEventStore.RunProjectionAsync<TState> contract.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2075:DynamicallyAccessedMembers",
+        Justification = "Reads Task<T>.Result via reflection; Task<T> is a framework type whose Result property is intrinsically preserved.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
+        Justification = "Calls into RunProjectionForReferenceTypeAsync<TState> which is annotated [RequiresUnreferencedCode]. The explicit interface impl can't propagate the requirement because the interface contract doesn't declare it yet (tracked in jasperfx#262 for the Events-side IEventStore annotation).")]
     async Task<ProjectionTimeline<TState>> IEventStore.RunProjectionAsync<TState>(
         string projectionName, object identity, IReadOnlyList<EventRecord> events,
         TState? startingState, CancellationToken ct) where TState : default
@@ -51,6 +60,8 @@ public partial class DocumentStore
         return (ProjectionTimeline<TState>)resultTask.GetType().GetProperty("Result")!.GetValue(resultTask)!;
     }
 
+    [RequiresUnreferencedCode("Routes projection events through the aggregator graph + ToDomainEvent reflective deserialization. TState's public members must survive trimming for the aggregator to access them.")]
+    [RequiresDynamicCode("ToDomainEvent routes through ISerializer.FromJson which uses STJ runtime code generation.")]
     private async Task<ProjectionTimeline<TState>> RunProjectionForReferenceTypeAsync<TState>(
         IReadOnlyList<EventRecord> events, TState? startingState, CancellationToken ct)
         where TState : class, new()
@@ -92,6 +103,12 @@ public partial class DocumentStore
         return new ProjectionTimeline<TState>(steps, current!);
     }
 
+    [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+        Justification = "MakeGenericMethod over the projection's published state type; required to dispatch into the strong-typed RunProjectionAsync<TState>. Diagnostic IEventStore surface — see RunProjectionAsync above for the rationale.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
+        Justification = "STJ JsonSerializer.Deserialize / SerializeToElement over the projection's published state type. AOT-publishing diagnostic-only consumers should supply an STJ source-generator context.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2075:DynamicallyAccessedMembers",
+        Justification = "Reads Task<T> + ProjectionTimeline<T> properties via reflection. The closed generic types' Result / Steps / FinalState properties are intrinsically preserved by the framework / by this class' own usage.")]
     async Task<ProjectionTimelineRaw> IEventStore.RunProjectionByNameAsync(
         string projectionName, object identity, IReadOnlyList<EventRecord> events,
         JsonElement? startingState, CancellationToken ct)
@@ -154,6 +171,8 @@ public partial class DocumentStore
     ///     domain event the aggregator can apply. Returns <c>null</c> when the
     ///     event type isn't registered with the store.
     /// </summary>
+    [RequiresUnreferencedCode("Walks loaded assemblies to resolve eventTypeName → CLR Type and routes through ISerializer.FromJson which is annotated [RequiresUnreferencedCode] for STJ usage.")]
+    [RequiresDynamicCode("ISerializer.FromJson uses STJ which requires runtime code generation for non-source-generated types.")]
     private IEvent? ToDomainEvent(EventRecord record)
     {
         var clrType = ResolveEventClrType(record.EventTypeName);
@@ -185,6 +204,7 @@ public partial class DocumentStore
         return wrapped;
     }
 
+    [RequiresUnreferencedCode("Walks AppDomain.GetAssemblies() + Assembly.GetTypes() to resolve eventTypeName → CLR Type. The trimmer cannot reason about which event types survive; AOT-publishing apps should register event types explicitly via EventGraph.AddEventType or use the source-generated event registry.")]
     private Type? ResolveEventClrType(string eventTypeName)
     {
         // 1. Most common: an event-type alias registered on the EventGraph


### PR DESCRIPTION
Second Polecat AOT-pillar slice (closes #71), mirroring the methodology that landed in [JasperFx #252-#255 + #260](https://github.com/JasperFx/jasperfx/pull/256) + polecat#74.

## Annotated surfaces

| Member | Annotation |
|---|---|
| `RunProjectionForReferenceTypeAsync<TState>` (private) | `[RequiresUnreferencedCode]` + `[RequiresDynamicCode]` — runs the aggregator graph + STJ event deserialize |
| `ToDomainEvent(EventRecord)` (private) | `[RequiresUnreferencedCode]` + `[RequiresDynamicCode]` — resolves CLR type from event name + STJ FromJson |
| `ResolveEventClrType(string eventTypeName)` (private) | `[RequiresUnreferencedCode]` — walks AppDomain assemblies + `Assembly.GetTypes()` |

## Suppressed at explicit interface impls

| Member | Suppressions |
|---|---|
| `IEventStore.RunProjectionAsync<TState>` | IL2091 + IL3050 + IL2075 + IL2026 |
| `IEventStore.RunProjectionByNameAsync` | IL3050 + IL2026 + IL2075 |

### Why suppress instead of annotate

Both methods are explicit interface implementations of `IEventStore` (in JasperFx.Events). Adding `[RequiresUnreferencedCode]` to the impl would generate IL2046 because the interface contract on `IEventStore.RunProjectionAsync` / `RunProjectionByNameAsync` isn't yet annotated. The Events-side annotation is tracked in [jasperfx#262](https://github.com/JasperFx/jasperfx/issues/262); when those interfaces gain `[RequiresUnreferencedCode]` / `[RequiresDynamicCode]`, the Polecat suppressions here can be replaced with matching annotations.

Justifications point at the design intent: projection step-through is a dev-time / diagnostic surface used by CritterWatch + projection replay, not a hot-path runtime API. AOT-publishing apps either avoid the surface entirely or supply a source-generated dispatcher.

## Effect on the punch list

```
ProjectionReplay slice:  48 → 0  (closed)
Polecat total:           422 → 374  (-48)
```

Note the slice grew from the originally-filed 44 to 48 between issue filing and this PR — propagation from polecat#74's Serializer slice surfaced 4 new IL3050 warnings on the `FromJson` call site that this PR also addresses.

## Verification

- `Polecat.csproj` + `Polecat.Tests.csproj` build clean (0 errors)

Closes #71.

🤖 Generated with [Claude Code](https://claude.com/claude-code)