### PR TITLE
Consume JFx.Events 2.0 lifted contracts (dedupe pillar, polecat#46)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,8 +5,8 @@
 
     <ItemGroup>
         <!-- Core dependencies -->
-        <PackageVersion Include="JasperFx" Version="2.0.0-alpha.11" />
-        <PackageVersion Include="JasperFx.Events" Version="2.0.0-alpha.4" />
+        <PackageVersion Include="JasperFx" Version="2.0.0-alpha.12" />
+        <PackageVersion Include="JasperFx.Events" Version="2.0.0-alpha.5" />
         <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,7 @@
     <ItemGroup>
         <!-- Core dependencies -->
         <PackageVersion Include="JasperFx" Version="2.0.0-alpha.12" />
-        <PackageVersion Include="JasperFx.Events" Version="2.0.0-alpha.5" />
+        <PackageVersion Include="JasperFx.Events" Version="2.0.0-alpha.6" />
         <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />

--- a/src/Polecat/Events/EventOperations.cs
+++ b/src/Polecat/Events/EventOperations.cs
@@ -223,43 +223,43 @@ internal class EventOperations : QueryEventStore, IEventOperations
         => StartStream(aggregateType, events.ToArray());
 
     public async Task<IEventStream<T>> FetchForWriting<T>(Guid id, CancellationToken cancellation = default)
-        where T : class, new()
+        where T : class
     {
         return await FetchForWritingInternal<T>(id, false, null, cancellation);
     }
 
     public async Task<IEventStream<T>> FetchForWriting<T>(string key, CancellationToken cancellation = default)
-        where T : class, new()
+        where T : class
     {
         return await FetchForWritingInternal<T>(key, false, null, cancellation);
     }
 
     public async Task<IEventStream<T>> FetchForWriting<T>(Guid id, long expectedVersion, CancellationToken cancellation = default)
-        where T : class, new()
+        where T : class
     {
         return await FetchForWritingInternal<T>(id, false, expectedVersion, cancellation);
     }
 
     public async Task<IEventStream<T>> FetchForWriting<T>(string key, long expectedVersion, CancellationToken cancellation = default)
-        where T : class, new()
+        where T : class
     {
         return await FetchForWritingInternal<T>(key, false, expectedVersion, cancellation);
     }
 
     public async Task<IEventStream<T>> FetchForExclusiveWriting<T>(Guid id, CancellationToken cancellation = default)
-        where T : class, new()
+        where T : class
     {
         return await FetchForWritingInternal<T>(id, true, null, cancellation);
     }
 
     public async Task<IEventStream<T>> FetchForExclusiveWriting<T>(string key, CancellationToken cancellation = default)
-        where T : class, new()
+        where T : class
     {
         return await FetchForWritingInternal<T>(key, true, null, cancellation);
     }
 
     public async ValueTask<T?> ProjectLatest<T>(Guid id, CancellationToken cancellation = default)
-        where T : class, new()
+        where T : class
     {
         var snapshot = await _sessionBase.Events.FetchLatest<T>(id, cancellation);
 
@@ -273,7 +273,7 @@ internal class EventOperations : QueryEventStore, IEventOperations
     }
 
     public async ValueTask<T?> ProjectLatest<T>(string key, CancellationToken cancellation = default)
-        where T : class, new()
+        where T : class
     {
         var snapshot = await _sessionBase.Events.FetchLatest<T>(key, cancellation);
 
@@ -287,7 +287,7 @@ internal class EventOperations : QueryEventStore, IEventOperations
     }
 
     public async Task WriteToAggregate<T>(Guid id, Action<IEventStream<T>> writing, CancellationToken cancellation = default)
-        where T : class, new()
+        where T : class
     {
         var stream = await FetchForWriting<T>(id, cancellation);
         writing(stream);
@@ -295,7 +295,7 @@ internal class EventOperations : QueryEventStore, IEventOperations
     }
 
     public async Task WriteToAggregate<T>(string key, Action<IEventStream<T>> writing, CancellationToken cancellation = default)
-        where T : class, new()
+        where T : class
     {
         var stream = await FetchForWriting<T>(key, cancellation);
         writing(stream);
@@ -303,7 +303,7 @@ internal class EventOperations : QueryEventStore, IEventOperations
     }
 
     public async Task WriteToAggregate<T>(Guid id, Func<IEventStream<T>, Task> writing, CancellationToken cancellation = default)
-        where T : class, new()
+        where T : class
     {
         var stream = await FetchForWriting<T>(id, cancellation);
         await writing(stream);
@@ -311,7 +311,7 @@ internal class EventOperations : QueryEventStore, IEventOperations
     }
 
     public async Task WriteToAggregate<T>(string key, Func<IEventStream<T>, Task> writing, CancellationToken cancellation = default)
-        where T : class, new()
+        where T : class
     {
         var stream = await FetchForWriting<T>(key, cancellation);
         await writing(stream);
@@ -319,7 +319,7 @@ internal class EventOperations : QueryEventStore, IEventOperations
     }
 
     public async Task WriteToAggregate<T>(Guid id, int initialVersion, Action<IEventStream<T>> writing, CancellationToken cancellation = default)
-        where T : class, new()
+        where T : class
     {
         var stream = await FetchForWriting<T>(id, initialVersion, cancellation);
         writing(stream);
@@ -327,7 +327,7 @@ internal class EventOperations : QueryEventStore, IEventOperations
     }
 
     public async Task WriteToAggregate<T>(Guid id, int initialVersion, Func<IEventStream<T>, Task> writing, CancellationToken cancellation = default)
-        where T : class, new()
+        where T : class
     {
         var stream = await FetchForWriting<T>(id, initialVersion, cancellation);
         await writing(stream);
@@ -335,7 +335,7 @@ internal class EventOperations : QueryEventStore, IEventOperations
     }
 
     public async Task WriteToAggregate<T>(string key, int initialVersion, Action<IEventStream<T>> writing, CancellationToken cancellation = default)
-        where T : class, new()
+        where T : class
     {
         var stream = await FetchForWriting<T>(key, initialVersion, cancellation);
         writing(stream);
@@ -343,7 +343,7 @@ internal class EventOperations : QueryEventStore, IEventOperations
     }
 
     public async Task WriteToAggregate<T>(string key, int initialVersion, Func<IEventStream<T>, Task> writing, CancellationToken cancellation = default)
-        where T : class, new()
+        where T : class
     {
         var stream = await FetchForWriting<T>(key, initialVersion, cancellation);
         await writing(stream);
@@ -351,7 +351,7 @@ internal class EventOperations : QueryEventStore, IEventOperations
     }
 
     public async Task WriteExclusivelyToAggregate<T>(Guid id, Action<IEventStream<T>> writing, CancellationToken cancellation = default)
-        where T : class, new()
+        where T : class
     {
         var stream = await FetchForExclusiveWriting<T>(id, cancellation);
         writing(stream);
@@ -359,7 +359,7 @@ internal class EventOperations : QueryEventStore, IEventOperations
     }
 
     public async Task WriteExclusivelyToAggregate<T>(string key, Action<IEventStream<T>> writing, CancellationToken cancellation = default)
-        where T : class, new()
+        where T : class
     {
         var stream = await FetchForExclusiveWriting<T>(key, cancellation);
         writing(stream);
@@ -367,7 +367,7 @@ internal class EventOperations : QueryEventStore, IEventOperations
     }
 
     public async Task WriteExclusivelyToAggregate<T>(Guid id, Func<IEventStream<T>, Task> writing, CancellationToken cancellation = default)
-        where T : class, new()
+        where T : class
     {
         var stream = await FetchForExclusiveWriting<T>(id, cancellation);
         await writing(stream);
@@ -375,7 +375,7 @@ internal class EventOperations : QueryEventStore, IEventOperations
     }
 
     public async Task WriteExclusivelyToAggregate<T>(string key, Func<IEventStream<T>, Task> writing, CancellationToken cancellation = default)
-        where T : class, new()
+        where T : class
     {
         var stream = await FetchForExclusiveWriting<T>(key, cancellation);
         await writing(stream);
@@ -533,7 +533,7 @@ internal class EventOperations : QueryEventStore, IEventOperations
     }
 
     private async Task<IEventStream<T>> FetchForWritingInternal<T>(object streamId, bool forExclusive,
-        long? expectedVersion, CancellationToken cancellation) where T : class, new()
+        long? expectedVersion, CancellationToken cancellation) where T : class
     {
         if (forExclusive)
         {
@@ -654,7 +654,7 @@ internal class EventOperations : QueryEventStore, IEventOperations
     }
 
     public async Task<IEventStream<T>> FetchForWriting<T, TId>(TId id, CancellationToken cancellation = default)
-        where T : class, new() where TId : notnull
+        where T : class where TId : notnull
     {
         var naturalKey = FindNaturalKeyDefinition<T>();
         return await NaturalKeyFetchPlanner.FetchForWritingByNaturalKey<T, TId>(
@@ -662,7 +662,7 @@ internal class EventOperations : QueryEventStore, IEventOperations
     }
 
     public async Task<IEventStream<T>> FetchForExclusiveWriting<T, TId>(TId id, CancellationToken cancellation = default)
-        where T : class, new() where TId : notnull
+        where T : class where TId : notnull
     {
         // FetchForWritingByNaturalKey already uses UPDLOCK, HOLDLOCK for exclusive locking
         var naturalKey = FindNaturalKeyDefinition<T>();
@@ -671,7 +671,7 @@ internal class EventOperations : QueryEventStore, IEventOperations
     }
 
     public async ValueTask<T?> FetchLatest<T, TId>(TId id, CancellationToken cancellation = default)
-        where T : class, new() where TId : notnull
+        where T : class where TId : notnull
     {
         var naturalKey = FindNaturalKeyDefinition<T>();
         var unwrapped = naturalKey.Unwrap(id);
@@ -714,7 +714,7 @@ internal class EventOperations : QueryEventStore, IEventOperations
         }
     }
 
-    private NaturalKeyDefinition FindNaturalKeyDefinition<T>() where T : class, new()
+    private NaturalKeyDefinition FindNaturalKeyDefinition<T>() where T : class
     {
         var definition = _sessionBase.Options.Projections.FindNaturalKeyDefinition(typeof(T));
         if (definition != null) return definition;

--- a/src/Polecat/Events/Fetching/NaturalKeyFetchPlanner.cs
+++ b/src/Polecat/Events/Fetching/NaturalKeyFetchPlanner.cs
@@ -21,7 +21,7 @@ internal static class NaturalKeyFetchPlanner
         NaturalKeyDefinition naturalKey,
         TId naturalKeyValue,
         string tenantId,
-        CancellationToken cancellation) where T : class, new() where TId : notnull
+        CancellationToken cancellation) where T : class where TId : notnull
     {
         var isGuidStream = events.StreamIdentity == StreamIdentity.AsGuid;
         var schema = events.DatabaseSchemaName;

--- a/src/Polecat/Events/IEventOperations.cs
+++ b/src/Polecat/Events/IEventOperations.cs
@@ -65,4 +65,17 @@ public interface IEventOperations : JasperFx.Events.IEventStoreOperations, IQuer
     ///     Compact a stream by replacing its events with a single Compacted&lt;T&gt; snapshot event.
     /// </summary>
     Task CompactStreamAsync<T>(string streamKey, Action<StreamCompactingRequest<T>>? configure = null) where T : class;
+
+    // FetchLatest is declared on two parent interfaces — JasperFx.Events.IEventStoreOperations
+    // (where Marten put it canonically) and Polecat.Events.IQueryEventStore (kept on the
+    // read-side as a Polecat convenience). Both declarations have identical signatures
+    // and resolve to the same impl on EventOperations, but the C# compiler can't pick
+    // between them through Polecat.IEventOperations, so we re-declare with `new` to
+    // collapse the diamond at this level and keep the caller-facing surface unambiguous.
+
+    /// <inheritdoc cref="IQueryEventStore.FetchLatest{T}(Guid, CancellationToken)" />
+    new ValueTask<T?> FetchLatest<T>(Guid id, CancellationToken cancellation = default) where T : class;
+
+    /// <inheritdoc cref="IQueryEventStore.FetchLatest{T}(string, CancellationToken)" />
+    new ValueTask<T?> FetchLatest<T>(string key, CancellationToken cancellation = default) where T : class;
 }

