### PR TITLE
Polecat#46: Tighten reflective surface annotations from class-level to call-site

### DIFF
--- a/src/Polecat.AotSmoke/Program.cs
+++ b/src/Polecat.AotSmoke/Program.cs
@@ -28,6 +28,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Polecat;
 using Polecat.AotSmoke;
+using Polecat.Projections;
 
 var builder = Host.CreateApplicationBuilder(args);
 
@@ -45,10 +46,18 @@ builder.Services.AddPolecat((StoreOptions opts) =>
         "Server=aot-smoke;Database=aot_smoke;Integrated Security=False;User Id=sa;Password=irrelevant;TrustServerCertificate=True";
     opts.DatabaseSchemaName = "aot_smoke";
 
-    // Registering the snapshot projection pulls QuestStarted into the
-    // EventGraph via ProjectionBase.IncludedEventTypes, so no separate
-    // EventGraph.AddEventType call is needed here.
-    opts.Projections.Snapshot<Quest>(SnapshotLifecycle.Inline);
+    // AOT-safe projection registration: use the new()-constrained Add<T>(...)
+    // overload with a concrete SingleStreamProjection<TDoc, TId> subclass.
+    //
+    // This is the registration shape AOT consumers must use. The reflective
+    // shortcut `opts.Projections.Snapshot<Quest>(...)` is annotated
+    // [RequiresDynamicCode] + [RequiresUnreferencedCode] (it closes
+    // SingleStreamProjection<,> over (T, T.Id) via Type.MakeGenericType and
+    // resolves T's Id property via DocumentMapping reflection) and would
+    // surface IL2026 + IL3050 here under our WarningsAsErrors. The concrete
+    // subclass below has both generic arguments closed at compile time, so the
+    // analyzer can prove AOT safety.
+    opts.Projections.Add<QuestProjection>(ProjectionLifecycle.Inline);
 });
 
 using var host = builder.Build();
@@ -67,9 +76,12 @@ var session = scope.ServiceProvider.GetRequiredService<IDocumentSession>();
 
 // --- LINQ query construction --------------------------------------------
 // Construct (but never enumerate) a Where-filtered IQueryable through the
-// LINQ provider. This exercises IQuerySession.Query<T> + the LINQ extension
-// surface (PolecatLinqQueryProvider) — both class-level RUC/RDC suppressed
-// today. Materialization (ToListAsync etc.) would require a DB.
+// LINQ provider. This exercises IQuerySession.Query<T> + the generic
+// IQueryProvider.CreateQuery<TElement>(Expression) entry on
+// PolecatLinqQueryProvider — both AOT-clean. Materialization (ToListAsync
+// etc.) routes through the reflective ExecuteAsync<TResult> path, which is
+// annotated [RequiresDynamicCode] + [RequiresUnreferencedCode] and would
+// surface here under our WarningsAsErrors.
 var query = session.Query<Quest>().Where(q => q.Title == "smoke-test");
 _ = query.Expression;
 
@@ -82,8 +94,8 @@ namespace Polecat.AotSmoke
     internal sealed record QuestStarted(string Title);
 
     /// <summary>
-    /// Self-aggregating aggregate so Projections.Snapshot&lt;T&gt; has a target.
-    /// Static Create mirrors the SingleStreamProjection convention.
+    /// Self-aggregating aggregate. Static Create mirrors the
+    /// SingleStreamProjection convention.
     /// </summary>
     internal sealed class Quest
     {
@@ -91,5 +103,13 @@ namespace Polecat.AotSmoke
         public string Title { get; set; } = string.Empty;
 
         public static Quest Create(QuestStarted e) => new() { Title = e.Title };
+    }
+
+    /// <summary>
+    /// Concrete projection with both generic args closed at compile time —
+    /// AOT-safe alternative to <c>Projections.Snapshot&lt;Quest&gt;()</c>.
+    /// </summary>
+    internal sealed class QuestProjection : SingleStreamProjection<Quest, Guid>
+    {
     }
 }

--- a/src/Polecat/Events/Linq/EventLinqQueryProvider.cs
+++ b/src/Polecat/Events/Linq/EventLinqQueryProvider.cs
@@ -17,10 +17,6 @@ namespace Polecat.Events.Linq;
 ///     IQueryProvider for LINQ queries against the event store.
 ///     Supports both QueryAllRawEvents (IEvent) and QueryRawEventDataOnly&lt;T&gt; (event data type).
 /// </summary>
