### PR TITLE
Bump Polecat to 4.0.0-alpha.4 (publishes #104 — HWM-populate)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>4.0.0-alpha.3</Version>
+        <Version>4.0.0-alpha.4</Version>
         <LangVersion>latest</LangVersion>
         <Authors>Jeremy D. Miller</Authors>
         <PackageIcon>logo.png</PackageIcon>


### PR DESCRIPTION
Publishes the EventStoreUsage.MaxEventSequence + ShardState.SkippedEventsCount populate work from #104. Manual workflow_dispatch publishes to nuget.org after merge.