--- a/src/Polecat/Events/IEventOperations.cs
+++ b/src/Polecat/Events/IEventOperations.cs
@@ -1,4 +1,3 @@
-using System.Linq.Expressions;
 using JasperFx.Events;
 using JasperFx.Events.Tags;
 using Polecat.Events.Dcb;
@@ -7,304 +6,31 @@ using Polecat.Events.Protected;
 namespace Polecat.Events;
 
 /// <summary>
-///     Write-side event operations. Extends IQueryEventStore with append/start capabilities.
-///     Operations are queued and flushed on SaveChangesAsync.
+///     Polecat's combined session-level event-store API: read + write + aggregate-handler
+///     workflow.
 /// </summary>
-public interface IEventOperations : IQueryEventStore
+/// <remarks>
+/// Polecat 4 dedupe pillar: the database-agnostic surface (Append, StartStream,
+/// FetchForWriting, WriteToAggregate, AppendOptimistic/Exclusive, FetchLatest,
+/// ProjectLatest, ArchiveStream, tag queries, natural-key fetches, OverwriteEvent,
+/// CompletelyReplaceEvent) now lives in <see cref="JasperFx.Events.IEventStoreOperations"/>
+/// and its parent <see cref="JasperFx.Events.IEventOperations"/>. This interface
+/// inherits the canonical contracts and adds the Polecat-specific extras:
+/// <list type="bullet">
+///   <item><c>UnArchiveStream</c> + <c>TombstoneStream</c> — Polecat-specific
+///   archive-lifecycle operations not yet present in the canonical surface.</item>
+///   <item><c>FetchForWritingByTags&lt;T&gt;</c> — DCB workflow returning
+///   <see cref="IEventBoundary{T}"/>. Lifts to JFx.Events once Polecat reaches DCB
+///   parity (JasperFx/polecat#80).</item>
+///   <item><c>CompactStreamAsync&lt;T&gt;</c> — execution depends on Polecat's
+///   <see cref="StreamCompactingRequest{T}"/>.</item>
+/// </list>
+/// Note: Marten's 3-tier split (IQueryEventStore + IEventOperations + IEventStoreOperations)
+/// is the canonical shape per the dedupe pillar. Polecat retains its 2-tier shape for
+/// now; the structural split is a follow-up issue (see Polecat 4 migration guide).
+/// </remarks>
+public interface IEventOperations : JasperFx.Events.IEventStoreOperations, IQueryEventStore
 {
-    /// <summary>
-    ///     Append events to an existing stream (or create it) by Guid id.
-    /// </summary>
-    StreamAction Append(Guid stream, params object[] events);
-
-    /// <summary>
-    ///     Append events to an existing stream (or create it) by string key.
-    /// </summary>
-    StreamAction Append(string stream, params object[] events);
-
-    /// <summary>
-    ///     Append events with an expected version for optimistic concurrency.
-    /// </summary>
-    StreamAction Append(Guid stream, long expectedVersion, params object[] events);
-
-    /// <summary>
-    ///     Append events with an expected version for optimistic concurrency.
-    /// </summary>
-    StreamAction Append(string stream, long expectedVersion, params object[] events);
-
-    /// <summary>
-    ///     Start a new stream with a Guid id. Throws if the stream already exists.
-    /// </summary>
-    StreamAction StartStream(Guid id, params object[] events);
-
-    /// <summary>
-    ///     Start a new stream with a string key. Throws if the stream already exists.
-    /// </summary>
-    StreamAction StartStream(string streamKey, params object[] events);
-
-    /// <summary>
-    ///     Start a new stream with a Guid id and aggregate type. Throws if the stream already exists.
-    /// </summary>
-    StreamAction StartStream<TAggregate>(Guid id, params object[] events) where TAggregate : class;
-
-    /// <summary>
-    ///     Start a new stream with a string key and aggregate type. Throws if the stream already exists.
-    /// </summary>
-    StreamAction StartStream<TAggregate>(string streamKey, params object[] events) where TAggregate : class;
-
-    /// <summary>
-    ///     Start a new stream with an auto-generated Guid id. Returns the StreamAction with the assigned id.
-    /// </summary>
-    StreamAction StartStream(params object[] events);
-
-    /// <summary>
-    ///     Start a new stream with an auto-generated Guid id and aggregate type.
-    /// </summary>
-    StreamAction StartStream<TAggregate>(params object[] events) where TAggregate : class;
-
-    // --- Append IEnumerable<object> overloads ------------------------------
-    // Parallel the params object[] variants above so callers that already
-    // have an IEnumerable<object> don't have to materialize an array.
-
-    /// <summary>
-    ///     Append events to an existing stream (or create it) by Guid id.
-    /// </summary>
-    StreamAction Append(Guid stream, IEnumerable<object> events);
-
-    /// <summary>
-    ///     Append events to an existing stream (or create it) by string key.
-    /// </summary>
-    StreamAction Append(string stream, IEnumerable<object> events);
-
-    /// <summary>
-    ///     Append events with an expected version for optimistic concurrency.
-    /// </summary>
-    StreamAction Append(Guid stream, long expectedVersion, IEnumerable<object> events);
-
-    /// <summary>
-    ///     Append events with an expected version for optimistic concurrency.
-    /// </summary>
-    StreamAction Append(string stream, long expectedVersion, IEnumerable<object> events);
-
-    // --- StartStream IEnumerable<object> + Type overloads ------------------
-    // Parallel the params object[] / generic variants above.
-
-    /// <summary>
-    ///     Start a new stream with a Guid id. Throws if the stream already exists.
-    /// </summary>
-    StreamAction StartStream(Guid id, IEnumerable<object> events);
-
-    /// <summary>
-    ///     Start a new stream with a string key. Throws if the stream already exists.
-    /// </summary>
-    StreamAction StartStream(string streamKey, IEnumerable<object> events);
-
-    /// <summary>
-    ///     Start a new stream with a Guid id and aggregate type. Throws if the stream already exists.
-    /// </summary>
-    StreamAction StartStream<TAggregate>(Guid id, IEnumerable<object> events) where TAggregate : class;
-
-    /// <summary>
-    ///     Start a new stream with a string key and aggregate type. Throws if the stream already exists.
-    /// </summary>
-    StreamAction StartStream<TAggregate>(string streamKey, IEnumerable<object> events) where TAggregate : class;
-
-    /// <summary>
-    ///     Start a new stream with an auto-generated Guid id.
-    /// </summary>
-    StreamAction StartStream(IEnumerable<object> events);
-
-    /// <summary>
-    ///     Start a new stream with an auto-generated Guid id and aggregate type.
-    /// </summary>
-    StreamAction StartStream<TAggregate>(IEnumerable<object> events) where TAggregate : class;
-
-    /// <summary>
-    ///     Start a new stream with a Guid id and a runtime-resolved aggregate type.
-    /// </summary>
-    StreamAction StartStream(Type aggregateType, Guid id, IEnumerable<object> events);
-
-    /// <summary>
-    ///     Start a new stream with a Guid id and a runtime-resolved aggregate type.
-    /// </summary>
-    StreamAction StartStream(Type aggregateType, Guid id, params object[] events);
-
-    /// <summary>
-    ///     Start a new stream with a string key and a runtime-resolved aggregate type.
-    /// </summary>
-    StreamAction StartStream(Type aggregateType, string streamKey, IEnumerable<object> events);
-
-    /// <summary>
-    ///     Start a new stream with a string key and a runtime-resolved aggregate type.
-    /// </summary>
-    StreamAction StartStream(Type aggregateType, string streamKey, params object[] events);
-
-    /// <summary>
-    ///     Start a new stream with an auto-generated Guid id and a runtime-resolved aggregate type.
-    /// </summary>
-    StreamAction StartStream(Type aggregateType, IEnumerable<object> events);
-
-    /// <summary>
-    ///     Start a new stream with an auto-generated Guid id and a runtime-resolved aggregate type.
-    /// </summary>
-    StreamAction StartStream(Type aggregateType, params object[] events);
-
-    /// <summary>
-    ///     Fetch the aggregate state and return a writable handle for optimistic concurrency.
-    /// </summary>
-    Task<IEventStream<T>> FetchForWriting<T>(Guid id, CancellationToken cancellation = default) where T : class, new();
-
-    /// <summary>
-    ///     Fetch the aggregate state and return a writable handle for optimistic concurrency.
-    /// </summary>
-    Task<IEventStream<T>> FetchForWriting<T>(string key, CancellationToken cancellation = default) where T : class, new();
-
-    /// <summary>
-    ///     Fetch the aggregate state with an expected version. Throws if the version does not match.
-    /// </summary>
-    Task<IEventStream<T>> FetchForWriting<T>(Guid id, long expectedVersion, CancellationToken cancellation = default) where T : class, new();
-
-    /// <summary>
-    ///     Fetch the aggregate state with an expected version. Throws if the version does not match.
-    /// </summary>
-    Task<IEventStream<T>> FetchForWriting<T>(string key, long expectedVersion, CancellationToken cancellation = default) where T : class, new();
-
-    /// <summary>
-    ///     Fetch the aggregate state with a pessimistic lock (UPDLOCK, HOLDLOCK) for exclusive writing.
-    /// </summary>
-    Task<IEventStream<T>> FetchForExclusiveWriting<T>(Guid id, CancellationToken cancellation = default) where T : class, new();
-
-    /// <summary>
-    ///     Fetch the aggregate state with a pessimistic lock (UPDLOCK, HOLDLOCK) for exclusive writing.
-    /// </summary>
-    Task<IEventStream<T>> FetchForExclusiveWriting<T>(string key, CancellationToken cancellation = default) where T : class, new();
-
-    /// <summary>
-    ///     Fetch the projected aggregate T by id, including any events appended
-    ///     in this session that have not yet been committed.
-    /// </summary>
-    ValueTask<T?> ProjectLatest<T>(Guid id, CancellationToken cancellation = default) where T : class, new();
-
-    /// <summary>
-    ///     Fetch the projected aggregate T by id, including any events appended
-    ///     in this session that have not yet been committed.
-    /// </summary>
-    ValueTask<T?> ProjectLatest<T>(string key, CancellationToken cancellation = default) where T : class, new();
-
-    /// <summary>
-    ///     Fetch the aggregate, apply events via callback, and save changes in one step.
-    /// </summary>
-    Task WriteToAggregate<T>(Guid id, Action<IEventStream<T>> writing, CancellationToken cancellation = default) where T : class, new();
-
-    /// <summary>
-    ///     Fetch the aggregate, apply events via callback, and save changes in one step.
-    /// </summary>
-    Task WriteToAggregate<T>(string key, Action<IEventStream<T>> writing, CancellationToken cancellation = default) where T : class, new();
-
-    /// <summary>
-    ///     Fetch the aggregate, apply events via async callback, and save changes in one step.
-    /// </summary>
-    Task WriteToAggregate<T>(Guid id, Func<IEventStream<T>, Task> writing, CancellationToken cancellation = default) where T : class, new();
-
-    /// <summary>
-    ///     Fetch the aggregate, apply events via async callback, and save changes in one step.
-    /// </summary>
-    Task WriteToAggregate<T>(string key, Func<IEventStream<T>, Task> writing, CancellationToken cancellation = default) where T : class, new();
-
-    /// <summary>
-    ///     Fetch the aggregate at a specific version, apply events via callback, and save changes in one step.
-    /// </summary>
-    Task WriteToAggregate<T>(Guid id, int initialVersion, Action<IEventStream<T>> writing, CancellationToken cancellation = default) where T : class, new();
-
-    /// <summary>
-    ///     Fetch the aggregate at a specific version, apply events via async callback, and save changes in one step.
-    /// </summary>
-    Task WriteToAggregate<T>(Guid id, int initialVersion, Func<IEventStream<T>, Task> writing, CancellationToken cancellation = default) where T : class, new();
-
-    /// <summary>
-    ///     Fetch the aggregate at a specific version, apply events via callback, and save changes in one step.
-    /// </summary>
-    Task WriteToAggregate<T>(string key, int initialVersion, Action<IEventStream<T>> writing, CancellationToken cancellation = default) where T : class, new();
-
-    /// <summary>
-    ///     Fetch the aggregate at a specific version, apply events via async callback, and save changes in one step.
-    /// </summary>
-    Task WriteToAggregate<T>(string key, int initialVersion, Func<IEventStream<T>, Task> writing, CancellationToken cancellation = default) where T : class, new();
-
-    /// <summary>
-    ///     Fetch the aggregate with an exclusive lock, apply events via callback, and save changes in one step.
-    /// </summary>
-    Task WriteExclusivelyToAggregate<T>(Guid id, Action<IEventStream<T>> writing, CancellationToken cancellation = default) where T : class, new();
-
-    /// <summary>
-    ///     Fetch the aggregate with an exclusive lock, apply events via callback, and save changes in one step.
-    /// </summary>
-    Task WriteExclusivelyToAggregate<T>(string key, Action<IEventStream<T>> writing, CancellationToken cancellation = default) where T : class, new();
-
-    /// <summary>
-    ///     Fetch the aggregate with an exclusive lock, apply events via async callback, and save changes in one step.
-    /// </summary>
-    Task WriteExclusivelyToAggregate<T>(Guid id, Func<IEventStream<T>, Task> writing, CancellationToken cancellation = default) where T : class, new();
-
-    /// <summary>
-    ///     Fetch the aggregate with an exclusive lock, apply events via async callback, and save changes in one step.
-    /// </summary>
-    Task WriteExclusivelyToAggregate<T>(string key, Func<IEventStream<T>, Task> writing, CancellationToken cancellation = default) where T : class, new();
-
-    /// <summary>
-    ///     Append events to an existing stream with optimistic concurrency. Reads the current
-    ///     version and sets ExpectedVersionOnServer. Throws NonExistentStreamException if the
-    ///     stream does not exist.
-    /// </summary>
-    Task AppendOptimistic(Guid streamId, CancellationToken token, params object[] events);
-
-    /// <summary>
-    ///     Append events to an existing stream with optimistic concurrency.
-    /// </summary>
-    Task AppendOptimistic(Guid streamId, params object[] events);
-
-    /// <summary>
-    ///     Append events to an existing stream with optimistic concurrency.
-    /// </summary>
-    Task AppendOptimistic(string streamKey, CancellationToken token, params object[] events);
-
-    /// <summary>
-    ///     Append events to an existing stream with optimistic concurrency.
-    /// </summary>
-    Task AppendOptimistic(string streamKey, params object[] events);
-
-    /// <summary>
-    ///     Append events to an existing stream with exclusive row locking. Begins a transaction
-    ///     and holds an exclusive lock until SaveChangesAsync. Throws StreamLockedException
-    ///     if the lock cannot be acquired.
-    /// </summary>
-    Task AppendExclusive(Guid streamId, CancellationToken token, params object[] events);
-
-    /// <summary>
-    ///     Append events to an existing stream with exclusive row locking.
-    /// </summary>
-    Task AppendExclusive(Guid streamId, params object[] events);
-
-    /// <summary>
-    ///     Append events to an existing stream with exclusive row locking.
-    /// </summary>
-    Task AppendExclusive(string streamKey, CancellationToken token, params object[] events);
-
-    /// <summary>
-    ///     Append events to an existing stream with exclusive row locking.
-    /// </summary>
-    Task AppendExclusive(string streamKey, params object[] events);
-
-    /// <summary>
-    ///     Mark a stream and all its events as archived by Guid id.
-    /// </summary>
-    void ArchiveStream(Guid streamId);
-
-    /// <summary>
-    ///     Mark a stream and all its events as archived by string key.
-    /// </summary>
-    void ArchiveStream(string streamKey);
-
     /// <summary>
     ///     Remove the archived flag from a stream and all its events by Guid id.
     /// </summary>
@@ -326,80 +52,17 @@ public interface IEventOperations : IQueryEventStore
     void TombstoneStream(string streamKey);
 
     /// <summary>
-    ///     Retroactively assign a tag to all events matching the given LINQ predicate.
-    ///     The tag must be of a registered tag type. The operation is queued and applied at SaveChangesAsync time.
-    /// </summary>
-    /// <param name="expression">LINQ predicate against IEvent properties (e.g. EventTypeName, StreamId, Timestamp)</param>
-    /// <param name="tag">Tag value whose type must be registered via RegisterTagType</param>
-    void AssignTagWhere(Expression<Func<IEvent, bool>> expression, object tag);
-
-    /// <summary>
-    ///     Overwrite the data and optionally headers of an existing event. Used for GDPR
-    ///     data masking operations.
-    /// </summary>
-    void OverwriteEvent(IEvent @event);
-
-    /// <summary>
-    ///     Replace event data at a specified spot in the event store without changing stream
-    ///     identity or version. Resets all header information to empty. Originally intended
-    ///     for stream-compacting workflows. Returns the new event id.
-    /// </summary>
-    Guid CompletelyReplaceEvent<T>(long sequence, T eventBody) where T : class;
-
-    /// <summary>
-    ///     Check whether any events exist that match the given tag query, without loading the events.
-    ///     This is a lightweight existence check useful for DCB guard clauses.
-    /// </summary>
-    Task<bool> EventsExistAsync(EventTagQuery query, CancellationToken cancellation = default);
-
-    /// <summary>
-    ///     Query events across streams by tag conditions (DCB support).
-    /// </summary>
-    Task<IReadOnlyList<IEvent>> QueryByTagsAsync(EventTagQuery query, CancellationToken cancellation = default);
-
-    /// <summary>
-    ///     Aggregate events matching tag conditions into a live aggregate (DCB support).
-    /// </summary>
-    Task<T?> AggregateByTagsAsync<T>(EventTagQuery query, CancellationToken cancellation = default) where T : class;
-
-    /// <summary>
     ///     Fetch events by tags and return a writable boundary with DCB consistency checking.
     /// </summary>
     Task<IEventBoundary<T>> FetchForWritingByTags<T>(EventTagQuery query, CancellationToken cancellation = default) where T : class;
 
     /// <summary>
     ///     Compact a stream by replacing its events with a single Compacted&lt;T&gt; snapshot event.
-    ///     Use this when you do not care about older stream data but want to keep database size down.
     /// </summary>
     Task CompactStreamAsync<T>(Guid streamId, Action<StreamCompactingRequest<T>>? configure = null) where T : class;
 
     /// <summary>
     ///     Compact a stream by replacing its events with a single Compacted&lt;T&gt; snapshot event.
-    ///     Use this when you do not care about older stream data but want to keep database size down.
     /// </summary>
     Task CompactStreamAsync<T>(string streamKey, Action<StreamCompactingRequest<T>>? configure = null) where T : class;
-
-    /// <summary>
-    ///     Build an IEvent wrapper for raw event data. Useful for setting tags before appending.
-    /// </summary>
-    IEvent BuildEvent(object data);
-
-    /// <summary>
-    ///     Fetch the aggregate state for writing by a natural key or any registered identifier type.
-    /// </summary>
-    Task<IEventStream<T>> FetchForWriting<T, TId>(TId id, CancellationToken cancellation = default)
-        where T : class, new() where TId : notnull;
-
-    /// <summary>
-    ///     Fetch the aggregate state by natural key for exclusive writing with row-level locking.
-    /// </summary>
-    Task<IEventStream<T>> FetchForExclusiveWriting<T, TId>(TId id, CancellationToken cancellation = default)
-        where T : class, new() where TId : notnull;
-
-    /// <summary>
-    ///     Fetch the projected aggregate T by a natural key or any registered identifier type.
-    ///     This is a lightweight, read-only version of FetchForWriting.
-    /// </summary>
-    ValueTask<T?> FetchLatest<T, TId>(TId id, CancellationToken cancellation = default)
-        where T : class, new() where TId : notnull;
 }

