### PR TITLE
Annotate Storage/Registry reflective surface for AOT (closes #73)

### DIFF
--- a/src/Polecat/DocumentStore.EventStoreExplorer.cs
+++ b/src/Polecat/DocumentStore.EventStoreExplorer.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using JasperFx.Descriptors;
@@ -17,6 +18,12 @@ namespace Polecat;
 ///     Implements the eight methods added in JasperFx.Events 1.36 against
 ///     Polecat's pc_streams / pc_events / pc_event_progression tables.
 /// </summary>
+[UnconditionalSuppressMessage("Trimming", "IL2075:DynamicallyAccessedMembers",
+    Justification = "Class-level: RehydrateAtVersionByNameAsync reflects on Task<T>.Result + .State/.Version/.EventsApplied properties of the returned strong-typed result. The framework Task<TResult> intrinsic and the strong-typed result type are preserved by the registered projection boundary.")]
+[UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
+    Justification = "Class-level: invokes ISerializer.ToJson, which is annotated RUC because the default STJ-reflection serializer requires unreferenced code. AOT consumers supply a source-generator-backed ISerializer impl per the AOT publishing guide.")]
+[UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+    Justification = "Class-level: RehydrateAtVersionByNameAsync uses MethodInfo.MakeGenericMethod with the resolved aggregate type — runtime code generation. AOT consumers should prefer the strong-typed RehydrateAtVersionAsync<T> overload (covered by the AOT publishing guide).")]
 public partial class DocumentStore
 {
     async Task<IReadOnlyList<StreamSummary>> IEventStore.GetRecentStreamsAsync(

--- a/src/Polecat/Internal/DocumentProvider.cs
+++ b/src/Polecat/Internal/DocumentProvider.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using JasperFx;
 using Polecat.Internal.Operations;
 using Polecat.Metadata;
@@ -11,6 +12,10 @@ namespace Polecat.Internal;
 ///     Per-document-type factory for storage operations. Caches the DocumentMapping
 ///     and generates SQL operations for a specific type.
 /// </summary>
+[UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
+    Justification = "Class-level: invokes ISerializer.ToJson, which is annotated RUC because the default STJ-reflection serializer requires unreferenced code. AOT consumers supply a source-generator-backed ISerializer impl per the AOT publishing guide.")]
+[UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+    Justification = "Class-level: ISerializer.ToJson is annotated RDC for the same reason as IL2026 above. AOT consumers supply a source-generator-backed ISerializer impl.")]
 internal class DocumentProvider
 {
     public DocumentProvider(DocumentMapping mapping)

--- a/src/Polecat/Internal/DocumentProviderRegistry.cs
+++ b/src/Polecat/Internal/DocumentProviderRegistry.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Polecat.Schema.Identity.Sequences;
 using Polecat.Storage;
@@ -9,6 +10,8 @@ namespace Polecat.Internal;
 ///     Thread-safe registry of DocumentProviders, one per document type.
 ///     Lazily creates mappings and providers on first access.
 /// </summary>
+[UnconditionalSuppressMessage("Trimming", "IL2075:DynamicallyAccessedMembers",
+    Justification = "Class-level: reads SubClasses/Indexes/ForeignKeys non-public fields off DocumentMappingExpression<T> via reflection. The expression type and fields are preserved by the registration boundary (Schema.For<T>()), where T flows in from caller code that trimming sees.")]
 internal class DocumentProviderRegistry
 {
     private readonly ConcurrentDictionary<Type, DocumentProvider> _providers = new();

--- a/src/Polecat/Storage/DocumentMapping.cs
+++ b/src/Polecat/Storage/DocumentMapping.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using JasperFx;
 using JasperFx.Core.Reflection;
@@ -10,6 +11,10 @@ namespace Polecat.Storage;
 /// <summary>
 ///     Discovers and caches metadata about a document type: ID property, table name, ID accessors.
 /// </summary>
+[UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
+    Justification = "Class-level: AddSubClassHierarchy uses Assembly.GetTypes() to discover subclasses; document hierarchies are part of the registered surface and AOT consumers must preserve subclass types via their JsonSerializerContext / per-type registration.")]
+[UnconditionalSuppressMessage("Trimming", "IL2070:DynamicallyAccessedMembers",
+    Justification = "Class-level: reflects PublicProperties on the document Type (FindIdProperty, DiscoverIndexAttributes). The document type is preserved at the registration boundary (Schema.For<T>()), where T flows in from caller code that trimming sees.")]
 internal class DocumentMapping
 {
     private static readonly HashSet<Type> SupportedIdTypes =

--- a/src/Polecat/Storage/DocumentMappingExpression.cs
+++ b/src/Polecat/Storage/DocumentMappingExpression.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 
 namespace Polecat.Storage;
@@ -6,6 +7,8 @@ namespace Polecat.Storage;
 ///     Fluent configuration builder for a document type's mapping.
 ///     Used via StoreOptions.Schema.For&lt;T&gt;().
 /// </summary>
+[UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
+    Justification = "Class-level: AddSubClassHierarchy uses Assembly.GetTypes() to discover subclasses of T. Document hierarchies are part of the registered surface and AOT consumers must preserve subclass types (JsonSerializerContext / per-type registration) per the AOT publishing guide.")]
 public class DocumentMappingExpression<T>
 {
     internal readonly Type DocumentType = typeof(T);


### PR DESCRIPTION
## Summary

Annotate Polecat's document-store core (DocumentMapping, DocumentProviderRegistry, DocumentProvider, DocumentMappingExpression, DocumentStore.EventStoreExplorer) so AOT smoke tests can run under `WarningsAsErrors=IL*`. Slice 4 of the AOT pillar (after #67 base config, #74 serializer, #75 ProjectionReplay, #76 LINQ).

The document type `T` flows in from caller code at the registration boundary (`Schema.For<T>()`), so trimming sees and preserves `T` plus its public surface. AOT consumers must swap in a source-generator-backed `ISerializer` impl and preserve subclass types per the AOT publishing guide.

Applied class-level `[UnconditionalSuppressMessage]`:

- `Storage/DocumentMapping` — IL2026 (`Assembly.GetTypes()` in `AddSubClassHierarchy`), IL2070 (`PublicProperties` discovery for Id / `[Index]` / `[UniqueIndex]`)
- `Storage/DocumentMappingExpression` — IL2026 (`Assembly.GetTypes()` subclass discovery)
- `Internal/DocumentProviderRegistry` — IL2075 (non-public field reflection on `DocumentMappingExpression<T>`)
- `Internal/DocumentProvider` — IL2026/IL3050 (consumer of `ISerializer.ToJson`)
- `DocumentStore.EventStoreExplorer` — IL2026/IL2075/IL3050 (reflective `Task<T>.Result` extraction + `MethodInfo.MakeGenericMethod` for `RehydrateAtVersionByNameAsync`; `ISerializer.ToJson`)

## Warning delta

`Polecat.csproj` IL warnings on this branch: **422 → 336 (-86)**.

Independent of #75 (ProjectionReplay) and #76 (LINQ); when all three land together, total will drop substantially further.

## Test plan

- [x] `dotnet build src/Polecat/Polecat.csproj -c Debug` — no new errors, -86 IL warnings
- [x] `dotnet build src/Polecat.Tests/Polecat.Tests.csproj -c Debug` — green
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)