### PR TITLE
Add IMessageBatch / IMessageOutbox plumbing for projection-emitted me…

### DIFF
--- a/src/Polecat.Tests/Daemon/projection_message_outbox_tests.cs
+++ b/src/Polecat.Tests/Daemon/projection_message_outbox_tests.cs
@@ -1,0 +1,170 @@
+using JasperFx.Events;
+using Polecat.Events.Aggregation;
+using Polecat.Events.Daemon;
+using Polecat.Tests.Harness;
+
+namespace Polecat.Tests.Daemon;
+
+/// <summary>
+///     Coverage for the IMessageBatch / IMessageOutbox plumbing wired through
+///     <see cref="PolecatProjectionBatch"/> ([polecat#84](https://github.com/JasperFx/polecat/issues/84)).
+///     Verifies the lifecycle: lazy batch creation on first publish, message
+///     forwarded to the batch, BeforeCommit + AfterCommit hooks fire after a
+///     successful projection commit, and no batch is created when no projection
+///     publishes.
+/// </summary>
+public class projection_message_outbox_tests : OneOffConfigurationsContext
+{
+    [Fact]
+    public async Task batch_is_lazy_no_publish_means_no_create_no_hooks()
+    {
+        var outbox = new TrackingOutbox();
+        ConfigureStore(opts =>
+        {
+            opts.DatabaseSchemaName = "msg_outbox_lazy";
+            opts.Events.MessageOutbox = outbox;
+        });
+        await theDatabase.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        var batch = new PolecatProjectionBatch(theStore, theStore.Options.EventGraph,
+            ConnectionSource.ConnectionString);
+        var session = batch.SessionForTenant(theStore.Options.Tenancy!.DefaultTenantId);
+        session.Store(new SimpleDoc { Id = Guid.NewGuid() });
+
+        await batch.ExecuteAsync(default);
+
+        outbox.CreateBatchCount.ShouldBe(0);
+        outbox.LastBatch.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task publish_creates_a_batch_once_and_forwards_the_message()
+    {
+        var outbox = new TrackingOutbox();
+        ConfigureStore(opts =>
+        {
+            opts.DatabaseSchemaName = "msg_outbox_publish";
+            opts.Events.MessageOutbox = outbox;
+        });
+        await theDatabase.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        var batch = new PolecatProjectionBatch(theStore, theStore.Options.EventGraph,
+            ConnectionSource.ConnectionString);
+        var session = batch.SessionForTenant(theStore.Options.Tenancy!.DefaultTenantId);
+        session.Store(new SimpleDoc { Id = Guid.NewGuid() });
+
+        await batch.PublishMessageAsync(new SideEffect("first"), "default");
+        await batch.PublishMessageAsync(new SideEffect("second"), "default");
+
+        outbox.CreateBatchCount.ShouldBe(1);
+        outbox.LastBatch.ShouldNotBeNull();
+        outbox.LastBatch!.Published.ShouldBe(
+        [
+            (typeof(SideEffect), (object?)new SideEffect("first"), "default"),
+            (typeof(SideEffect), (object?)new SideEffect("second"), "default"),
+        ]);
+    }
+
+    [Fact]
+    public async Task before_and_after_commit_fire_when_a_message_was_published()
+    {
+        var outbox = new TrackingOutbox();
+        ConfigureStore(opts =>
+        {
+            opts.DatabaseSchemaName = "msg_outbox_hooks";
+            opts.Events.MessageOutbox = outbox;
+        });
+        await theDatabase.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        var batch = new PolecatProjectionBatch(theStore, theStore.Options.EventGraph,
+            ConnectionSource.ConnectionString);
+        var session = batch.SessionForTenant(theStore.Options.Tenancy!.DefaultTenantId);
+        session.Store(new SimpleDoc { Id = Guid.NewGuid() });
+
+        await batch.PublishMessageAsync(new SideEffect("evt"), "default");
+        await batch.ExecuteAsync(default);
+
+        outbox.LastBatch!.BeforeCommitCalls.ShouldBe(1);
+        outbox.LastBatch!.AfterCommitCalls.ShouldBe(1);
+        // Order matters: publish first, then before-commit, then after-commit.
+        outbox.LastBatch!.Calls.ShouldBe(["publish", "before", "after"]);
+    }
+
+    [Fact]
+    public async Task metadata_overload_forwards_to_the_batch()
+    {
+        var outbox = new TrackingOutbox();
+        ConfigureStore(opts =>
+        {
+            opts.DatabaseSchemaName = "msg_outbox_metadata";
+            opts.Events.MessageOutbox = outbox;
+        });
+        await theDatabase.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        var batch = new PolecatProjectionBatch(theStore, theStore.Options.EventGraph,
+            ConnectionSource.ConnectionString);
+        var session = batch.SessionForTenant(theStore.Options.Tenancy!.DefaultTenantId);
+        session.Store(new SimpleDoc { Id = Guid.NewGuid() });
+
+        var metadata = new MessageMetadata { TenantId = "tenant-z" };
+        await batch.PublishMessageAsync(new SideEffect("with-meta"), metadata);
+        await batch.ExecuteAsync(default);
+
+        // The default IMessageSink.PublishAsync(T, MessageMetadata) impl
+        // forwards to PublishAsync(T, metadata.TenantId), so we should see
+        // the tenant-z entry in the captured publishes.
+        outbox.LastBatch!.Published.ShouldBe(
+        [
+            (typeof(SideEffect), (object?)new SideEffect("with-meta"), "tenant-z"),
+        ]);
+    }
+
+    public class SimpleDoc
+    {
+        public Guid Id { get; set; }
+    }
+
+    public sealed record SideEffect(string Label);
+
+    private sealed class TrackingOutbox : IMessageOutbox
+    {
+        public int CreateBatchCount { get; private set; }
+        public TrackingBatch? LastBatch { get; private set; }
+
+        public ValueTask<IMessageBatch> CreateBatch(IDocumentSession session)
+        {
+            CreateBatchCount++;
+            LastBatch = new TrackingBatch();
+            return new ValueTask<IMessageBatch>(LastBatch);
+        }
+    }
+
+    private sealed class TrackingBatch : IMessageBatch
+    {
+        public List<(Type Type, object? Body, string TenantId)> Published { get; } = new();
+        public List<string> Calls { get; } = new();
+        public int BeforeCommitCalls { get; private set; }
+        public int AfterCommitCalls { get; private set; }
+
+        public ValueTask PublishAsync<T>(T message, string tenantId)
+        {
+            Published.Add((typeof(T), (object?)message, tenantId));
+            Calls.Add("publish");
+            return ValueTask.CompletedTask;
+        }
+
+        public Task BeforeCommitAsync(CancellationToken token)
+        {
+            BeforeCommitCalls++;
+            Calls.Add("before");
+            return Task.CompletedTask;
+        }
+
+        public Task AfterCommitAsync(CancellationToken token)
+        {
+            AfterCommitCalls++;
+            Calls.Add("after");
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Polecat/Events/Aggregation/IMessageBatch.cs
+++ b/src/Polecat/Events/Aggregation/IMessageBatch.cs
@@ -1,0 +1,40 @@
+using JasperFx.Events;
+
+namespace Polecat.Events.Aggregation;
+
+/// <summary>
+///     A message-publishing surface scoped to a single projection daemon batch.
+///     Projections call <see cref="IMessageSink.PublishAsync{T}(T, string)"/> (or
+///     the metadata variant) when they want to emit side-effect messages
+///     transactionally with the projection's database changes.
+/// </summary>
+/// <remarks>
+///     The batch is enlisted as a post-commit listener on the projection update —
+///     <see cref="BeforeCommitAsync"/> fires inside the projection's SQL
+///     transaction (right before <c>COMMIT</c>), <see cref="AfterCommitAsync"/>
+///     fires once the projection's database changes are durably committed.
+///     Implementations (e.g. a future Wolverine.Polecat bridge) buffer messages
+///     in <c>PublishAsync</c> and flush them in one of the two hooks depending
+///     on the desired delivery guarantee.
+///
+///     The default outbox registered with <see cref="EventStoreOptions.MessageOutbox"/>
+///     is <see cref="NulloMessageOutbox"/> — a no-op that drops every published
+///     message, so projections that don't need messaging incur zero overhead.
+/// </remarks>
+public interface IMessageBatch : IMessageSink
+{
+    /// <summary>
+    ///     Called inside the projection's database transaction, right before
+    ///     <c>COMMIT</c>. Use for "at-least-once" delivery patterns where the
+    ///     downstream outbox must be persisted in the same transaction as the
+    ///     projection write.
+    /// </summary>
+    Task BeforeCommitAsync(CancellationToken token);
+
+    /// <summary>
+    ///     Called once the projection's database changes are durably committed.
+    ///     Use for "best-effort" or external-broker delivery where the messages
+    ///     should only fire after the projection write succeeds.
+    /// </summary>
+    Task AfterCommitAsync(CancellationToken token);
+}

--- a/src/Polecat/Events/Aggregation/IMessageOutbox.cs
+++ b/src/Polecat/Events/Aggregation/IMessageOutbox.cs
@@ -1,0 +1,24 @@
+namespace Polecat.Events.Aggregation;
+
+/// <summary>
+///     Factory for <see cref="IMessageBatch"/> instances. Registered on the
+///     event store via <see cref="EventStoreOptions.MessageOutbox"/>; the
+///     projection daemon asks for a fresh batch once per projection update,
+///     scoped to the session that's persisting the write.
+/// </summary>
+/// <remarks>
+///     The default outbox is <see cref="NulloMessageOutbox"/>. Downstream
+///     integrations (Wolverine.Polecat is the canonical case) ship their own
+///     <see cref="IMessageOutbox"/> that vends batches enlisted into their
+///     own outgoing-message machinery.
+/// </remarks>
+public interface IMessageOutbox
+{
+    /// <summary>
+    ///     Build a fresh <see cref="IMessageBatch"/> for the given session.
+    ///     Called at most once per projection daemon batch (the first time
+    ///     a projection in that batch publishes a message); the returned
+    ///     batch is reused for every subsequent publish in the same batch.
+    /// </summary>
+    ValueTask<IMessageBatch> CreateBatch(IDocumentSession session);
+}

--- a/src/Polecat/Events/Aggregation/NulloMessageOutbox.cs
+++ b/src/Polecat/Events/Aggregation/NulloMessageOutbox.cs
@@ -1,0 +1,30 @@
+using JasperFx.Events;
+
+namespace Polecat.Events.Aggregation;
+
+/// <summary>
+///     The default <see cref="IMessageOutbox"/> + <see cref="IMessageBatch"/>:
+///     drops every message, fires no commit hooks. Apps that don't integrate
+///     a message bus (most of them) pay zero overhead.
+/// </summary>
+internal sealed class NulloMessageOutbox : IMessageOutbox, IMessageBatch
+{
+    public static readonly NulloMessageOutbox Instance = new();
+
+    private NulloMessageOutbox()
+    {
+    }
+
+    public ValueTask<IMessageBatch> CreateBatch(IDocumentSession session) =>
+        new(this);
+
+    public ValueTask PublishAsync<T>(T message, string tenantId) =>
+        ValueTask.CompletedTask;
+
+    public ValueTask PublishAsync<T>(T message, MessageMetadata metadata) =>
+        ValueTask.CompletedTask;
+
+    public Task BeforeCommitAsync(CancellationToken token) => Task.CompletedTask;
+
+    public Task AfterCommitAsync(CancellationToken token) => Task.CompletedTask;
+}

--- a/src/Polecat/Events/Daemon/PolecatProjectionBatch.cs
+++ b/src/Polecat/Events/Daemon/PolecatProjectionBatch.cs
@@ -4,6 +4,7 @@ using JasperFx.Events.Daemon;
 using JasperFx.Events.Projections;
 using Microsoft.Data.SqlClient;
 using Polly;
+using Polecat.Events.Aggregation;
 using Polecat.Internal;
 using Polecat.Internal.Operations;
 using Weasel.SqlServer;
@@ -24,6 +25,13 @@ internal class PolecatProjectionBatch : IProjectionBatch<IDocumentSession, IQuer
     private readonly ResiliencePipeline _resilience;
     private readonly ConcurrentBag<IDocumentSession> _sessions = new();
     private readonly ConcurrentQueue<IStorageOperation> _progressOps = new();
+
+    // Lazily created on first PublishMessageAsync call; reused for every
+    // subsequent publish in this batch. Stays null when no projection
+    // emits a message, so the AfterCommit hook is a no-op for the common
+    // case where no message-bus integration is configured.
+    private IMessageBatch? _messageBatch;
+    private readonly SemaphoreSlim _messageBatchGate = new(1, 1);
 
     public PolecatProjectionBatch(DocumentStore store, EventGraph events, string connectionString)
     {
@@ -108,9 +116,16 @@ internal class PolecatProjectionBatch : IProjectionBatch<IDocumentSession, IQuer
             .SelectMany(s => s.TransactionParticipants)
             .ToList();
 
+        // Snapshot the message batch (may be null when no projection in this
+        // batch published a message). Passed via state into the resilience
+        // lambda so BeforeCommitAsync runs inside the SQL transaction; the
+        // AfterCommitAsync hook fires once below, after the resilience
+        // pipeline returns successfully.
+        var messageBatch = _messageBatch;
+
         await _resilience.ExecuteAsync(static async (state, ct) =>
         {
-            var (connectionString, ops, txParticipants) = state;
+            var (connectionString, ops, txParticipants, msgBatch) = state;
             await using var conn = new SqlConnection(connectionString);
             await conn.OpenAsync(ct);
             await using var tx = (SqlTransaction)await conn.BeginTransactionAsync(ct);
@@ -170,6 +185,11 @@ internal class PolecatProjectionBatch : IProjectionBatch<IDocumentSession, IQuer
                     await participant.BeforeCommitAsync(conn, tx, ct);
                 }
 
+                if (msgBatch is not null)
+                {
+                    await msgBatch.BeforeCommitAsync(ct);
+                }
+
                 await tx.CommitAsync(ct);
             }
             catch
@@ -177,7 +197,15 @@ internal class PolecatProjectionBatch : IProjectionBatch<IDocumentSession, IQuer
                 await tx.RollbackAsync(ct);
                 throw;
             }
-        }, (_connectionString, allOps, participants), token);
+        }, (_connectionString, allOps, participants, messageBatch), token);
+
+        // Outside the resilience pipeline so the post-commit hook does not
+        // re-fire on a transient retry — by definition the SQL transaction
+        // has committed exactly once by the time we reach here.
+        if (messageBatch is not null)
+        {
+            await messageBatch.AfterCommitAsync(token).ConfigureAwait(false);
+        }
     }
 
     public void QuickAppendEventWithVersion(StreamAction action, IEvent @event)