--- a/src/Polecat/Events/IEventStream.cs
+++ b/src/Polecat/Events/IEventStream.cs
@@ -3,73 +3,13 @@ using Polecat.Internal;
 
 namespace Polecat.Events;
 
-/// <summary>
-///     A writable handle to an event stream with its current aggregate state.
-///     Returned by FetchForWriting / FetchForExclusiveWriting.
-/// </summary>
-public interface IEventStream<out T> where T : class
-{
-    /// <summary>
-    ///     The current aggregate state, or null if the stream does not exist yet.
-    /// </summary>
-    T? Aggregate { get; }
+// NOTE: The public IEventStream<T> contract moved to JasperFx.Events.IEventStream<T>
+// as part of the Polecat 4 dedupe pillar consumption (see migration guide).
+// Code that previously imported Polecat.Events.IEventStream<T> now resolves the
+// unqualified `IEventStream<T>` to the JasperFx.Events version via
+// `using JasperFx.Events;`.
 
-    /// <summary>
-    ///     The version of the stream when it was fetched (used for optimistic concurrency).
-    /// </summary>
-    long? StartingVersion { get; }
-
-    /// <summary>
-    ///     StartingVersion + count of appended events, or null if StartingVersion is null.
-    /// </summary>
-    long? CurrentVersion { get; }
-
-    /// <summary>
-    ///     The Guid identity of the stream (Guid.Empty if using string keys).
-    /// </summary>
-    Guid Id { get; }
-
-    /// <summary>
-    ///     The string key of the stream (null if using Guid identity).
-    /// </summary>
-    string? Key { get; }
-
-    /// <summary>
-    ///     The events that have been appended to this stream handle (not yet saved).
-    /// </summary>
-    IReadOnlyList<IEvent> Events { get; }
-
-    /// <summary>
-    ///     Append a single event to the stream.
-    /// </summary>
-    void AppendOne(object @event);
-
-    /// <summary>
-    ///     Append multiple events to the stream.
-    /// </summary>
-    void AppendMany(params object[] events);
-
-    /// <summary>
-    ///     Append multiple events to the stream.
-    /// </summary>
-    void AppendMany(IEnumerable<object> events);
-
-    /// <summary>
-    ///     If true, Polecat will enforce an optimistic concurrency check on this stream even if no
-    ///     events are appended at the time of calling SaveChangesAsync(). This is useful when you want
-    ///     to ensure the stream version has not advanced since it was fetched, even if the command
-    ///     handler decides not to emit any new events.
-    /// </summary>
-    bool AlwaysEnforceConsistency { get; set; }
-
-    /// <summary>
-    ///     Try to advance the expected starting version for optimistic concurrency checks to the current version
-    ///     so that you can reuse a stream object for multiple units of work.
-    /// </summary>
-    void TryFastForwardVersion();
-}
-
-internal class EventStream<T> : IEventStream<T> where T : class
+internal class EventStream<T> : JasperFx.Events.IEventStream<T> where T : class
 {
     private StreamAction _stream;
     private readonly Func<object, IEvent> _wrapper;
@@ -89,6 +29,7 @@ internal class EventStream<T> : IEventStream<T> where T : class
         _stream = stream;
         _stream.AggregateType = typeof(T);
 
+        Cancellation = cancellation;
         Aggregate = aggregate;
     }
 
