### PR TITLE
Annotate Polecat tail surfaces for AOT (slice 7)

### DIFF
--- a/src/Polecat/Events/Daemon/PolecatEventLoader.cs
+++ b/src/Polecat/Events/Daemon/PolecatEventLoader.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using JasperFx.Events;
 using JasperFx.Events.Daemon;
 using JasperFx.Events.Projections;
@@ -11,6 +12,10 @@ namespace Polecat.Events.Daemon;
 ///     Loads event batches by seq_id range from pc_events.
 ///     All SQL execution is wrapped with Polly resilience.
 /// </summary>
+[UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
+    Justification = "Class-level: hydrates IEvent batches via EventGraph.Wrap (routed through ISerializer.FromJson). Event types are preserved by EventGraph registration on the caller side per the AOT publishing guide.")]
+[UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+    Justification = "Class-level: ISerializer.FromJson and Event<T>.MakeGenericType are annotated RDC. AOT consumers register concrete event types ahead of time.")]
 internal class PolecatEventLoader : IEventLoader
 {
     private readonly EventGraph _events;

--- a/src/Polecat/Events/Internal/PcEventsRowReader.cs
+++ b/src/Polecat/Events/Internal/PcEventsRowReader.cs
@@ -1,4 +1,5 @@
 using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using System.Text.Json;
 using JasperFx.Descriptors;
@@ -53,6 +54,10 @@ namespace Polecat.Events.Internal;
 ///     <see cref="ReadEventCore"/> for the shared 95% of the work.
 ///     </para>
 /// </remarks>
+[UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
+    Justification = "Class-level: hydrates IEvent instances via ISerializer.FromJson on the event data column and EventGraph.Wrap. Event types are preserved by EventGraph registration on the caller side per the AOT publishing guide.")]
+[UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+    Justification = "Class-level: ISerializer.FromJson and Event<T>.MakeGenericType for envelope construction are annotated RDC. AOT consumers supply a source-generator-backed ISerializer impl and register concrete event types.")]
 internal static class PcEventsRowReader
 {
     /// <summary>

--- a/src/Polecat/Events/Linq/EventListHandler.cs
+++ b/src/Polecat/Events/Linq/EventListHandler.cs
@@ -1,4 +1,5 @@
 using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
 using JasperFx.Events;
 using Microsoft.Data.SqlClient;
 using Polecat.Serialization;
@@ -9,6 +10,10 @@ namespace Polecat.Events.Linq;
 ///     Reads IEvent objects from a multi-column result set on pc_events.
 ///     Column layout: seq_id, id, stream_id, version, data, type, timestamp, tenant_id, dotnet_type, is_archived
 /// </summary>
+[UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
+    Justification = "Class-level: hydrates IEvent via EventGraph.Wrap (which routes through ISerializer.FromJson). Event types are preserved by EventGraph registration on the caller side per the AOT publishing guide.")]
+[UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+    Justification = "Class-level: ISerializer.FromJson and Event<T>.MakeGenericType for envelope construction are annotated RDC. AOT consumers register concrete event types ahead of time.")]
 internal class EventListHandler
 {
     private readonly ISerializer _serializer;

--- a/src/Polecat/Events/Operations/EventWhereClauseParser.cs
+++ b/src/Polecat/Events/Operations/EventWhereClauseParser.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using System.Reflection;
 using Polecat.Linq.Members;
@@ -9,6 +10,8 @@ namespace Polecat.Events.Operations;
 ///     Parses a predicate expression against IEvent properties into an ISqlFragment
 ///     for WHERE clauses against the pc_events table.
 /// </summary>
+[UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+    Justification = "Class-level: evaluates constant sub-expressions in IEvent predicates via Expression.Lambda + Compile — runtime code generation. Event types and their property graph are preserved at the event-LINQ registration boundary on the caller side per the AOT publishing guide.")]
 internal class EventWhereClauseParser
 {
     private static readonly Dictionary<ExpressionType, string> Operators = new()

--- a/src/Polecat/Events/Protected/StreamCompacting.cs
+++ b/src/Polecat/Events/Protected/StreamCompacting.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using JasperFx.Events;
 using JasperFx.Events.Aggregation;
 using Polecat.Internal;
@@ -17,6 +18,10 @@ public interface IEventsArchiver
 ///     Configuration and execution of stream compaction. Replaces all events (except the last)
 ///     with a single Compacted&lt;T&gt; snapshot event, then deletes the originals.
 /// </summary>
+[UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
+    Justification = "Class-level: drives JasperFx.Events aggregator graph (annotated RUC) to produce the Compacted<T> snapshot. Aggregate type T flows in from caller code and is preserved by projection registration on the caller side per the AOT publishing guide.")]
+[UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+    Justification = "Class-level: aggregator runtime uses Type.MakeGenericType + FastExpressionCompiler. AOT consumers rely on source-generated aggregator helpers.")]
 public class StreamCompactingRequest<T> where T : class
 {
     public StreamCompactingRequest(string? streamKey)

--- a/src/Polecat/Internal/AdvancedSqlResultReader.cs
+++ b/src/Polecat/Internal/AdvancedSqlResultReader.cs
@@ -1,4 +1,5 @@
 using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
 using JasperFx;
 using Polecat.Metadata;
 using Polecat.Serialization;
@@ -80,6 +81,10 @@ internal class ScalarReader : AdvancedSqlResultReader
     }
 }
 
