### PR TITLE
Bump Polecat → 4.0.0-alpha.2

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>4.0.0-alpha.1</Version>
+        <Version>4.0.0-alpha.2</Version>
         <LangVersion>latest</LangVersion>
         <Authors>Jeremy D. Miller</Authors>
         <PackageIcon>logo.png</PackageIcon>


### PR DESCRIPTION
Releases the dedupe-pillar consumption work onto NuGet so downstream products (Wolverine.Polecat, third-party consumers) can pick up:

- #87 — Consumption of JFx.Events 2.0 lifted contracts (IEventStream<T>, IEventStoreOperations, IEventOperations, IQueryEventStore, StreamState resolved to JasperFx.Events; Polecat-only extras retained on inheriting interfaces).

- #93 — Pre-consumption gap-fills: Append/StartStream IEnumerable + Type-parameter overloads, IQueryEventStore.LoadAsync<T>(Guid) / LoadAsync(Guid), IEventOperations.CompletelyReplaceEvent<T>.

- #94 (#81) — IDocumentOperations.StoreObjects(IEnumerable<object>) so heterogeneous bulk-store routes through Polecat's existing per-type dispatch with no MakeGenericMethod / Activator on the hot path.

Mechanics: bumps Directory.Build.props Version 4.0.0-alpha.1 → 4.0.0-alpha.2. Pack/push runs through the existing publish workflow (tag push or manual workflow_dispatch).