### PR TITLE
Round Polecat event-store API up to JFx.Events 2.0 surface (closes #88, #89, #90)

### DIFF
--- a/src/Polecat.Tests/Events/event_store_api_completeness_tests.cs
+++ b/src/Polecat.Tests/Events/event_store_api_completeness_tests.cs
@@ -1,0 +1,204 @@
+using JasperFx.Events;
+using Polecat.Tests.Harness;
+
+namespace Polecat.Tests.Events;
+
+/// <summary>
+///     Coverage for the methods added to round Polecat's event-store API up to the
+///     <see cref="JasperFx.Events.IEventStoreOperations"/> surface: issue #88
+///     (Append / StartStream IEnumerable + Type overloads), issue #89 (LoadAsync),
+///     issue #90 (CompletelyReplaceEvent).
+/// </summary>
+[Collection("integration")]
+public class event_store_api_completeness_tests : IntegrationContext
+{
+    public event_store_api_completeness_tests(DefaultStoreFixture fixture) : base(fixture)
+    {
+    }
+
+    // -- Issue #88: IEnumerable<object> + Type-parameter overloads ---------
+
+    [Fact]
+    public async Task append_accepts_ienumerable_payload()
+    {
+        var streamId = Guid.NewGuid();
+        theSession.Events.StartStream(streamId, new QuestStarted("Enumerable Quest"));
+        await theSession.SaveChangesAsync();
+
+        IEnumerable<object> incoming =
+        [
+            new MembersJoined(1, "Town", ["A"]),
+            new ArrivedAtLocation("Castle", 2),
+        ];
+
+        await using var session2 = theStore.LightweightSession();
+        session2.Events.Append(streamId, incoming);
+        await session2.SaveChangesAsync();
+
+        await using var query = theStore.QuerySession();
+        (await query.Events.FetchStreamAsync(streamId)).Count.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task append_with_expected_version_accepts_ienumerable_payload()
+    {
+        var streamId = Guid.NewGuid();
+        theSession.Events.StartStream(streamId, new QuestStarted("Versioned"));
+        await theSession.SaveChangesAsync();
+
+        IEnumerable<object> more = [new MembersJoined(1, "Town", ["A"])];
+
+        await using var session2 = theStore.LightweightSession();
+        session2.Events.Append(streamId, 2L, more);
+        await session2.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task start_stream_accepts_ienumerable_payload()
+    {
+        var streamId = Guid.NewGuid();
+        IEnumerable<object> events =
+        [
+            new QuestStarted("Lazy"),
+            new MembersJoined(1, "Town", ["A"]),
+        ];
+
+        theSession.Events.StartStream(streamId, events);
+        await theSession.SaveChangesAsync();
+
+        await using var query = theStore.QuerySession();
+        (await query.Events.FetchStreamAsync(streamId)).Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task start_stream_with_runtime_aggregate_type_sets_aggregate_type()
+    {
+        var streamId = Guid.NewGuid();
+
+        var action = theSession.Events.StartStream(typeof(QuestParty), streamId, new QuestStarted("RuntimeType"));
+        await theSession.SaveChangesAsync();
+
+        // Client-side state on the StreamAction carries the aggregate type;
+        // existing Polecat.FetchStreamStateAsync doesn't hydrate AggregateType
+        // on the returned StreamState yet (see start_stream_with_aggregate_type).
+        action.AggregateType.ShouldBe(typeof(QuestParty));
+
+        await using var query = theStore.QuerySession();
+        (await query.Events.FetchStreamStateAsync(streamId))!.Version.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task start_stream_generic_with_ienumerable_payload()
+    {
+        var streamId = Guid.NewGuid();
+        IEnumerable<object> events = [new QuestStarted("GenericIEnumerable")];
+
+        var action = theSession.Events.StartStream<QuestParty>(streamId, events);
+        await theSession.SaveChangesAsync();
+
+        action.AggregateType.ShouldBe(typeof(QuestParty));
+        await using var query = theStore.QuerySession();
+        (await query.Events.FetchStreamStateAsync(streamId))!.Version.ShouldBe(1);
+    }
+
+    // -- Issue #89: LoadAsync single-event lookup --------------------------
+
+    [Fact]
+    public async Task load_async_typed_returns_typed_event_when_found()
+    {
+        var streamId = Guid.NewGuid();
+        var action = theSession.Events.StartStream(streamId, new QuestStarted("Loaded"));
+        await theSession.SaveChangesAsync();
+
+        var eventId = action.Events[0].Id;
+
+        await using var query = theStore.QuerySession();
+        var loaded = await query.Events.LoadAsync<QuestStarted>(eventId);
+
+        loaded.ShouldNotBeNull();
+        loaded.Id.ShouldBe(eventId);
+        loaded.StreamId.ShouldBe(streamId);
+        loaded.Data.Name.ShouldBe("Loaded");
+    }
+
+    [Fact]
+    public async Task load_async_typed_returns_null_when_event_type_mismatches()
+    {
+        var streamId = Guid.NewGuid();
+        var action = theSession.Events.StartStream(streamId, new QuestStarted("Mismatched"));
+        await theSession.SaveChangesAsync();
+
+        var eventId = action.Events[0].Id;
+
+        await using var query = theStore.QuerySession();
+        var wrongCast = await query.Events.LoadAsync<MembersJoined>(eventId);
+
+        wrongCast.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task load_async_typed_returns_null_when_event_id_not_found()
+    {
+        await using var query = theStore.QuerySession();
+        var notThere = await query.Events.LoadAsync<QuestStarted>(Guid.NewGuid());
+        notThere.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task load_async_untyped_returns_event_wrapper_with_runtime_data_type()
+    {
+        var streamId = Guid.NewGuid();
+        var action = theSession.Events.StartStream(streamId, new QuestStarted("Untyped"));
+        await theSession.SaveChangesAsync();
+
+        var eventId = action.Events[0].Id;
+
+        await using var query = theStore.QuerySession();
+        var loaded = await query.Events.LoadAsync(eventId);
+
+        loaded.ShouldNotBeNull();
+        loaded.Id.ShouldBe(eventId);
+        loaded.Data.ShouldBeOfType<QuestStarted>();
+        ((QuestStarted)loaded.Data).Name.ShouldBe("Untyped");
+    }
+
+    [Fact]
+    public async Task load_async_untyped_returns_null_when_event_id_not_found()
+    {
+        await using var query = theStore.QuerySession();
+        var notThere = await query.Events.LoadAsync(Guid.NewGuid());
+        notThere.ShouldBeNull();
+    }
+
+    // -- Issue #90: CompletelyReplaceEvent --------------------------------
+
+    [Fact]
+    public async Task completely_replace_event_swaps_data_and_returns_new_id()
+    {
+        var streamId = Guid.NewGuid();
+        var action = theSession.Events.StartStream(streamId, new QuestStarted("Original"));
+        await theSession.SaveChangesAsync();
+
+        var sequence = action.Events[0].Sequence;
+        var originalId = action.Events[0].Id;
+
+        // Replace with a Compacted-style snapshot event at the same sequence.
+        await using var session2 = theStore.LightweightSession();
+        var newId = session2.Events.CompletelyReplaceEvent(sequence, new QuestStarted("Compacted"));
+        await session2.SaveChangesAsync();
+
+        newId.ShouldNotBe(originalId);
+        newId.ShouldNotBe(Guid.Empty);
+
+        // The id at that sequence is now the replacement id; data is the new payload.
+        await using var query = theStore.QuerySession();
+        var loaded = await query.Events.LoadAsync<QuestStarted>(newId);
+        loaded.ShouldNotBeNull();
+        loaded.Data.Name.ShouldBe("Compacted");
+    }
+
+    public class QuestParty
+    {
+        public Guid Id { get; set; }
+    }
+}

--- a/src/Polecat/Events/EventOperations.cs
+++ b/src/Polecat/Events/EventOperations.cs
@@ -157,6 +157,71 @@ internal class EventOperations : QueryEventStore, IEventOperations
         return StartStream<TAggregate>(Guid.NewGuid(), events);
     }
 
+    // --- IEnumerable<object> + Type-parameter overloads (issue #88) -------
+    // Thin delegators; concrete behavior lives in the params object[] impls
+    // above. These exist so the JasperFx.Events.IEventOperations contract
+    // can be satisfied without forcing callers to materialize arrays.
+
+    public StreamAction Append(Guid stream, IEnumerable<object> events)
+        => Append(stream, events.ToArray());
+
+    public StreamAction Append(string stream, IEnumerable<object> events)
+        => Append(stream, events.ToArray());
+
+    public StreamAction Append(Guid stream, long expectedVersion, IEnumerable<object> events)
+        => Append(stream, expectedVersion, events.ToArray());
+
+    public StreamAction Append(string stream, long expectedVersion, IEnumerable<object> events)
+        => Append(stream, expectedVersion, events.ToArray());
+
+    public StreamAction StartStream(Guid id, IEnumerable<object> events)
+        => StartStream(id, events.ToArray());
+
+    public StreamAction StartStream(string streamKey, IEnumerable<object> events)
+        => StartStream(streamKey, events.ToArray());
+
+    public StreamAction StartStream<TAggregate>(Guid id, IEnumerable<object> events) where TAggregate : class
+        => StartStream<TAggregate>(id, events.ToArray());
+
+    public StreamAction StartStream<TAggregate>(string streamKey, IEnumerable<object> events) where TAggregate : class
+        => StartStream<TAggregate>(streamKey, events.ToArray());
+
+    public StreamAction StartStream(IEnumerable<object> events)
+        => StartStream(events.ToArray());
+
+    public StreamAction StartStream<TAggregate>(IEnumerable<object> events) where TAggregate : class
+        => StartStream<TAggregate>(events.ToArray());
+
+    public StreamAction StartStream(Type aggregateType, Guid id, params object[] events)
+    {
+        var action = StartStream(id, events);
+        action.AggregateType = aggregateType;
+        return action;
+    }
+
+    public StreamAction StartStream(Type aggregateType, Guid id, IEnumerable<object> events)
+        => StartStream(aggregateType, id, events.ToArray());
+
+    public StreamAction StartStream(Type aggregateType, string streamKey, params object[] events)
+    {
+        var action = StartStream(streamKey, events);
+        action.AggregateType = aggregateType;
+        return action;
+    }
+
+    public StreamAction StartStream(Type aggregateType, string streamKey, IEnumerable<object> events)
+        => StartStream(aggregateType, streamKey, events.ToArray());
+
+    public StreamAction StartStream(Type aggregateType, params object[] events)
+    {
+        var action = StartStream(events);
+        action.AggregateType = aggregateType;
+        return action;
+    }
+
+    public StreamAction StartStream(Type aggregateType, IEnumerable<object> events)
+        => StartStream(aggregateType, events.ToArray());
+
     public async Task<IEventStream<T>> FetchForWriting<T>(Guid id, CancellationToken cancellation = default)
         where T : class, new()
     {
@@ -449,6 +514,22 @@ internal class EventOperations : QueryEventStore, IEventOperations
             ? _sessionBase.Serializer.ToJson(@event.Headers)
             : null;
         _workTracker.Add(new Protected.OverwriteEventOperation(_events, @event, serializedData, serializedHeaders));
+    }
+
+    public Guid CompletelyReplaceEvent<T>(long sequence, T eventBody) where T : class
+    {
+        // Register the runtime event type and resolve its mapping so the
+        // replacement row carries the right `type` / `dotnet_type` columns —
+        // the existing ReplaceEventOperation just persists what we hand it.
+        _events.AddEventType(typeof(T));
+        var mapping = _events.EventMappingFor(typeof(T));
+
+        var serializedData = _sessionBase.Serializer.ToJson(eventBody);
+        var op = new Protected.ReplaceEventOperation(
+            _events, sequence, serializedData, mapping.EventTypeName, mapping.DotNetTypeName);
+
+        _workTracker.Add(op);
+        return op.Id;
     }
 
     private async Task<IEventStream<T>> FetchForWritingInternal<T>(object streamId, bool forExclusive,

--- a/src/Polecat/Events/IEventOperations.cs
+++ b/src/Polecat/Events/IEventOperations.cs
@@ -62,6 +62,93 @@ public interface IEventOperations : IQueryEventStore
     /// </summary>
     StreamAction StartStream<TAggregate>(params object[] events) where TAggregate : class;
 
+    // --- Append IEnumerable<object> overloads ------------------------------
+    // Parallel the params object[] variants above so callers that already
+    // have an IEnumerable<object> don't have to materialize an array.
+
+    /// <summary>
+    ///     Append events to an existing stream (or create it) by Guid id.
+    /// </summary>
+    StreamAction Append(Guid stream, IEnumerable<object> events);
+
+    /// <summary>
+    ///     Append events to an existing stream (or create it) by string key.
+    /// </summary>
+    StreamAction Append(string stream, IEnumerable<object> events);
+
+    /// <summary>
+    ///     Append events with an expected version for optimistic concurrency.
+    /// </summary>
+    StreamAction Append(Guid stream, long expectedVersion, IEnumerable<object> events);
+
+    /// <summary>
+    ///     Append events with an expected version for optimistic concurrency.
+    /// </summary>
+    StreamAction Append(string stream, long expectedVersion, IEnumerable<object> events);
+
+    // --- StartStream IEnumerable<object> + Type overloads ------------------
+    // Parallel the params object[] / generic variants above.
+
+    /// <summary>
+    ///     Start a new stream with a Guid id. Throws if the stream already exists.
+    /// </summary>
+    StreamAction StartStream(Guid id, IEnumerable<object> events);
+
+    /// <summary>
+    ///     Start a new stream with a string key. Throws if the stream already exists.
+    /// </summary>
+    StreamAction StartStream(string streamKey, IEnumerable<object> events);
+
+    /// <summary>
+    ///     Start a new stream with a Guid id and aggregate type. Throws if the stream already exists.
+    /// </summary>
+    StreamAction StartStream<TAggregate>(Guid id, IEnumerable<object> events) where TAggregate : class;
+
+    /// <summary>
+    ///     Start a new stream with a string key and aggregate type. Throws if the stream already exists.
+    /// </summary>
+    StreamAction StartStream<TAggregate>(string streamKey, IEnumerable<object> events) where TAggregate : class;
+
+    /// <summary>
+    ///     Start a new stream with an auto-generated Guid id.
+    /// </summary>
+    StreamAction StartStream(IEnumerable<object> events);
+
+    /// <summary>
+    ///     Start a new stream with an auto-generated Guid id and aggregate type.
+    /// </summary>
+    StreamAction StartStream<TAggregate>(IEnumerable<object> events) where TAggregate : class;
+
+    /// <summary>
+    ///     Start a new stream with a Guid id and a runtime-resolved aggregate type.
+    /// </summary>
+    StreamAction StartStream(Type aggregateType, Guid id, IEnumerable<object> events);
+
+    /// <summary>
+    ///     Start a new stream with a Guid id and a runtime-resolved aggregate type.
+    /// </summary>
+    StreamAction StartStream(Type aggregateType, Guid id, params object[] events);
+
+    /// <summary>
+    ///     Start a new stream with a string key and a runtime-resolved aggregate type.
+    /// </summary>
+    StreamAction StartStream(Type aggregateType, string streamKey, IEnumerable<object> events);
+
+    /// <summary>
+    ///     Start a new stream with a string key and a runtime-resolved aggregate type.
+    /// </summary>
+    StreamAction StartStream(Type aggregateType, string streamKey, params object[] events);
+
+    /// <summary>
+    ///     Start a new stream with an auto-generated Guid id and a runtime-resolved aggregate type.
+    /// </summary>
+    StreamAction StartStream(Type aggregateType, IEnumerable<object> events);
+
+    /// <summary>
+    ///     Start a new stream with an auto-generated Guid id and a runtime-resolved aggregate type.
+    /// </summary>
+    StreamAction StartStream(Type aggregateType, params object[] events);
+
     /// <summary>
     ///     Fetch the aggregate state and return a writable handle for optimistic concurrency.
     /// </summary>
@@ -251,6 +338,13 @@ public interface IEventOperations : IQueryEventStore
     ///     data masking operations.
     /// </summary>
     void OverwriteEvent(IEvent @event);
+
+    /// <summary>
+    ///     Replace event data at a specified spot in the event store without changing stream
+    ///     identity or version. Resets all header information to empty. Originally intended
+    ///     for stream-compacting workflows. Returns the new event id.
+    /// </summary>
+    Guid CompletelyReplaceEvent<T>(long sequence, T eventBody) where T : class;
 
     /// <summary>
     ///     Check whether any events exist that match the given tag query, without loading the events.

--- a/src/Polecat/Events/IQueryEventStore.cs
+++ b/src/Polecat/Events/IQueryEventStore.cs
@@ -34,6 +34,19 @@ public interface IQueryEventStore
         DateTimeOffset? timestamp = null, long fromVersion = 0, CancellationToken token = default);
 
     /// <summary>
+    ///     Load a single event by its id, knowing the event type upfront.
+    ///     Returns null when the event id does not exist.
+    /// </summary>
+    Task<IEvent<T>?> LoadAsync<T>(Guid id, CancellationToken token = default) where T : class;
+
+    /// <summary>
+    ///     Load a single event by its id. The runtime event type is resolved through the
+    ///     event registry from the stored <c>dotnet_type</c> column. Returns null when the
+    ///     event id does not exist.
+    /// </summary>
+    Task<IEvent?> LoadAsync(Guid id, CancellationToken token = default);
+
+    /// <summary>
     ///     Fetch stream metadata by Guid id.
     /// </summary>
     Task<StreamState?> FetchStreamStateAsync(Guid streamId, CancellationToken token = default);

--- a/src/Polecat/Events/QueryEventStore.cs
+++ b/src/Polecat/Events/QueryEventStore.cs
@@ -131,6 +131,54 @@ internal class QueryEventStore : IQueryEventStore
         return results;
     }
 
+    public async Task<IEvent<T>?> LoadAsync<T>(Guid id, CancellationToken token = default) where T : class
+    {
+        var @event = await LoadInternalAsync(id, token);
+        return @event as IEvent<T>;
+    }
+
+    public Task<IEvent?> LoadAsync(Guid id, CancellationToken token = default)
+        => LoadInternalAsync(id, token);
+
+    private async Task<IEvent?> LoadInternalAsync(Guid id, CancellationToken token)
+    {
+        // Mirrors FetchStreamInternalAsync but filters by the event UUID
+        // rather than stream id, and reads the row's stream_id column to
+        // assemble the context (since the caller doesn't know the stream
+        // up-front for a load-by-event-id lookup).
+        await using var cmd = new SqlCommand();
+        cmd.CommandText = $"""
+            SELECT {PcEventsRowReader.ComposeSelectColumns(_events.EventOptions)}
+            FROM {_events.EventsTableName}
+            WHERE id = @id AND tenant_id = @tenant_id AND is_archived = 0;
+            """;
+        cmd.Parameters.AddWithValue("@id", id);
+        cmd.Parameters.AddWithValue("@tenant_id", _session.TenantId);
+
+        await using var reader = await _session.ExecuteReaderAsync(cmd, token);
+        if (!await reader.ReadAsync(token)) return null;
+
+        // Pull stream_id off the row so PcEventsRowReader's stream-id
+        // assignment (driven by ctx.StreamId) gets the right value. Ordinal 2
+        // matches PcEventsRowReader.ComposeSelectColumns(...).
+        object streamId = _events.StreamIdentity == StreamIdentity.AsGuid
+            ? reader.GetGuid(2)
+            : reader.GetString(2);
+
+        var ctx = new EventHydrationContext(
+            _events,
+            _session.Serializer,
+            streamId,
+            defaultTenantId: _session.TenantId);
+
+        var slots = MetadataSlots.Compute(_events.EventOptions);
+        var cache = new EventTypeCache();
+
+        return _events.StreamIdentity == StreamIdentity.AsGuid
+            ? PcEventsRowReader.ReadEventAsGuid(reader, ctx, slots, ref cache)
+            : PcEventsRowReader.ReadEventAsString(reader, ctx, slots, ref cache);
+    }
+
     public async Task<StreamState?> FetchStreamStateAsync(Guid streamId, CancellationToken token = default)
     {
         return await FetchStreamStateInternalAsync(streamId, token);


### PR DESCRIPTION
## Summary

Three pre-consumption additions to Polecat's event-store API, identified during the JFx.Events 2.0 consumption dry-run ([polecat#87](https://github.com/JasperFx/polecat/pull/87)). Each is purely additive Polecat capability and is independent of the consumption PR — landing these on `main` lets [#87](https://github.com/JasperFx/polecat/pull/87) rebase and go green.

**5 files changed, +440 lines. 0 production code deletions. 11/11 tests pass.**

Closes [#88](https://github.com/JasperFx/polecat/issues/88), [#89](https://github.com/JasperFx/polecat/issues/89), [#90](https://github.com/JasperFx/polecat/issues/90).

## #88 — Append / StartStream `IEnumerable<object>` + Type overloads

- 4 `Append(...)` overloads taking `IEnumerable<object>` (Guid+IEnumerable, string+IEnumerable, Guid+long+IEnumerable, string+long+IEnumerable)
- 6 `StartStream(...)` overloads taking `IEnumerable<object>` (Guid, string, `<TAggregate>` Guid, `<TAggregate>` string, untyped, `<TAggregate>` untyped)
- 6 `StartStream(Type aggregateType, ...)` runtime-type overloads — full set: Guid, string, untyped × params/IEnumerable

All are thin delegators on top of the existing `params object[]` impls (e.g. `=> StartStream<TAggregate>(id, events.ToArray());`). Type-parameter variants delegate to the untyped helper and set `action.AggregateType = aggregateType` afterward. No behavioral change beyond what `JasperFx.Events.IEventOperations` requires.

## #89 — `IQueryEventStore.LoadAsync<T>(Guid)` + `LoadAsync(Guid)`

Single-event-by-id lookup against `pc_events`. Mirrors the existing pattern from `FetchStreamInternalAsync` — same `PcEventsRowReader.ComposeSelectColumns(...)`, same `PcEventsRowReader.ReadEventAsGuid/AsString` hydration, just filters by `id` rather than `stream_id` and reads `stream_id` off the row to assemble the hydration context (callers don't know the stream up-front for a load-by-event-id lookup).

- Typed `LoadAsync<T>(Guid)` returns `IEvent<T>?` — null when the stored event's runtime type isn't assignable to `IEvent<T>` (via `as`).
- Non-generic `LoadAsync(Guid)` returns `IEvent?` — the runtime type is resolved through the event registry from the stored `dotnet_type` column.
- Both variants return `null` when the event id isn't found.

## #90 — `IEventOperations.CompletelyReplaceEvent<T>(long, T)`

Replaces event data + headers at a specific sequence id by queuing the existing `Protected.ReplaceEventOperation` with a freshly-serialized payload. The existing operation already resets `headers` / `correlation_id` / `causation_id` to `NULL` per the documented contract; this method just wires up the type-name and serialization at the entry point. Returns the new event id.

```csharp
public Guid CompletelyReplaceEvent<T>(long sequence, T eventBody) where T : class
{
    _events.AddEventType(typeof(T));
    var mapping = _events.EventMappingFor(typeof(T));
    var serializedData = _sessionBase.Serializer.ToJson(eventBody);
    var op = new Protected.ReplaceEventOperation(
        _events, sequence, serializedData, mapping.EventTypeName, mapping.DotNetTypeName);
    _workTracker.Add(op);
    return op.Id;
}
```

## Tests

`src/Polecat.Tests/Events/event_store_api_completeness_tests.cs` adds 11 focused tests:

- **5 for #88** — `Append(IEnumerable)`, `Append(string, version, IEnumerable)`, `StartStream(IEnumerable)`, `StartStream(typeof(...))`, `StartStream<T>(IEnumerable)`. Verifies the same persisted behavior as the existing params-array variants.
- **5 for #89** — typed found, typed type-mismatch returns null, typed not-found returns null, untyped found returns wrapped event with correct runtime data type, untyped not-found returns null.
- **1 for #90** — replace returns a new id, the replacement is observable via `LoadAsync<T>` with the new payload.

All 11 pass against the dockerized SQL Server 2025 on net9.0.

## Test plan

- [x] `dotnet build src/Polecat/Polecat.csproj` — 0 errors, 0 warnings (clean)
- [x] `dotnet build src/Polecat.Tests/Polecat.Tests.csproj` — 0 errors
- [x] 11 new tests pass against SQL Server docker
- [ ] CI green on Polecat
- [ ] Rebase consumption PR [#87](https://github.com/JasperFx/polecat/pull/87) on top of this once merged; confirm the 46 errors collapse to 0 and the consumption-internal items [#91](https://github.com/JasperFx/polecat/issues/91)/[#92](https://github.com/JasperFx/polecat/issues/92) can be closed as resolved by it

Refs JasperFx/polecat#46, JasperFx/jasperfx#214, JasperFx/jasperfx#268, JasperFx/polecat#87.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