@@ -106,6 +47,7 @@ internal class EventStream<T> : IEventStream<T> where T : class
         _stream = stream;
         _stream.AggregateType = typeof(T);
 
+        Cancellation = cancellation;
         Aggregate = aggregate;
     }
 
@@ -118,6 +60,8 @@ internal class EventStream<T> : IEventStream<T> where T : class
     public long? CurrentVersion => _stream.ExpectedVersionOnServer == null
         ? null
         : _stream.ExpectedVersionOnServer.Value + _stream.Events.Count;
+
+    public CancellationToken Cancellation { get; }
 
     public bool AlwaysEnforceConsistency
     {

--- a/src/Polecat/Events/IQueryEventStore.cs
+++ b/src/Polecat/Events/IQueryEventStore.cs
@@ -27,4 +27,19 @@ public interface IQueryEventStore : JasperFx.Events.IQueryEventStore
     ///     Returns IEvent wrappers with full metadata.
     /// </summary>
     IPolecatQueryable<IEvent> QueryAllRawEvents();
+
+    /// <summary>
+    ///     Fetch the latest aggregate state for a stream by Guid id.
+    ///     Convenience wrapper around AggregateStreamAsync. Available from the
+    ///     read-only query session; the write-side equivalent on
+    ///     <see cref="IEventOperations"/> additionally includes events appended
+    ///     in the current unit of work.
+    /// </summary>
+    ValueTask<T?> FetchLatest<T>(Guid id, CancellationToken cancellation = default) where T : class;
+
+    /// <summary>
+    ///     Fetch the latest aggregate state for a stream by string key.
+    ///     Convenience wrapper around AggregateStreamAsync.
+    /// </summary>
+    ValueTask<T?> FetchLatest<T>(string key, CancellationToken cancellation = default) where T : class;
 }

