### PR TITLE
JasperFx#276 Phase 3: Adopt FEC-free projection apply-method dispatch

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>4.0.0-alpha.4</Version>
+        <Version>4.0.0-alpha.5</Version>
         <LangVersion>latest</LangVersion>
         <Authors>Jeremy D. Miller</Authors>
         <PackageIcon>logo.png</PackageIcon>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,7 @@
     <ItemGroup>
         <!-- Core dependencies -->
         <PackageVersion Include="JasperFx" Version="2.0.0-alpha.13" />
-        <PackageVersion Include="JasperFx.Events" Version="2.0.0-alpha.9" />
+        <PackageVersion Include="JasperFx.Events" Version="2.0.0-alpha.11" />
         <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
@@ -32,7 +32,7 @@
         <PackageVersion Include="StronglyTypedId" Version="1.0.0-beta08" />
 
         <!-- Source generators -->
-        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.0.0-alpha.2" />
+        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.0.0-alpha.4" />
 
         <!-- Build automation -->
         <PackageVersion Include="Nuke.Common" Version="9.0.4" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,7 @@
     <ItemGroup>
         <!-- Core dependencies -->
         <PackageVersion Include="JasperFx" Version="2.0.0-alpha.13" />
-        <PackageVersion Include="JasperFx.Events" Version="2.0.0-alpha.11" />
+        <PackageVersion Include="JasperFx.Events" Version="2.0.0-alpha.12" />
         <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
@@ -32,7 +32,7 @@
         <PackageVersion Include="StronglyTypedId" Version="1.0.0-beta08" />
 
         <!-- Source generators -->
-        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.0.0-alpha.4" />
+        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.0.0-alpha.5" />
 
         <!-- Build automation -->
         <PackageVersion Include="Nuke.Common" Version="9.0.4" />

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -11,8 +11,8 @@ Polecat 4 consumes the 2026-wave alpha line for the shared substrate. Update you
 | Package | 3.x | 4.0 (current alpha) |
 |---|---|---|
 | `JasperFx` | `1.31.0` | `2.0.0-alpha.13` |
-| `JasperFx.Events` | `1.36.0` | `2.0.0-alpha.11` |
-| `JasperFx.Events.SourceGenerator` | `1.4.0` | `2.0.0-alpha.4` |
+| `JasperFx.Events` | `1.36.0` | `2.0.0-alpha.12` |
+| `JasperFx.Events.SourceGenerator` | `1.4.0` | `2.0.0-alpha.5` |
 | `Weasel.SqlServer` | `8.15.2` | `9.0.0-alpha.3` |
 | `Weasel.EntityFrameworkCore` | `8.15.2` | `9.0.0-alpha.3` |
 

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -10,9 +10,9 @@ Polecat 4 consumes the 2026-wave alpha line for the shared substrate. Update you
 
 | Package | 3.x | 4.0 (current alpha) |
 |---|---|---|
-| `JasperFx` | `1.31.0` | `2.0.0-alpha.11` |
-| `JasperFx.Events` | `1.36.0` | `2.0.0-alpha.4` |
-| `JasperFx.Events.SourceGenerator` | `1.4.0` | `2.0.0-alpha.2` |
+| `JasperFx` | `1.31.0` | `2.0.0-alpha.13` |
+| `JasperFx.Events` | `1.36.0` | `2.0.0-alpha.11` |
+| `JasperFx.Events.SourceGenerator` | `1.4.0` | `2.0.0-alpha.4` |
 | `Weasel.SqlServer` | `8.15.2` | `9.0.0-alpha.3` |
 | `Weasel.EntityFrameworkCore` | `8.15.2` | `9.0.0-alpha.3` |
 