-[UnconditionalSuppressMessage("Trimming", "IL2075:DynamicallyAccessedMembers",
-    Justification = "Class-level: Task<T>.Result property is accessed via reflection (GetType().GetProperty(\"Result\")). The framework Task<TResult> intrinsic and its Result property are preserved by the runtime.")]
-[UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
-    Justification = "Class-level: dynamic LINQ over event-store rows uses Type.MakeGenericType for selector/handler types — runtime code generation. AOT consumers must register concrete query shapes per the AOT publishing guide.")]
 internal class EventLinqQueryProvider : IPolecatAsyncQueryProvider
 {
     private readonly QuerySession _session;
@@ -58,6 +54,12 @@ internal class EventLinqQueryProvider : IPolecatAsyncQueryProvider
         _eventDataType = eventDataType;
     }
 
+    [UnconditionalSuppressMessage("Trimming", "IL2046",
+        Justification = "IQueryProvider.CreateQuery(Expression) lacks RUC; the AOT-safe entry is the generic CreateQuery<TElement>(Expression).")]
+    [UnconditionalSuppressMessage("AOT", "IL3051",
+        Justification = "IQueryProvider.CreateQuery(Expression) lacks RDC; the AOT-safe entry is the generic CreateQuery<TElement>(Expression).")]
+    [RequiresDynamicCode("Closes PolecatLinqQueryable<> over the element type via Type.MakeGenericType. AOT consumers should call CreateQuery<TElement>(Expression) instead.")]
+    [RequiresUnreferencedCode("Activator.CreateInstance reflects over the constructor of PolecatLinqQueryable<>.")]
     public IQueryable CreateQuery(Expression expression)
     {
         var elementType = GetElementType(expression);
@@ -82,6 +84,8 @@ internal class EventLinqQueryProvider : IPolecatAsyncQueryProvider
             "Polecat does not support synchronous LINQ execution. Use async methods (ToListAsync, etc.) instead.");
     }
 
+    [RequiresDynamicCode("Event-store LINQ execution closes ListQueryHandler<>/DeserializingSelector<>/etc. over the event/event-data type via Type.MakeGenericType.")]
+    [RequiresUnreferencedCode("Event-store LINQ execution reflects over the event type (Activator.CreateInstance on handler types, MethodInfo.Invoke on HandleAsync). AOT consumers must preserve event + handler members through DAM or source generation.")]
     public async Task<TResult> ExecuteAsync<TResult>(Expression expression, CancellationToken token)
     {
         var parser = new LinqQueryParser(_memberFactory, _eventsTable);
@@ -147,6 +151,8 @@ internal class EventLinqQueryProvider : IPolecatAsyncQueryProvider
         return await HandleResultAsync<TResult>(reader, parser, token);
     }
 
+    [RequiresDynamicCode("Routes to handler invocations that close generic handler types over the event/event-data type via Type.MakeGenericType.")]
+    [RequiresUnreferencedCode("Routes to handler invocations that reflect over handler types.")]
     private async Task<TResult> HandleResultAsync<TResult>(
         DbDataReader reader, LinqQueryParser parser, CancellationToken token)
     {
@@ -235,6 +241,8 @@ internal class EventLinqQueryProvider : IPolecatAsyncQueryProvider
         return typeof(IEvent);
     }
 
+    [RequiresDynamicCode("Closes DeserializingSelector<> + ListQueryHandler<> over itemType via Type.MakeGenericType.")]
+    [RequiresUnreferencedCode("Reflects over handler/selector types (Activator.CreateInstance, MethodInfo.Invoke on HandleAsync, GetProperty on Task<>.Result).")]
     private async Task<TResult> InvokeListHandlerAsync<TResult>(
         Type itemType, DbDataReader reader, CancellationToken token)
     {
@@ -252,6 +260,8 @@ internal class EventLinqQueryProvider : IPolecatAsyncQueryProvider
         return (TResult)resultProperty.GetValue(task)!;
     }
 