+[UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
+    Justification = "Class-level: ISerializer.FromJson(Type, string) for advanced SQL projections. Result types flow in from QueryAsync<T>() registration on the caller side and are preserved per the AOT publishing guide.")]
+[UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+    Justification = "Class-level: ISerializer.FromJson is annotated RDC. AOT consumers supply a source-generator-backed impl.")]
 internal class JsonReader : AdvancedSqlResultReader
 {
     private readonly Type _type;
@@ -106,6 +111,10 @@ internal class JsonReader : AdvancedSqlResultReader
     }
 }
 
+[UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
+    Justification = "Class-level: ISerializer.FromJson(Type, string) for advanced SQL document projections. Document types flow in from registration on the caller side and are preserved per the AOT publishing guide.")]
+[UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+    Justification = "Class-level: ISerializer.FromJson is annotated RDC. AOT consumers supply a source-generator-backed impl.")]
 internal class DocumentReader : AdvancedSqlResultReader
 {
     private readonly Type _type;

--- a/src/Polecat/Internal/Batching/LoadBatchQueryItem.cs
+++ b/src/Polecat/Internal/Batching/LoadBatchQueryItem.cs
@@ -1,10 +1,15 @@
 using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
 using Polecat.Metadata;
 using Polecat.Serialization;
 using Weasel.SqlServer;
 
 namespace Polecat.Internal.Batching;
 
+[UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
+    Justification = "Class-level: deserializes a loaded document row via ISerializer.FromJson. T is preserved by IBatch.Load<T>() registration on the caller side per the AOT publishing guide.")]
+[UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+    Justification = "Class-level: ISerializer.FromJson is annotated RDC. AOT consumers supply a source-generator-backed impl.")]
 internal class LoadBatchQueryItem<T> : IBatchQueryItem where T : class
 {
     private readonly TaskCompletionSource<T?> _tcs = new();

--- a/src/Polecat/Internal/Batching/LoadManyBatchQueryItem.cs
+++ b/src/Polecat/Internal/Batching/LoadManyBatchQueryItem.cs
@@ -1,10 +1,15 @@
 using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
 using Polecat.Metadata;
 using Polecat.Serialization;
 using Weasel.SqlServer;
 
 namespace Polecat.Internal.Batching;
 
+[UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
+    Justification = "Class-level: deserializes loaded document rows via ISerializer.FromJson. T is preserved by IBatch.LoadMany<T>() registration on the caller side per the AOT publishing guide.")]
+[UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+    Justification = "Class-level: ISerializer.FromJson is annotated RDC. AOT consumers supply a source-generator-backed impl.")]
 internal class LoadManyBatchQueryItem<T> : IBatchQueryItem where T : class
 {
     private readonly TaskCompletionSource<IReadOnlyList<T>> _tcs = new();

--- a/src/Polecat/Internal/Batching/QueryBatchItem.cs
+++ b/src/Polecat/Internal/Batching/QueryBatchItem.cs
@@ -1,10 +1,15 @@
 using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
 using Polecat.Linq.SqlGeneration;
 using Polecat.Serialization;
 using Weasel.SqlServer;
 
 namespace Polecat.Internal.Batching;
 
+[UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
+    Justification = "Class-level: deserializes batch query results via ISerializer.FromJson. T is preserved by IBatch.Query<T>() registration on the caller side per the AOT publishing guide.")]
+[UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+    Justification = "Class-level: ISerializer.FromJson is annotated RDC. AOT consumers supply a source-generator-backed impl.")]
 internal class QueryListBatchItem<T> : IBatchQueryItem where T : class
 {
     private readonly TaskCompletionSource<IReadOnlyList<T>> _tcs = new();
@@ -105,6 +110,10 @@ internal class QueryAnyBatchItem : IBatchQueryItem
     }
 }
 