--- a/src/Polecat/Events/IQueryEventStore.cs
+++ b/src/Polecat/Events/IQueryEventStore.cs
@@ -4,9 +4,16 @@ using Polecat.Linq;
 namespace Polecat.Events;
 
 /// <summary>
-///     Read-only event store queries. Available from both query sessions and document sessions.
+///     Polecat's read-side event-store API.
 /// </summary>
-public interface IQueryEventStore
+/// <remarks>
+/// Polecat 4 dedupe pillar: the database-agnostic surface (FetchStreamAsync,
+/// AggregateStreamAsync, AggregateStreamToLastKnownAsync, LoadAsync,
+/// FetchStreamStateAsync) now lives in <see cref="JasperFx.Events.IQueryEventStore"/>.
+/// This interface adds the Polecat-specific LINQ-returning methods that return
+/// <see cref="IPolecatQueryable{T}"/>.
+/// </remarks>
+public interface IQueryEventStore : JasperFx.Events.IQueryEventStore
 {
     /// <summary>
     ///     Query directly against ONLY the raw event data for a specific event type.
@@ -20,79 +27,4 @@ public interface IQueryEventStore
     ///     Returns IEvent wrappers with full metadata.
     /// </summary>
     IPolecatQueryable<IEvent> QueryAllRawEvents();
-
-    /// <summary>
-    ///     Fetch all events for a stream by Guid id.
-    /// </summary>
-    Task<IReadOnlyList<IEvent>> FetchStreamAsync(Guid streamId, long version = 0,
-        DateTimeOffset? timestamp = null, long fromVersion = 0, CancellationToken token = default);
-
-    /// <summary>
-    ///     Fetch all events for a stream by string key.
-    /// </summary>
-    Task<IReadOnlyList<IEvent>> FetchStreamAsync(string streamKey, long version = 0,
-        DateTimeOffset? timestamp = null, long fromVersion = 0, CancellationToken token = default);
-
-    /// <summary>
-    ///     Load a single event by its id, knowing the event type upfront.
-    ///     Returns null when the event id does not exist.
-    /// </summary>
-    Task<IEvent<T>?> LoadAsync<T>(Guid id, CancellationToken token = default) where T : class;
-
-    /// <summary>
-    ///     Load a single event by its id. The runtime event type is resolved through the
-    ///     event registry from the stored <c>dotnet_type</c> column. Returns null when the
-    ///     event id does not exist.
-    /// </summary>
-    Task<IEvent?> LoadAsync(Guid id, CancellationToken token = default);
-
-    /// <summary>
-    ///     Fetch stream metadata by Guid id.
-    /// </summary>
-    Task<StreamState?> FetchStreamStateAsync(Guid streamId, CancellationToken token = default);
-
-    /// <summary>
-    ///     Fetch stream metadata by string key.
-    /// </summary>
-    Task<StreamState?> FetchStreamStateAsync(string streamKey, CancellationToken token = default);
-
-    /// <summary>
-    ///     Aggregate events from a stream into a transient document of type T (not persisted).
-    /// </summary>
-    Task<T?> AggregateStreamAsync<T>(Guid streamId, long version = 0,
-        DateTimeOffset? timestamp = null, T? state = null, long fromVersion = 0,
-        CancellationToken token = default) where T : class, new();
-
-    /// <summary>
-    ///     Aggregate events from a stream into a transient document of type T (not persisted).
-    /// </summary>
-    Task<T?> AggregateStreamAsync<T>(string streamKey, long version = 0,
-        DateTimeOffset? timestamp = null, T? state = null, long fromVersion = 0,
-        CancellationToken token = default) where T : class, new();
-
-    /// <summary>
-    ///     Perform a live aggregation but return the last known non-null version of the aggregate,
-    ///     walking backwards through events if the aggregate is deleted at the current version.
-    /// </summary>
-    Task<T?> AggregateStreamToLastKnownAsync<T>(Guid streamId, long version = 0,
-        DateTimeOffset? timestamp = null, CancellationToken token = default) where T : class, new();
-
-    /// <summary>
-    ///     Perform a live aggregation but return the last known non-null version of the aggregate,
-    ///     walking backwards through events if the aggregate is deleted at the current version.
-    /// </summary>
-    Task<T?> AggregateStreamToLastKnownAsync<T>(string streamKey, long version = 0,
-        DateTimeOffset? timestamp = null, CancellationToken token = default) where T : class, new();
-
-    /// <summary>
-    ///     Fetch the latest aggregate state for a stream by Guid id.
-    ///     Convenience wrapper around AggregateStreamAsync.
-    /// </summary>
-    ValueTask<T?> FetchLatest<T>(Guid id, CancellationToken cancellation = default) where T : class, new();
-
-    /// <summary>
-    ///     Fetch the latest aggregate state for a stream by string key.
-    ///     Convenience wrapper around AggregateStreamAsync.
-    /// </summary>
-    ValueTask<T?> FetchLatest<T>(string key, CancellationToken cancellation = default) where T : class, new();
 }

