### PR TITLE
Annotate Patching subsystem for AOT (slice 5)

### DIFF
--- a/src/Polecat/Patching/JsonPathHelper.cs
+++ b/src/Polecat/Patching/JsonPathHelper.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Text.Json;
@@ -8,6 +9,8 @@ namespace Polecat.Patching;
 ///     Extracts JSON paths (e.g., "$.camelCase.path") from lambda expressions,
 ///     using the serializer's JsonNamingPolicy.
 /// </summary>
+[UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+    Justification = "Class-level: builds Expression.Lambda delegates for evaluating constant sub-expressions in patch paths — runtime code generation. The targeted lambdas reference document properties whose owning types are preserved by registration on the caller side.")]
 internal static class JsonPathHelper
 {
     public static string ToPath(Expression expression, JsonNamingPolicy? namingPolicy)

--- a/src/Polecat/Patching/PatchExpression.cs
+++ b/src/Polecat/Patching/PatchExpression.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Polecat.Internal;
 using Polecat.Serialization;
 using System.Linq.Expressions;
@@ -6,6 +7,10 @@ using Weasel.SqlServer;
 
 namespace Polecat.Patching;
 
+[UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
+    Justification = "Class-level: invokes ISerializer.ToJson on patch values whose runtime types are derived from the document's reflected properties. Document type T flows in from the registration boundary (Schema.For<T>()) and is preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed ISerializer impl.")]
+[UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+    Justification = "Class-level: ISerializer.ToJson is annotated RDC for the same reason as IL2026 above. AOT consumers supply a source-generator-backed ISerializer impl.")]
 internal class PatchExpression<T> : IPatchExpression<T>
 {
     private readonly List<Action<ICommandBuilder>> _actions = new();

--- a/src/Polecat/Patching/PatchOperation.cs
+++ b/src/Polecat/Patching/PatchOperation.cs
@@ -1,4 +1,5 @@
 using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
 using Polecat.Internal;
 using Polecat.Serialization;
 using Weasel.Core;
@@ -11,6 +12,10 @@ namespace Polecat.Patching;
 ///     IStorageOperation that generates SQL UPDATE statements using JSON_MODIFY()
 ///     to patch document JSON data in-place.
 /// </summary>
+[UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
+    Justification = "Class-level: serializes patch values via ISerializer.ToJson when building the JSON_MODIFY() command. Document types are preserved at registration; AOT consumers supply a source-generator-backed ISerializer impl per the AOT publishing guide.")]
+[UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+    Justification = "Class-level: ISerializer.ToJson is annotated RDC for the same reason as IL2026 above. AOT consumers supply a source-generator-backed ISerializer impl.")]
 internal class PatchOperation : Polecat.Internal.IStorageOperation
 {
     private readonly DocumentMapping _mapping;


### PR DESCRIPTION
## Summary

Fifth slice in Polecat's AOT-pillar ([jasperfx#213](https://github.com/JasperFx/jasperfx/issues/213)) cleanup, following the Serializer (#74), ProjectionReplay (#75), LINQ (#76), and Storage/Registry (#77) slices already on main.

The patching subsystem reflects on the document's property expressions to build JSON path strings and feeds the resulting patch values through `ISerializer.ToJson` when emitting `JSON_MODIFY()` SQL. `JsonPathHelper` also compiles small `Expression.Lambda` delegates to evaluate constant sub-expressions during path resolution. Document types `T` flow in from `Schema.For<T>()` / `IDocumentSession.Patch<T>()` at the registration boundary and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed `ISerializer` impl.

Applied class-level `[UnconditionalSuppressMessage]`:

| File | Codes |
|---|---|
| `Patching/PatchExpression<T>` | IL2026/IL3050 (`ISerializer.ToJson` on patch values) |
| `Patching/PatchOperation` | IL2026/IL3050 (`ISerializer.ToJson` when building `JSON_MODIFY` commands) |
| `Patching/JsonPathHelper` | IL3050 (`Expression.Lambda` for constant sub-expression evaluation) |

## Warning delta

`Polecat.csproj` IL warnings: **194 → 152 (-42)**.

## Test plan

- [x] `dotnet build src/Polecat/Polecat.csproj -c Debug` — 0 errors, -42 IL warnings
- [x] `dotnet build src/Polecat.Tests/Polecat.Tests.csproj -c Debug` — 0 errors
- [ ] CI passes