+    [RequiresDynamicCode("Closes ScalarListHandler<> over TResult's element type via Type.MakeGenericType.")]
+    [RequiresUnreferencedCode("Reflects over ScalarListHandler<>.HandleAsync via MethodInfo.Invoke and Task<>.Result via GetProperty.")]
     private async Task<TResult> InvokeScalarListHandlerAsync<TResult>(
         DbDataReader reader, CancellationToken token)
     {
@@ -267,6 +277,8 @@ internal class EventLinqQueryProvider : IPolecatAsyncQueryProvider
         return (TResult)resultProperty.GetValue(task)!;
     }
 
+    [RequiresDynamicCode("Closes DeserializingSelector<> + OneResultHandler<> over documentType via Type.MakeGenericType.")]
+    [RequiresUnreferencedCode("Reflects over handler/selector types (Activator.CreateInstance, MethodInfo.Invoke on HandleAsync, GetProperty on Task<>.Result).")]
     private async Task<TResult> InvokeOneResultHandlerAsync<TResult>(
         Type documentType, DbDataReader reader, CancellationToken token,
         bool canBeNull, bool canBeMultiples)

--- a/src/Polecat/Internal/DocumentSessionBase.cs
+++ b/src/Polecat/Internal/DocumentSessionBase.cs
@@ -24,10 +24,6 @@ namespace Polecat.Internal;
 ///     processing, and SaveChangesAsync. Uses IAlwaysConnectedLifetime for
 ///     persistent connection + transaction management.
 /// </summary>
-[UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
-    Justification = "Class-level: store/update/delete operations call into ISerializer.ToJson and JasperFx.Events projection infrastructure. Document and event types flow in from caller registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed ISerializer impl.")]
-[UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
-    Justification = "Class-level: ISerializer.ToJson and inline projection runners use Type.MakeGenericType / FastExpressionCompiler — runtime code generation. AOT consumers rely on source-generated event/projection helpers.")]
 internal abstract class DocumentSessionBase : QuerySession, IDocumentSession
 {
     private readonly WorkTracker _workTracker = new();
@@ -692,6 +688,18 @@ internal abstract class DocumentSessionBase : QuerySession, IDocumentSession
         }
     }
 
+    // IL2026 / IL3050 here originate from two Serializer.ToJson(object) call
+    // sites below (@event.Data ~line 796, @event.Headers ~line 816). Promoting
+    // [RequiresUnreferencedCode] / [RequiresDynamicCode] up the call chain would
+    // propagate to IDocumentSession.SaveChangesAsync — out of scope for #46's
+    // reflective-callsite tightening (which targets the four projection/LINQ
+    // classes). The AOT escape hatch remains: AOT consumers supply a
+    // source-generator-backed ISerializer implementation; the default reflective
+    // STJ serializer is the only thing that trips RUC/RDC here.
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "Serializer.ToJson(@event.Data) + Serializer.ToJson(@event.Headers). Default STJ ISerializer reflects over event types; AOT consumers supply a source-generator-backed ISerializer.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "Serializer.ToJson uses STJ runtime codegen by default; AOT consumers supply a source-generator-backed ISerializer.")]
     private async Task InsertEventAsync(IEvent @event, StreamAction stream, CancellationToken token)
     {
         var streamId = _eventGraph.StreamIdentity == JasperFx.Events.StreamIdentity.AsGuid

--- a/src/Polecat/Linq/IPolecatAsyncQueryProvider.cs
+++ b/src/Polecat/Linq/IPolecatAsyncQueryProvider.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 
 namespace Polecat.Linq;
@@ -7,5 +8,7 @@ namespace Polecat.Linq;
 /// </summary>
 internal interface IPolecatAsyncQueryProvider : IQueryProvider
 {
+    [RequiresDynamicCode("LINQ execution closes generic handler types over the document/result type via Type.MakeGenericType.")]
+    [RequiresUnreferencedCode("LINQ execution reflects over the document type and over handler types (Activator.CreateInstance, MethodInfo.Invoke).")]
     Task<TResult> ExecuteAsync<TResult>(Expression expression, CancellationToken token);
 }

--- a/src/Polecat/Linq/PolecatLinqQueryProvider.cs
+++ b/src/Polecat/Linq/PolecatLinqQueryProvider.cs
@@ -27,14 +27,6 @@ namespace Polecat.Linq;
 ///     either avoid LINQ entirely (use the raw <c>session.QueryAsync</c> path with
 ///     SQL strings) or use source-generated compiled queries.
 /// </remarks>
-[UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
-    Justification = "Class-level: LINQ-to-SQL translation references framework Queryable / Enumerable methods + user document types via Expression trees. Trim invariant lives at the document-registration boundary.")]
-[UnconditionalSuppressMessage("Trimming", "IL2070:DynamicallyAccessedMembers",
-    Justification = "Class-level: reflection over user document types whose members are preserved by the document-registration surface.")]
-[UnconditionalSuppressMessage("Trimming", "IL2075:DynamicallyAccessedMembers",
-    Justification = "Class-level: same as IL2070.")]
-[UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
-    Justification = "Class-level: Type.MakeGenericType / Expression.Call(Type, string, ...) for LINQ expression construction. AOT consumers should bypass this layer.")]
 internal class PolecatLinqQueryProvider : IPolecatAsyncQueryProvider
 {
     private readonly QuerySession _session;
@@ -51,6 +43,17 @@ internal class PolecatLinqQueryProvider : IPolecatAsyncQueryProvider
         _tableEnsurer = tableEnsurer;
     }
 