--- a/src/Polecat/Events/QueryEventStore.cs
+++ b/src/Polecat/Events/QueryEventStore.cs
@@ -216,21 +216,21 @@ internal class QueryEventStore : IQueryEventStore
 
     public async Task<T?> AggregateStreamAsync<T>(Guid streamId, long version = 0,
         DateTimeOffset? timestamp = null, T? state = null, long fromVersion = 0,
-        CancellationToken token = default) where T : class, new()
+        CancellationToken token = default) where T : class
     {
         return await AggregateStreamInternalAsync<T>(streamId, version, timestamp, state, fromVersion, token);
     }
 
     public async Task<T?> AggregateStreamAsync<T>(string streamKey, long version = 0,
         DateTimeOffset? timestamp = null, T? state = null, long fromVersion = 0,
-        CancellationToken token = default) where T : class, new()
+        CancellationToken token = default) where T : class
     {
         return await AggregateStreamInternalAsync<T>(streamKey, version, timestamp, state, fromVersion, token);
     }
 
     private async Task<T?> AggregateStreamInternalAsync<T>(object streamId, long version,
         DateTimeOffset? timestamp, T? state, long fromVersion,
-        CancellationToken token) where T : class, new()
+        CancellationToken token) where T : class
     {
         IReadOnlyList<IEvent> events;
         if (streamId is Guid guid)
@@ -249,19 +249,19 @@ internal class QueryEventStore : IQueryEventStore
     }
 
     public async Task<T?> AggregateStreamToLastKnownAsync<T>(Guid streamId, long version = 0,
-        DateTimeOffset? timestamp = null, CancellationToken token = default) where T : class, new()
+        DateTimeOffset? timestamp = null, CancellationToken token = default) where T : class
     {
         return await AggregateStreamToLastKnownInternalAsync<T>(streamId, version, timestamp, token);
     }
 
     public async Task<T?> AggregateStreamToLastKnownAsync<T>(string streamKey, long version = 0,
-        DateTimeOffset? timestamp = null, CancellationToken token = default) where T : class, new()
+        DateTimeOffset? timestamp = null, CancellationToken token = default) where T : class
     {
         return await AggregateStreamToLastKnownInternalAsync<T>(streamKey, version, timestamp, token);
     }
 
     private async Task<T?> AggregateStreamToLastKnownInternalAsync<T>(object streamId, long version,
-        DateTimeOffset? timestamp, CancellationToken token) where T : class, new()
+        DateTimeOffset? timestamp, CancellationToken token) where T : class
     {
         IReadOnlyList<IEvent> events;
         if (streamId is Guid guid)
@@ -290,7 +290,7 @@ internal class QueryEventStore : IQueryEventStore
     }
 
     public async ValueTask<T?> FetchLatest<T>(Guid id, CancellationToken cancellation = default)