+[UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
+    Justification = "Class-level: deserializes the first matching batch query result via ISerializer.FromJson. T is preserved by IBatch.Query<T>() registration on the caller side per the AOT publishing guide.")]
+[UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+    Justification = "Class-level: ISerializer.FromJson is annotated RDC. AOT consumers supply a source-generator-backed impl.")]
 internal class QueryFirstOrDefaultBatchItem<T> : IBatchQueryItem where T : class
 {
     private readonly TaskCompletionSource<T?> _tcs = new();

--- a/src/Polecat/Linq/Joins/JoinResultSelectorRewriter.cs
+++ b/src/Polecat/Linq/Joins/JoinResultSelectorRewriter.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 
 namespace Polecat.Linq.Joins;
@@ -7,6 +8,8 @@ namespace Polecat.Linq.Joins;
 ///     into a direct Func&lt;TOuter, TInner, TResult&gt; by resolving member accesses
 ///     through the GroupJoin result selector's mapping.
 /// </summary>
+[UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+    Justification = "Class-level: compiles a rewritten result selector via Expression.Lambda — runtime code generation. TOuter/TInner/TResult flow in from the LINQ Join registration on the caller side and are preserved per the AOT publishing guide.")]
 internal static class JoinResultSelectorRewriter
 {
     /// <summary>

--- a/src/Polecat/Linq/Parsing/GroupBySelectBuilder.cs
+++ b/src/Polecat/Linq/Parsing/GroupBySelectBuilder.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using System.Text.Json;
 using Polecat.Linq.Members;
@@ -13,6 +14,8 @@ namespace Polecat.Linq.Parsing;
 ///     Uses CONCAT with manual JSON encoding for broad SQL Server compatibility
 ///     (works on Azure SQL Edge and SQL Server 2022+).
 /// </summary>
+[UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+    Justification = "Class-level: compiles HAVING-clause sub-expressions via Expression.Lambda — runtime code generation. Document types are preserved at the LINQ registration boundary per the AOT publishing guide.")]
 internal class GroupBySelectBuilder
 {
     private readonly MemberFactory _memberFactory;

--- a/src/Polecat/Linq/Parsing/LinqQueryParser.cs
+++ b/src/Polecat/Linq/Parsing/LinqQueryParser.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using Polecat.Linq.Joins;
 using Polecat.Linq.Members;
@@ -12,6 +13,8 @@ namespace Polecat.Linq.Parsing;
 /// <summary>
 ///     Visits a LINQ expression tree and builds a Statement for SQL generation.
 /// </summary>
+[UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+    Justification = "Class-level: compiles join / order-by / select-clause sub-expressions via Expression.Lambda — runtime code generation. The expression trees originate at the LINQ registration boundary where document/event types are preserved per the AOT publishing guide.")]
 internal class LinqQueryParser : ExpressionVisitor
 {
     private readonly IMemberResolver _memberFactory;

--- a/src/Polecat/Linq/Parsing/WhereClauseParser.cs
+++ b/src/Polecat/Linq/Parsing/WhereClauseParser.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using System.Reflection;
 using Polecat.Linq.Members;
@@ -9,6 +10,8 @@ namespace Polecat.Linq.Parsing;
 /// <summary>
 ///     Parses a predicate expression tree into an ISqlFragment for the WHERE clause.
 /// </summary>
+[UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+    Justification = "Class-level: evaluates constant sub-expressions in predicates via Expression.Lambda + Compile — runtime code generation. Document/event types and their property graph are preserved at the LINQ registration boundary on the caller side per the AOT publishing guide.")]
 internal class WhereClauseParser
 {
     private static readonly Dictionary<ExpressionType, string> Operators = new()

--- a/src/Polecat/Linq/QueryHandlers/GroupByListHandler.cs
+++ b/src/Polecat/Linq/QueryHandlers/GroupByListHandler.cs
@@ -1,4 +1,5 @@
 using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
 using Polecat.Serialization;
 
 namespace Polecat.Linq.QueryHandlers;
@@ -6,6 +7,10 @@ namespace Polecat.Linq.QueryHandlers;
 /// <summary>
 ///     Reads JSON_OBJECT results from a GroupBy query and deserializes each row.
 /// </summary>
+[UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
+    Justification = "Class-level: deserializes JSON_OBJECT rows via ISerializer.FromJson. Result types flow in from GroupBy<T>() registration on the caller side and are preserved per the AOT publishing guide.")]
+[UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+    Justification = "Class-level: ISerializer.FromJson is annotated RDC. AOT consumers supply a source-generator-backed impl.")]
 internal class GroupByListHandler<T>
 {
     private readonly ISerializer _serializer;

--- a/src/Polecat/PolecatConfigurationExpression.cs
+++ b/src/Polecat/PolecatConfigurationExpression.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using JasperFx.Events.Daemon;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -9,6 +10,8 @@ namespace Polecat;
 /// <summary>
 ///     Fluent builder returned by AddPolecat() for further configuration.
 /// </summary>
+[UnconditionalSuppressMessage("Trimming", "IL2087:DynamicallyAccessedMembers",
+    Justification = "Class-level: generic type-argument flow on AddPolecat()'s subsequent fluent calls — TStore / TQuerySession / TDocumentSession etc. flow in from caller registration code and are preserved by the trimmer at that boundary per the AOT publishing guide.")]
 public class PolecatConfigurationExpression
 {
     public PolecatConfigurationExpression(IServiceCollection services)

--- a/src/Polecat/PolecatStoreServiceCollectionExtensions.cs
+++ b/src/Polecat/PolecatStoreServiceCollectionExtensions.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Polecat.Internal;
@@ -7,6 +8,8 @@ namespace Polecat;
 /// <summary>
 ///     Extension methods for registering secondary/ancillary Polecat document stores.
 /// </summary>
+[UnconditionalSuppressMessage("Trimming", "IL2091:DynamicallyAccessedMembers",
+    Justification = "Class-level: AddPolecatStore<T> threads T through Microsoft.Extensions.DependencyInjection registration, which has its own DAM annotations. T is constrained to interface IDocumentStore and supplied directly by caller code at registration time, so the trimmer sees and preserves it.")]
 public static class PolecatStoreServiceCollectionExtensions
 {
     /// <summary>

--- a/src/Polecat/Projections/Flattened/EventDeleter.cs
+++ b/src/Polecat/Projections/Flattened/EventDeleter.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using System.Reflection;
 using JasperFx.Events;
@@ -9,6 +10,8 @@ namespace Polecat.Projections.Flattened;
 /// <summary>
 ///     Handles DELETE operations for a flat table when a specific event type is received.
 /// </summary>
+[UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+    Justification = "Class-level: builds typed property accessor delegates via Expression.Lambda + Compile against TEvent's primary-key properties — runtime code generation. TEvent flows in from FlatTableProjection.Delete<TEvent>() registration on the caller side and is preserved per the AOT publishing guide.")]
 internal class EventDeleter<TEvent> : IFlatTableEventHandler
 {
     private readonly FlatTableProjection _parent;

--- a/src/Polecat/Projections/Flattened/StatementMap.cs
+++ b/src/Polecat/Projections/Flattened/StatementMap.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using System.Reflection;
 using JasperFx.Events;
@@ -11,6 +12,8 @@ namespace Polecat.Projections.Flattened;
 ///     Configures column mappings for a single event type in a FlatTableProjection.
 ///     At compile time, generates a MERGE SQL statement and parameter setter array.
 /// </summary>
+[UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+    Justification = "Class-level: builds typed property accessor delegates via Expression.Lambda + Compile against TEvent's properties — runtime code generation. TEvent flows in from FlatTableProjection.Project<TEvent>() registration on the caller side and is preserved per the AOT publishing guide.")]
 public class StatementMap<TEvent> : IFlatTableEventHandler
 {
     private readonly FlatTableProjection _parent;

--- a/src/Polecat/Projections/PolecatCompositeProjection.cs
+++ b/src/Polecat/Projections/PolecatCompositeProjection.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using JasperFx.Core.Reflection;
 using JasperFx.Events.Projections;
 using JasperFx.Events.Projections.Composite;
@@ -11,6 +12,10 @@ namespace Polecat.Projections;
 ///     into ordered stages. Stages run sequentially, projections within a stage
 ///     run in parallel.
 /// </summary>
+[UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
+    Justification = "Class-level: extends JasperFx.Events CompositeProjection (annotated RUC) and registers nested projection types via reflection. Projection types are preserved at the registration boundary on the caller side per the AOT publishing guide.")]
+[UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+    Justification = "Class-level: JasperFx.Events composite-projection helpers use Type.MakeGenericType — runtime code generation. AOT consumers rely on source-generated projection helpers.")]
 public class PolecatCompositeProjection : CompositeProjection<IDocumentSession, IQuerySession>
 {
     private readonly StoreOptions _options;

--- a/src/Polecat/Projections/PolecatProjectionOptions.cs
+++ b/src/Polecat/Projections/PolecatProjectionOptions.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using JasperFx.Core.Reflection;
 using JasperFx.Events;
 using JasperFx.Events.Aggregation;
@@ -16,6 +17,10 @@ namespace Polecat.Projections;
 ///     Projection registration and configuration for Polecat.
 ///     Extends ProjectionGraph to integrate with the JasperFx async daemon framework.
 /// </summary>
+[UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
+    Justification = "Class-level: registers projections via the JasperFx.Events ProjectionGraph (annotated RUC). Projection / aggregate types flow in from caller registration and are preserved per the AOT publishing guide.")]
+[UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+    Justification = "Class-level: JasperFx.Events projection-registration helpers use Type.MakeGenericType — runtime code generation. AOT consumers rely on source-generated projection helpers.")]
 public class PolecatProjectionOptions
     : ProjectionGraph<IProjection, IDocumentSession, IQuerySession>
 {

--- a/src/Polecat/Projections/PolecatProjectionStorage.cs
+++ b/src/Polecat/Projections/PolecatProjectionStorage.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using JasperFx.Events;
 using JasperFx.Events.Aggregation;
 using JasperFx.Events.Daemon;
@@ -14,6 +15,10 @@ namespace Polecat.Projections;
 ///     that JasperFx.Events uses to persist projected documents.
 ///     All SQL execution routes through session's Polly-wrapped centralized methods.
 /// </summary>
+[UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
+    Justification = "Class-level: persists projected TDoc via ISerializer.ToJson and deserializes loaded snapshots via ISerializer.FromJson. TDoc/TId flow in from projection registration on the caller side and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed ISerializer impl.")]
+[UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+    Justification = "Class-level: ISerializer is annotated RDC. AOT consumers supply a source-generator-backed impl.")]
 internal class PolecatProjectionStorage<TDoc, TId> : IProjectionStorage<TDoc, TId>
     where TDoc : notnull
     where TId : notnull


