### PR TITLE
Annotate operations / sessions / EventGraph for AOT (slice 6)

### DIFF
--- a/src/Polecat/AdvancedOperations.cs
+++ b/src/Polecat/AdvancedOperations.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using JasperFx;
 using Microsoft.Data.SqlClient;
@@ -11,6 +12,10 @@ using Weasel.Core;
 
 namespace Polecat;
 
+[UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
+    Justification = "Class-level: BulkInsertAsync / BulkInsertWithVersionAsync stream documents through ISerializer.ToJson. Document types T flow in from caller code (BulkInsertAsync<T>(docs)) and are preserved per the AOT publishing guide.")]
+[UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+    Justification = "Class-level: ISerializer.ToJson is annotated RDC. AOT consumers supply a source-generator-backed ISerializer impl.")]
 public class AdvancedOperations
 {
     private readonly DocumentStore _store;

--- a/src/Polecat/Events/EventGraph.cs
+++ b/src/Polecat/Events/EventGraph.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using JasperFx.Events;
 using JasperFx.Events.Aggregation;
@@ -15,6 +16,12 @@ namespace Polecat.Events;
 ///     Analogous to Marten's EventGraph. Manages event type registration
 ///     and wrapping of raw event data into IEvent instances.
 /// </summary>
+[UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
+    Justification = "Class-level: extends JasperFx.Events.EventRegistry (annotated RUC) for type-aliased event construction; also wires aggregator sources via reflection. Event types are preserved by registration on the caller side per the AOT publishing guide.")]
+[UnconditionalSuppressMessage("Trimming", "IL2057:UnrecognizedTypeName",
+    Justification = "Class-level: AggregateTypeFor uses Type.GetType(string) as a fallback to resolve aggregate types persisted by .NET type name in event metadata. The aggregate types are preserved by projection registration on the caller side; AOT consumers should register all aggregate types ahead of time per the AOT publishing guide.")]
+[UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+    Justification = "Class-level: aggregator-source factories and event-type registration use Type.MakeGenericType — runtime code generation. AOT consumers register concrete event types ahead of time.")]
 public class EventGraph : EventRegistry, IAggregationSourceFactory<IQuerySession>
 {
     private readonly StoreOptions _options;
@@ -319,6 +326,8 @@ internal class FuncMasker<T> : IMasker where T : notnull
 ///     Metadata and wrapping logic for a single event type.
 ///     Implements IEventType from JasperFx.Events.
 /// </summary>
+[UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+    Justification = "Class-level: Wrap uses Type.MakeGenericType(typeof(Event<>), eventType) to construct Event<T> envelopes — runtime code generation. Event types are preserved by registration on the caller side per the AOT publishing guide.")]
 public class PolecatEventType : IEventType
 {
     private readonly Type _eventType;

--- a/src/Polecat/Events/EventOperations.cs
+++ b/src/Polecat/Events/EventOperations.cs
@@ -1,4 +1,5 @@
 using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Text;
@@ -22,6 +23,12 @@ namespace Polecat.Events;
 ///     Per-session event operations. Wraps raw events and queues StreamActions
 ///     in the session's WorkTracker for execution on SaveChangesAsync.
 /// </summary>
+[UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
+    Justification = "Class-level: bridges into JasperFx.Events aggregator/projection infrastructure and the Polecat serializer for event payload (de)serialization. Event and aggregate types are preserved at the EventGraph / projection-registration boundary on the caller side per the AOT publishing guide.")]
+[UnconditionalSuppressMessage("Trimming", "IL2090:DynamicallyAccessedMembers",
+    Justification = "Class-level: FindNaturalKeyDefinition<T> reflects PublicProperties on aggregate type T. T flows in from the natural-key-aware Append API on the caller side and is preserved by projection registration.")]
+[UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+    Justification = "Class-level: routes through JasperFx.Events generic factories and serializer paths that require runtime code generation. AOT consumers register concrete event types and supply a source-generator-backed ISerializer impl.")]
 internal class EventOperations : QueryEventStore, IEventOperations
 {
     private readonly DocumentSessionBase _sessionBase;

--- a/src/Polecat/Internal/DocumentSessionBase.cs
+++ b/src/Polecat/Internal/DocumentSessionBase.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using JasperFx;
 using JasperFx.Events;
@@ -22,6 +23,10 @@ namespace Polecat.Internal;
 ///     processing, and SaveChangesAsync. Uses IAlwaysConnectedLifetime for
 ///     persistent connection + transaction management.
 /// </summary>
+[UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
+    Justification = "Class-level: store/update/delete operations call into ISerializer.ToJson and JasperFx.Events projection infrastructure. Document and event types flow in from caller registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed ISerializer impl.")]
+[UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+    Justification = "Class-level: ISerializer.ToJson and inline projection runners use Type.MakeGenericType / FastExpressionCompiler — runtime code generation. AOT consumers rely on source-generated event/projection helpers.")]
 internal abstract class DocumentSessionBase : QuerySession, IDocumentSession
 {
     private readonly WorkTracker _workTracker = new();

--- a/src/Polecat/Internal/QuerySession.cs
+++ b/src/Polecat/Internal/QuerySession.cs
@@ -1,4 +1,5 @@
 using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
 using JasperFx;
 using Microsoft.Data.SqlClient;
 using Polly;
@@ -17,6 +18,10 @@ namespace Polecat.Internal;
 ///     Read-only query session. All SQL execution flows through Polly-wrapped
 ///     centralized methods backed by IConnectionLifetime.
 /// </summary>
+[UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
+    Justification = "Class-level (all partials): routes load/query operations through ISerializer.FromJson and per-document DocumentProvider reflection. Document types T flow in from caller registration (Schema.For<T>() / session.Load<T>) and are preserved per the AOT publishing guide.")]
+[UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+    Justification = "Class-level (all partials): ISerializer.FromJson is annotated RDC; AOT consumers supply a source-generator-backed ISerializer impl.")]
 internal partial class QuerySession : IQuerySession
 {
     internal readonly IConnectionLifetime _lifetime;


### PR DESCRIPTION
## Summary

Sixth slice in Polecat's AOT-pillar ([jasperfx#213](https://github.com/JasperFx/jasperfx/issues/213)) cleanup, following the Patching slice (#79).

The session + event-operations layer threads document and event types through `ISerializer` (`ToJson`/`FromJson`), the JasperFx.Events event-registry infrastructure (`Event<T>.MakeGenericType` + aggregator-source factories), and JasperFx natural-key reflection. Document and event types are preserved by registration on the caller side (`Schema.For<T>()` / `StoreOptions.Events.AddEventType` / projection registration) per the AOT publishing guide. AOT consumers supply a source-generator-backed `ISerializer` impl.

Applied class-level `[UnconditionalSuppressMessage]`:

| File | Codes |
|---|---|
| `Events/EventOperations` | IL2026/IL2090/IL3050 (serializer + JasperFx.Events generic factories + `FindNaturalKeyDefinition<T>` property reflection) |
| `Internal/QuerySession` (all partials) | IL2026/IL3050 (load/query through `ISerializer.FromJson`) |
| `Internal/DocumentSessionBase` | IL2026/IL3050 (store/update/delete through `ISerializer.ToJson` + inline projection runners) |
| `AdvancedOperations` | IL2026/IL3050 (`BulkInsertAsync` / `BulkInsertWithVersionAsync` via `ISerializer.ToJson`) |
| `Events/EventGraph` | IL2026/IL2057/IL3050 (`EventRegistry` extension, dynamic aggregate-type resolution by .NET type name as a fallback, `Type.MakeGenericType` for aggregator-source factories) |
| `Events/EventGraph.PolecatEventType` | IL3050 (`Wrap` uses `Event<T>.MakeGenericType` for envelope construction) |

## Warning delta

\`Polecat.csproj\` IL warnings on this branch: **194 → 88 (-106 cumulative with #79's -42; this slice alone -64)**.

## Test plan

- [x] \`dotnet build src/Polecat/Polecat.csproj -c Debug\` — 0 errors
- [x] \`dotnet build src/Polecat.Tests/Polecat.Tests.csproj -c Debug\` — 0 errors
- [ ] CI passes

Stacks on #79 (Patching slice).