+    // IL2046 — IQueryProvider.CreateQuery(Expression) is not annotated [RUC]/[RDC]
+    // in the BCL, but the only AOT-safe implementation is the generic
+    // CreateQuery<TElement>(Expression) overload below. The non-generic
+    // implementation requires runtime codegen + reflection on the element type;
+    // the (necessary) annotation mismatch with the interface is suppressed here.
+    [UnconditionalSuppressMessage("Trimming", "IL2046",
+        Justification = "IQueryProvider.CreateQuery(Expression) lacks RUC; the AOT-safe entry is the generic CreateQuery<TElement>(Expression).")]
+    [UnconditionalSuppressMessage("AOT", "IL3051",
+        Justification = "IQueryProvider.CreateQuery(Expression) lacks RDC; the AOT-safe entry is the generic CreateQuery<TElement>(Expression).")]
+    [RequiresDynamicCode("Closes PolecatLinqQueryable<> over the element type via Type.MakeGenericType. AOT consumers should call CreateQuery<TElement>(Expression) instead.")]
+    [RequiresUnreferencedCode("Activator.CreateInstance reflects over the constructor of PolecatLinqQueryable<>. AOT consumers should call CreateQuery<TElement>(Expression) instead.")]
     public IQueryable CreateQuery(Expression expression)
     {
         var elementType = GetElementType(expression);
@@ -173,6 +176,8 @@ internal class PolecatLinqQueryProvider : IPolecatAsyncQueryProvider
         return sb.ToString();
     }
 
+    [RequiresDynamicCode("LINQ-to-SQL execution closes ListQueryHandler<>/DeserializingSelector<>/etc. over the document type via Type.MakeGenericType.")]
+    [RequiresUnreferencedCode("LINQ-to-SQL execution reflects over the document type (Activator.CreateInstance on handler types, MethodInfo.Invoke on HandleAsync). AOT consumers must preserve handler + document members through DAM or source generation.")]
     public async Task<TResult> ExecuteAsync<TResult>(Expression expression, CancellationToken token)
     {
         var documentType = FindDocumentType(expression);
@@ -294,6 +299,8 @@ internal class PolecatLinqQueryProvider : IPolecatAsyncQueryProvider
             isHierarchy ? provider.Mapping : null);
     }
 
+    [RequiresDynamicCode("GroupBy execution closes GroupByListHandler<>/ScalarListHandler<> over the projected type via Type.MakeGenericType.")]
+    [RequiresUnreferencedCode("GroupBy execution reflects over handler types (Activator.CreateInstance + MethodInfo.Invoke).")]
     private async Task<TResult> ExecuteGroupByAsync<TResult>(
         LinqQueryParser parser, MemberFactory memberFactory, CancellationToken token)
     {
@@ -366,6 +373,8 @@ internal class PolecatLinqQueryProvider : IPolecatAsyncQueryProvider
         return await InvokeScalarListHandlerAsync<TResult>(reader, token);
     }
 
