### PR TITLE
Polecat#46: Add Polecat.AotSmoke consumer project

### DIFF
--- a/.github/workflows/aot-smoke.yml
+++ b/.github/workflows/aot-smoke.yml
@@ -1,0 +1,47 @@
+name: aot-smoke
+
+# AOT smoke gate (Polecat#46 — Critter Stack 2026 AOT pillar).
+# Builds src/Polecat.AotSmoke, which references Polecat as a static-mode AOT
+# consumer (no JasperFx.RuntimeCompiler, no AddRuntimeCompilation). The
+# project's csproj sets IsAotCompatible=true + WarningsAsErrors for the AOT
+# analyzer warning codes (IL2026/IL2046/IL2055/IL2065/IL2067/IL2070/IL2072/
+# IL2075/IL2090/IL2091/IL2111/IL3050/IL3051), so any regression in Polecat's
+# AOT-clean surface fails this build.
+#
+# No SQL Server needed — the smoke test never opens a connection.
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+env:
+  DOTNET_CLI_TELEMETRY_OPTOUT: 1
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install .NET 9.0.x
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 9.0.x
+
+      - name: Install .NET 10.0.x
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Restore
+        run: dotnet restore src/Polecat.AotSmoke/Polecat.AotSmoke.csproj
+
+      - name: Build (Polecat.AotSmoke — fails on IL2026/IL2046/IL2055/IL2065/IL2067/IL2070/IL2072/IL2075/IL2090/IL2091/IL2111/IL3050/IL3051)
+        run: dotnet build src/Polecat.AotSmoke/Polecat.AotSmoke.csproj -c Release --no-restore

--- a/polecat.slnx
+++ b/polecat.slnx
@@ -5,6 +5,7 @@
   </Folder>
   <Folder Name="/src/">
     <Project Path="src/DcbLoadTest/DcbLoadTest.csproj" />
+    <Project Path="src/Polecat.AotSmoke/Polecat.AotSmoke.csproj" />
     <Project Path="src/Polecat.AspNetCore.Testing/Polecat.AspNetCore.Testing.csproj" />
     <Project Path="src/Polecat.AspNetCore/Polecat.AspNetCore.csproj" />
     <Project Path="src/Polecat.CodeGeneration/Polecat.CodeGeneration.csproj" />