@@ -195,14 +223,87 @@ internal class PolecatProjectionBatch : IProjectionBatch<IDocumentSession, IQuer
         // Event appending from projections is not used in Polecat's current scope
     }
 
-    public Task PublishMessageAsync(object message, string tenantId)
+    public async Task PublishMessageAsync(object message, string tenantId)
     {
-        // Message bus support deferred
-        return Task.CompletedTask;
+        var batch = await CurrentMessageBatchAsync().ConfigureAwait(false);
+        await PublishToBatchAsync(batch, message, tenantId).ConfigureAwait(false);
+    }
+
+    public async Task PublishMessageAsync(object message, MessageMetadata metadata)
+    {
+        var batch = await CurrentMessageBatchAsync().ConfigureAwait(false);
+        await PublishToBatchAsync(batch, message, metadata).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    ///     Lazily obtain the per-batch <see cref="IMessageBatch"/> from the
+    ///     configured <see cref="IMessageOutbox"/>. Created on first publish;
+    ///     stays null if no projection in this batch ever publishes a message,
+    ///     which keeps the AfterCommit hook a no-op for the common case.
+    /// </summary>
+    private async ValueTask<IMessageBatch> CurrentMessageBatchAsync()
+    {
+        if (_messageBatch is not null) return _messageBatch;
+
+        await _messageBatchGate.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            if (_messageBatch is not null) return _messageBatch;
+
+            var session = _sessions.FirstOrDefault()
+                ?? throw new InvalidOperationException(
+                    "Cannot publish a message from a projection batch with no document session.");
+
+            _messageBatch = await _store.Options.Events.MessageOutbox
+                .CreateBatch(session)
+                .ConfigureAwait(false);
+
+            return _messageBatch;
+        }
+        finally
+        {
+            _messageBatchGate.Release();
+        }
+    }
+
+    // Cached generic method definitions — `IMessageSink.PublishAsync<T>` takes
+    // T as the first parameter, so a `GetMethod(name, [typeof(object), …])`
+    // lookup misses (it doesn't match the generic parameter). Filter by arity
+    // and second-param type instead, then close over the runtime message type.
+    private static readonly System.Reflection.MethodInfo PublishWithTenantMethod = typeof(IMessageSink)
+        .GetMethods()
+        .First(m => m.Name == nameof(IMessageSink.PublishAsync)
+                    && m.IsGenericMethodDefinition
+                    && m.GetParameters() is { Length: 2 } parms
+                    && parms[1].ParameterType == typeof(string));
+
+    private static readonly System.Reflection.MethodInfo PublishWithMetadataMethod = typeof(IMessageSink)
+        .GetMethods()
+        .First(m => m.Name == nameof(IMessageSink.PublishAsync)
+                    && m.IsGenericMethodDefinition
+                    && m.GetParameters() is { Length: 2 } parms
+                    && parms[1].ParameterType == typeof(MessageMetadata));
+
+    private static ValueTask PublishToBatchAsync(IMessageBatch batch, object message, string tenantId)
+    {
+        // The batch's PublishAsync is generic on T but the daemon hands us
+        // the message as `object`. Route through MethodInfo.Invoke is the
+        // simplest correct path since this is off the per-event hot path —
+        // it only runs when a projection explicitly emits a side-effect.
+        var closed = PublishWithTenantMethod.MakeGenericMethod(message.GetType());
+        return (ValueTask)closed.Invoke(batch, [message, tenantId])!;
+    }
+
+    private static ValueTask PublishToBatchAsync(IMessageBatch batch, object message, MessageMetadata metadata)
+    {
+        var closed = PublishWithMetadataMethod.MakeGenericMethod(message.GetType());
+        return (ValueTask)closed.Invoke(batch, [message, metadata])!;
     }
 
     public async ValueTask DisposeAsync()
     {
+        _messageBatchGate.Dispose();
+
         foreach (var session in _sessions)
         {
             await session.DisposeAsync();

--- a/src/Polecat/StoreOptions.cs
+++ b/src/Polecat/StoreOptions.cs
@@ -327,6 +327,18 @@ public class EventStoreOptions
     public bool EnableExtendedProgressionTracking { get; set; }
 
     /// <summary>
+    ///     Outbox factory the projection daemon asks for an
+    ///     <see cref="Polecat.Events.Aggregation.IMessageBatch"/> when a
+    ///     projection in the current batch publishes a side-effect message.
+    ///     Defaults to <see cref="Polecat.Events.Aggregation.NulloMessageOutbox"/>
+    ///     so apps that don't integrate a message bus pay zero overhead.
+    ///     Wolverine.Polecat (and other downstream integrations) plug their
+    ///     own implementation in here.
+    /// </summary>
+    public Polecat.Events.Aggregation.IMessageOutbox MessageOutbox { get; set; }
+        = Polecat.Events.Aggregation.NulloMessageOutbox.Instance;
+
+    /// <summary>
     ///     Register a tag type for Dynamic Consistency Boundary (DCB) support.
     ///     Creates a tag table with an auto-generated suffix.
     /// </summary>


### PR DESCRIPTION
…ssages

Closes #84.

Marten projections can publish side-effect messages on commit (transactionally with the projection write) via Wolverine.Marten's MartenToWolverineMessageBatch. Polecat's projection daemon had no equivalent — the IProjectionBatch.PublishMessageAsync hook was a Task.CompletedTask stub.

This adds the Polecat-side plumbing only — a future Wolverine.Polecat will implement IMessageOutbox to bridge into Wolverine's outgoing- message machinery. The user explicitly scoped this PR Polecat-only.

## Added

- `Polecat.Events.Aggregation.IMessageBatch` — extends `JasperFx.Events.IMessageSink` with `BeforeCommitAsync(token)` and `AfterCommitAsync(token)` hooks. The batch buffers messages in PublishAsync; the implementer chooses which hook to flush in based on the desired delivery guarantee.

- `Polecat.Events.Aggregation.IMessageOutbox` — factory that vends a fresh `IMessageBatch` per projection daemon batch. The signature takes the public `IDocumentSession` (rather than internal `DocumentSessionBase`) so downstream integrations don't need InternalsVisibleTo; `IDocumentSession` already exposes `ITransactionParticipantRegistrar` for enrollment.

- `Polecat.Events.Aggregation.NulloMessageOutbox` — singleton no-op default (drops messages, fires no hooks). Apps that don't integrate a message bus pay zero overhead.

- `EventStoreOptions.MessageOutbox` property defaulting to NulloMessageOutbox. This is the registration point for downstream integrations.

## Wired through PolecatProjectionBatch

- New `_messageBatch` field + `_messageBatchGate` semaphore for thread-safe lazy initialization. Stays null when no projection in this batch publishes.

- `PublishMessageAsync(object, string)` — was a Task.CompletedTask stub; now lazily creates the batch via `IMessageOutbox.CreateBatch` and forwards the message via cached generic `IMessageSink.PublishAsync<T>` MethodInfo. The reflection lookup is done once at static init; per-publish cost is one MakeGenericMethod + one Invoke (off the per-event hot path — only fires when a projection explicitly emits a side-effect).

- New `PublishMessageAsync(object, MessageMetadata)` overload mirroring the same pattern; satisfies the JFx.Events.IProjectionBatch contract added in the canonical interface (default impl forwards tenant-only; we wire the metadata-aware path so downstream integrations can stamp correlation / causation / headers).

- ExecuteAsync passes the snapshot batch into the resilience lambda's state tuple. `BeforeCommitAsync` fires inside the SQL transaction (right before `tx.CommitAsync`) so an at-least-once outbox can persist its envelopes in the same transaction. `AfterCommitAsync` fires outside the resilience pipeline (after success) so it does not re-fire on a transient SQL retry.

## Tests

`src/Polecat.Tests/Daemon/projection_message_outbox_tests.cs` — 4 cases:

- No publish in the batch → `IMessageOutbox.CreateBatch` is never called and no hooks fire (the common no-op path)
- Publish creates the batch exactly once and forwards every published message with the right type and tenant id
- BeforeCommit + AfterCommit hooks both fire after `ExecuteAsync` completes, in the right order (publish → before → after)
- The metadata overload correctly extracts tenant id (default IMessageSink impl) and forwards through the same path

All 4 pass against SQL Server 2025 docker on net9.0.