+    [RequiresDynamicCode("Closes GroupByListHandler<> over TResult's element type via Type.MakeGenericType.")]
+    [RequiresUnreferencedCode("Reflects over GroupByListHandler<>.HandleAsync via MethodInfo.Invoke and Task<>.Result via GetProperty.")]
     private async Task<TResult> InvokeGroupByListHandlerAsync<TResult>(
         System.Data.Common.DbDataReader reader, LambdaExpression selectExpression,
         CancellationToken token)
@@ -406,6 +415,8 @@ internal class PolecatLinqQueryProvider : IPolecatAsyncQueryProvider
         }
     }
 
+    [RequiresDynamicCode("GroupJoin execution closes JoinListHandler<,,> + Func<,,> over outer/inner/result types via Type.MakeGenericType.")]
+    [RequiresUnreferencedCode("GroupJoin execution reflects over handler types and the result selector. AOT consumers must preserve outer/inner/result type members through DAM or source generation.")]
     private async Task<TResult> ExecuteGroupJoinAsync<TResult>(LinqQueryParser parser, CancellationToken token)
     {
         var joinData = parser.GroupJoinData!;
@@ -676,6 +687,7 @@ internal class PolecatLinqQueryProvider : IPolecatAsyncQueryProvider
     ///     Finds the original MemberExpression on the document type for an anonymous type member.
     ///     Traces through the SelectMany result selector to find the source expression.
     /// </summary>
+    [RequiresUnreferencedCode("Routes through FindDeepestMemberExpression which reflects over the document type's members.")]
     private static MemberExpression? FindOriginalProperty(GroupJoinData joinData, string memberName, bool isOuter)
     {
         if (joinData.SelectManyResultSelector?.Body is not NewExpression resultNew || resultNew.Members == null)
@@ -693,6 +705,7 @@ internal class PolecatLinqQueryProvider : IPolecatAsyncQueryProvider
         return null;
     }
 
+    [RequiresUnreferencedCode("Reflects over the document type's properties/fields via Type.GetProperty/GetField when rebuilding member access for join order-by translation.")]
     private static MemberExpression? FindDeepestMemberExpression(Expression expr)
     {
         // Walk through member chains to find the deepest member on a document type
@@ -724,6 +737,7 @@ internal class PolecatLinqQueryProvider : IPolecatAsyncQueryProvider
         return lastType;
     }
 
+    [RequiresUnreferencedCode("Reflects over param.Type's public properties/fields via Type.GetProperty/GetField when rebuilding join order-by member access.")]
     private static MemberExpression? RebuildMemberAccess(MemberExpression original, ParameterExpression param)
     {
         // Collect the member chain from innermost to outermost
@@ -773,6 +787,8 @@ internal class PolecatLinqQueryProvider : IPolecatAsyncQueryProvider
             $"Join key selector must be a member expression, got: {keyBody.NodeType}");
     }
 
+    [RequiresDynamicCode("Closes Func<,,> + JoinListHandler<,,> over outer/inner/result types via Type.MakeGenericType.")]
+    [RequiresUnreferencedCode("Reflects over JoinListHandler<,,>.HandleAsync via MethodInfo.Invoke and Task<>.Result via GetProperty.")]
     private async Task<TResult> InvokeJoinHandlerAsync<TResult>(
         Type outerType, Type innerType,
         LambdaExpression rewrittenSelector, bool isLeftJoin,
@@ -904,6 +920,8 @@ internal class PolecatLinqQueryProvider : IPolecatAsyncQueryProvider
         }
     }
 
+    [RequiresDynamicCode("Routes to handler invocations that close generic handler types over the document/result type via Type.MakeGenericType.")]
+    [RequiresUnreferencedCode("Routes to handler invocations that reflect over handler/result types.")]
     private async Task<TResult> HandleResultAsync<TResult>(
         DbDataReader reader, LinqQueryParser parser, Type documentType, CancellationToken token,
         bool syncRevision = false, bool syncGuidVersion = false, DocumentMapping? hierarchyMapping = null)
@@ -964,6 +982,8 @@ internal class PolecatLinqQueryProvider : IPolecatAsyncQueryProvider
         }
     }
 