-        where T : class, new()
+        where T : class
     {
         if (_session.TryGetAggregateFromIdentityMap<T, Guid>(id, out var cached))
         {
@@ -301,7 +301,7 @@ internal class QueryEventStore : IQueryEventStore
     }
 
     public async ValueTask<T?> FetchLatest<T>(string key, CancellationToken cancellation = default)
-        where T : class, new()
+        where T : class
     {
         if (_session.TryGetAggregateFromIdentityMap<T, string>(key, out var cached))
         {

--- a/src/Polecat/Events/StreamState.cs
+++ b/src/Polecat/Events/StreamState.cs
@@ -1,39 +1,6 @@
-namespace Polecat.Events;
-
-/// <summary>
-///     Metadata about an event stream.
-/// </summary>
-public class StreamState
-{
-    public StreamState()
-    {
-    }
-
-    public StreamState(Guid id, long version, Type? aggregateType,
-        DateTimeOffset lastTimestamp, DateTimeOffset created)
-    {
-        Id = id;
-        Version = version;
-        AggregateType = aggregateType;
-        LastTimestamp = lastTimestamp;
-        Created = created;
-    }
-
-    public StreamState(string key, long version, Type? aggregateType,
-        DateTimeOffset lastTimestamp, DateTimeOffset created)
-    {
-        Key = key;
-        Version = version;
-        AggregateType = aggregateType;
-        LastTimestamp = lastTimestamp;
-        Created = created;
-    }
-
-    public Guid Id { get; set; }
-    public string? Key { get; set; }
-    public long Version { get; set; }
-    public Type? AggregateType { get; set; }
-    public DateTimeOffset LastTimestamp { get; set; }
-    public DateTimeOffset Created { get; set; }
-    public bool IsArchived { get; set; }
-}
+// The Polecat.Events.StreamState class moved to JasperFx.Events.StreamState as part
+// of the Polecat 4 dedupe pillar consumption (see migration guide).
+//
+// Code that previously referenced Polecat.Events.StreamState now resolves the
+// unqualified `StreamState` to JasperFx.Events.StreamState via `using JasperFx.Events;`.
+// Code that fully-qualified Polecat.Events.StreamState must change to JasperFx.Events.StreamState.

--- a/src/Polecat/IDocumentSession.cs
+++ b/src/Polecat/IDocumentSession.cs
@@ -17,7 +17,7 @@ public interface IDocumentSession : IDocumentOperations, IStorageOperations, ITr
     /// <summary>
     ///     Event store operations (append, start stream, fetch).
     /// </summary>
-    new IEventOperations Events { get; }
+    new Polecat.Events.IEventOperations Events { get; }
 
     /// <summary>
     ///     Flush all pending operations to the database in a single transaction.

--- a/src/Polecat/Internal/DocumentSessionBase.cs
+++ b/src/Polecat/Internal/DocumentSessionBase.cs
@@ -54,8 +54,8 @@ internal abstract class DocumentSessionBase : QuerySession, IDocumentSession
 
     public IWorkTracker PendingChanges => _workTracker;
 
-    IQueryEventStore IQuerySession.Events => EventOps;
-    public new IEventOperations Events => EventOps;
+    Polecat.Events.IQueryEventStore IQuerySession.Events => EventOps;
+    public new Polecat.Events.IEventOperations Events => EventOps;
 
     private EventOperations EventOps =>
         _eventOperations ??= new EventOperations(this, _eventGraph, Options, _workTracker, TenantId);

--- a/src/Polecat/Polecat.csproj
+++ b/src/Polecat/Polecat.csproj
@@ -26,12 +26,7 @@
 
     <ItemGroup>
         <PackageReference Include="JasperFx" />
-        <!-- TEMPORARY (dedupe pillar consumption): ProjectReference to local JFx.Events
-             worktree because the contracts merged in JasperFx/jasperfx#268 are not yet
-             published as a 2.0.0-alpha.N package. Revert to PackageReference once the
-             alpha is published. -->
-        <!-- <PackageReference Include="JasperFx.Events" /> -->
-        <ProjectReference Include="..\..\..\..\..\..\jasperfx\.claude\worktrees\sleepy-wilson-b2e793\src\JasperFx.Events\JasperFx.Events.csproj" />
+        <PackageReference Include="JasperFx.Events" />
         <PackageReference Include="Microsoft.Data.SqlClient" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
         <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />

--- a/src/Polecat/Polecat.csproj
+++ b/src/Polecat/Polecat.csproj
@@ -26,7 +26,12 @@
 
     <ItemGroup>
         <PackageReference Include="JasperFx" />
-        <PackageReference Include="JasperFx.Events" />
+        <!-- TEMPORARY (dedupe pillar consumption): ProjectReference to local JFx.Events
+             worktree because the contracts merged in JasperFx/jasperfx#268 are not yet
+             published as a 2.0.0-alpha.N package. Revert to PackageReference once the
+             alpha is published. -->
+        <!-- <PackageReference Include="JasperFx.Events" /> -->
+        <ProjectReference Include="..\..\..\..\..\..\jasperfx\.claude\worktrees\sleepy-wilson-b2e793\src\JasperFx.Events\JasperFx.Events.csproj" />
         <PackageReference Include="Microsoft.Data.SqlClient" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
         <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />


### PR DESCRIPTION
## Summary

Consumes the database-agnostic event-store contracts that landed in [`JasperFx/jasperfx#268`](https://github.com/JasperFx/jasperfx/pull/268) and shipped as `JasperFx.Events 2.0.0-alpha.6`. Part of [Polecat 4 master plan #46](https://github.com/JasperFx/polecat/issues/46) under the [Critter Stack 2026 dedupe pillar](https://github.com/JasperFx/jasperfx/issues/214). Mirrors the Marten-side consumption work in [`JasperFx/marten#4399`](https://github.com/JasperFx/marten/pull/4399).

Builds on the gap-fills landed in [polecat#93](https://github.com/JasperFx/polecat/pull/93) (Append/StartStream overloads, LoadAsync, CompletelyReplaceEvent).

**0 build errors. 39/39 focused event-store-API tests pass against SQL Server 2025 docker.**

## What changed

### Type deletions (force resolution to `JasperFx.Events`)

- `Polecat.Events.IEventStream<T>` — public interface removed. Internal `EventStream<T>` now implements `JasperFx.Events.IEventStream<T>` directly and exposes the `Cancellation` property the canonical contract requires.
- `Polecat.Events.StreamState` — class removed; file kept as a migration breadcrumb.

### Interface restructuring (Polecat keeps namespace + Polecat-only extras)

- `Polecat.Events.IQueryEventStore` — now `: JasperFx.Events.IQueryEventStore`. Keeps:
  - `QueryRawEventDataOnly<T>` + `QueryAllRawEvents` (return `IPolecatQueryable`)
  - `FetchLatest<T>(Guid|string)` — Marten's canonical position is `IEventStoreOperations` (write side) only; Polecat retains the read-side convenience so `theStore.QuerySession().Events.FetchLatest<T>(...)` keeps working.
- `Polecat.Events.IEventOperations` — now `: JasperFx.Events.IEventStoreOperations, IQueryEventStore` (Polecat retains its 2-tier shape; Marten's 3-tier split is a follow-up). Keeps Polecat extras: `UnArchiveStream`, `TombstoneStream`, `FetchForWritingByTags<T>` (DCB), `CompactStreamAsync<T>`. Plus a `new FetchLatest<T>` declaration to collapse the diamond between Polecat.IQueryEventStore.FetchLatest and JFx.IEventStoreOperations.FetchLatest at the IEventOperations level — both inherited slots have identical signatures and resolve to the same impl on `EventOperations`; the `new` declaration just keeps caller-facing references unambiguous.

### Constraint relaxation

- `where T : class, new()` → `where T : class` in 3 files (`EventOperations`, `QueryEventStore`, `NaturalKeyFetchPlanner`). The `new()` constraint was defensive — no `new T()` call sites exist in Polecat's event-store impls.

### Disambiguation surgery (consumption-internal — resolves issues #91 / #92)

- `IDocumentSession.Events` return type fully-qualified to `Polecat.Events.IEventOperations` (was ambiguous against `JasperFx.Events.IEventOperations`).
- `DocumentSessionBase.Events` explicit/public properties same fix (`Polecat.Events.IEventOperations` / `Polecat.Events.IQueryEventStore`).

### Package version bumps

- `Directory.Packages.props` — `JasperFx` 2.0.0-alpha.11 → 2.0.0-alpha.12, `JasperFx.Events` 2.0.0-alpha.4 → **2.0.0-alpha.6** (the alpha that ships the lifted contracts).

## Test plan

- [x] `dotnet build src/Polecat/Polecat.csproj` — 0 errors, 2 warnings
- [x] `dotnet build src/Polecat.Tests/Polecat.Tests.csproj` — 0 errors, 8 warnings
- [x] 39 event-store-API tests pass on net9.0 against SQL Server 2025 docker (`event_store_api_completeness`, `fetch_latest_tests`, `project_latest_tests`, `start_stream_tests`, `append_stream_tests`)
- [ ] Full Polecat.Tests suite green
- [ ] CI green on Polecat
- [ ] Close [#91](https://github.com/JasperFx/polecat/issues/91) and [#92](https://github.com/JasperFx/polecat/issues/92) as resolved by this PR

Refs JasperFx/polecat#46, JasperFx/jasperfx#214, JasperFx/jasperfx#268, JasperFx/polecat#93, JasperFx/marten#4399.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
