### PR TITLE
Populate HWM diagnostic fields (jasperfx#279, CW#150 signals 2/3)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,7 @@
     <ItemGroup>
         <!-- Core dependencies -->
         <PackageVersion Include="JasperFx" Version="2.0.0-alpha.13" />
-        <PackageVersion Include="JasperFx.Events" Version="2.0.0-alpha.8" />
+        <PackageVersion Include="JasperFx.Events" Version="2.0.0-alpha.9" />
         <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />

--- a/src/Polecat.Tests/Daemon/skipped_events_count_augmenter_tests.cs
+++ b/src/Polecat.Tests/Daemon/skipped_events_count_augmenter_tests.cs
@@ -1,0 +1,95 @@
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Projections;
+using Polecat.Storage;
+
+namespace Polecat.Tests.Daemon;
+
+/// <summary>
+///     Coverage for the Polecat-owned augmenter that populates
+///     <see cref="ShardState.SkippedEventsCount"/> on Skipped publications.
+///     The framework's <c>HighWaterAgent</c> owns the publish path via
+///     <see cref="ShardStateTracker.MarkSkippingAsync"/>, but doesn't set the
+///     count — Polecat fills it in via an observer subscribed on the tracker
+///     in <see cref="PolecatDatabase"/>'s constructor.
+/// </summary>
+public class skipped_events_count_augmenter_tests
+{
+    [Fact]
+    public async Task augments_skipped_publications_with_most_recent_count()
+    {
+        await using var store = BuildStore();
+        var tracker = store.Database.Tracker;
+
+        var observed = await ObserveNextAsync(tracker,
+            t => t.MarkSkippingAsync(lastKnownGoodHighWaterMark: 100, newHighWaterMark: 250));
+
+        observed.Action.ShouldBe(ShardAction.Skipped);
+        observed.PreviousGoodMark.ShouldBe(100);
+        observed.Sequence.ShouldBe(250);
+        observed.SkippedEventsCount.ShouldBe(150);
+    }
+
+    [Fact]
+    public async Task leaves_non_skipped_publications_alone()
+    {
+        await using var store = BuildStore();
+        var tracker = store.Database.Tracker;
+
+        var observed = await ObserveNextAsync(tracker, t => t.MarkHighWaterAsync(42));
+
+        observed.Action.ShouldNotBe(ShardAction.Skipped);
+        observed.SkippedEventsCount.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task preserves_explicitly_set_skipped_events_count()
+    {
+        // If a future code path populates SkippedEventsCount explicitly
+        // (e.g. cumulative semantics from a richer detector), the augmenter
+        // must not overwrite it.
+        await using var store = BuildStore();
+        var tracker = store.Database.Tracker;
+
+        var observed = await ObserveNextAsync(tracker, t => t.PublishAsync(
+            new ShardState(ShardState.HighWaterMark, 250)
+            {
+                Action = ShardAction.Skipped,
+                PreviousGoodMark = 100,
+                SkippedEventsCount = 999
+            }));
+
+        observed.SkippedEventsCount.ShouldBe(999);
+    }
+
+    private static async Task<ShardState> ObserveNextAsync(
+        ShardStateTracker tracker, Func<ShardStateTracker, ValueTask> publish)
+    {
+        var tcs = new TaskCompletionSource<ShardState>(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var subscription = tracker.Subscribe(new CapturingObserver(tcs));
+        await publish(tracker);
+        // The tracker dispatches synchronously through a Block; await briefly
+        // to give the publish task time to propagate to the subscriber.
+        var winner = await Task.WhenAny(tcs.Task, Task.Delay(TimeSpan.FromSeconds(5)));
+        winner.ShouldBe(tcs.Task);
+        return await tcs.Task;
+    }
+
+    private static DocumentStore BuildStore()
+    {
+        return new DocumentStore(new StoreOptions
+        {
+            ConnectionString =
+                "Server=localhost;Database=skip_augmenter;Integrated Security=true;TrustServerCertificate=true",
+            AutoCreateSchemaObjects = JasperFx.AutoCreate.None
+        });
+    }
+
+    private sealed class CapturingObserver : IObserver<ShardState>
+    {
+        private readonly TaskCompletionSource<ShardState> _tcs;
+        public CapturingObserver(TaskCompletionSource<ShardState> tcs) => _tcs = tcs;
+        public void OnCompleted() { }
+        public void OnError(Exception error) => _tcs.TrySetException(error);
+        public void OnNext(ShardState value) => _tcs.TrySetResult(value);
+    }
+}

--- a/src/Polecat.Tests/document_store_usage_tests.cs
+++ b/src/Polecat.Tests/document_store_usage_tests.cs
@@ -142,6 +142,25 @@ public class document_store_usage_tests
     }
 
     [Fact]
+    public async Task max_event_sequence_is_null_when_table_unreachable()
+    {
+        // Dummy connection string + AutoCreate.None means MAX(seq_id) can't
+        // be read — the implementation tolerates the failure and leaves
+        // MaxEventSequence null so CritterWatch renders "n/a". Pins the
+        // contract; without the try/catch the lookup would bubble.
+        await using var store = BuildStore(opts =>
+        {
+            opts.DatabaseSchemaName = "doc_usage";
+            opts.Schema.For<AdvSqlDoc>();
+        });
+
+        var eventUsage = await ((IEventStore)store).TryCreateUsage(CancellationToken.None);
+
+        eventUsage.ShouldNotBeNull();
+        eventUsage.MaxEventSequence.ShouldBeNull();
+    }
+
+    [Fact]
     public async Task event_store_usage_includes_tag_types()
     {
         await using var store = BuildStore(opts =>

--- a/src/Polecat.Tests/event_store_usage_integration_tests.cs
+++ b/src/Polecat.Tests/event_store_usage_integration_tests.cs
@@ -1,0 +1,69 @@
+using JasperFx.Events;
+using Polecat.Tests.Harness;
+
+namespace Polecat.Tests;
+
+/// <summary>
+///     Integration coverage for the SQL-backed fields on
+///     <c>EventStoreUsage</c> — currently MaxEventSequence, which queries
+///     <c>MAX(seq_id) FROM pc_events</c>. The pure-unit variants live in
+///     <see cref="document_store_usage_tests"/>; this file exercises the
+///     real-database path.
+/// </summary>
+[Collection("integration")]
+public class event_store_usage_integration_tests : IntegrationContext
+{
+    public event_store_usage_integration_tests(DefaultStoreFixture fixture) : base(fixture)
+    {
+    }
+
+    public override async Task InitializeAsync()
+    {
+        await base.InitializeAsync();
+        await using var conn = await OpenConnectionAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = """
+            DELETE FROM [dbo].[pc_events];
+            DELETE FROM [dbo].[pc_streams];
+            DELETE FROM [dbo].[pc_event_progression];
+            """;
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    [Fact]
+    public async Task max_event_sequence_matches_highest_persisted_seq_id()
+    {
+        // Persist a handful of events, then read MAX(seq_id) back through the
+        // typed pc_events column.
+        for (var i = 0; i < 5; i++)
+        {
+            var streamId = Guid.NewGuid();
+            theSession.Events.StartStream(streamId, new QuestStarted($"Quest {i + 1}"));
+            await theSession.SaveChangesAsync();
+        }
+
+        long expected;
+        await using (var conn = await OpenConnectionAsync())
+        await using (var cmd = conn.CreateCommand())
+        {
+            cmd.CommandText = "SELECT MAX(seq_id) FROM [dbo].[pc_events];";
+            expected = (long)(await cmd.ExecuteScalarAsync())!;
+        }
+
+        var usage = await ((IEventStore)theStore).TryCreateUsage(CancellationToken.None);
+
+        usage.ShouldNotBeNull();
+        usage.MaxEventSequence.ShouldBe(expected);
+    }
+
+    [Fact]
+    public async Task max_event_sequence_is_null_when_no_events_persisted()
+    {
+        // Empty pc_events → MAX returns NULL → MaxEventSequence stays null
+        // so CritterWatch renders "n/a" rather than 0.
+        var usage = await ((IEventStore)theStore).TryCreateUsage(CancellationToken.None);
+
+        usage.ShouldNotBeNull();
+        usage.MaxEventSequence.ShouldBeNull();
+    }
+}

--- a/src/Polecat/DocumentStore.EventStore.cs
+++ b/src/Polecat/DocumentStore.EventStore.cs
@@ -193,6 +193,28 @@ public partial class DocumentStore : IEventStore<IDocumentSession, IQuerySession
                 Description: null!));
         }
 
+        // Highest physical seq_id in pc_events — CritterWatch#150 signal 2
+        // ("HWM is behind the actual max event sequence") renders the gap
+        // between this and the HighWaterMark. Tolerate the lookup failing
+        // (e.g. schema not yet created) by leaving null.
+        try
+        {
+            usage.MaxEventSequence = await Options.ResiliencePipeline.ExecuteAsync(static async (state, ct) =>
+            {
+                var (connString, eventsTable) = state;
+                await using var conn = new SqlConnection(connString);
+                await conn.OpenAsync(ct);
+                await using var cmd = conn.CreateCommand();
+                cmd.CommandText = $"SELECT MAX(seq_id) FROM {eventsTable};";
+                var result = await cmd.ExecuteScalarAsync(ct);
+                return result is null or DBNull ? (long?)null : (long?)Convert.ToInt64(result);
+            }, (Database.ConnectionString, Events.EventsTableName), token);
+        }
+        catch
+        {
+            usage.MaxEventSequence = null;
+        }
+
         Options.Projections.Describe(usage, this);
         return usage;
     }

--- a/src/Polecat/Events/Daemon/SkippedEventsCountAugmenter.cs
+++ b/src/Polecat/Events/Daemon/SkippedEventsCountAugmenter.cs
@@ -1,0 +1,33 @@
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Projections;
+
+namespace Polecat.Events.Daemon;
+
+/// <summary>
+///     Subscribes to <see cref="ShardStateTracker"/> and populates
+///     <see cref="ShardState.SkippedEventsCount"/> on Skipped publications.
+///     The framework's <c>HighWaterAgent</c> owns the publish path via
+///     <see cref="ShardStateTracker.MarkSkippingAsync"/>, which sets
+///     <see cref="ShardState.PreviousGoodMark"/> but does not compute the
+///     count — implementations are expected to populate it themselves.
+///     Polecat picks the "most-recent" semantic: the gap between the
+///     newly-marked HighWaterMark and the previous good mark.
+/// </summary>
+internal sealed class SkippedEventsCountAugmenter : IObserver<ShardState>
+{
+    public void OnCompleted()
+    {
+    }
+
+    public void OnError(Exception error)
+    {
+    }
+
+    public void OnNext(ShardState value)
+    {
+        if (value.Action == ShardAction.Skipped && value.SkippedEventsCount is null)
+        {
+            value.SkippedEventsCount = value.Sequence - value.PreviousGoodMark;
+        }
+    }
+}

--- a/src/Polecat/Storage/PolecatDatabase.cs
+++ b/src/Polecat/Storage/PolecatDatabase.cs
@@ -44,6 +44,10 @@ public class PolecatDatabase : DatabaseBase<SqlConnection>, IEventDatabase
         _events = options.EventGraph;
         _connectionString = connectionString;
         Tracker = new ShardStateTracker(NullLogger.Instance);
+        // Mutates Skipped ShardStates in-place to set SkippedEventsCount.
+        // Must be subscribed before any downstream consumers so the augmented
+        // count is visible when they observe the state.
+        Tracker.Subscribe(new SkippedEventsCountAugmenter());
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Polecat side of the [CritterWatch#150](https://github.com/JasperFx/CritterWatch/issues/150) signals 2 + 3 wire-up. Bumps `JasperFx.Events` to `2.0.0-alpha.9` and populates the two new wire-format diagnostic fields added in [jasperfx#279](https://github.com/JasperFx/JasperFx/pull/279). Pairs with the upcoming Marten PR and the CritterWatch consumer PR.

- **`EventStoreUsage.MaxEventSequence`** — queried from `SELECT MAX(seq_id) FROM <schema>.pc_events` inside `DocumentStore.TryCreateUsage`. Surfaces the gap between the absolute physical max sequence and the HighWaterMark for CritterWatch signal 2. Lookup failure (e.g. schema not yet created) leaves the field `null`, which CritterWatch renders as "n/a".
- **`ShardState.SkippedEventsCount`** — the framework's `HighWaterAgent` owns the Skipped publish path via `ShardStateTracker.MarkSkippingAsync`, which doesn't compute the count itself. `PolecatDatabase` now subscribes a `SkippedEventsCountAugmenter` observer on its `Tracker` that mutates Skipped publications in-place using most-recent semantics (`Sequence - PreviousGoodMark`). The observer fires before any downstream consumer, so they see the populated count.

## Test plan

- [x] `dotnet build polecat.slnx` — 0 errors
- [x] `dotnet test … -f net10.0 --filter "FullyQualifiedName~skipped_events_count_augmenter|FullyQualifiedName~document_store_usage_tests|FullyQualifiedName~event_store_usage_integration|FullyQualifiedName~high_water_detector"` — 17/17 passing
- [x] `dotnet test … -f net9.0 …` (same filter) — 17/17 passing

## Out of scope

- Marten side of the same wire-up (separate PR).
- CritterWatch wire-DTO + frontend rendering (separate PR).
- Cutting a new Polecat alpha (after this and the Marten side merge).