### PR TITLE
Add IDocumentOperations.StoreObjects(IEnumerable<object>)

### DIFF
--- a/src/Polecat.Tests/Storage/store_objects_tests.cs
+++ b/src/Polecat.Tests/Storage/store_objects_tests.cs
@@ -1,0 +1,112 @@
+using Polecat.Tests.Harness;
+
+namespace Polecat.Tests.Storage;
+
+/// <summary>
+///     Coverage for IDocumentOperations.StoreObjects(IEnumerable&lt;object&gt;) —
+///     the heterogeneous bulk-store entry point added for parity with
+///     JasperFx/jasperfx#268's IDocumentOperations surface and to let
+///     Wolverine.Polecat drop its per-document reflection workaround
+///     (closes JasperFx/polecat#81).
+/// </summary>
+[Collection("integration")]
+public class store_objects_tests : IntegrationContext
+{
+    public store_objects_tests(DefaultStoreFixture fixture) : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task stores_a_homogeneous_batch_via_runtime_type_dispatch()
+    {
+        var docs = new object[]
+        {
+            new GreenDoc { Id = Guid.NewGuid(), Color = "green-1" },
+            new GreenDoc { Id = Guid.NewGuid(), Color = "green-2" },
+        };
+
+        theSession.StoreObjects(docs);
+        await theSession.SaveChangesAsync();
+
+        await using var query = theStore.QuerySession();
+        var loaded1 = await query.LoadAsync<GreenDoc>(((GreenDoc)docs[0]).Id);
+        var loaded2 = await query.LoadAsync<GreenDoc>(((GreenDoc)docs[1]).Id);
+
+        loaded1.ShouldNotBeNull();
+        loaded1!.Color.ShouldBe("green-1");
+        loaded2.ShouldNotBeNull();
+        loaded2!.Color.ShouldBe("green-2");
+    }
+
+    [Fact]
+    public async Task stores_a_heterogeneous_batch_routes_each_to_its_provider()
+    {
+        var greenId = Guid.NewGuid();
+        var redId = Guid.NewGuid();
+        var docs = new object[]
+        {
+            new GreenDoc { Id = greenId, Color = "leaf" },
+            new RedDoc { Id = redId, Label = "tomato" },
+        };
+
+        theSession.StoreObjects(docs);
+        await theSession.SaveChangesAsync();
+
+        await using var query = theStore.QuerySession();
+        (await query.LoadAsync<GreenDoc>(greenId))!.Color.ShouldBe("leaf");
+        (await query.LoadAsync<RedDoc>(redId))!.Label.ShouldBe("tomato");
+    }
+
+    [Fact]
+    public async Task skips_null_entries_silently()
+    {
+        var id = Guid.NewGuid();
+        var docs = new object?[]
+        {
+            null,
+            new GreenDoc { Id = id, Color = "alone" },
+            null,
+        };
+
+        theSession.StoreObjects(docs!);
+        await theSession.SaveChangesAsync();
+
+        await using var query = theStore.QuerySession();
+        (await query.LoadAsync<GreenDoc>(id))!.Color.ShouldBe("alone");
+    }
+
+    [Fact]
+    public async Task subsequent_store_objects_updates_existing_documents()
+    {
+        var id = Guid.NewGuid();
+
+        theSession.StoreObjects(new object[] { new GreenDoc { Id = id, Color = "v1" } });
+        await theSession.SaveChangesAsync();
+
+        await using var session2 = theStore.LightweightSession();
+        session2.StoreObjects(new object[] { new GreenDoc { Id = id, Color = "v2" } });
+        await session2.SaveChangesAsync();
+
+        await using var query = theStore.QuerySession();
+        (await query.LoadAsync<GreenDoc>(id))!.Color.ShouldBe("v2");
+    }
+
+    [Fact]
+    public async Task empty_collection_is_a_no_op()
+    {
+        theSession.StoreObjects(Array.Empty<object>());
+        await theSession.SaveChangesAsync(); // should not throw
+    }
+
+    public class GreenDoc
+    {
+        public Guid Id { get; set; }
+        public string Color { get; set; } = "";
+    }
+
+    public class RedDoc
+    {
+        public Guid Id { get; set; }
+        public string Label { get; set; } = "";
+    }
+}