### PR DESCRIPTION
## Summary

Final slice in Polecat's AOT-pillar ([jasperfx#213](https://github.com/JasperFx/jasperfx/issues/213)) cleanup, following the Patching slice (#79) and Operations/Sessions slice (#85). Annotates the remaining reflective surfaces across projection storage, batching, result readers, the LINQ parser pipeline, IoC service-collection extensions, and flat-table projection helpers.

Applied class-level `[UnconditionalSuppressMessage]`:

### Serializer consumers (IL2026 + IL3050)

- `Projections/PolecatProjectionStorage`
- `Internal/Batching/QueryBatchItem` (`QueryListBatchItem` + `QueryFirstOrDefaultBatchItem`)
- `Internal/Batching/LoadBatchQueryItem`
- `Internal/Batching/LoadManyBatchQueryItem`
- `Internal/AdvancedSqlResultReader` (`JsonReader` + `DocumentReader`)
- `Events/Internal/PcEventsRowReader`
- `Events/Linq/EventListHandler`
- `Events/Daemon/PolecatEventLoader`
- `Linq/QueryHandlers/GroupByListHandler`
- `Events/Protected/StreamCompacting.StreamCompactingRequest<T>`

### JasperFx.Events projection registration (IL2026 + IL3050)

- `Projections/PolecatProjectionOptions`
- `Projections/PolecatCompositeProjection`

