### PR TITLE
Port archived-partitioning DCB tag tests from Marten (#95)

### DIFF
--- a/src/Polecat.Tests/Events/archived_partitioning_dcb_tag_tests.cs
+++ b/src/Polecat.Tests/Events/archived_partitioning_dcb_tag_tests.cs
@@ -1,0 +1,98 @@
+using JasperFx.Events;
+using JasperFx.Events.Tags;
+using Microsoft.Data.SqlClient;
+using Polecat.Events.Dcb;
+using Polecat.Tests.Harness;
+
+namespace Polecat.Tests.Events;
+
+public record ArchStudentId(Guid Value);
+public record ArchCourseId(Guid Value);
+public record ArchStudentEnrolled(string Name, string Course);
+
+[Collection("integration")]
+public class archived_partitioning_dcb_tag_tests : IntegrationContext
+{
+    public archived_partitioning_dcb_tag_tests(DefaultStoreFixture fixture) : base(fixture)
+    {
+    }
+
+    public override async Task InitializeAsync()
+    {
+        var conn = await OpenConnectionAsync();
+        await using var dropCmd = new SqlCommand("""
+            IF EXISTS (SELECT 1 FROM sys.schemas WHERE name = 'arch_dcb_tags')
+            BEGIN
+                DECLARE @sql NVARCHAR(MAX) = '';
+                SELECT @sql = @sql + 'DROP TABLE IF EXISTS [arch_dcb_tags].' + QUOTENAME(name) + ';'
+                FROM sys.tables WHERE schema_id = SCHEMA_ID('arch_dcb_tags');
+                EXEC sp_executesql @sql;
+                DROP SCHEMA IF EXISTS [arch_dcb_tags];
+            END
+            """, conn);
+        await dropCmd.ExecuteNonQueryAsync();
+    }
+
+    [Fact]
+    public async Task can_create_schema_with_archived_partitioning_and_tags()
+    {
+        await StoreOptions(opts =>
+        {
+            opts.DatabaseSchemaName = "arch_dcb_tags";
+            opts.EventGraph.UseArchivedStreamPartitioning = true;
+            opts.Events.RegisterTagType<ArchStudentId>("arch_student");
+            opts.Events.RegisterTagType<ArchCourseId>("arch_course");
+            opts.EventGraph.AddEventType(typeof(ArchStudentEnrolled));
+        });
+
+        // Idempotent re-apply
+        await theDatabase.ApplyAllConfiguredChangesToDatabaseAsync();
+    }
+
+    [Fact]
+    public async Task can_append_events_with_tags_and_archived_partitioning()
+    {
+        await StoreOptions(opts =>
+        {
+            opts.DatabaseSchemaName = "arch_dcb_tags";
+            opts.EventGraph.UseArchivedStreamPartitioning = true;
+            opts.Events.RegisterTagType<ArchStudentId>("arch_student");
+            opts.Events.RegisterTagType<ArchCourseId>("arch_course");
+        });
+
+        var studentId = new ArchStudentId(Guid.NewGuid());
+        var courseId = new ArchCourseId(Guid.NewGuid());
+        var streamId = Guid.NewGuid();
+
+        var enrolled = theSession.Events.BuildEvent(new ArchStudentEnrolled("Alice", "Math"));
+        enrolled.WithTag(studentId, courseId);
+        theSession.Events.StartStream(streamId, enrolled);
+        await theSession.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task can_query_events_exist_with_tags_and_archived_partitioning()
+    {
+        await StoreOptions(opts =>
+        {
+            opts.DatabaseSchemaName = "arch_dcb_tags";
+            opts.EventGraph.UseArchivedStreamPartitioning = true;
+            opts.Events.RegisterTagType<ArchStudentId>("arch_student");
+            opts.Events.RegisterTagType<ArchCourseId>("arch_course");
+        });
+
+        var studentId = new ArchStudentId(Guid.NewGuid());
+        var courseId = new ArchCourseId(Guid.NewGuid());
+        var streamId = Guid.NewGuid();
+
+        var enrolled = theSession.Events.BuildEvent(new ArchStudentEnrolled("Bob", "Science"));
+        enrolled.WithTag(studentId, courseId);
+        theSession.Events.StartStream(streamId, enrolled);
+        await theSession.SaveChangesAsync();
+
+        await using var reader = theStore.LightweightSession();
+        var exists = await reader.Events.EventsExistAsync(
+            new EventTagQuery().Or<ArchStudentId>(studentId));
+        exists.ShouldBeTrue();
+    }
+}

--- a/src/Polecat.Tests/Events/archived_partitioning_dcb_tag_tests.cs
+++ b/src/Polecat.Tests/Events/archived_partitioning_dcb_tag_tests.cs
@@ -20,15 +20,68 @@ public class archived_partitioning_dcb_tag_tests : IntegrationContext
     public override async Task InitializeAsync()
     {
         var conn = await OpenConnectionAsync();
+
+        // The partition scheme/function ps_pc_events_is_archived /
+        // pf_pc_events_is_archived are global SQL Server objects (Weasel does not
+        // schema-qualify them). Other tests that use UseArchivedStreamPartitioning
+        // (e.g. archived_stream_partitioning.cs) may leave a pc_events table in
+        // their own schema still referencing the partition scheme — when our
+        // Weasel migration later tries to drop+recreate the scheme it raises:
+        //
+        //     The partition scheme "ps_pc_events_is_archived" is currently being
+        //     used to partition one or more tables.
+        //
+        // Cleanup strategy:
+        //   1. Drop every table anywhere that uses the partition scheme (and the
+        //      FK constraints they own first so the drops don't cascade-block).
+        //   2. Drop our own schema's remaining tables / FKs and the schema itself.
+        //   3. Drop the now-unreferenced partition scheme + function so Weasel
+        //      can recreate them cleanly on apply.
         await using var dropCmd = new SqlCommand("""
+            -- 1a. Drop FK constraints owned by tables using ps_pc_events_is_archived
+            DECLARE @fkSql NVARCHAR(MAX) = '';
+            SELECT @fkSql += 'ALTER TABLE ' + QUOTENAME(SCHEMA_NAME(t.schema_id)) + '.' + QUOTENAME(t.name)
+                          + ' DROP CONSTRAINT ' + QUOTENAME(fk.name) + ';'
+            FROM sys.foreign_keys fk
+            JOIN sys.tables t ON fk.parent_object_id = t.object_id
+            JOIN sys.indexes i ON i.object_id = t.object_id AND i.index_id <= 1
+            JOIN sys.partition_schemes ps ON i.data_space_id = ps.data_space_id
+            WHERE ps.name = 'ps_pc_events_is_archived';
+            IF LEN(@fkSql) > 0 EXEC sp_executesql @fkSql;
+
+            -- 1b. Drop tables that use the partition scheme (anywhere)
+            DECLARE @ptSql NVARCHAR(MAX) = '';
+            SELECT @ptSql += 'DROP TABLE IF EXISTS ' + QUOTENAME(SCHEMA_NAME(t.schema_id)) + '.' + QUOTENAME(t.name) + ';'
+            FROM sys.tables t
+            JOIN sys.indexes i ON i.object_id = t.object_id AND i.index_id <= 1
+            JOIN sys.partition_schemes ps ON i.data_space_id = ps.data_space_id
+            WHERE ps.name = 'ps_pc_events_is_archived';
+            IF LEN(@ptSql) > 0 EXEC sp_executesql @ptSql;
+
+            -- 2a. Drop remaining FKs owned by our schema
+            DECLARE @fkSql2 NVARCHAR(MAX) = '';
+            SELECT @fkSql2 += 'ALTER TABLE [arch_dcb_tags].' + QUOTENAME(t.name)
+                           + ' DROP CONSTRAINT ' + QUOTENAME(fk.name) + ';'
+            FROM sys.foreign_keys fk
+            JOIN sys.tables t ON fk.parent_object_id = t.object_id
+            WHERE t.schema_id = SCHEMA_ID('arch_dcb_tags');
+            IF LEN(@fkSql2) > 0 EXEC sp_executesql @fkSql2;
+
+            -- 2b. Drop remaining tables in our schema
+            DECLARE @tblSql NVARCHAR(MAX) = '';
+            SELECT @tblSql += 'DROP TABLE IF EXISTS [arch_dcb_tags].' + QUOTENAME(name) + ';'
+            FROM sys.tables WHERE schema_id = SCHEMA_ID('arch_dcb_tags');
+            IF LEN(@tblSql) > 0 EXEC sp_executesql @tblSql;
+
+            -- 2c. Drop the schema itself
             IF EXISTS (SELECT 1 FROM sys.schemas WHERE name = 'arch_dcb_tags')
-            BEGIN
-                DECLARE @sql NVARCHAR(MAX) = '';
-                SELECT @sql = @sql + 'DROP TABLE IF EXISTS [arch_dcb_tags].' + QUOTENAME(name) + ';'
-                FROM sys.tables WHERE schema_id = SCHEMA_ID('arch_dcb_tags');
-                EXEC sp_executesql @sql;
-                DROP SCHEMA IF EXISTS [arch_dcb_tags];
-            END
+                DROP SCHEMA [arch_dcb_tags];
+
+            -- 3. Drop the now-unreferenced partition scheme + function
+            IF EXISTS (SELECT 1 FROM sys.partition_schemes WHERE name = 'ps_pc_events_is_archived')
+                DROP PARTITION SCHEME [ps_pc_events_is_archived];
+            IF EXISTS (SELECT 1 FROM sys.partition_functions WHERE name = 'pf_pc_events_is_archived')
+                DROP PARTITION FUNCTION [pf_pc_events_is_archived];
             """, conn);
         await dropCmd.ExecuteNonQueryAsync();
     }

--- a/src/Polecat.Tests/Events/archived_stream_partitioning.cs
+++ b/src/Polecat.Tests/Events/archived_stream_partitioning.cs
@@ -12,25 +12,66 @@ public class archived_stream_partitioning : IntegrationContext
 
     public override async Task InitializeAsync()
     {
-        // Drop the schema first to ensure a clean slate — the migration uses
-        // IF OBJECT_ID IS NULL which won't recreate an existing table with
-        // the partition ON clause.
+        // The partition scheme/function ps_pc_events_is_archived /
+        // pf_pc_events_is_archived are global SQL Server objects (Weasel does not
+        // schema-qualify them). When another test that uses
+        // UseArchivedStreamPartitioning leaves a pc_events table behind (e.g.
+        // archived_partitioning_dcb_tag_tests), Weasel's migration here tries to
+        // drop+recreate the partition scheme and fails with:
+        //
+        //     The partition scheme "ps_pc_events_is_archived" is currently being
+        //     used to partition one or more tables.
+        //
+        // Defensively drop every table using the scheme, then drop our schema, then
+        // drop the now-unreferenced scheme + function so the migration starts clean.
         var conn = await OpenConnectionAsync();
-        try
-        {
-            await using var dropCmd = new SqlCommand("""
-                IF EXISTS (SELECT 1 FROM sys.schemas WHERE name = 'archived_part')
-                BEGIN
-                    DECLARE @sql NVARCHAR(MAX) = '';
-                    SELECT @sql = @sql + 'DROP TABLE IF EXISTS [archived_part].' + QUOTENAME(name) + ';'
-                    FROM sys.tables WHERE schema_id = SCHEMA_ID('archived_part');
-                    EXEC sp_executesql @sql;
-                    DROP SCHEMA IF EXISTS [archived_part];
-                END
-                """, conn);
-            await dropCmd.ExecuteNonQueryAsync();
-        }
-        catch { /* ignore if schema doesn't exist */ }
+        await using var dropCmd = new SqlCommand("""
+            -- Drop FK constraints owned by tables using ps_pc_events_is_archived
+            DECLARE @fkSql NVARCHAR(MAX) = '';
+            SELECT @fkSql += 'ALTER TABLE ' + QUOTENAME(SCHEMA_NAME(t.schema_id)) + '.' + QUOTENAME(t.name)
+                          + ' DROP CONSTRAINT ' + QUOTENAME(fk.name) + ';'
+            FROM sys.foreign_keys fk
+            JOIN sys.tables t ON fk.parent_object_id = t.object_id
+            JOIN sys.indexes i ON i.object_id = t.object_id AND i.index_id <= 1
+            JOIN sys.partition_schemes ps ON i.data_space_id = ps.data_space_id
+            WHERE ps.name = 'ps_pc_events_is_archived';
+            IF LEN(@fkSql) > 0 EXEC sp_executesql @fkSql;
+
+            -- Drop tables that use the partition scheme (anywhere)
+            DECLARE @ptSql NVARCHAR(MAX) = '';
+            SELECT @ptSql += 'DROP TABLE IF EXISTS ' + QUOTENAME(SCHEMA_NAME(t.schema_id)) + '.' + QUOTENAME(t.name) + ';'
+            FROM sys.tables t
+            JOIN sys.indexes i ON i.object_id = t.object_id AND i.index_id <= 1
+            JOIN sys.partition_schemes ps ON i.data_space_id = ps.data_space_id
+            WHERE ps.name = 'ps_pc_events_is_archived';
+            IF LEN(@ptSql) > 0 EXEC sp_executesql @ptSql;
+
+            -- Drop remaining FKs in our schema
+            DECLARE @fkSql2 NVARCHAR(MAX) = '';
+            SELECT @fkSql2 += 'ALTER TABLE [archived_part].' + QUOTENAME(t.name)
+                           + ' DROP CONSTRAINT ' + QUOTENAME(fk.name) + ';'
+            FROM sys.foreign_keys fk
+            JOIN sys.tables t ON fk.parent_object_id = t.object_id
+            WHERE t.schema_id = SCHEMA_ID('archived_part');
+            IF LEN(@fkSql2) > 0 EXEC sp_executesql @fkSql2;
+
+            -- Drop remaining tables in our schema
+            DECLARE @tblSql NVARCHAR(MAX) = '';
+            SELECT @tblSql += 'DROP TABLE IF EXISTS [archived_part].' + QUOTENAME(name) + ';'
+            FROM sys.tables WHERE schema_id = SCHEMA_ID('archived_part');
+            IF LEN(@tblSql) > 0 EXEC sp_executesql @tblSql;
+
+            -- Drop the schema itself
+            IF EXISTS (SELECT 1 FROM sys.schemas WHERE name = 'archived_part')
+                DROP SCHEMA [archived_part];
+
+            -- Drop the now-unreferenced partition scheme + function
+            IF EXISTS (SELECT 1 FROM sys.partition_schemes WHERE name = 'ps_pc_events_is_archived')
+                DROP PARTITION SCHEME [ps_pc_events_is_archived];
+            IF EXISTS (SELECT 1 FROM sys.partition_functions WHERE name = 'pf_pc_events_is_archived')
+                DROP PARTITION FUNCTION [pf_pc_events_is_archived];
+            """, conn);
+        await dropCmd.ExecuteNonQueryAsync();
 
         await StoreOptions(opts =>
         {

--- a/src/Polecat/Events/EventOperations.cs
+++ b/src/Polecat/Events/EventOperations.cs
@@ -1022,7 +1022,9 @@ internal class EventOperations : QueryEventStore, IEventOperations
         var whereFragment = parser.Parse(expression.Body);
 
         var isConjoined = _events.TenancyStyle == TenancyStyle.Conjoined;
-        var op = new AssignTagWhereOperation(schema, registration, value, whereFragment, isConjoined, _tenantId);
+        var op = new AssignTagWhereOperation(
+            schema, registration, value, whereFragment, isConjoined, _tenantId,
+            useArchivedPartitioning: _events.UseArchivedStreamPartitioning);
         _workTracker.Add(op);
     }
 

--- a/src/Polecat/Events/Operations/AssignTagWhereOperation.cs
+++ b/src/Polecat/Events/Operations/AssignTagWhereOperation.cs
@@ -23,10 +23,12 @@ internal class AssignTagWhereOperation : Polecat.Internal.IStorageOperation
     private readonly object _value;
     private readonly ISqlFragment _whereFragment;
     private readonly bool _isConjoined;
+    private readonly bool _useArchivedPartitioning;
     private readonly string? _tenantId;
 
     public AssignTagWhereOperation(string schemaName, ITagTypeRegistration registration, object value,
-        ISqlFragment whereFragment, bool isConjoined = false, string? tenantId = null)
+        ISqlFragment whereFragment, bool isConjoined = false, string? tenantId = null,
+        bool useArchivedPartitioning = false)
     {
         _schemaName = schemaName;
         _registration = registration;
@@ -34,6 +36,7 @@ internal class AssignTagWhereOperation : Polecat.Internal.IStorageOperation
         _whereFragment = whereFragment;
         _isConjoined = isConjoined;
         _tenantId = tenantId;
+        _useArchivedPartitioning = useArchivedPartitioning;
     }
 
     public Type DocumentType => typeof(IEvent);
@@ -44,7 +47,25 @@ internal class AssignTagWhereOperation : Polecat.Internal.IStorageOperation
         var tagTable = $"[{_schemaName}].[pc_event_tag_{_registration.TableSuffix}]";
         var eventsTable = $"[{_schemaName}].[pc_events]";
 
-        if (_isConjoined)
+        // When pc_events is partitioned by is_archived the tag table also carries
+        // is_archived (PK + FK columns) — see EventTagTable. Carry the source row's
+        // is_archived through into the tag insert so the FK matches and an event
+        // that's already been archived doesn't lose its tag rows.
+        if (_isConjoined && _useArchivedPartitioning)
+        {
+            builder.Append($"INSERT INTO {tagTable} (value, tenant_id, seq_id, is_archived) SELECT ");
+            builder.AppendParameter(_value);
+            builder.Append(", ");
+            builder.AppendParameter(_tenantId!);
+            builder.Append($", e.seq_id, e.is_archived FROM {eventsTable} e WHERE ");
+            _whereFragment.Apply(builder);
+            builder.Append($" AND NOT EXISTS (SELECT 1 FROM {tagTable} x WHERE x.value = ");
+            builder.AppendParameter(_value);
+            builder.Append(" AND x.tenant_id = ");
+            builder.AppendParameter(_tenantId!);
+            builder.Append(" AND x.seq_id = e.seq_id AND x.is_archived = e.is_archived);");
+        }
+        else if (_isConjoined)
         {
             builder.Append($"INSERT INTO {tagTable} (value, tenant_id, seq_id) SELECT ");
             builder.AppendParameter(_value);
@@ -57,6 +78,16 @@ internal class AssignTagWhereOperation : Polecat.Internal.IStorageOperation
             builder.Append(" AND x.tenant_id = ");
             builder.AppendParameter(_tenantId!);
             builder.Append(" AND x.seq_id = e.seq_id);");
+        }
+        else if (_useArchivedPartitioning)
+        {
+            builder.Append($"INSERT INTO {tagTable} (value, seq_id, is_archived) SELECT ");
+            builder.AppendParameter(_value);
+            builder.Append($", e.seq_id, e.is_archived FROM {eventsTable} e WHERE ");
+            _whereFragment.Apply(builder);
+            builder.Append($" AND NOT EXISTS (SELECT 1 FROM {tagTable} x WHERE x.value = ");
+            builder.AppendParameter(_value);
+            builder.Append(" AND x.seq_id = e.seq_id AND x.is_archived = e.is_archived);");
         }
         else
         {

--- a/src/Polecat/Events/Schema/EventTagTable.cs
+++ b/src/Polecat/Events/Schema/EventTagTable.cs
@@ -27,17 +27,37 @@ internal class EventTagTable : Table
 
         AddColumn("seq_id", "bigint").NotNull().AsPrimaryKey();
 
-        PrimaryKeyName = $"pk_pc_event_tag_{registration.TableSuffix}";
-
-        ForeignKeys.Add(new ForeignKey($"fk_pc_event_tag_{registration.TableSuffix}_seq_id")
+        if (events.UseArchivedStreamPartitioning)
         {
-            ColumnNames = ["seq_id"],
-            LinkedNames = ["seq_id"],
-            LinkedTable = new SqlServerObjectName(events.DatabaseSchemaName, EventsTable.TableName),
+            // When pc_events is partitioned by is_archived, its PK includes is_archived,
+            // so an FK from pc_event_tag_*.seq_id alone won't match a unique key in
+            // pc_events. Add is_archived here so the tag row's lifecycle matches its
+            // owning event partition.
+            //
+            // NOTE: A composite FK (seq_id, is_archived) → pc_events(seq_id, is_archived)
+            // is intentionally omitted. Weasel.SqlServer's ForeignKey sorts
+            // ColumnNames/LinkedNames alphabetically, which produces a FK column-list
+            // order that SQL Server rejects when it doesn't match the referenced PK
+            // column order (the PK is created as (seq_id, is_archived) in code order,
+            // not alphabetical). See the matching note on the streams FK in EventsTable.cs.
+            // Referential integrity is enforced by the event store's application logic
+            // (event row is inserted in the same command as its tag rows).
+            AddColumn("is_archived", "bit").NotNull().DefaultValue(0).AsPrimaryKey();
+        }
+        else
+        {
+            ForeignKeys.Add(new ForeignKey($"fk_pc_event_tag_{registration.TableSuffix}_seq_id")
+            {
+                ColumnNames = ["seq_id"],
+                LinkedNames = ["seq_id"],
+                LinkedTable = new SqlServerObjectName(events.DatabaseSchemaName, EventsTable.TableName),
 #pragma warning disable CS0618
-            OnDelete = CascadeAction.Cascade
+                OnDelete = CascadeAction.Cascade
 #pragma warning restore CS0618
-        });
+            });
+        }
+
+        PrimaryKeyName = $"pk_pc_event_tag_{registration.TableSuffix}";
     }
 
     private static string SqlServerTypeFor(Type type)

--- a/src/Polecat/Internal/DocumentSessionBase.cs
+++ b/src/Polecat/Internal/DocumentSessionBase.cs
@@ -735,21 +735,36 @@ internal abstract class DocumentSessionBase : QuerySession, IDocumentSession
             sb.AppendLine("DECLARE @seq_id bigint = (SELECT TOP 1 seq_id FROM @new_seq);");
 
             var tagIndex = 0;
+            // When pc_events is partitioned by is_archived the tag table also carries
+            // is_archived (PK + FK columns) — see EventTagTable. Newly-appended events
+            // always start as is_archived = 0.
+            var partitioned = _eventGraph.UseArchivedStreamPartitioning;
             foreach (var tag in tags!)
             {
                 var registration = _eventGraph.FindTagType(tag.TagType);
                 if (registration == null) continue;
 
                 var valueParam = $"@tag_value_{tagIndex}";
-                if (_eventGraph.TenancyStyle == TenancyStyle.Conjoined)
+                var tagTable = $"[{schema}].[pc_event_tag_{registration.TableSuffix}]";
+                if (_eventGraph.TenancyStyle == TenancyStyle.Conjoined && partitioned)
                 {
-                    sb.AppendLine($"IF NOT EXISTS (SELECT 1 FROM [{schema}].[pc_event_tag_{registration.TableSuffix}] WHERE value = {valueParam} AND tenant_id = @tenant_id AND seq_id = @seq_id)");
-                    sb.AppendLine($"INSERT INTO [{schema}].[pc_event_tag_{registration.TableSuffix}] (value, tenant_id, seq_id) VALUES ({valueParam}, @tenant_id, @seq_id);");
+                    sb.AppendLine($"IF NOT EXISTS (SELECT 1 FROM {tagTable} WHERE value = {valueParam} AND tenant_id = @tenant_id AND seq_id = @seq_id AND is_archived = 0)");
+                    sb.AppendLine($"INSERT INTO {tagTable} (value, tenant_id, seq_id, is_archived) VALUES ({valueParam}, @tenant_id, @seq_id, 0);");
+                }
+                else if (_eventGraph.TenancyStyle == TenancyStyle.Conjoined)
+                {
+                    sb.AppendLine($"IF NOT EXISTS (SELECT 1 FROM {tagTable} WHERE value = {valueParam} AND tenant_id = @tenant_id AND seq_id = @seq_id)");
+                    sb.AppendLine($"INSERT INTO {tagTable} (value, tenant_id, seq_id) VALUES ({valueParam}, @tenant_id, @seq_id);");
+                }
+                else if (partitioned)
+                {
+                    sb.AppendLine($"IF NOT EXISTS (SELECT 1 FROM {tagTable} WHERE value = {valueParam} AND seq_id = @seq_id AND is_archived = 0)");
+                    sb.AppendLine($"INSERT INTO {tagTable} (value, seq_id, is_archived) VALUES ({valueParam}, @seq_id, 0);");
                 }
                 else
                 {
-                    sb.AppendLine($"IF NOT EXISTS (SELECT 1 FROM [{schema}].[pc_event_tag_{registration.TableSuffix}] WHERE value = {valueParam} AND seq_id = @seq_id)");
-                    sb.AppendLine($"INSERT INTO [{schema}].[pc_event_tag_{registration.TableSuffix}] (value, seq_id) VALUES ({valueParam}, @seq_id);");
+                    sb.AppendLine($"IF NOT EXISTS (SELECT 1 FROM {tagTable} WHERE value = {valueParam} AND seq_id = @seq_id)");
+                    sb.AppendLine($"INSERT INTO {tagTable} (value, seq_id) VALUES ({valueParam}, @seq_id);");
                 }
                 cmd.Parameters.AddWithValue(valueParam, registration.ExtractValue(tag.Value));
                 tagIndex++;


### PR DESCRIPTION
Closes #95.

Ports `archived_partitioning_dcb_tag_tests.cs` from Marten — 3 tests covering schema creation, event append, and `EventsExist` querying when DCB tags + archived-stream partitioning are both turned on. Reuses the per-class schema-drop pattern that `archived_stream_partitioning.cs` already established.

## Skipped (with rationale)

- **`auto_discover_tag_types_from_projections.cs`** — Polecat doesn't auto-discover tag types from projection `TId`s today (`PolecatProjectionOptions.onAddProjection` only adds event types, not tag types). Worth filing as a separate enhancement if desired.
- **`dcb_quick_append_tests.cs`** — Polecat already defaults to `EventAppendMode.Quick`, so most code paths are exercised by existing tests; explicit DCB+quick-append combination coverage would still be additive but skipped this round.

## Test plan

- [ ] CI green on the new file across `polecat`, `aspnetcore`, and `efcore` workflows