--- a/src/Polecat.AotSmoke/Polecat.AotSmoke.csproj
+++ b/src/Polecat.AotSmoke/Polecat.AotSmoke.csproj
@@ -1,0 +1,39 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+
+        <!--
+        AOT smoke test (Polecat#46 — Critter Stack 2026 AOT pillar). Builds in CI
+        and verifies that an app consuming Polecat through the AOT-clean surfaces
+        (no JasperFx.RuntimeCompiler reference, no AddRuntimeCompilation) compiles
+        with no IL2026 / IL2046 / IL2055 / IL2065 / IL2067 / IL2070 / IL2072 /
+        IL2075 / IL2090 / IL2091 / IL2111 / IL3050 / IL3051 warnings.
+
+        If a previously-AOT-clean API in Polecat later gains a
+        [RequiresUnreferencedCode] / [RequiresDynamicCode] annotation, or sheds a
+        class-level [UnconditionalSuppressMessage] suppression, the build of this
+        project will fail and the regression is caught in our CI rather than
+        downstream consumers'. New IL warnings introduced by edits to this
+        project (e.g. someone calls into a reflective surface from Program.cs)
+        are equally caught.
+
+        Mirrors JasperFx.AotSmoke (jasperfx#213, commit d4077d8).
+        -->
+        <IsAotCompatible>true</IsAotCompatible>
+        <TrimMode>full</TrimMode>
+        <WarningsAsErrors>IL2026;IL2046;IL2055;IL2065;IL2067;IL2070;IL2072;IL2075;IL2090;IL2091;IL2111;IL3050;IL3051</WarningsAsErrors>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Polecat\Polecat.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.Hosting" />
+    </ItemGroup>
+
+</Project>

--- a/src/Polecat.AotSmoke/Program.cs
+++ b/src/Polecat.AotSmoke/Program.cs
@@ -1,0 +1,95 @@
+// AOT smoke test (Polecat#46).
+//
+// This program touches a representative cross-section of the AOT-clean Polecat
+// consumer surface — DI registration via AddPolecat, projection registration,
+// session resolution, and one LINQ query construction. The csproj sets
+// IsAotCompatible=true and promotes the AOT analyzer warning codes to errors,
+// so any change that adds [RequiresDynamicCode] / [RequiresUnreferencedCode]
+// to an API exercised here — or any change to this file that calls into a
+// reflective Polecat surface — fails the build in CI.
+//
+// Crucially, this project does NOT reference JasperFx.RuntimeCompiler and does
+// NOT call services.AddRuntimeCompilation(). It represents a "Static
+// TypeLoadMode" consumer — the path AOT publishers take. If Polecat needs
+// runtime codegen on a path we exercise here, the build will fail and we'll
+// either annotate the underlying surface or narrow the smoke test.
+//
+// Intentionally *not* exercised here (these paths carry AOT annotations or
+// depend on runtime codegen that's outside the static-mode contract):
+//   - DocumentStore.LightweightSession() called from outside DI (we go through
+//     ISessionFactory so the AddPolecat extension is what's gated).
+//   - SaveChangesAsync / session command execution (would require a real DB and
+//     is on the codegen path — Polecat.CodeGeneration provides the static
+//     manifest for AOT consumers).
+//   - Async daemon / projection runtime (also codegen-backed).
+
+using JasperFx.Events.Projections;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Polecat;
+using Polecat.AotSmoke;
+
+var builder = Host.CreateApplicationBuilder(args);
+
+// --- AddPolecat: the main consumer DI surface ---------------------------
+// Configures a StoreOptions and registers a single self-aggregating snapshot
+// projection. Connection string is intentionally bogus — the smoke test
+// never opens a connection.
+//
+// Lambda is explicitly typed StoreOptions to disambiguate from the
+// Func<IServiceProvider, StoreOptions> overload — both are extension methods
+// on IServiceCollection with the same arity.
+builder.Services.AddPolecat((StoreOptions opts) =>
+{
+    opts.ConnectionString =
+        "Server=aot-smoke;Database=aot_smoke;Integrated Security=False;User Id=sa;Password=irrelevant;TrustServerCertificate=True";
+    opts.DatabaseSchemaName = "aot_smoke";
+
+    // Registering the snapshot projection pulls QuestStarted into the
+    // EventGraph via ProjectionBase.IncludedEventTypes, so no separate
+    // EventGraph.AddEventType call is needed here.
+    opts.Projections.Snapshot<Quest>(SnapshotLifecycle.Inline);
+});
+
+using var host = builder.Build();
+
+// --- IDocumentSession resolution ----------------------------------------
+// Resolve a session through the DI surface so AddPolecat's scoped registration
+// (ISessionFactory -> IDocumentSession) is reachable code. DocumentStore's
+// ctor does not open a SQL connection; LightweightSession is lazy on first
+// command. We never issue a command.
+//
+// CreateAsyncScope (vs CreateScope) so IDocumentSession's IAsyncDisposable
+// is honored on scope teardown — LightweightSession does not implement sync
+// IDisposable.
+await using var scope = host.Services.CreateAsyncScope();
+var session = scope.ServiceProvider.GetRequiredService<IDocumentSession>();
+
+// --- LINQ query construction --------------------------------------------
+// Construct (but never enumerate) a Where-filtered IQueryable through the
+// LINQ provider. This exercises IQuerySession.Query<T> + the LINQ extension
+// surface (PolecatLinqQueryProvider) — both class-level RUC/RDC suppressed
+// today. Materialization (ToListAsync etc.) would require a DB.
+var query = session.Query<Quest>().Where(q => q.Title == "smoke-test");
+_ = query.Expression;
+
+Console.WriteLine("Polecat AOT smoke OK.");
+return 0;
+
+namespace Polecat.AotSmoke
+{
+    /// <summary>One event type — included via ProjectionBase.IncludedEventTypes.</summary>
+    internal sealed record QuestStarted(string Title);
+
+    /// <summary>
+    /// Self-aggregating aggregate so Projections.Snapshot&lt;T&gt; has a target.
+    /// Static Create mirrors the SingleStreamProjection convention.
+    /// </summary>
+    internal sealed class Quest
+    {
+        public Guid Id { get; set; }
+        public string Title { get; set; } = string.Empty;
+
+        public static Quest Create(QuestStarted e) => new() { Title = e.Title };
+    }
+}


### PR DESCRIPTION
## Summary

Adds a CI-gated AOT smoke-test project (`src/Polecat.AotSmoke`) that references Polecat as a static-mode AOT consumer and fails the build on any IL2026/IL2046/IL2055/IL2065/IL2067/IL2070/IL2072/IL2075/IL2090/IL2091/IL2111/IL3050/IL3051 warning emitted from its compilation. Ticks off the AOT-smoke checkbox on #46.

Mirrors [`src/JasperFx.AotSmoke`](https://github.com/JasperFx/jasperfx/tree/main/src/JasperFx.AotSmoke) (jasperfx commit `d4077d8`) adapted for Polecat's surface.

## What's exercised

Top-level statements in `Program.cs` touch:
- `IServiceCollection.AddPolecat(Action<StoreOptions>)` (the main consumer DI surface)
- `PolecatProjectionOptions.Snapshot<T>(SnapshotLifecycle.Inline)` (projection registration)
- Scoped `IDocumentSession` resolution through `ISessionFactory`
- `IQuerySession.Query<Quest>().Where(...)` (LINQ provider entry + extension surface)

Crucially, the project does **NOT** reference `JasperFx.RuntimeCompiler` and does **NOT** call `services.AddRuntimeCompilation()` — it's the "Static `TypeLoadMode`" consumer Polecat#46 promises.

The smoke runs to completion (`Polecat AOT smoke OK.` then `return 0`) — it never opens a SQL connection, so no DB container is needed in CI.

## Gate verification

Temporarily added a deliberately-AOT-hostile call (`JsonSerializer.Serialize((object)session)`) and confirmed it broke the build on both net9.0 and net10.0:

```
error IL2026: Using member 'System.Text.Json.JsonSerializer.Serialize<TValue>(TValue, JsonSerializerOptions)' which has 'RequiresUnreferencedCodeAttribute' …
error IL3050: Using member 'System.Text.Json.JsonSerializer.Serialize<TValue>(TValue, JsonSerializerOptions)' which has 'RequiresDynamicCodeAttribute' …
Build FAILED.
```

Reverted before commit. Final `dotnet build -c Release` is clean (0 warnings, 0 errors) on net9.0 and net10.0; `dotnet run` exits 0 on both.

## CI wiring

New workflow `.github/workflows/aot-smoke.yml` runs on push/PR to main, builds only `src/Polecat.AotSmoke/Polecat.AotSmoke.csproj`. Cannot piggy-back on `polecat.yml` because that workflow targets only `Polecat.Tests.csproj` — adding the project to `polecat.slnx` alone wouldn't gate CI.

## Pre-existing Polecat IL warnings (not addressed in this PR)

`dotnet build` of `Polecat.csproj` emits 14 pre-existing IL warnings (PolecatProjectionBatch `MakeGenericMethod`, DocumentMapping `ValueTypeInfo.ForType`, StreamCompacting `ISerializer.ToJson`). These don't fail the smoke gate (which only promotes warnings emitted under the AotSmoke compilation context to errors), and they're real reflective surfaces not currently reached from the smoke surface. Capturing as a follow-up under #46 rather than expanding scope of this PR.

## Test plan

- [x] `dotnet build src/Polecat.AotSmoke/Polecat.AotSmoke.csproj -c Release` succeeds with 0 warnings, 0 errors locally on net9.0 + net10.0
- [x] `dotnet run --project src/Polecat.AotSmoke/Polecat.AotSmoke.csproj` exits 0 on both TFMs
- [x] Deliberate-break verification: bad reflective call surfaced IL2026 + IL3050 as build errors, then reverted
- [ ] CI `aot-smoke` workflow passes on this PR

References #46.

🤖 Generated with [Claude Code](https://claude.com/claude-code)