--- a/src/Polecat/IDocumentOperations.cs
+++ b/src/Polecat/IDocumentOperations.cs
@@ -19,6 +19,13 @@ public interface IDocumentOperations : IQuerySession
     void Store<T>(params T[] documents) where T : notnull;
 
     /// <summary>
+    ///     Store a heterogeneous collection of documents by their runtime type.
+    ///     Each document is routed through the document provider for its runtime
+    ///     type — there is no per-document reflection on the hot path.
+    /// </summary>
+    void StoreObjects(IEnumerable<object> documents);
+
+    /// <summary>
     ///     Insert a document. Throws if a document with the same id already exists.
     /// </summary>
     void Insert<T>(T document) where T : notnull;

--- a/src/Polecat/Internal/DocumentSessionBase.cs
+++ b/src/Polecat/Internal/DocumentSessionBase.cs
@@ -108,6 +108,24 @@ internal abstract class DocumentSessionBase : QuerySession, IDocumentSession
         }
     }
 
+    public void StoreObjects(IEnumerable<object> documents)
+    {
+        // Dispatch by runtime type via the non-generic GetProvider(Type) +
+        // BuildUpsert(object, ...) — no MakeGenericMethod / Activator on the
+        // hot path. Mirrors Store<T> per-document otherwise.
+        foreach (var document in documents)
+        {
+            if (document is null) continue;
+
+            var documentType = document.GetType();
+            SyncMetadata(document);
+            var provider = _providers.GetProvider(documentType);
+            var op = provider.BuildUpsert(document, Serializer, TenantId);
+            _workTracker.Add(op);
+            OnDocumentStored(documentType, provider.Mapping.GetId(document), document);
+        }
+    }
+
     public void Insert<T>(T document) where T : notnull
     {
         SyncMetadata(document);

--- a/src/Polecat/Internal/NestedTenantSession.cs
+++ b/src/Polecat/Internal/NestedTenantSession.cs
@@ -112,6 +112,22 @@ internal class NestedTenantSession : ITenantOperations
         foreach (var doc in documents) Store(doc);
     }
 
+    public void StoreObjects(IEnumerable<object> documents)
+    {
+        // Per-document runtime-type dispatch through the non-generic
+        // GetProvider(Type) + BuildUpsert(object, ...) — no reflection on
+        // the hot path. Tenant scoping uses _tenantId, mirroring Store<T>.
+        foreach (var document in documents)
+        {
+            if (document is null) continue;
+
+            SyncMetadata(document);
+            var provider = _parent.Providers.GetProvider(document.GetType());
+            var op = provider.BuildUpsert(document, Serializer, _tenantId);
+            _parent.WorkTracker.Add(op);
+        }
+    }
+
     public void Insert<T>(T document) where T : notnull
     {
         SyncMetadata(document);


### PR DESCRIPTION
Closes #81.

Polecat's existing Store<T>(T) / Store<T>(params T[]) require T at compile time. Heterogeneous batches that only know their elements as `object` had to round-trip through MakeGenericMethod + Invoke per document — the path Wolverine.Polecat.PolecatOps.StoreObjects falls back to today and the reason the consumption PR can't share Wolverine.Marten's one-liner.

Adds:
- `void StoreObjects(IEnumerable<object> documents)` on IDocumentOperations
- DocumentSessionBase impl that dispatches by runtime type through the existing non-generic GetProvider(Type) + BuildUpsert(object, ...) machinery — no MakeGenericMethod / Activator on the hot path
- NestedTenantSession impl with the same dispatch pattern, scoped to the tenant id (mirrors NestedTenantSession.Store<T>)
- Null entries in the input are skipped silently, matching the Wolverine.Polecat workaround's behavior

Tests (src/Polecat.Tests/Storage/store_objects_tests.cs, 5 cases):
- homogeneous batch round-trips
- heterogeneous batch (two distinct doc types) routed to the right provider
- null entries silently skipped
- subsequent StoreObjects updates existing docs (upsert semantics)
- empty collection is a no-op

All 5 pass against the dockerized SQL Server 2025 on net9.0.

Follow-up: Wolverine.Polecat.PolecatOps.StoreObjects can collapse to `ResolveSession(session).StoreObjects(Documents)` once it's targeting a Polecat alpha with this method — tracked as part of the Wolverine 6 extraction.