+    [RequiresDynamicCode("Closes DeserializingSelector<> + ListQueryHandler<> over itemType via Type.MakeGenericType.")]
+    [RequiresUnreferencedCode("Reflects over handler/selector types (Activator.CreateInstance, MethodInfo.Invoke on HandleAsync, GetProperty on Task<>.Result).")]
     private async Task<TResult> InvokeListHandlerAsync<TResult>(
         Type itemType, DbDataReader reader, CancellationToken token,
         bool syncRevision = false, bool syncGuidVersion = false, DocumentMapping? hierarchyMapping = null)
@@ -983,6 +1003,8 @@ internal class PolecatLinqQueryProvider : IPolecatAsyncQueryProvider
         return (TResult)resultProperty.GetValue(task)!;
     }
 
+    [RequiresDynamicCode("Closes ScalarListHandler<> over TResult's element type via Type.MakeGenericType.")]
+    [RequiresUnreferencedCode("Reflects over ScalarListHandler<>.HandleAsync via MethodInfo.Invoke and Task<>.Result via GetProperty.")]
     private async Task<TResult> InvokeScalarListHandlerAsync<TResult>(
         DbDataReader reader, CancellationToken token)
     {
@@ -999,6 +1021,8 @@ internal class PolecatLinqQueryProvider : IPolecatAsyncQueryProvider
         return (TResult)resultProperty.GetValue(task)!;
     }
 
+    [RequiresDynamicCode("Closes ProjectionListHandler<,> over (sourceType, TResult's projected type) via Type.MakeGenericType.")]
+    [RequiresUnreferencedCode("Reflects over ProjectionListHandler<,>.HandleAsync via MethodInfo.Invoke and Task<>.Result via GetProperty.")]
     private async Task<TResult> InvokeProjectionHandlerAsync<TResult>(
         Type sourceType, DbDataReader reader, LambdaExpression selectExpression,
         CancellationToken token)
@@ -1016,6 +1040,8 @@ internal class PolecatLinqQueryProvider : IPolecatAsyncQueryProvider
         return (TResult)resultProperty.GetValue(task)!;
     }
 
