### PR TITLE
Support projection side effects on Inline projections (#99)

### DIFF
--- a/docs/events/projections/side-effects.md
+++ b/docs/events/projections/side-effects.md
@@ -1,8 +1,9 @@
 # Side Effects
 
 ::: tip
-Side effects only fire during _continuous_ asynchronous projection execution.
-They do not run during projection rebuilds or for `Inline` projections.
+By default, side effects only fire during _continuous_ asynchronous projection execution.
+They do not run during projection rebuilds. Inline projections can opt in via
+[`EnableSideEffectsOnInlineProjections`](#side-effects-in-inline-projections).
 :::
 
 _Sometimes_, it can be valuable to emit new events during the processing of a projection
@@ -74,7 +75,8 @@ public class TripProjection : SingleStreamProjection<Trip, Guid>
 A few important facts about this functionality:
 
 - The `RaiseSideEffects()` method is only called during _continuous_ asynchronous projection
-  execution. It is **not** called during projection rebuilds or `Inline` projection usage.
+  execution. It is **not** called during projection rebuilds. For `Inline` projections,
+  it is opt-in via [`EnableSideEffectsOnInlineProjections`](#side-effects-in-inline-projections).
 - Events emitted during the side effect method are _not_ immediately applied to the current
   projected document value by Polecat
 - You _can_ alter the aggregate value or replace it yourself in this side effect method to
@@ -112,3 +114,33 @@ messages to a database table inside the same transaction) and "best-effort" patt
 A first-class [Wolverine](https://wolverinefx.net) integration is on the roadmap that will
 plug Wolverine's outbox in via `IntegrateWithWolverine()`, mirroring the existing
 Marten/Wolverine bridge.
+
+## Side Effects in Inline Projections
+
+By default, Polecat only processes projection side effects during continuous asynchronous
+processing. To process them when running projections under the `Inline` lifecycle as well,
+flip the opt-in setting on the event store options:
+
+```cs
+builder.Services.AddPolecat(opts =>
+{
+    opts.Connection(builder.Configuration.GetConnectionString("polecat"));
+
+    // Run RaiseSideEffects() for inline projections too
+    opts.EventGraph.EnableSideEffectsOnInlineProjections = true;
+});
+```
+
+When the flag is on, `slice.PublishMessage(...)` from an inline projection's
+`RaiseSideEffects()` method enqueues the message into the configured `IMessageOutbox`'s
+batch on the active document session. `BeforeCommitAsync` fires inside the session's SQL
+transaction (right before `COMMIT`), and `AfterCommitAsync` fires once the session's
+database changes are durably committed.
+
+::: warning
+Inline `RaiseSideEffects()` may **not** call `slice.AppendEvent(...)` — appending events
+back into the same session that's currently committing them is not supported. Doing so
+throws `InvalidOperationException`. Side effects from inline projections are limited to
+published messages.
+:::
+

--- a/src/Polecat.Tests/Events/inline_projection_side_effects_tests.cs
+++ b/src/Polecat.Tests/Events/inline_projection_side_effects_tests.cs
@@ -1,0 +1,151 @@
+using JasperFx.Events;
+using JasperFx.Events.Projections;
+using Polecat.Events.Aggregation;
+using Polecat.Projections;
+using Polecat.Tests.Harness;
+
+namespace Polecat.Tests.Events;
+
+/// <summary>
+///     Coverage for projection side effects on Inline projections
+///     ([polecat#99](https://github.com/JasperFx/polecat/issues/99)).
+///     Verifies the EnableSideEffectsOnInlineProjections gate, the
+///     IMessageOutbox round-trip on the session commit path, and the
+///     before/after-commit lifecycle ordering.
+/// </summary>
+public class inline_projection_side_effects_tests : OneOffConfigurationsContext
+{
+    [Fact]
+    public async Task flag_off_means_raise_side_effects_is_not_invoked()
+    {
+        var outbox = new TrackingOutbox();
+        ConfigureStore(opts =>
+        {
+            opts.DatabaseSchemaName = "inline_se_off";
+            opts.Events.MessageOutbox = outbox;
+            // EnableSideEffectsOnInlineProjections defaults to false
+            opts.Projections.Add(
+                new SingleStreamProjection<InlineSeAggregate, Guid>(),
+                ProjectionLifecycle.Inline);
+        });
+        await theDatabase.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        var streamId = Guid.NewGuid();
+        await using var session = theStore.LightweightSession();
+        session.Events.StartStream(streamId, new InlineSeStarted("hello"));
+        await session.SaveChangesAsync();
+
+        outbox.CreateBatchCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task flag_on_routes_published_message_through_outbox()
+    {
+        var outbox = new TrackingOutbox();
+        ConfigureStore(opts =>
+        {
+            opts.DatabaseSchemaName = "inline_se_on";
+            opts.Events.MessageOutbox = outbox;
+            opts.EventGraph.EnableSideEffectsOnInlineProjections = true;
+            opts.Projections.Add(
+                new InlineSeProjection(),
+                ProjectionLifecycle.Inline);
+        });
+        await theDatabase.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        var streamId = Guid.NewGuid();
+        await using var session = theStore.LightweightSession();
+        session.Events.StartStream(streamId, new InlineSeStarted("hello"));
+        await session.SaveChangesAsync();
+
+        outbox.CreateBatchCount.ShouldBe(1);
+        outbox.LastBatch.ShouldNotBeNull();
+        outbox.LastBatch!.Published.Count.ShouldBe(1);
+        outbox.LastBatch.Published[0].Body.ShouldBeOfType<InlineSeNotice>();
+        ((InlineSeNotice)outbox.LastBatch.Published[0].Body!).Label.ShouldBe("hello");
+    }
+
+    [Fact]
+    public async Task before_and_after_commit_fire_in_order_around_publish()
+    {
+        var outbox = new TrackingOutbox();
+        ConfigureStore(opts =>
+        {
+            opts.DatabaseSchemaName = "inline_se_hooks";
+            opts.Events.MessageOutbox = outbox;
+            opts.EventGraph.EnableSideEffectsOnInlineProjections = true;
+            opts.Projections.Add(
+                new InlineSeProjection(),
+                ProjectionLifecycle.Inline);
+        });
+        await theDatabase.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        var streamId = Guid.NewGuid();
+        await using var session = theStore.LightweightSession();
+        session.Events.StartStream(streamId, new InlineSeStarted("evt"));
+        await session.SaveChangesAsync();
+
+        outbox.LastBatch!.Calls.ShouldBe(["publish", "before", "after"]);
+    }
+
+    public record InlineSeStarted(string Label);
+    public record InlineSeNotice(string Label);
+
+    public class InlineSeAggregate
+    {
+        public Guid Id { get; set; }
+        public string Label { get; set; } = "";
+
+        public void Apply(InlineSeStarted e) => Label = e.Label;
+    }
+
+    public class InlineSeProjection : SingleStreamProjection<InlineSeAggregate, Guid>
+    {
+        public override ValueTask RaiseSideEffects(IDocumentSession session, IEventSlice<InlineSeAggregate> slice)
+        {
+            if (slice.Snapshot is not null)
+            {
+                slice.PublishMessage(new InlineSeNotice(slice.Snapshot.Label));
+            }
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class TrackingOutbox : IMessageOutbox
+    {
+        public int CreateBatchCount { get; private set; }
+        public TrackingBatch? LastBatch { get; private set; }
+
+        public ValueTask<IMessageBatch> CreateBatch(IDocumentSession session)
+        {
+            CreateBatchCount++;
+            LastBatch = new TrackingBatch();
+            return new ValueTask<IMessageBatch>(LastBatch);
+        }
+    }
+
+    private sealed class TrackingBatch : IMessageBatch
+    {
+        public List<(Type Type, object? Body, string TenantId)> Published { get; } = new();
+        public List<string> Calls { get; } = new();
+
+        public ValueTask PublishAsync<T>(T message, string tenantId)
+        {
+            Published.Add((typeof(T), (object?)message, tenantId));
+            Calls.Add("publish");
+            return ValueTask.CompletedTask;
+        }
+
+        public Task BeforeCommitAsync(CancellationToken token)
+        {
+            Calls.Add("before");
+            return Task.CompletedTask;
+        }
+
+        public Task AfterCommitAsync(CancellationToken token)
+        {
+            Calls.Add("after");
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Polecat/Events/EventGraph.cs
+++ b/src/Polecat/Events/EventGraph.cs
@@ -90,6 +90,15 @@ public class EventGraph : EventRegistry, IAggregationSourceFactory<IQuerySession
     /// </summary>
     public bool UseArchivedStreamPartitioning { get; set; }
 
+    /// <summary>
+    ///     Process projection side effects (slice.PublishMessage) when running
+    ///     projections under the Inline lifecycle. Off by default — flip on to
+    ///     route inline-projection-emitted messages through the configured
+    ///     <see cref="StoreOptions.MessageOutbox"/>. Inline appended events
+    ///     (slice.AppendEvent) are not supported and will throw at runtime.
+    /// </summary>
+    public bool EnableSideEffectsOnInlineProjections { get; set; }
+
     internal string StreamsTableName => $"[{DatabaseSchemaName}].[pc_streams]";
     internal string EventsTableName => $"[{DatabaseSchemaName}].[pc_events]";
     internal string ProgressionTableName => $"[{DatabaseSchemaName}].[pc_event_progression]";

--- a/src/Polecat/Internal/DocumentSessionBase.cs
+++ b/src/Polecat/Internal/DocumentSessionBase.cs
@@ -6,6 +6,7 @@ using JasperFx.Events.Daemon;
 using JasperFx.Events.Projections;
 using Microsoft.Data.SqlClient;
 using Polecat.Events;
+using Polecat.Events.Aggregation;
 using Polecat.Exceptions;
 using Polecat.Internal.Operations;
 using Polecat.Internal.Sessions;
@@ -488,6 +489,11 @@ internal abstract class DocumentSessionBase : QuerySession, IDocumentSession
                 await participant.BeforeCommitAsync(_transactional.Connection!, tx, token);
             }
 
+            if (_inlineMessageBatch is not null)
+            {
+                await _inlineMessageBatch.BeforeCommitAsync(token);
+            }
+
             await tx.CommitAsync(token);
             _workTracker.Reset();
 
@@ -502,6 +508,11 @@ internal abstract class DocumentSessionBase : QuerySession, IDocumentSession
             foreach (var listener in _sessionListeners)
             {
                 await listener.AfterCommitAsync(this, token);
+            }
+
+            if (_inlineMessageBatch is not null)
+            {
+                await _inlineMessageBatch.AfterCommitAsync(token);
             }
         }
         finally
@@ -802,7 +813,20 @@ internal abstract class DocumentSessionBase : QuerySession, IDocumentSession
     }
 
     // IStorageOperations
-    public bool EnableSideEffectsOnInlineProjections => false;
+    public bool EnableSideEffectsOnInlineProjections => _eventGraph.EnableSideEffectsOnInlineProjections;
+
+    private IMessageBatch? _inlineMessageBatch;
+
+    public async ValueTask<IMessageSink> GetOrStartMessageSink()
+    {
+        if (_inlineMessageBatch is not null) return _inlineMessageBatch;
+
+        _inlineMessageBatch = await Options.Events.MessageOutbox
+            .CreateBatch(this)
+            .ConfigureAwait(false);
+
+        return _inlineMessageBatch;
+    }
 
     Task<IProjectionStorage<TDoc, TId>> IStorageOperations.FetchProjectionStorageAsync<TDoc, TId>(
         string tenantId, CancellationToken cancellationToken)
@@ -821,10 +845,6 @@ internal abstract class DocumentSessionBase : QuerySession, IDocumentSession
         return Task.FromResult(storage);
     }
 
-    public ValueTask<IMessageSink> GetOrStartMessageSink()
-    {
-        throw new NotSupportedException("Message sinks are not supported in Polecat.");
-    }
 
     public void Eject<T>(T document) where T : notnull
     {


### PR DESCRIPTION
Promotes EnableSideEffectsOnInlineProjections from a hardcoded false to a configurable setting on EventGraph. When the flag is on:

- RaiseSideEffects() runs for projections registered with the Inline lifecycle (the gate inside JFx.Events' projection bases reads IStorageOperations.EnableSideEffectsOnInlineProjections).
- slice.PublishMessage(...) routes through the configured IMessageOutbox via a new GetOrStartMessageSink() impl on DocumentSessionBase, lazily creating an IMessageBatch on first publish and reusing it for the rest of the session's commit.
- The session's SaveChangesInternalAsync calls BeforeCommitAsync on the message batch inside the SQL transaction (right before tx.CommitAsync) and AfterCommitAsync once after the commit + listeners have run.

slice.AppendEvent(...) from an inline RaiseSideEffects override is disallowed at the JFx.Events level (throws InvalidOperationException).

Test coverage in src/Polecat.Tests/Events/inline_projection_side_effects_tests.cs: flag-off no-op, flag-on publish round-trip, lifecycle ordering.