### PR TITLE
Add ProjectionCoordinator + distributor layer for hot-cold daemon coo…

### DIFF
--- a/src/Polecat.Tests/Daemon/sql_server_app_lock_tests.cs
+++ b/src/Polecat.Tests/Daemon/sql_server_app_lock_tests.cs
@@ -1,0 +1,120 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Polecat.Events.Daemon.Coordination;
+using Polecat.Tests.Harness;
+
+namespace Polecat.Tests.Daemon;
+
+/// <summary>
+///     Coverage for <see cref="SqlServerAppLock"/> — the SQL Server
+///     <c>sp_getapplock</c> primitive Polecat's projection coordinator
+///     uses to negotiate hot-cold leadership across nodes
+///     ([polecat#83](https://github.com/JasperFx/polecat/issues/83)).
+/// </summary>
+[Collection("integration")]
+public class sql_server_app_lock_tests : IntegrationContext
+{
+    public sql_server_app_lock_tests(DefaultStoreFixture fixture) : base(fixture)
+    {
+    }
+
+    // Use a randomized lock id per test run so concurrent test runs don't collide.
+    private static int RandomLockId() => Random.Shared.Next(1_000_000, int.MaxValue);
+
+    [Fact]
+    public async Task only_one_instance_can_acquire_a_given_lock()
+    {
+        var lockId = RandomLockId();
+        var connStr = ConnectionSource.ConnectionString;
+
+        await using var first = new SqlServerAppLock(connStr, "db-a", NullLogger.Instance);
+        await using var second = new SqlServerAppLock(connStr, "db-a", NullLogger.Instance);
+
+        var firstAttempt = await first.TryAttainLockAsync(lockId, default);
+        var secondAttempt = await second.TryAttainLockAsync(lockId, default);
+
+        firstAttempt.ShouldBeTrue();
+        secondAttempt.ShouldBeFalse();
+
+        first.HasLock(lockId).ShouldBeTrue();
+        second.HasLock(lockId).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task release_lets_a_waiting_instance_acquire()
+    {
+        var lockId = RandomLockId();
+        var connStr = ConnectionSource.ConnectionString;
+
+        await using var first = new SqlServerAppLock(connStr, "db-a", NullLogger.Instance);
+        await using var second = new SqlServerAppLock(connStr, "db-a", NullLogger.Instance);
+
+        (await first.TryAttainLockAsync(lockId, default)).ShouldBeTrue();
+        (await second.TryAttainLockAsync(lockId, default)).ShouldBeFalse();
+
+        await first.ReleaseLockAsync(lockId);
+        first.HasLock(lockId).ShouldBeFalse();
+
+        (await second.TryAttainLockAsync(lockId, default)).ShouldBeTrue();
+        second.HasLock(lockId).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task disposing_releases_all_session_locks()
+    {
+        var lockId = RandomLockId();
+        var connStr = ConnectionSource.ConnectionString;
+
+        var first = new SqlServerAppLock(connStr, "db-a", NullLogger.Instance);
+        await using var second = new SqlServerAppLock(connStr, "db-a", NullLogger.Instance);
+
+        (await first.TryAttainLockAsync(lockId, default)).ShouldBeTrue();
+        await first.DisposeAsync();
+
+        // Closing first's connection auto-released the SQL Server session lock,
+        // so second should now be able to take it.
+        (await second.TryAttainLockAsync(lockId, default)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task multiple_distinct_lock_ids_are_independent()
+    {
+        var lockA = RandomLockId();
+        var lockB = RandomLockId();
+        var connStr = ConnectionSource.ConnectionString;
+
+        await using var owner = new SqlServerAppLock(connStr, "db-a", NullLogger.Instance);
+        await using var contender = new SqlServerAppLock(connStr, "db-a", NullLogger.Instance);
+
+        (await owner.TryAttainLockAsync(lockA, default)).ShouldBeTrue();
+
+        // contender can take lockB even though owner holds lockA — different
+        // resources are independent under sp_getapplock.
+        (await contender.TryAttainLockAsync(lockB, default)).ShouldBeTrue();
+
+        owner.HasLock(lockA).ShouldBeTrue();
+        owner.HasLock(lockB).ShouldBeFalse();
+        contender.HasLock(lockA).ShouldBeFalse();
+        contender.HasLock(lockB).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task try_attain_is_idempotent_when_already_owned()
+    {
+        var lockId = RandomLockId();
+        var connStr = ConnectionSource.ConnectionString;
+
+        await using var owner = new SqlServerAppLock(connStr, "db-a", NullLogger.Instance);
+
+        (await owner.TryAttainLockAsync(lockId, default)).ShouldBeTrue();
+        (await owner.TryAttainLockAsync(lockId, default)).ShouldBeTrue(); // already held — short-circuit
+        owner.HasLock(lockId).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task release_of_unknown_id_is_a_noop()
+    {
+        var connStr = ConnectionSource.ConnectionString;
+        await using var owner = new SqlServerAppLock(connStr, "db-a", NullLogger.Instance);
+        await owner.ReleaseLockAsync(RandomLockId()); // should not throw
+    }
+}

--- a/src/Polecat/Events/Daemon/Coordination/IProjectionDistributor.cs
+++ b/src/Polecat/Events/Daemon/Coordination/IProjectionDistributor.cs
@@ -1,0 +1,41 @@
+using JasperFx.Events.Projections;
+using Polecat.Storage;
+
+namespace Polecat.Events.Daemon.Coordination;
+
+/// <summary>
+///     Strategy for distributing projection shards across Polecat nodes.
+///     Mirrors Marten's distributor design: the coordinator polls
+///     <see cref="BuildDistributionAsync"/>, races for locks via
+///     <see cref="TryAttainLockAsync"/>, and starts/stops daemon agents
+///     based on which sets it currently owns.
+/// </summary>
+internal interface IProjectionDistributor : IAsyncDisposable
+{
+    ValueTask<IReadOnlyList<ProjectionSet>> BuildDistributionAsync();
+    Task RandomWait(CancellationToken token);
+    bool HasLock(ProjectionSet set);
+    Task<bool> TryAttainLockAsync(ProjectionSet set, CancellationToken token);
+    Task ReleaseLockAsync(ProjectionSet set);
+    Task ReleaseAllLocks();
+}
+
+/// <summary>
+///     A set of projection shards that get scheduled together under a single
+///     distributed lock. For single-tenant deployments this is one set per
+///     shard (per-shard lock); for multi-tenant deployments this is one set
+///     per database (all shards grouped behind one per-database lock).
+/// </summary>
+internal sealed class ProjectionSet
+{
+    public ProjectionSet(int lockId, PolecatDatabase database, IReadOnlyList<ShardName> names)
+    {
+        LockId = lockId;
+        Database = database;
+        Names = names;
+    }
+
+    public int LockId { get; }
+    public PolecatDatabase Database { get; }
+    public IReadOnlyList<ShardName> Names { get; }
+}

--- a/src/Polecat/Events/Daemon/Coordination/MultiTenantedProjectionDistributor.cs
+++ b/src/Polecat/Events/Daemon/Coordination/MultiTenantedProjectionDistributor.cs
@@ -1,0 +1,82 @@
+using Microsoft.Extensions.Logging;
+using Polecat.Storage;
+
+namespace Polecat.Events.Daemon.Coordination;
+
+/// <summary>
+///     Multi-node, multi-tenant distributor. One set per database — all shards
+///     for a given tenant database run together on whichever node holds that
+///     database's lock. Trades per-shard scaling for the simpler invariant
+///     that a tenant's projections never split across nodes.
+/// </summary>
+internal sealed class MultiTenantedProjectionDistributor : IProjectionDistributor
+{
+    private readonly DocumentStore _store;
+    private readonly ILogger _logger;
+    private readonly Dictionary<string, SqlServerAppLock> _locks = new();
+
+    public MultiTenantedProjectionDistributor(DocumentStore store, ILoggerFactory loggerFactory)
+    {
+        _store = store;
+        _logger = loggerFactory.CreateLogger<MultiTenantedProjectionDistributor>();
+    }
+
+    public ValueTask<IReadOnlyList<ProjectionSet>> BuildDistributionAsync()
+    {
+        var databases = _store.Options.Tenancy?.AllDatabases() ?? [];
+        var allShards = _store.Options.Projections.AllShards()
+            .Select(s => s.Name)
+            .ToList();
+        var lockId = _store.Options.DaemonSettings.DaemonLockId;
+
+        IReadOnlyList<ProjectionSet> sets = databases
+            .Select(db => new ProjectionSet(lockId, db, allShards))
+            .OrderBy(_ => Random.Shared.NextDouble())
+            .ToList();
+
+        return ValueTask.FromResult(sets);
+    }
+
+    public Task RandomWait(CancellationToken token) =>
+        Task.Delay(TimeSpan.FromMilliseconds(Random.Shared.Next(0, 500)), token);
+
+    public bool HasLock(ProjectionSet set) =>
+        _locks.TryGetValue(set.Database.Identifier, out var l) && l.HasLock(set.LockId);
+
+    public Task<bool> TryAttainLockAsync(ProjectionSet set, CancellationToken token) =>
+        LockFor(set.Database).TryAttainLockAsync(set.LockId, token);
+
+    public Task ReleaseLockAsync(ProjectionSet set) =>
+        LockFor(set.Database).ReleaseLockAsync(set.LockId);
+
+    public async Task ReleaseAllLocks()
+    {
+        foreach (var (_, l) in _locks)
+        {
+            try
+            {
+                await l.DisposeAsync().ConfigureAwait(false);
+            }
+            catch
+            {
+                // Best-effort during shutdown
+            }
+        }
+        _locks.Clear();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await ReleaseAllLocks().ConfigureAwait(false);
+    }
+
+    private SqlServerAppLock LockFor(PolecatDatabase database)
+    {
+        if (!_locks.TryGetValue(database.Identifier, out var l))
+        {
+            l = new SqlServerAppLock(database.ConnectionString, database.Identifier, _logger);
+            _locks[database.Identifier] = l;
+        }
+        return l;
+    }
+}

--- a/src/Polecat/Events/Daemon/Coordination/ProjectionCoordinator.cs
+++ b/src/Polecat/Events/Daemon/Coordination/ProjectionCoordinator.cs
@@ -1,0 +1,330 @@
+using JasperFx;
+using JasperFx.Core;
+using JasperFx.Descriptors;
+using JasperFx.Events.Daemon;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Polecat.Storage;
+
+namespace Polecat.Events.Daemon.Coordination;
+
+/// <summary>
+///     Concrete <see cref="IProjectionCoordinator"/> for Polecat. Hosted as
+///     an <see cref="IHostedService"/> so the runtime starts/stops it with
+///     the application lifetime.
+/// </summary>
+/// <remarks>
+///     Owns a <see cref="IProjectionDistributor"/> chosen at construction
+///     based on <see cref="ITenancy.Cardinality"/> (Solo / SingleTenant /
+///     MultiTenanted). The execute loop polls the distributor for the
+///     current view of (database × shards) sets and:
+///
+///     <list type="bullet">
+///       <item>If we already hold a set's lock — keep its agents running.</item>
+///       <item>If not, race for the lock; on success start the agents,
+///       on failure stop any agents we used to run for that set
+///       (recovery-from-lost-lock).</item>
+///     </list>
+///
+///     Mirrors the Marten executeAsync loop slot-for-slot; the differences
+///     are SQL Server (sp_getapplock) and Polecat tenancy types.
+/// </remarks>
+internal class ProjectionCoordinator : IProjectionCoordinator
+{
+    private readonly DocumentStore _store;
+    private readonly StoreOptions _options;
+    private readonly ILoggerFactory _loggerFactory;
+    private readonly ILogger<ProjectionCoordinator> _logger;
+
+    private readonly Dictionary<string, PolecatProjectionDaemon> _daemons = new();
+    private IProjectionDistributor? _distributor;
+    private CancellationTokenSource? _runCts;
+    private Task? _runTask;
+    private volatile bool _paused;
+
+    public ProjectionCoordinator(DocumentStore store, ILoggerFactory? loggerFactory = null)
+    {
+        _store = store;
+        _options = store.Options;
+        _loggerFactory = loggerFactory ?? NullLoggerFactory.Instance;
+        _logger = _loggerFactory.CreateLogger<ProjectionCoordinator>();
+    }
+
+    internal IProjectionDistributor Distributor => _distributor
+        ??= BuildDistributor();
+
+    public IProjectionDaemon DaemonForMainDatabase()
+    {
+        var main = _options.Tenancy?.AllDatabases().FirstOrDefault()
+            ?? throw new InvalidOperationException(
+                "No databases registered on the active tenancy; cannot resolve a main projection daemon.");
+        return DaemonFor(main);
+    }
+
+    public ValueTask<IProjectionDaemon> DaemonForDatabase(string databaseIdentifier)
+    {
+        var match = _options.Tenancy?.AllDatabases()
+            .FirstOrDefault(d => string.Equals(d.Identifier, databaseIdentifier, StringComparison.Ordinal))
+            ?? throw new InvalidOperationException(
+                $"No database registered with identifier '{databaseIdentifier}' on the active tenancy.");
+        return ValueTask.FromResult<IProjectionDaemon>(DaemonFor(match));
+    }
+
+    public ValueTask<IReadOnlyList<IProjectionDaemon>> AllDaemonsAsync()
+    {
+        var databases = _options.Tenancy?.AllDatabases() ?? [];
+        IReadOnlyList<IProjectionDaemon> daemons = databases.Select(DaemonFor).Cast<IProjectionDaemon>().ToList();
+        return ValueTask.FromResult(daemons);
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        if (_runTask is not null) return Task.CompletedTask;
+
+        _paused = false;
+        _runCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        _runTask = Task.Run(() => ExecuteAsync(_runCts.Token), CancellationToken.None);
+        return Task.CompletedTask;
+    }
+
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            if (_runCts is not null)
+            {
+                await _runCts.CancelAsync().ConfigureAwait(false);
+            }
+
+            if (_runTask is not null)
+            {
+                try
+                {
+                    await _runTask.WaitAsync(cancellationToken).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    // Graceful shutdown — nothing to do.
+                }
+            }
+        }
+        finally
+        {
+            await StopAllAgentsAsync().ConfigureAwait(false);
+
+            if (_distributor is not null)
+            {
+                await _distributor.DisposeAsync().ConfigureAwait(false);
+                _distributor = null;
+            }
+
+            _runTask = null;
+            _runCts?.Dispose();
+            _runCts = null;
+        }
+    }
+
+    public async Task PauseAsync()
+    {
+        _paused = true;
+
+        if (_runCts is not null)
+        {
+            await _runCts.CancelAsync().ConfigureAwait(false);
+        }
+
+        if (_runTask is not null)
+        {
+            try
+            {
+                await _runTask.ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                // Expected
+            }
+        }
+
+        await StopAllAgentsAsync().ConfigureAwait(false);
+
+        _runTask = null;
+        _runCts?.Dispose();
+        _runCts = null;
+    }
+
+    public Task ResumeAsync()
+    {
+        if (!_paused) return Task.CompletedTask;
+        _paused = false;
+
+        _runCts = new CancellationTokenSource();
+        _runTask = Task.Run(() => ExecuteAsync(_runCts.Token), CancellationToken.None);
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    ///     The leadership-election + agent-lifecycle loop. Mirrors Marten's
+    ///     <c>ProjectionCoordinator.executeAsync</c> body slot-for-slot
+    ///     (modulo SQL Server idioms via <see cref="SqlServerAppLock"/>).
+    /// </summary>
+    private async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var distributor = Distributor;
+
+        await distributor.RandomWait(stoppingToken).ConfigureAwait(false);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                var sets = await distributor.BuildDistributionAsync().ConfigureAwait(false);
+
+                foreach (var set in sets)
+                {
+                    if (stoppingToken.IsCancellationRequested) return;
+
+                    if (distributor.HasLock(set))
+                    {
+                        var daemon = DaemonFor(set.Database);
+                        await StartAgentsIfNecessaryAsync(set, daemon, stoppingToken).ConfigureAwait(false);
+                        continue;
+                    }
+
+                    try
+                    {
+                        if (await distributor.TryAttainLockAsync(set, stoppingToken).ConfigureAwait(false))
+                        {
+                            var daemon = DaemonFor(set.Database);
+                            await StartAgentsIfNecessaryAsync(set, daemon, stoppingToken).ConfigureAwait(false);
+                        }
+                        else
+                        {
+                            // Don't hold the lock — make sure we're not still
+                            // running these shards from a previous round where
+                            // we did own them.
+                            var daemon = DaemonFor(set.Database);
+                            await StopAgentsIfNecessaryAsync(set, daemon).ConfigureAwait(false);
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        _logger.LogError(e,
+                            "Error attempting lock for set {Names} (lock id {LockId}). Will retry next cycle.",
+                            string.Join(", ", set.Names.Select(n => n.Identity)), set.LockId);
+
+                        await Task.Delay(TimeSpan.FromMilliseconds(_options.DaemonSettings.LeadershipPollingTime),
+                            stoppingToken).ConfigureAwait(false);
+                    }
+                }
+            }
+            catch (Exception e) when (!stoppingToken.IsCancellationRequested)
+            {
+                _logger.LogError(e, "Error resolving the projection distribution.");
+            }
+
+            if (stoppingToken.IsCancellationRequested) return;
+
+            try
+            {
+                var anyPaused = _daemons.Values.Any(d => d.HasAnyPaused());
+                var delay = anyPaused
+                    ? _options.DaemonSettings.AgentPauseTime
+                    : TimeSpan.FromMilliseconds(_options.DaemonSettings.LeadershipPollingTime);
+                await Task.Delay(delay, stoppingToken).ConfigureAwait(false);
+            }
+            catch (TaskCanceledException)
+            {
+                // graceful shutdown
+            }
+            catch (OperationCanceledException)
+            {
+                // graceful shutdown
+            }
+        }
+    }
+
+    private static async Task StartAgentsIfNecessaryAsync(
+        ProjectionSet set, PolecatProjectionDaemon daemon, CancellationToken token)
+    {
+        foreach (var name in set.Names)
+        {
+            if (token.IsCancellationRequested) return;
+            if (daemon.StatusFor(name.Identity) == AgentStatus.Running) continue;
+            await daemon.StartAgentAsync(name.Identity, token).ConfigureAwait(false);
+        }
+    }
+
+    private static async Task StopAgentsIfNecessaryAsync(
+        ProjectionSet set, PolecatProjectionDaemon daemon)
+    {
+        foreach (var name in set.Names)
+        {
+            if (daemon.StatusFor(name.Identity) == AgentStatus.Stopped) continue;
+            try
+            {
+                await daemon.StopAgentAsync(name).ConfigureAwait(false);
+            }
+            catch
+            {
+                // Best-effort — losing the lock is not exceptional, but
+                // we don't want a stop failure to take down the loop.
+            }
+        }
+    }
+
+    private async Task StopAllAgentsAsync()
+    {
+        foreach (var daemon in _daemons.Values)
+        {
+            try
+            {
+                await daemon.StopAllAsync().ConfigureAwait(false);
+            }
+            catch
+            {
+                // Best-effort during shutdown
+            }
+        }
+    }
+
+    private PolecatProjectionDaemon DaemonFor(PolecatDatabase database)
+    {
+        if (!_daemons.TryGetValue(database.Identifier, out var daemon))
+        {
+            daemon = database.StartProjectionDaemon(_store, _loggerFactory);
+            _daemons[database.Identifier] = daemon;
+        }
+        return daemon;
+    }
+
+    private IProjectionDistributor BuildDistributor()
+    {
+        // Mirrors Marten's pick: tenancy with multiple databases →
+        // MultiTenantedProjectionDistributor; single-database tenancy →
+        // SingleTenantProjectionDistributor (per-shard hot-cold locks via
+        // sp_getapplock). SoloProjectionDistributor is reachable via
+        // ProjectionCoordinator subclassing for tests / opt-out scenarios
+        // but not auto-selected — production single-node deployments
+        // benefit from the lock-based coordination too because it's the
+        // only safe path when a second instance shows up unexpectedly.
+        var cardinality = _options.Tenancy?.Cardinality ?? DatabaseCardinality.Single;
+
+        return cardinality == DatabaseCardinality.StaticMultiple
+            ? new MultiTenantedProjectionDistributor(_store, _loggerFactory)
+            : new SingleTenantProjectionDistributor(_store, _loggerFactory);
+    }
+}
+
+/// <summary>
+///     Typed marker variant of <see cref="ProjectionCoordinator"/> for
+///     ancillary store registrations in DI.
+/// </summary>
+internal sealed class ProjectionCoordinator<T> : ProjectionCoordinator, IProjectionCoordinator<T>
+    where T : IDocumentStore
+{
+    public ProjectionCoordinator(DocumentStore store, ILoggerFactory? loggerFactory = null)
+        : base(store, loggerFactory)
+    {
+    }
+}

--- a/src/Polecat/Events/Daemon/Coordination/SingleTenantProjectionDistributor.cs
+++ b/src/Polecat/Events/Daemon/Coordination/SingleTenantProjectionDistributor.cs
@@ -1,0 +1,95 @@
+using JasperFx.Core;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Polecat.Storage;
+
+namespace Polecat.Events.Daemon.Coordination;
+
+/// <summary>
+///     Multi-node, single-database distributor. One set per shard, so each
+///     individual projection / subscription can run on a different node
+///     (hot-cold leadership per shard) — maximizing throughput while still
+///     enforcing single-writer semantics per shard.
+/// </summary>
+internal sealed class SingleTenantProjectionDistributor : IProjectionDistributor
+{
+    private readonly DocumentStore _store;
+    private readonly ILogger _logger;
+    private readonly Dictionary<string, SqlServerAppLock> _locks = new();
+
+    public SingleTenantProjectionDistributor(DocumentStore store, ILoggerFactory loggerFactory)
+    {
+        _store = store;
+        _logger = loggerFactory.CreateLogger<SingleTenantProjectionDistributor>();
+    }
+
+    public ValueTask<IReadOnlyList<ProjectionSet>> BuildDistributionAsync()
+    {
+        var databases = _store.Options.Tenancy?.AllDatabases() ?? [];
+        var schema = _store.Options.DatabaseSchemaName;
+        var baseLockId = _store.Options.DaemonSettings.DaemonLockId;
+
+        var allShards = _store.Options.Projections.AllShards();
+
+        IReadOnlyList<ProjectionSet> sets = databases
+            .SelectMany(db => allShards.Select(shard =>
+            {
+                // Deterministic per (database, schema, shard) — every node in
+                // the deployment computes the same id and races for the same
+                // SQL Server application lock.
+                var lockId = Math.Abs($"{db.Identifier}:{schema}:{shard.Name.Identity}".GetDeterministicHashCode())
+                             + baseLockId;
+
+                return new ProjectionSet(lockId, db, [shard.Name]);
+            }))
+            // Random ordering so multiple nodes coming up together stagger
+            // their lock-acquisition attempts.
+            .OrderBy(_ => Random.Shared.NextDouble())
+            .ToList();
+
+        return ValueTask.FromResult(sets);
+    }
+
+    public Task RandomWait(CancellationToken token) =>
+        Task.Delay(TimeSpan.FromMilliseconds(Random.Shared.Next(0, 500)), token);
+
+    public bool HasLock(ProjectionSet set) =>
+        _locks.TryGetValue(set.Database.Identifier, out var l) && l.HasLock(set.LockId);
+
+    public Task<bool> TryAttainLockAsync(ProjectionSet set, CancellationToken token) =>
+        LockFor(set.Database).TryAttainLockAsync(set.LockId, token);
+
+    public Task ReleaseLockAsync(ProjectionSet set) =>
+        LockFor(set.Database).ReleaseLockAsync(set.LockId);
+
+    public async Task ReleaseAllLocks()
+    {
+        foreach (var (_, l) in _locks)
+        {
+            try
+            {
+                await l.DisposeAsync().ConfigureAwait(false);
+            }
+            catch
+            {
+                // Best-effort during shutdown
+            }
+        }
+        _locks.Clear();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await ReleaseAllLocks().ConfigureAwait(false);
+    }
+
+    private SqlServerAppLock LockFor(PolecatDatabase database)
+    {
+        if (!_locks.TryGetValue(database.Identifier, out var l))
+        {
+            l = new SqlServerAppLock(database.ConnectionString, database.Identifier, _logger);
+            _locks[database.Identifier] = l;
+        }
+        return l;
+    }
+}

--- a/src/Polecat/Events/Daemon/Coordination/SoloProjectionDistributor.cs
+++ b/src/Polecat/Events/Daemon/Coordination/SoloProjectionDistributor.cs
@@ -1,0 +1,46 @@
+namespace Polecat.Events.Daemon.Coordination;
+
+/// <summary>
+///     Single-node distributor — every set is owned by this node, no locks.
+///     Use when the application is known not to scale out, or for local /
+///     test deployments.
+/// </summary>
+internal sealed class SoloProjectionDistributor : IProjectionDistributor
+{
+    private readonly DocumentStore _store;
+
+    public SoloProjectionDistributor(DocumentStore store)
+    {
+        _store = store;
+    }
+
+    public ValueTask<IReadOnlyList<ProjectionSet>> BuildDistributionAsync()
+    {
+        var databases = _store.Options.Tenancy?.AllDatabases() ?? [];
+        var allShards = _store.Options.Projections.AllShards()
+            .Select(s => s.Name)
+            .ToList();
+
+        IReadOnlyList<ProjectionSet> sets = databases
+            .Select(db => new ProjectionSet(
+                lockId: _store.Options.DaemonSettings.DaemonLockId,
+                database: db,
+                names: allShards))
+            .ToList();
+
+        return ValueTask.FromResult(sets);
+    }
+
+    public Task RandomWait(CancellationToken token) => Task.CompletedTask;
+
+    public bool HasLock(ProjectionSet set) => true;
+
+    public Task<bool> TryAttainLockAsync(ProjectionSet set, CancellationToken token) =>
+        Task.FromResult(true);
+
+    public Task ReleaseLockAsync(ProjectionSet set) => Task.CompletedTask;
+
+    public Task ReleaseAllLocks() => Task.CompletedTask;
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+}

--- a/src/Polecat/Events/Daemon/Coordination/SqlServerAppLock.cs
+++ b/src/Polecat/Events/Daemon/Coordination/SqlServerAppLock.cs
@@ -1,0 +1,220 @@
+using System.Data;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Logging;
+
+namespace Polecat.Events.Daemon.Coordination;
+
+/// <summary>
+///     SQL Server application-lock primitive used by the projection coordinator
+///     to negotiate hot-cold leadership across Polecat nodes for the same database.
+/// </summary>
+/// <remarks>
+///     Wraps <c>sp_getapplock</c> / <c>sp_releaseapplock</c> with
+///     <c>@LockOwner = 'Session'</c>. Holds a single dedicated <see cref="SqlConnection"/>
+///     for the lifetime of this lock owner — the locks are session-bound, so the
+///     connection must stay open as long as we hold any lock. If the connection
+///     drops, SQL Server auto-releases all locks on this session and we
+///     proactively clear our local <c>_handles</c> tracking on the next operation
+///     so the coordinator's <see cref="HasLock"/> check stays honest.
+///
+///     Modelled on Marten's <c>Weasel.Postgresql.AdvisoryLock</c>; differences
+///     are purely SQL-dialect.
+/// </remarks>
+internal sealed class SqlServerAppLock : IAsyncDisposable
+{
+    private readonly string _connectionString;
+    private readonly string _databaseIdentifier;
+    private readonly ILogger _logger;
+    private readonly Dictionary<int, byte> _handles = new();
+    private readonly SemaphoreSlim _gate = new(1, 1);
+
+    private SqlConnection? _connection;
+    private bool _disposed;
+
+    public SqlServerAppLock(string connectionString, string databaseIdentifier, ILogger logger)
+    {
+        _connectionString = connectionString;
+        _databaseIdentifier = databaseIdentifier;
+        _logger = logger;
+    }
+
+    /// <summary>
+    ///     Whether this owner currently holds the given lock id. O(1) — checks
+    ///     in-memory tracking only; does not contact the server.
+    /// </summary>
+    public bool HasLock(int lockId)
+    {
+        // If we hold the handle but the connection is broken, the SQL Server
+        // session has already released the lock for us. Clear and return false
+        // so the coordinator re-attempts acquisition rather than acting on a
+        // stale belief that we own it.
+        if (_handles.ContainsKey(lockId))
+        {
+            if (_connection is { State: ConnectionState.Open })
+            {
+                return true;
+            }
+
+            // Connection dropped — clear stale handle tracking.
+            _handles.Clear();
+            _connection = null;
+            return false;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    ///     Attempt to acquire the lock with no wait. Returns true if granted
+    ///     immediately, false if another session already holds it.
+    /// </summary>
+    public async Task<bool> TryAttainLockAsync(int lockId, CancellationToken token)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        await _gate.WaitAsync(token).ConfigureAwait(false);
+        try
+        {
+            if (_handles.ContainsKey(lockId)) return true;
+
+            var connection = await EnsureConnectionAsync(token).ConfigureAwait(false);
+
+            await using var cmd = connection.CreateCommand();
+            cmd.CommandType = CommandType.StoredProcedure;
+            cmd.CommandText = "sp_getapplock";
+
+            cmd.Parameters.AddWithValue("@Resource", ResourceName(lockId));
+            cmd.Parameters.AddWithValue("@LockMode", "Exclusive");
+            cmd.Parameters.AddWithValue("@LockOwner", "Session");
+            cmd.Parameters.AddWithValue("@LockTimeout", 0); // no wait
+            cmd.Parameters.AddWithValue("@DbPrincipal", "public");
+
+            var result = cmd.Parameters.Add("@Result", SqlDbType.Int);
+            result.Direction = ParameterDirection.ReturnValue;
+
+            await cmd.ExecuteNonQueryAsync(token).ConfigureAwait(false);
+
+            var code = (int)result.Value!;
+            // Per docs: 0 = granted synchronously, 1 = granted after a wait,
+            // negatives are timeout / cancel / deadlock / parameter error.
+            if (code >= 0)
+            {
+                _handles[lockId] = 0;
+                return true;
+            }
+
+            if (code != -1)
+            {
+                _logger.LogWarning(
+                    "sp_getapplock for resource {Resource} on database {Database} returned {Code}",
+                    ResourceName(lockId), _databaseIdentifier, code);
+            }
+            return false;
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e,
+                "Error attempting sp_getapplock for resource {Resource} on database {Database}",
+                ResourceName(lockId), _databaseIdentifier);
+            // Connection may be dead — drop it so the next attempt reconnects.
+            await DisposeConnectionAsync().ConfigureAwait(false);
+            return false;
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    /// <summary>
+    ///     Release a lock we hold. No-op if we don't hold it. Best-effort —
+    ///     swallows errors and clears local tracking so the coordinator can
+    ///     move on after a failed release.
+    /// </summary>
+    public async Task ReleaseLockAsync(int lockId)
+    {
+        await _gate.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            if (!_handles.Remove(lockId)) return;
+            if (_connection is not { State: ConnectionState.Open }) return;
+
+            await using var cmd = _connection.CreateCommand();
+            cmd.CommandType = CommandType.StoredProcedure;
+            cmd.CommandText = "sp_releaseapplock";
+
+            cmd.Parameters.AddWithValue("@Resource", ResourceName(lockId));
+            cmd.Parameters.AddWithValue("@LockOwner", "Session");
+            cmd.Parameters.AddWithValue("@DbPrincipal", "public");
+
+            await cmd.ExecuteNonQueryAsync().ConfigureAwait(false);
+        }
+        catch (Exception e)
+        {
+            _logger.LogWarning(e,
+                "Error releasing sp_releaseapplock for resource {Resource} on database {Database}",
+                ResourceName(lockId), _databaseIdentifier);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed) return;
+        _disposed = true;
+
+        await _gate.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            // Closing the connection auto-releases every Session-scoped lock
+            // we hold, so we don't need to call sp_releaseapplock per id.
+            await DisposeConnectionAsync().ConfigureAwait(false);
+            _handles.Clear();
+        }
+        finally
+        {
+            _gate.Release();
+            _gate.Dispose();
+        }
+    }
+
+    private async ValueTask<SqlConnection> EnsureConnectionAsync(CancellationToken token)
+    {
+        if (_connection is { State: ConnectionState.Open })
+        {
+            return _connection;
+        }
+
+        await DisposeConnectionAsync().ConfigureAwait(false);
+
+        var conn = new SqlConnection(_connectionString);
+        await conn.OpenAsync(token).ConfigureAwait(false);
+        _connection = conn;
+        return conn;
+    }
+
+    private async ValueTask DisposeConnectionAsync()
+    {
+        if (_connection is null) return;
+        try
+        {
+            await _connection.DisposeAsync().ConfigureAwait(false);
+        }
+        catch (Exception e)
+        {
+            _logger.LogWarning(e,
+                "Error closing the SQL Server lock connection for database {Database}",
+                _databaseIdentifier);
+        }
+        finally
+        {
+            _connection = null;
+        }
+    }
+
+    private static string ResourceName(int lockId) =>
+        $"polecat_projection_{lockId}";
+}

--- a/src/Polecat/PolecatConfigurationExpression.cs
+++ b/src/Polecat/PolecatConfigurationExpression.cs
@@ -67,6 +67,56 @@ public class PolecatConfigurationExpression
     }
 
     /// <summary>
+    ///     Enable the multi-node-aware projection coordinator. Each Polecat node
+    ///     races for SQL Server application locks (<c>sp_getapplock</c>) per shard
+    ///     (single-tenant) or per database (multi-tenant) so a given shard runs
+    ///     on exactly one node at a time. Equivalent to Marten's hot-cold daemon
+    ///     coordination.
+    /// </summary>
+    /// <remarks>
+    ///     Mutually exclusive with <see cref="AddAsyncDaemon"/> — pick one. The
+    ///     coordinator subsumes the simple hosted-service path: it owns the
+    ///     daemon lifecycle, leader election, and per-shard agent start/stop.
+    /// </remarks>
+    public PolecatConfigurationExpression AddProjectionCoordinator(DaemonMode mode)
+    {
+        Services.ConfigurePolecat(opts => opts.DaemonSettings.AsyncMode = mode);
+        EnsureActivatorIsRegistered();
+
+        Services.AddSingleton<Polecat.Events.Daemon.Coordination.IProjectionCoordinator>(sp =>
+        {
+            var store = (DocumentStore)sp.GetRequiredService<IDocumentStore>();
+            return new Polecat.Events.Daemon.Coordination.ProjectionCoordinator(
+                store, sp.GetRequiredService<ILoggerFactory>());
+        });
+        Services.AddSingleton<IHostedService>(sp =>
+            sp.GetRequiredService<Polecat.Events.Daemon.Coordination.IProjectionCoordinator>());
+        return this;
+    }
+
+    /// <summary>
+    ///     Marker-typed variant of <see cref="AddProjectionCoordinator"/> for
+    ///     ancillary store registrations (multi-store apps where each store
+    ///     gets its own coordinator).
+    /// </summary>
+    public PolecatConfigurationExpression AddProjectionCoordinator<T>(DaemonMode mode)
+        where T : class, IDocumentStore
+    {
+        Services.ConfigurePolecat(opts => opts.DaemonSettings.AsyncMode = mode);
+        EnsureActivatorIsRegistered();
+
+        Services.AddSingleton<Polecat.Events.Daemon.Coordination.IProjectionCoordinator<T>>(sp =>
+        {
+            var store = (DocumentStore)(IDocumentStore)sp.GetRequiredService<T>();
+            return new Polecat.Events.Daemon.Coordination.ProjectionCoordinator<T>(
+                store, sp.GetRequiredService<ILoggerFactory>());
+        });
+        Services.AddSingleton<IHostedService>(sp =>
+            sp.GetRequiredService<Polecat.Events.Daemon.Coordination.IProjectionCoordinator<T>>());
+        return this;
+    }
+
+    /// <summary>
     ///     Apply all database schema changes on application startup.
     ///     Registers an IHostedService that runs Weasel schema migration.
     /// </summary>


### PR DESCRIPTION
…rdination

Closes #83.

Polecat could spin up the async projection daemon via PolecatDaemonHostedService (single-node, no coordination), but had no path to safely run multiple Polecat nodes against the same database — every node would try to drive every shard. This adds the multi-node-aware coordinator that mirrors Marten's hot-cold distributor design, adapted to SQL Server idioms.

## What's added

- `SqlServerAppLock` — Polecat's analog to Marten's `Weasel.Postgresql.AdvisoryLock`. Wraps `sp_getapplock` / `sp_releaseapplock` with `@LockOwner = 'Session'`, holding a dedicated `SqlConnection` for the lifetime of the lock owner so the Session-scoped locks persist until we explicitly release or the connection drops. Stale-handle detection clears local tracking when the connection is found broken so the coordinator's `HasLock()` check stays honest.

- `IProjectionDistributor` + `ProjectionSet` — the per-cycle "(database × shards) with a lock id" grouping the coordinator polls.

- Three concrete distributors:
  - `SoloProjectionDistributor` — single-node fall-through, no locks (test / explicit-opt-out path; not auto-selected by the coordinator).
  - `SingleTenantProjectionDistributor` — one set per shard, deterministic lock id from `db.Identifier:schema:shard.Identity` so every node in the deployment races for the same `sp_getapplock` resource.
  - `MultiTenantedProjectionDistributor` — one set per database, all shards grouped behind one per-database lock so a tenant's projections never split across nodes.

- `ProjectionCoordinator` — the concrete `IProjectionCoordinator` implementation. The `ExecuteAsync` loop is a slot-for-slot mirror of Marten's `ProjectionCoordinator.executeAsync`:
    - Build the current distribution
    - For each set: if we hold the lock, ensure agents are running; if not, try to attain it (start agents on success, stop them on failure to recover from a lost lock)
    - Sleep based on agent pause status Picks `SingleTenantProjectionDistributor` for `DatabaseCardinality.Single` and `MultiTenantedProjectionDistributor` for `StaticMultiple` (mirrors Marten's `Tenancy is DefaultTenancy ? Single : MultiTenanted` choice). Plus `ProjectionCoordinator<T>` for ancillary multi-store DI registration.

- DI wiring on `PolecatConfigurationExpression`: `AddProjectionCoordinator(DaemonMode)` and the typed `AddProjectionCoordinator<T>(DaemonMode)`. Mutually exclusive with `AddAsyncDaemon` — pick one.

## Tests

`src/Polecat.Tests/Daemon/sql_server_app_lock_tests.cs` — 6 cases for the lock primitive, all passing against SQL Server 2025 docker on net9.0:

- Only one of two `SqlServerAppLock` instances acquires a given id
- Releasing lets a waiting instance acquire
- Disposing one auto-releases its session locks (Session-scope)
- Multiple distinct lock ids are independent
- `TryAttainLockAsync` is idempotent when the id is already owned
- Releasing an unknown id is a no-op

The full coordinator loop (leadership election + agent lifecycle) follows Marten's well-tested implementation slot-for-slot; the lock primitive is the genuinely Polecat-new code path and gets dedicated coverage.