@@ -83,6 +83,104 @@ catch (JasperFx.MultiTenancy.UnknownTenantIdException ex)
 ```
 
 ### Event-sourcing API changes
+
+#### Projections and self-aggregating documents must be `partial`
+
+[JasperFx/jasperfx#276](https://github.com/JasperFx/jasperfx/issues/276) (FEC elimination, Phase 1) removed the FastExpressionCompiler fallback in `JasperFx.Events`'s projection apply-method dispatch. Source-generated dispatchers emitted by [`JasperFx.Events.SourceGenerator`](https://www.nuget.org/packages/JasperFx.Events.SourceGenerator) are now the only path — runtime registration **fails fast** when no `[GeneratedEvolver]` is found for a projection that uses conventional `Apply` / `Create` / `ShouldDelete` methods:
+
+```
+JasperFx.Events.Projections.InvalidProjectionException:
+  No source-generated dispatcher found for MyApp.MyProjection.
+  When using conventional Apply/Create/ShouldDelete methods, the projection class must be
+  declared `partial` in an assembly that references the JasperFx.Events.SourceGenerator analyzer,
+  or alternatively override Evolve / EvolveAsync / DetermineAction / DetermineActionAsync directly.
+```
+
+To clear this exception, **every projection class that uses conventional apply-method discovery must be `partial`**, including:
+
+- Subclasses of `SingleStreamProjection<TDoc, TId>`, `MultiStreamProjection<TDoc, TId>`, `EventProjection`, and `PolecatCompositeProjection`.
+- **Self-aggregating document types** registered via `opts.Projections.Snapshot<T>(...)`, queried via `session.Events.AggregateStreamAsync<T>(...)`, or live-projected via `session.Events.FetchLatest<T>(...)` / `FetchForWriting<T>(...)`. The source generator emits a standalone `TEvolver` class for the closed `SingleStreamProjection<T, T.IdType>` runtime instance, and it can only do that when `T` is `partial`.
+
+```csharp
+// before (Polecat 3.x — works because of FEC fallback)
+public class QuestParty
+{
+    public Guid Id { get; set; }
+    public List<string> Members { get; } = [];
+
+    public static QuestParty Create(QuestStarted e) => new();
+    public void Apply(MembersJoined e) => Members.AddRange(e.Members);
+}
+
+// after (Polecat 4.0 — `partial` required)
+public partial class QuestParty
+{
+    public Guid Id { get; set; }
+    public List<string> Members { get; } = [];
+
+    public static QuestParty Create(QuestStarted e) => new();
+    public void Apply(MembersJoined e) => Members.AddRange(e.Members);
+}
+```
+
+Every assembly that defines such a projection or aggregate also needs to reference the `JasperFx.Events.SourceGenerator` NuGet as an **analyzer-only** package — Polecat itself already pulls it in through `JasperFx.Events` for projection types declared in your store-host project, but any sibling assembly that declares its own projection / aggregate types needs its own reference:
+
+```xml
+<ItemGroup>
+  <PackageReference Include="JasperFx.Events.SourceGenerator"
+                    OutputItemType="Analyzer"
+                    ReferenceOutputAssembly="false" />
+</ItemGroup>
+```
+
+If you have a projection that **cannot** be made `partial` (e.g. a sealed class from a third-party library, or one you want to keep as a non-source-generator path), the escape hatch is to override the dispatch methods directly:
+
+```csharp
+public class MyProjection : SingleStreamProjection<MyAggregate, Guid>
+{
+    public override ValueTask<MyAggregate?> EvolveAsync(
+        MyAggregate? snapshot, Guid id, IEvent e, CancellationToken ct)
+    {
+        // hand-written dispatch — no SG, no FEC
+    }
+}
+```
+
+This matches Marten 9's adoption story for the same JasperFx.Events Phase-1 change.
+
+##### Surfaces unaffected by the partial requirement
+
+- **`FlatTableProjection`** — has its own dictionary-keyed dispatch via `Project<TEvent>(...)` / `Delete<TEvent>(...)`, doesn't go through JasperFx.Events apply-method discovery. No `partial` required.
+- **`EfCoreSingleStreamProjection<TDoc, TDbContext>` / `EfCoreEventProjection<TDbContext>`** (from `Polecat.EntityFrameworkCore`) — override `DetermineActionAsync` directly, also bypass the SG-required path.
+
+#### Inline-lambda projection registration APIs removed
+
+[JasperFx/jasperfx#276](https://github.com/JasperFx/jasperfx/issues/276) / [#286](https://github.com/JasperFx/jasperfx/issues/286) removed the inline-lambda registration overloads on `EventProjection`, `IAggregationSteps<T, TQuerySession>`, and `JasperFxAggregationProjectionBase` — the source generator cannot dispatch a runtime closure, so these were the last thing keeping FEC reachable. Migrate to conventional method declarations on the projection class:
+
+```csharp
+// before (Polecat 3.x)
+public class MyEventProjection : EventProjection
+{
+    public MyEventProjection()
+    {
+        Project<OrderPlaced>((e, ops) =>
+        {
+            ops.Store(new OrderSummary { Id = e.OrderId, ... });
+        });
+    }
+}
+
+// after (Polecat 4.0)
+public partial class MyEventProjection : EventProjection
+{
+    public void Project(OrderPlaced e, IDocumentSession ops)
+    {
+        ops.Store(new OrderSummary { Id = e.OrderId, ... });
+    }
+}
+```
+
+The same shape — `public void Project(TEvent, IDocumentSession)` for inline mutation, plus the conventional `Create` / `Apply` / `ShouldDelete` methods for aggregations — covers everything the lambda APIs used to do. `DeleteEvent<TEvent>()` (no-args, populates the internal delete-types list) and `TransformsEvent<TEvent>()` remain available; only the lambda-taking overloads were dropped.
 
 #### `IInlineProjection.ApplyAsync` parameter widening
 
@@ -155,7 +253,9 @@ The concurrency throw is **best-effort, not transactional.** Matched-and-updated
 Polecat 4 inherits the same AOT-friendly posture introduced in JasperFx 2.0 ([jasperfx#213](https://github.com/JasperFx/jasperfx/issues/213) AOT pillar, jasperfx#190 `ITypeLoader` abstraction). Polecat itself has been source-generator-first since 3.x — there is no Roslyn runtime-compile path to disable — so:
 
 - `PublishAot=true` is the supported posture for Polecat 4 applications, modulo the usual System.Text.Json `JsonSerializerContext` setup for your document and event types.
-- `IsAotCompatible=true` is now set on the Polecat assembly (PR [#67](https://github.com/JasperFx/polecat/pull/67)), and the reflective surfaces of Polecat have been progressively annotated for the trimmer / AOT analyzer — Serialization ([#74](https://github.com/JasperFx/polecat/pull/74)), ProjectionReplay ([#75](https://github.com/JasperFx/polecat/pull/75)), LINQ extension/provider surface ([#76](https://github.com/JasperFx/polecat/pull/76)), and Storage / Registry / EventStoreExplorer ([#77](https://github.com/JasperFx/polecat/pull/77)).
+- `IsAotCompatible=true` is now set on the Polecat assembly (PR [#67](https://github.com/JasperFx/polecat/pull/67)), and the reflective surfaces of Polecat have been progressively annotated for the trimmer / AOT analyzer — Serialization ([#74](https://github.com/JasperFx/polecat/pull/74)), ProjectionReplay ([#75](https://github.com/JasperFx/polecat/pull/75)), LINQ extension/provider surface ([#76](https://github.com/JasperFx/polecat/pull/76)), Storage / Registry / EventStoreExplorer ([#77](https://github.com/JasperFx/polecat/pull/77)), and the class-level → call-site refactor of the remaining reflective surface ([#107](https://github.com/JasperFx/polecat/pull/107)).
+- **FastExpressionCompiler is no longer pulled in transitively** through `JasperFx.Events` ([jasperfx#276](https://github.com/JasperFx/jasperfx/issues/276)). Projection apply-method dispatch routes exclusively through `[GeneratedEvolver]` outputs from `JasperFx.Events.SourceGenerator` — see the **"Projections and self-aggregating documents must be `partial`"** section above for the consumer-side migration.
+- An AOT smoke-test consumer ([Polecat.AotSmoke](https://github.com/JasperFx/polecat/tree/main/src/Polecat.AotSmoke), PR [#106](https://github.com/JasperFx/polecat/pull/106)) ships with the repo and runs in CI with `WarningsAsErrors` covering `IL2026 / IL2046 / IL2055 / IL2065 / IL2067 / IL2070 / IL2072 / IL2075 / IL2090 / IL2091 / IL2111 / IL3050 / IL3051`. Regressions in Polecat's AOT-clean surface fail the build.
 
 For the end-to-end "how do I publish AOT against the Critter Stack" walkthrough — recommended csproj flags, `WarningsAsErrors=IL*` setup, the source-generator-backed `ISerializer` swap, and the smoke-test pattern — see the **[Publishing AOT with JasperFx](https://jasperfx.github.io/codegen/aot)** guide on jasperfx.github.io. The guide is written for the whole Critter Stack; Polecat-specific call-outs are listed in the "Per-package status" table there.
 

--- a/src/Polecat.AotSmoke/Polecat.AotSmoke.csproj
+++ b/src/Polecat.AotSmoke/Polecat.AotSmoke.csproj
@@ -34,6 +34,15 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Hosting" />
+        <!--
+        JasperFx#276 (Phase 3): JasperFx.Events 2.0.0-alpha.11 removed the
+        FastExpressionCompiler fallback for projection apply-method dispatch.
+        Source-generated dispatchers ([GeneratedEvolver]) are now the only
+        path. Wire the SG analyzer so projections declared in this assembly
+        (e.g. QuestProjection in Program.cs) get a generated dispatcher and
+        don't trip DocumentStore's fail-fast InvalidProjectionException.
+        -->
+        <PackageReference Include="JasperFx.Events.SourceGenerator" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
     </ItemGroup>
 
 </Project>

--- a/src/Polecat.AotSmoke/Program.cs
+++ b/src/Polecat.AotSmoke/Program.cs
@@ -108,8 +108,14 @@ namespace Polecat.AotSmoke
     /// <summary>
     /// Concrete projection with both generic args closed at compile time —
     /// AOT-safe alternative to <c>Projections.Snapshot&lt;Quest&gt;()</c>.
+    ///
+    /// `partial` so JasperFx.Events.SourceGenerator (wired in the csproj as
+    /// an Analyzer-only PackageReference) emits the [GeneratedEvolver]
+    /// dispatcher. JasperFx#276 / Phase 3 removed the FEC fallback for
+    /// projection apply dispatch — without `partial` + the SG analyzer,
+    /// DocumentStore construction throws InvalidProjectionException at boot.
     /// </summary>
-    internal sealed class QuestProjection : SingleStreamProjection<Quest, Guid>
+    internal sealed partial class QuestProjection : SingleStreamProjection<Quest, Guid>
     {
     }
 }

--- a/src/Polecat.AspNetCore.Testing/Polecat.AspNetCore.Testing.csproj
+++ b/src/Polecat.AspNetCore.Testing/Polecat.AspNetCore.Testing.csproj
@@ -20,6 +20,11 @@
     <ItemGroup>
         <ProjectReference Include="..\Polecat.AspNetCore\Polecat.AspNetCore.csproj" />
         <ProjectReference Include="..\Polecat.TestUtils\Polecat.TestUtils.csproj" />
+        <!-- JasperFx#276 Phase 3: any assembly that registers projections (or
+             live-aggregates self-aggregating document types via AggregateStream)
+             must reference the SG analyzer so [GeneratedEvolver] dispatchers
+             are emitted for partial document classes. -->
+        <PackageReference Include="JasperFx.Events.SourceGenerator" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
     </ItemGroup>
 
 </Project>

--- a/src/Polecat.AspNetCore.Testing/Program.cs
+++ b/src/Polecat.AspNetCore.Testing/Program.cs
@@ -50,7 +50,7 @@ namespace Polecat.AspNetCore.Testing
     }
 
     // Aggregate type for StreamAggregate tests
-    public class StreamingQuestParty
+    public partial class StreamingQuestParty
     {
         public Guid Id { get; set; }
         public string Name { get; set; } = "";

--- a/src/Polecat.Tests/Events/Bug_4197_fetch_for_writing_natural_key.cs
+++ b/src/Polecat.Tests/Events/Bug_4197_fetch_for_writing_natural_key.cs
@@ -10,7 +10,7 @@ public sealed record Bug4197AggregateKey(string Value);
 
 public sealed record Bug4197AggregateCreatedEvent(Guid Id, string Key);
 
-public sealed class Bug4197Aggregate
+public sealed partial class Bug4197Aggregate
 {
     public Guid Id { get; set; }
 

--- a/src/Polecat.Tests/Events/aggregate_stream_to_last_known_tests.cs
+++ b/src/Polecat.Tests/Events/aggregate_stream_to_last_known_tests.cs
@@ -5,7 +5,7 @@ namespace Polecat.Tests.Events;
 
 // An aggregate that can be "deleted" — ShouldDelete returns true when the aggregate
 // should be considered removed, causing the aggregator to return null.
-public class DeletableAggregate
+public partial class DeletableAggregate
 {
     public Guid Id { get; set; }
     public string Name { get; set; } = string.Empty;

--- a/src/Polecat.Tests/Events/always_enforce_consistency_tests.cs
+++ b/src/Polecat.Tests/Events/always_enforce_consistency_tests.cs
@@ -3,6 +3,21 @@ using Polecat.Tests.Harness;
 
 namespace Polecat.Tests.Events;
 
+// String-keyed sibling of QuestAggregate. The SG keys the generated evolver on
+// the document's `Id` property type, so a Guid-id aggregate can't double-serve
+// string-keyed streams under Polecat 4 the way it did under 3.x's FEC fallback.
+public partial class StringQuestAggregate
+{
+    public string Id { get; set; } = "";
+    public string Name { get; set; } = "";
+    public List<string> Members { get; } = [];
+    public int MonstersSlain { get; set; }
+
+    public static StringQuestAggregate Create(QuestStarted e) => new() { Name = e.Name };
+    public void Apply(MembersJoined e) => Members.AddRange(e.Members);
+    public void Apply(MonsterSlain e) => MonstersSlain++;
+}
+
 [Collection("integration")]
 public class always_enforce_consistency_tests : IntegrationContext
 {
@@ -111,7 +126,7 @@ public class always_enforce_consistency_tests : IntegrationContext
         await session1.SaveChangesAsync();
 
         await using var session2 = theStore.LightweightSession();
-        var stream = await session2.Events.FetchForWriting<QuestAggregate>(key);
+        var stream = await session2.Events.FetchForWriting<StringQuestAggregate>(key);
         stream.AlwaysEnforceConsistency = true;
 
         // Modify the stream in another session

--- a/src/Polecat.Tests/Events/dcb_tag_query_and_consistency_tests.cs
+++ b/src/Polecat.Tests/Events/dcb_tag_query_and_consistency_tests.cs
@@ -27,7 +27,7 @@ public record SystemNotification(string Message);
 
 #region sample_polecat_dcb_aggregate
 // Aggregate for DCB
-public class StudentCourseEnrollment
+public partial class StudentCourseEnrollment
 {
     public Guid Id { get; set; }
     public string StudentName { get; set; } = "";

--- a/src/Polecat.Tests/Events/fetch_for_writing_tests.cs
+++ b/src/Polecat.Tests/Events/fetch_for_writing_tests.cs
@@ -3,7 +3,7 @@ using Polecat.Tests.Harness;
 
 namespace Polecat.Tests.Events;
 
-public class QuestAggregate
+public partial class QuestAggregate
 {
     public Guid Id { get; set; }
     public string Name { get; set; } = string.Empty;

--- a/src/Polecat.Tests/Events/inline_projection_side_effects_tests.cs
+++ b/src/Polecat.Tests/Events/inline_projection_side_effects_tests.cs
@@ -91,7 +91,7 @@ public partial class inline_projection_side_effects_tests : OneOffConfigurations
     public record InlineSeStarted(string Label);
     public record InlineSeNotice(string Label);
 
-    public class InlineSeAggregate
+    public partial class InlineSeAggregate
     {
         public Guid Id { get; set; }
         public string Label { get; set; } = "";

--- a/src/Polecat.Tests/Events/inline_projection_side_effects_tests.cs
+++ b/src/Polecat.Tests/Events/inline_projection_side_effects_tests.cs
@@ -13,7 +13,7 @@ namespace Polecat.Tests.Events;
 ///     IMessageOutbox round-trip on the session commit path, and the
 ///     before/after-commit lifecycle ordering.
 /// </summary>
-public class inline_projection_side_effects_tests : OneOffConfigurationsContext
+public partial class inline_projection_side_effects_tests : OneOffConfigurationsContext
 {
     [Fact]
     public async Task flag_off_means_raise_side_effects_is_not_invoked()
@@ -99,7 +99,7 @@ public class inline_projection_side_effects_tests : OneOffConfigurationsContext
         public void Apply(InlineSeStarted e) => Label = e.Label;
     }
 
-    public class InlineSeProjection : SingleStreamProjection<InlineSeAggregate, Guid>
+    public partial class InlineSeProjection : SingleStreamProjection<InlineSeAggregate, Guid>
     {
         public override ValueTask RaiseSideEffects(IDocumentSession session, IEventSlice<InlineSeAggregate> slice)
         {

--- a/src/Polecat.Tests/Events/natural_key_tests.cs
+++ b/src/Polecat.Tests/Events/natural_key_tests.cs
@@ -10,7 +10,7 @@ namespace Polecat.Tests.Events;
 
 public record OrderNumber(string Value);
 
-public class OrderAggregate
+public partial class OrderAggregate
 {
     public Guid Id { get; set; }
 
@@ -45,7 +45,7 @@ public class OrderAggregate
     }
 }
 
-public class InvoiceAggregate
+public partial class InvoiceAggregate
 {
     public Guid Id { get; set; }
 

--- a/src/Polecat.Tests/Events/project_latest_tests.cs
+++ b/src/Polecat.Tests/Events/project_latest_tests.cs
@@ -19,6 +19,23 @@ public partial class Report
     public void Apply(ReportPublished e) => IsPublished = true;
 }
 
+// String-keyed variant of Report. Has its own Id type so the source generator
+// emits a distinct `IGeneratedSyncEvolver<StringReport, string>` for it — the
+// SG keys the generated evolver on the document's `Id` property type, so a
+// single Report class can't double-serve Guid- and string-keyed streams the
+// way it did under Polecat 3.x's FEC fallback.
+public partial class StringReport
+{
+    public string Id { get; set; } = "";
+    public string Title { get; set; } = "";
+    public int SectionCount { get; set; }
+    public bool IsPublished { get; set; }
+
+    public static StringReport Create(ReportCreated e) => new StringReport { Title = e.Title };
+    public void Apply(SectionAdded e) => SectionCount++;
+    public void Apply(ReportPublished e) => IsPublished = true;
+}
+
 [Collection("integration")]
 public class project_latest_tests : IntegrationContext
 {
@@ -147,7 +164,7 @@ public class project_latest_tests : IntegrationContext
             new ReportPublished()
         );
 
-        var report = await session.Events.ProjectLatest<Report>(key);
+        var report = await session.Events.ProjectLatest<StringReport>(key);
 
         report.ShouldNotBeNull();
         report.Title.ShouldBe("Quarterly Report");
@@ -184,7 +201,7 @@ public class project_latest_tests : IntegrationContext
                 new ReportPublished()
             );
 
-            var report = await session.Events.ProjectLatest<Report>(key);
+            var report = await session.Events.ProjectLatest<StringReport>(key);
 
             report.ShouldNotBeNull();
             report.Title.ShouldBe("Annual Report");

--- a/src/Polecat.Tests/Events/project_latest_tests.cs
+++ b/src/Polecat.Tests/Events/project_latest_tests.cs
@@ -7,7 +7,7 @@ public record ReportCreated(string Title);
 public record SectionAdded(string SectionName);
 public record ReportPublished;
 
-public class Report
+public partial class Report
 {
     public Guid Id { get; set; }
     public string Title { get; set; } = "";

--- a/src/Polecat.Tests/Events/projection_scenario_tests.cs
+++ b/src/Polecat.Tests/Events/projection_scenario_tests.cs
@@ -5,7 +5,7 @@ using Polecat.Tests.Harness;
 
 namespace Polecat.Tests.Events;
 
-public class ScenarioQuestParty
+public partial class ScenarioQuestParty
 {
     public Guid Id { get; set; }
     public List<string> Members { get; set; } = [];

--- a/src/Polecat.Tests/Projections/composite_projection_tests.cs
+++ b/src/Polecat.Tests/Projections/composite_projection_tests.cs
@@ -4,7 +4,7 @@ using Polecat.Tests.Harness;
 namespace Polecat.Tests.Projections;
 
 // Aggregate for stage 1: track quest party
-public class CompositeQuestParty
+public partial class CompositeQuestParty
 {
     public Guid Id { get; set; }
     public string Name { get; set; } = string.Empty;
@@ -21,7 +21,7 @@ public class CompositeQuestParty
 }
 
 // Aggregate for stage 2: depends on quest party being projected first
-public class QuestStats
+public partial class QuestStats
 {
     public Guid Id { get; set; }
     public int EventCount { get; set; }

--- a/src/Polecat.Tests/Projections/composite_try_find_upstream_cache_tests.cs
+++ b/src/Polecat.Tests/Projections/composite_try_find_upstream_cache_tests.cs
@@ -34,7 +34,7 @@ public class OrderShippingNotification
 
 #endregion
 
-public class CompositeOrderProjection : SingleStreamProjection<CompositeOrder, Guid>
+public partial class CompositeOrderProjection : SingleStreamProjection<CompositeOrder, Guid>
 {
     public CompositeOrderProjection()
     {
@@ -65,7 +65,7 @@ public class CompositeOrderProjection : SingleStreamProjection<CompositeOrder, G
 
 #region sample_polecat_try_find_upstream_cache
 
-public class OrderShippingNotificationProjection : MultiStreamProjection<OrderShippingNotification, Guid>
+public partial class OrderShippingNotificationProjection : MultiStreamProjection<OrderShippingNotification, Guid>
 {
     public OrderShippingNotificationProjection()
     {

--- a/src/Polecat.Tests/Projections/event_projection_enrichment_tests.cs
+++ b/src/Polecat.Tests/Projections/event_projection_enrichment_tests.cs
@@ -109,17 +109,14 @@ public class EnrichmentUser
 
 #region Projections
 
-public class SimpleEnrichmentProjection : EventProjection
+public partial class SimpleEnrichmentProjection : EventProjection
 {
-    public SimpleEnrichmentProjection()
+    public void Project(EnrichmentTaskAssigned e, IDocumentSession ops)
     {
-        Project<EnrichmentTaskAssigned>((e, ops) =>
+        ops.Store(new EnrichmentTaskSummary
         {
-            ops.Store(new EnrichmentTaskSummary
-            {
-                Id = e.TaskId,
-                AssignedUserName = e.UserName
-            });
+            Id = e.TaskId,
+            AssignedUserName = e.UserName
         });
     }
 
@@ -134,18 +131,18 @@ public class SimpleEnrichmentProjection : EventProjection
     }
 }
 
-public class EnrichmentCallOrderProjection : EventProjection
+public partial class EnrichmentCallOrderProjection : EventProjection
 {
     private readonly List<string> _callOrder;
 
     public EnrichmentCallOrderProjection(List<string> callOrder)
     {
         _callOrder = callOrder;
+    }
 
-        Project<EnrichmentTaskAssigned>((e, ops) =>
-        {
-            _callOrder.Add($"Apply:{nameof(EnrichmentTaskAssigned)}");
-        });
+    public void Project(EnrichmentTaskAssigned e, IDocumentSession ops)
+    {
+        _callOrder.Add($"Apply:{nameof(EnrichmentTaskAssigned)}");
     }
 
     public override Task EnrichEventsAsync(IQuerySession querySession,
@@ -156,17 +153,14 @@ public class EnrichmentCallOrderProjection : EventProjection
     }
 }
 
-public class DbLookupEnrichmentProjection : EventProjection
+public partial class DbLookupEnrichmentProjection : EventProjection
 {
-    public DbLookupEnrichmentProjection()
+    public void Project(EnrichmentTaskAssigned e, IDocumentSession ops)
     {
-        Project<EnrichmentTaskAssigned>((e, ops) =>
+        ops.Store(new EnrichmentTaskSummary
         {
-            ops.Store(new EnrichmentTaskSummary
-            {
-                Id = e.TaskId,
-                AssignedUserName = e.UserName
-            });
+            Id = e.TaskId,
+            AssignedUserName = e.UserName
         });
     }
 

--- a/src/Polecat.Tests/Projections/event_projection_tests.cs
+++ b/src/Polecat.Tests/Projections/event_projection_tests.cs
@@ -12,7 +12,7 @@ public class QuestLog
     public int MemberCount { get; set; }
 }
 
-public class QuestLogProjection : EventProjection
+public partial class QuestLogProjection : EventProjection
 {
     public void Project(QuestStarted e, IDocumentSession ops)
     {
@@ -20,18 +20,7 @@ public class QuestLogProjection : EventProjection
     }
 }
 
-public class QuestLogWithLambdaProjection : EventProjection
-{
-    public QuestLogWithLambdaProjection()
-    {
-        Project<QuestStarted>((e, ops) =>
-        {
-            ops.Store(new QuestLog { Id = Guid.NewGuid(), QuestName = e.Name });
-        });
-    }
-}
-
-public class MultiEventQuestLogProjection : EventProjection
+public partial class MultiEventQuestLogProjection : EventProjection
 {
     // Store a QuestLog keyed by stream ID via event data
     public void Project(QuestStarted e, IDocumentSession ops)
@@ -75,27 +64,6 @@ public class event_projection_tests : IntegrationContext
         // The QuestLog should have been created with a new Guid
         // We can verify it exists by loading all QuestLogs
         // Since we don't know the exact Id, we use a raw query
-        await using var conn = await OpenConnectionAsync();
-        await using var cmd = conn.CreateCommand();
-        cmd.CommandText = $"SELECT COUNT(*) FROM {theStore.Options.DatabaseSchemaName}.pc_doc_questlog;";
-        var count = (int)(await cmd.ExecuteScalarAsync())!;
-        count.ShouldBeGreaterThan(0);
-    }
-
-    [Fact]
-    public async Task event_projection_with_lambda()
-    {
-        await StoreOptions(opts =>
-        {
-            opts.Projections.Add<QuestLogWithLambdaProjection>(ProjectionLifecycle.Inline);
-        });
-
-        var streamId = Guid.NewGuid();
-        await using var session = theStore.LightweightSession();
-        session.Events.StartStream(streamId,
-            new QuestStarted("Lambda Quest"));
-        await session.SaveChangesAsync();
-
         await using var conn = await OpenConnectionAsync();
         await using var cmd = conn.CreateCommand();
         cmd.CommandText = $"SELECT COUNT(*) FROM {theStore.Options.DatabaseSchemaName}.pc_doc_questlog;";

--- a/src/Polecat.Tests/Projections/inline_projection_tests.cs
+++ b/src/Polecat.Tests/Projections/inline_projection_tests.cs
@@ -9,7 +9,7 @@ namespace Polecat.Tests.Projections;
 ///     Self-aggregating document type for testing inline projections.
 ///     Uses conventional Apply/Create methods.
 /// </summary>
-public class QuestParty
+public partial class QuestParty
 {
     public Guid Id { get; set; }
     public string Name { get; set; } = string.Empty;

--- a/src/Polecat.Tests/Projections/multi_stream_projection_tests.cs
+++ b/src/Polecat.Tests/Projections/multi_stream_projection_tests.cs
@@ -4,7 +4,7 @@ using Polecat.Tests.Harness;
 
 namespace Polecat.Tests.Projections;
 
-public class CustomerSummary
+public partial class CustomerSummary
 {
     public Guid Id { get; set; }
     public string Name { get; set; } = string.Empty;

--- a/src/Polecat.Tests/Projections/multi_stream_projection_tests.cs
+++ b/src/Polecat.Tests/Projections/multi_stream_projection_tests.cs
@@ -13,7 +13,7 @@ public class CustomerSummary
     public decimal TotalPaid { get; set; }
 }
 
-public class CustomerSummaryProjection : MultiStreamProjection<CustomerSummary, Guid>
+public partial class CustomerSummaryProjection : MultiStreamProjection<CustomerSummary, Guid>
 {
     public CustomerSummaryProjection()
     {

--- a/src/Polecat.Tests/Projections/single_stream_projection_with_string_identity_tests.cs
+++ b/src/Polecat.Tests/Projections/single_stream_projection_with_string_identity_tests.cs
@@ -42,7 +42,7 @@ public class SelfAggregatingStringQuest
 ///     Custom SingleStreamProjection with TId = string, demonstrating the new
 ///     two-type-parameter signature that mirrors Marten's SingleStreamProjection&lt;TDoc, TId&gt;.
 /// </summary>
-public class StringQuestPartyProjection : SingleStreamProjection<StringQuestParty, string>
+public partial class StringQuestPartyProjection : SingleStreamProjection<StringQuestParty, string>
 {
     public StringQuestPartyProjection()
     {

--- a/src/Polecat.Tests/Projections/single_stream_projection_with_string_identity_tests.cs
+++ b/src/Polecat.Tests/Projections/single_stream_projection_with_string_identity_tests.cs
@@ -8,7 +8,7 @@ namespace Polecat.Tests.Projections;
 /// <summary>
 ///     Aggregate document with a string identity, for use with string-keyed streams.
 /// </summary>
-public class StringQuestParty
+public partial class StringQuestParty
 {
     public string Id { get; set; } = string.Empty;
     public string Name { get; set; } = string.Empty;
@@ -21,7 +21,7 @@ public class StringQuestParty
 ///     Self-aggregating document type with string identity, for use with
 ///     the Snapshot&lt;T, TId&gt; API (conventional Apply/Create methods on the type itself).
 /// </summary>
-public class SelfAggregatingStringQuest
+public partial class SelfAggregatingStringQuest
 {
     public string Id { get; set; } = string.Empty;
     public string Name { get; set; } = string.Empty;

--- a/src/Polecat.Tests/Projections/snapshot_registration_tests.cs
+++ b/src/Polecat.Tests/Projections/snapshot_registration_tests.cs
@@ -9,7 +9,7 @@ namespace Polecat.Tests.Projections;
 public record SnapshotPartyStarted(string Name);
 public record SnapshotMemberJoined(string Name);
 
-public class SnapshotParty
+public partial class SnapshotParty
 {
     public Guid Id { get; set; }
     public string Name { get; set; } = "";
@@ -19,7 +19,7 @@ public class SnapshotParty
     public void Apply(SnapshotMemberJoined e) => Members.Add(e.Name);
 }
 
-public class SnapshotPartyByString
+public partial class SnapshotPartyByString
 {
     public string Id { get; set; } = "";
     public string Name { get; set; } = "";

--- a/src/Polecat.Tests/Projections/time_based_multi_stream_projection_tests.cs
+++ b/src/Polecat.Tests/Projections/time_based_multi_stream_projection_tests.cs
@@ -31,7 +31,7 @@ public class MonthlyAccountActivity
 
 #region sample_polecat_monthly_account_activity_projection
 
-public class MonthlyAccountActivityProjection : MultiStreamProjection<MonthlyAccountActivity, string>
+public partial class MonthlyAccountActivityProjection : MultiStreamProjection<MonthlyAccountActivity, string>
 {
     public MonthlyAccountActivityProjection()
     {

--- a/src/Polecat.Tests/Projections/time_based_multi_stream_projection_tests.cs
+++ b/src/Polecat.Tests/Projections/time_based_multi_stream_projection_tests.cs
@@ -16,7 +16,7 @@ public record AccountCredited(decimal Amount, string Description);
 
 #region sample_polecat_monthly_account_activity_document
 
-public class MonthlyAccountActivity
+public partial class MonthlyAccountActivity
 {
     public string Id { get; set; } = "";
     public Guid AccountId { get; set; }

--- a/src/Polecat.Tests/Projections/using_guid_based_strong_typed_id_for_aggregate_identity.cs
+++ b/src/Polecat.Tests/Projections/using_guid_based_strong_typed_id_for_aggregate_identity.cs
@@ -22,7 +22,7 @@ public record PaymentCreated(DateTimeOffset CreatedAt);
 public record PaymentCanceled(DateTimeOffset CanceledAt);
 public record PaymentVerified(DateTimeOffset VerifiedAt);
 
-public class Payment
+public partial class Payment
 {
     [JsonInclude] public PaymentId Id { get; private set; }
     [JsonInclude] public DateTimeOffset CreatedAt { get; private set; }

--- a/src/Polecat.Tests/Projections/using_guid_based_strong_typed_id_for_aggregate_identity.cs
+++ b/src/Polecat.Tests/Projections/using_guid_based_strong_typed_id_for_aggregate_identity.cs
@@ -84,7 +84,11 @@ public class using_guid_based_strong_typed_id_for_aggregate_identity : Integrati
         await StoreOptions(opts =>
         {
             opts.DatabaseSchemaName = "guid_stid_inline";
-            opts.Projections.Add<SingleStreamProjection<Payment, Guid>>(ProjectionLifecycle.Inline);
+            // Closed with PaymentId (the strong-typed wrapper) so the runtime instance
+            // matches the SG-emitted IGeneratedSyncEvolver<Payment, PaymentId>. Closing
+            // with Guid (the underlying primitive) misses the wrapper and trips the
+            // post-FEC fail-fast (JasperFx/jasperfx#276).
+            opts.Projections.Add<SingleStreamProjection<Payment, PaymentId>>(ProjectionLifecycle.Inline);
         });
 
         var streamId = Guid.NewGuid();
@@ -157,7 +161,7 @@ public class using_guid_based_strong_typed_id_for_aggregate_identity : Integrati
         await StoreOptions(opts =>
         {
             opts.DatabaseSchemaName = "guid_stid_async";
-            opts.Projections.Add<SingleStreamProjection<Payment, Guid>>(ProjectionLifecycle.Async);
+            opts.Projections.Add<SingleStreamProjection<Payment, PaymentId>>(ProjectionLifecycle.Async);
         });
 
         var streamId = Guid.NewGuid();

--- a/src/Polecat.Tests/Projections/using_string_based_strong_typed_id_for_aggregate_identity.cs
+++ b/src/Polecat.Tests/Projections/using_string_based_strong_typed_id_for_aggregate_identity.cs
@@ -10,7 +10,7 @@ namespace Polecat.Tests.Projections;
 [StronglyTypedId(Template.String)]
 public readonly partial struct Payment2Id;
 
-public class Payment2
+public partial class Payment2
 {
     [JsonInclude] public Payment2Id Id { get; private set; }
     [JsonInclude] public DateTimeOffset CreatedAt { get; private set; }

--- a/src/Polecat/Events/EventGraph.cs
+++ b/src/Polecat/Events/EventGraph.cs
@@ -8,6 +8,7 @@ using JasperFx.Events.Tags;
 using Polecat.Events.Schema;
 using Polecat.Projections;
 using Polecat.Serialization;
+using Polecat.Storage;
 
 namespace Polecat.Events;
 
@@ -147,8 +148,15 @@ public class EventGraph : EventRegistry, IAggregationSourceFactory<IQuerySession
     /// </summary>
     IAggregatorSource<IQuerySession>? IAggregationSourceFactory<IQuerySession>.Build<TDoc>()
     {
-        // Use the appropriate identity type based on stream identity configuration
-        var idType = StreamIdentity == StreamIdentity.AsGuid ? typeof(Guid) : typeof(string);
+        // Resolve the identity type the same way Projections.Snapshot<T>() does — by
+        // inspecting TDoc's Id property via DocumentMapping. Strong-typed-id aggregates
+        // (TDoc.Id is a wrapper struct over Guid / string / int / long) must be closed
+        // with their *wrapper* type so the SG-emitted IGeneratedSyncEvolver<TDoc, TId>
+        // dispatcher matches the runtime SingleStreamProjection<TDoc, TId> instance.
+        // Falling back to typeof(Guid) / typeof(string) (the underlying stream-identity
+        // primitive) misses the wrapper and trips the post-FEC fail-fast in
+        // JasperFxAggregationProjectionBase.tryUseAssemblyRegisteredEvolver (JasperFx#276).
+        var idType = new DocumentMapping(typeof(TDoc), _options).IdType;
         var projectionType = typeof(SingleStreamProjection<,>).MakeGenericType(typeof(TDoc), idType);
 #pragma warning disable CS8714 // notnull constraint mismatch
         var projection = (ProjectionBase)Activator.CreateInstance(projectionType)!;


### PR DESCRIPTION
> ⚠️ **DRAFT — blocked on [JasperFx/jasperfx#291](https://github.com/JasperFx/jasperfx/pull/291)** publishing `JasperFx.Events.SourceGenerator 2.0.0-alpha.4`. CI will go red until #291 merges and alpha.4 is on NuGet. Once it lands, this PR can be marked ready.

## Summary

Pin-bumps Polecat to the post-FEC JasperFx.Events alphas and wires every Polecat-registered projection through the source-generator-only dispatch path:

- `JasperFx.Events 2.0.0-alpha.9 → 2.0.0-alpha.11` (Phase 1 — FEC removal landed)
- `JasperFx.Events.SourceGenerator 2.0.0-alpha.2 → 2.0.0-alpha.4` (alpha.4 = jasperfx#291)

Closes Polecat's slot on the #276 Phase 3 checkbox.

## What changed

### 1. Pin bump (`Directory.Packages.props`)

Straightforward bump. SG alpha.4 is the only target — alpha.3 has a sync-`DetermineActionAsync` emit bug that trips on 3 Polecat test projections combining sync `Apply` + `ShouldDelete` (StringQuestPartyProjection, QuestPartyProjection, DeletableAggregate). The bug is fixed in `JasperFx/jasperfx#291` with a CS8135 regression test.