+    [RequiresDynamicCode("Closes DeserializingSelector<> + OneResultHandler<> over documentType via Type.MakeGenericType.")]
+    [RequiresUnreferencedCode("Reflects over handler/selector types (Activator.CreateInstance, MethodInfo.Invoke on HandleAsync, GetProperty on Task<>.Result).")]
     private async Task<TResult> InvokeOneResultHandlerAsync<TResult>(
         Type documentType, DbDataReader reader, CancellationToken token,
         bool canBeNull, bool canBeMultiples,

--- a/src/Polecat/Projections/PolecatCompositeProjection.cs
+++ b/src/Polecat/Projections/PolecatCompositeProjection.cs
@@ -12,10 +12,6 @@ namespace Polecat.Projections;
 ///     into ordered stages. Stages run sequentially, projections within a stage
 ///     run in parallel.
 /// </summary>
-[UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
-    Justification = "Class-level: extends JasperFx.Events CompositeProjection (annotated RUC) and registers nested projection types via reflection. Projection types are preserved at the registration boundary on the caller side per the AOT publishing guide.")]
-[UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
-    Justification = "Class-level: JasperFx.Events composite-projection helpers use Type.MakeGenericType — runtime code generation. AOT consumers rely on source-generated projection helpers.")]
 public class PolecatCompositeProjection : CompositeProjection<IDocumentSession, IQuerySession>
 {
     private readonly StoreOptions _options;
@@ -71,6 +67,8 @@ public class PolecatCompositeProjection : CompositeProjection<IDocumentSession, 
     /// <param name="stageNumber">
     ///     Optionally move the execution of this snapshot projection to a later stage. The default is 1.
     /// </param>
+    [RequiresDynamicCode("Closes SingleStreamProjection<,> over (T, T.Id) via Type.MakeGenericType. AOT consumers should register a concrete SingleStreamProjection<TDoc, TId> subclass via composite.Add() instead.")]
+    [RequiresUnreferencedCode("Resolves T's Id property via DocumentMapping reflection. AOT consumers must preserve T's Id member through DynamicallyAccessedMembers or source generation.")]
     public void Snapshot<T>(int stageNumber = 1) where T : notnull
     {
         if (typeof(T).CanBeCastTo<ProjectionBase>())

--- a/src/Polecat/Projections/PolecatProjectionOptions.cs
+++ b/src/Polecat/Projections/PolecatProjectionOptions.cs
@@ -17,10 +17,6 @@ namespace Polecat.Projections;
 ///     Projection registration and configuration for Polecat.
 ///     Extends ProjectionGraph to integrate with the JasperFx async daemon framework.
 /// </summary>
-[UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
-    Justification = "Class-level: registers projections via the JasperFx.Events ProjectionGraph (annotated RUC). Projection / aggregate types flow in from caller registration and are preserved per the AOT publishing guide.")]
-[UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
-    Justification = "Class-level: JasperFx.Events projection-registration helpers use Type.MakeGenericType — runtime code generation. AOT consumers rely on source-generated projection helpers.")]
 public class PolecatProjectionOptions
     : ProjectionGraph<IProjection, IDocumentSession, IQuerySession>
 {
@@ -78,11 +74,15 @@ public class PolecatProjectionOptions
     ///     The snapshot lifecycle: <see cref="SnapshotLifecycle.Inline"/> updates the snapshot in the
     ///     same transaction as the events; <see cref="SnapshotLifecycle.Async"/> updates via the async daemon.
     /// </param>
+    [RequiresDynamicCode("Closes SingleStreamProjection<,> over (T, T.Id) via Type.MakeGenericType. AOT consumers should register a concrete SingleStreamProjection<TDoc, TId> subclass via Projections.Add() instead.")]
+    [RequiresUnreferencedCode("Resolves T's Id property via DocumentMapping reflection. AOT consumers must preserve T's Id member through DynamicallyAccessedMembers or source generation.")]
     public void Snapshot<T>(SnapshotLifecycle lifecycle) where T : notnull
     {
         AddSnapshotProjection<T>(lifecycle.ToProjectionLifecycle());
     }
 
+    [RequiresDynamicCode("Closes SingleStreamProjection<,> over (T, T.Id) via Type.MakeGenericType.")]
+    [RequiresUnreferencedCode("Resolves T's Id property via DocumentMapping reflection.")]
     private void AddSnapshotProjection<T>(ProjectionLifecycle lifecycle) where T : notnull
     {
         if (typeof(T).CanBeCastTo<ProjectionBase>())


### PR DESCRIPTION
## Summary

Replaces class-level `[UnconditionalSuppressMessage]` umbrellas on Polecat's reflective surfaces with method-level annotations that name the exact contract. Downstream `IsAotCompatible=true` consumers now see a precise punch-list instead of a wall of silenced classes. Ticks the **"Audit reflective surfaces that aren't covered by `Polecat.CodeGeneration`. Annotate or migrate."** checkbox on #46.

`Polecat.AotSmoke` (from #102/#106) still builds clean — the gate confirms no AOT regression.

## Before/after

| File | Class-level attrs (before) | Class-level attrs (after) | Method-level attrs added |
|---|---|---|---|
| `Projections/PolecatCompositeProjection.cs` | 2 (IL2026, IL3050) | 0 | 2 on `Snapshot<T>` |
| `Projections/PolecatProjectionOptions.cs` | 2 (IL2026, IL3050) | 0 | 4 across `Snapshot<T>` + `AddSnapshotProjection<T>` |
| `Linq/PolecatLinqQueryProvider.cs` | 4 (IL2026, IL2070, IL2075, IL3050) | 0 | 25 across 12 methods (`CreateQuery`, `ExecuteAsync`, `ExecuteGroupBy`/`ExecuteGroupJoin`, all `Invoke*Handler*Async`, `FindOriginalProperty`, `FindDeepestMemberExpression`, `RebuildMemberAccess`) |
| `Events/Linq/EventLinqQueryProvider.cs` *(sibling)* | 2 (IL2075, IL3050) | 0 | 14 across 6 methods |
| `Internal/DocumentSessionBase.cs` | 2 (IL2026, IL3050) | 0 | 2 method-level `UnconditionalSuppressMessage` on `InsertEventAsync` |
| `Linq/IPolecatAsyncQueryProvider.cs` *(propagation)* | 0 | 0 | 2 on the interface `ExecuteAsync<TResult>` so impls match |

**Why method-level `UnconditionalSuppressMessage` on DocumentSessionBase instead of RUC/RDC?**
The reflective surface in DocumentSessionBase is two `Serializer.ToJson(object)` call sites in `InsertEventAsync` (a private method). Promoting [RUC]/[RDC] up the call chain would propagate to `IDocumentSession.SaveChangesAsync` — a public interface change beyond #46's scope. Per the chip's style guide, method-level `UnconditionalSuppressMessage` is the documented fallback when "no method-level annotation expresses the constraint cleanly" — in this case "cleanly" includes "without widening scope to the public surface." Justifications name the exact call sites.

**EventLinqQueryProvider** wasn't in the chip's primary four but came in scope because adding RUC/RDC to `IPolecatAsyncQueryProvider.ExecuteAsync` (required to match `PolecatLinqQueryProvider`'s impl annotation) cascaded an IL2046 mismatch on the only other implementer. Tightening both impls + the interface in one go is cleaner than leaving the sibling with a stale class-level umbrella.

## Verification

- `dotnet build src/Polecat/Polecat.csproj -c Release` — clean (same 7 pre-existing IL warnings as `main`, all in files outside this PR's scope; no new warnings introduced)
- `dotnet build src/Polecat.AotSmoke/Polecat.AotSmoke.csproj -c Release` — clean (0 warnings, 0 errors on net9.0 + net10.0); smoke surface migrated from `opts.Projections.Snapshot<Quest>(...)` (now correctly RUC/RDC) to the AOT-safe `opts.Projections.Add<QuestProjection>(ProjectionLifecycle.Inline)` pattern with a concrete `SingleStreamProjection<Quest, Guid>` subclass
- `dotnet build src/Polecat.EntityFrameworkCore.Tests/Polecat.EntityFrameworkCore.Tests.csproj -c Release` — clean (only pre-existing CS8767 nullability noise unrelated to AOT)
- `dotnet run --project src/Polecat.AotSmoke -c Release` — exits 0 on both net9.0 + net10.0

Local test suite couldn't be run end-to-end — the Docker SQL Server image is `linux/amd64` and the host is `arm64`, so emulated connection handshakes time out before tests can even open a connection (every test fails at `ConnectionSource.DetectNativeJsonSupport()` with `Connection Timeout Expired`, handshake=3881ms). All test failures are environmental; the changes are annotation-only with no runtime semantics, so the existing CI run on amd64 is the authoritative verification.

## Out of scope (per chip's "Don't widen scope")

Pre-existing class-level suppressions remain in: `DocumentStore.{EventStoreExplorer,ProjectionReplay}.cs`, `AdvancedOperations.cs`, `AdvancedSqlResultReader.cs`, `Serialization/Serializer.cs`, `Events/EventGraph.cs`, `Events/EventOperations.cs`, `Events/Daemon/PolecatEventLoader.cs`, `Events/Internal/PcEventsRowReader.cs`, `Internal/QuerySession.cs`, `Internal/DocumentProvider*.cs`, `Internal/Batching/*.cs`, `Storage/DocumentMapping*.cs`, `Linq/{NonStaleDataExtensions,SoftDeletes/SoftDeletedExtensions,Metadata/*,Selectors/DeserializingSelector,Joins/JoinResultSelectorRewriter,Parsing/*,QueryHandlers/*,PolecatQueryableExtensions,LinqExtensions}.cs`, `Patching/*.cs`, `Projections/{PolecatProjectionStorage,Flattened/{StatementMap,EventDeleter}}.cs`, `PolecatConfigurationExpression.cs`, `PolecatStoreServiceCollectionExtensions.cs`. A follow-up chip can sweep these.

Also out of scope: migrating reflective patterns to `GenericFactoryCache` / source generators (separate Polecat#46 checkbox under the cold-start pillar).

## Commit shape

1. `ae97c3b` — Projections cluster (PolecatCompositeProjection + PolecatProjectionOptions) + AotSmoke surface migration
2. `112da8b` — LINQ providers (PolecatLinqQueryProvider + IPolecatAsyncQueryProvider + EventLinqQueryProvider sibling)
3. `b1de9f6` — DocumentSessionBase

References #46.

🤖 Generated with [Claude Code](https://claude.com/claude-code)