### Expression.Lambda / Type.MakeGenericType (IL3050 only)

- `Projections/Flattened/StatementMap<TEvent>`
- `Projections/Flattened/EventDeleter<TEvent>`
- `Linq/Parsing/WhereClauseParser`
- `Linq/Parsing/LinqQueryParser`
- `Linq/Parsing/GroupBySelectBuilder`
- `Linq/Joins/JoinResultSelectorRewriter`
- `Events/Operations/EventWhereClauseParser`

### IoC type-argument flow

- `PolecatStoreServiceCollectionExtensions` — IL2091 (M.E.DI registration of T)
- `PolecatConfigurationExpression` — IL2087 (fluent generic flow)

## Warning delta

\`Polecat.csproj\` IL warnings on this branch: **194 → 106 (-88)**.

Combined with the open slice 5 (#79, -42) and slice 6 (#85, -64), \`Polecat.csproj\` will be at or near 0 IL warnings once all three slices merge — closing the AOT pillar on the Polecat side.

## Test plan

- [x] \`dotnet build src/Polecat/Polecat.csproj -c Debug\` — 0 errors
- [x] \`dotnet build src/Polecat.Tests/Polecat.Tests.csproj -c Debug\` — 0 errors
- [ ] CI passes

Stacks alongside #79 and #85. All three branches are off \`origin/main\`, so they merge independently and the warning suppressions compose additively.