### 2. `partial` on projection classes registered through DI

Phase 1's fail-fast contract: any projection registered via `Projections.Add<T>(...)` or `Snapshot<T>(...)` must have a `[GeneratedEvolver]` dispatcher emitted by the SG. The SG only emits for `partial` classes in assemblies referencing the SG analyzer.

Marked `partial`:
- `QuestLogProjection`, `MultiEventQuestLogProjection`
- `SimpleEnrichmentProjection`, `EnrichmentCallOrderProjection`, `DbLookupEnrichmentProjection`
- `MonthlyAccountActivityProjection`
- `CompositeOrderProjection`, `OrderShippingNotificationProjection`
- `StringQuestPartyProjection`
- `CustomerSummaryProjection`
- `InlineSeProjection` (nested — outer `inline_projection_side_effects_tests` class also marked partial)

### 3. AotSmoke wired to the SG-only path

- Added `JasperFx.Events.SourceGenerator` as an Analyzer-only `PackageReference` in `Polecat.AotSmoke.csproj`.
- Made `QuestProjection` partial.

Without these, the smoke binary throws `InvalidProjectionException` at host build (fail-fast). Verified locally: AotSmoke now builds + runs clean on net9.0 + net10.0.

### 4. Migrated off the removed inline-lambda API

JasperFx#276 / #286 dropped `Project<TEvent>((e, ops) => ...)`, `CreateEvent<TEvent>(handler)`, `DeleteEvent<TEvent>(handler)`, `ProjectEvent<TEvent>(handler)` — the SG can't dispatch a runtime closure, so these had been the only thing keeping FEC reachable from JasperFx.Events.

Polecat impact:
- 3 projections in `event_projection_enrichment_tests.cs` — converted constructor `Project<TEvent>((e, ops) => ...)` to conventional `public void Project(TEvent e, IDocumentSession ops)` methods. Semantics identical (the SG dispatches to either shape).
- `event_projection_tests.cs` — removed `QuestLogWithLambdaProjection` + the `event_projection_with_lambda` test. The class was a literal duplicate of `QuestLogProjection` that existed solely to exercise the lambda API; the conventional path is already covered.

## Not affected

- **`FlatTableProjection`** — uses its own `_handlers` dictionary for Apply dispatch, doesn't go through JasperFx.Events Apply discovery. SG-only contract doesn't apply.
- **EF Core projections** (`EfCoreSingleStreamProjection`, `EfCoreEventProjection`) — override `DetermineActionAsync` directly, which `JasperFxAggregationProjectionBase.isOverridden` recognizes as "the user supplied their own dispatch, FEC/SG path not exercised". No changes needed.
- **`Polecat.csproj` itself** — defines no projections; the SG analyzer doesn't need to flow into it.

## Verification

Once SG alpha.4 lands on NuGet:
- `dotnet build polecat.slnx -c Release` — should be clean (only the 3 sync-DetermineActionAsync sites currently fail)
- `dotnet build src/Polecat.AotSmoke/Polecat.AotSmoke.csproj` — clean
- `dotnet run --project src/Polecat.AotSmoke` — exits 0
- Full test suite — runtime verified once container is healthy on CI's native amd64

Local sanity (against SG alpha.3 with the bug): 8 of the 12 projection generators emit clean dispatchers; only the 3 ShouldDelete-bearing projections plus 1 self-aggregating DeletableAggregate hit the alpha.3 bug.

## Polecat alpha bump

Deferring `Bump Polecat to 4.0.0-alpha.5` to a follow-up commit on this branch once CI is green. Easier review.

## Commits

1. `77d83ca` — Pin bump (`JasperFx.Events` alpha.11 + `SourceGenerator` alpha.4)
2. `29a86f5` — `partial` migration + SG wiring + inline-lambda API rewrites

References `JasperFx/jasperfx#276`. Blocked on `JasperFx/jasperfx#291`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)