### PR TITLE
Polecat: bump JasperFx + Weasel alpha matrix + cut 4.0.0-alpha.8

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>4.0.0-alpha.7</Version>
+        <Version>4.0.0-alpha.8</Version>
         <LangVersion>latest</LangVersion>
         <Authors>Jeremy D. Miller</Authors>
         <PackageIcon>logo.png</PackageIcon>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,16 +5,16 @@
 
     <ItemGroup>
         <!-- Core dependencies -->
-        <PackageVersion Include="JasperFx" Version="2.0.0-alpha.16" />
-        <PackageVersion Include="JasperFx.Events" Version="2.0.0-alpha.15" />
+        <PackageVersion Include="JasperFx" Version="2.0.0-alpha.17" />
+        <PackageVersion Include="JasperFx.Events" Version="2.0.0-alpha.16" />
         <!-- Pin the sibling JasperFx packages for parity with Marten 9's matrix
              even though Polecat doesn't currently reference them directly —
              keeps the lockstep matrix coherent when transitive resolution
              surfaces them through JasperFx / JasperFx.Events updates. The
              RuntimeCompiler 5.x line is the active continuation of the 4.x
              lineage; do not pin against the parallel stale 2.0.x series. -->
-        <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0-alpha.4" />
-        <PackageVersion Include="JasperFx.SourceGeneration" Version="2.0.0-alpha.5" />
+        <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0-alpha.5" />
+        <PackageVersion Include="JasperFx.SourceGeneration" Version="2.0.0-alpha.6" />
         <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
@@ -33,14 +33,14 @@
         <PackageVersion Include="Shouldly" Version="4.3.0" />
         <PackageVersion Include="xunit" Version="2.9.3" />
         <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.4" />
-        <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.0.0-alpha.5" />
-        <PackageVersion Include="Weasel.SqlServer" Version="9.0.0-alpha.5" />
+        <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.0.0-alpha.6" />
+        <PackageVersion Include="Weasel.SqlServer" Version="9.0.0-alpha.6" />
 
         <!-- Strongly typed IDs -->
         <PackageVersion Include="StronglyTypedId" Version="1.0.0-beta08" />
 
         <!-- Source generators -->
-        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.0.0-alpha.8" />
+        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.0.0-alpha.9" />
 
         <!-- Build automation -->
         <PackageVersion Include="Nuke.Common" Version="9.0.4" />

--- a/src/Polecat/Linq/Joins/AliasingCommandBuilder.cs
+++ b/src/Polecat/Linq/Joins/AliasingCommandBuilder.cs
@@ -1,4 +1,5 @@
 using System.Data;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Data.SqlClient;
 using Weasel.SqlServer;
 
@@ -43,6 +44,12 @@ internal class AliasingCommandBuilder : ICommandBuilder
     public SqlParameter[] AppendWithParameters(string text) => _inner.AppendWithParameters(JoinStatement.AliasLocator(text, _alias));
     public SqlParameter[] AppendWithParameters(string text, char placeholder) => _inner.AppendWithParameters(JoinStatement.AliasLocator(text, _alias), placeholder);
     public void StartNewCommand() => _inner.StartNewCommand();
+
+    // Mirror the RUC annotation that Weasel.SqlServer's ICommandBuilder.AddParameters(object)
+    // declaration carries (added in Weasel 9.0.0-alpha.6). The AOT-trim-clean route is the
+    // IDictionary<string, T> overload below; this override exists so AliasingCommandBuilder
+    // satisfies the interface contract verbatim.
+    [RequiresUnreferencedCode("AddParameters(object) reflects on the parameters object's public properties via Type.GetProperties(). Use the IDictionary<string, T> overload when publishing AOT-trim-clean.")]
     public void AddParameters(object parameters) => _inner.AddParameters(parameters);
     public void AddParameters(IDictionary<string, object?> parameters) => _inner.AddParameters(parameters);
     public void AddParameters<T>(IDictionary<string, T> parameters) => _inner.AddParameters(parameters);


### PR DESCRIPTION
## Summary

Coordinated lockstep matrix tick — every `JasperFx.*` / `Weasel.*` package bumped by exactly one alpha to pick up upstream changes, plus the corresponding Polecat alpha cut.

## Package bumps

| Package | From | To |
|---|---|---|
| `JasperFx` | 2.0.0-alpha.16 | **2.0.0-alpha.17** |
| `JasperFx.Events` | 2.0.0-alpha.15 | **2.0.0-alpha.16** |
| `JasperFx.RuntimeCompiler` | 5.0.0-alpha.4 | **5.0.0-alpha.5** |
| `JasperFx.SourceGeneration` | 2.0.0-alpha.5 | **2.0.0-alpha.6** |
| `JasperFx.Events.SourceGenerator` | 2.0.0-alpha.8 | **2.0.0-alpha.9** |
| `Weasel.SqlServer` | 9.0.0-alpha.5 | **9.0.0-alpha.6** |
| `Weasel.EntityFrameworkCore` | 9.0.0-alpha.5 | **9.0.0-alpha.6** |

Polecat version: `4.0.0-alpha.7` → **`4.0.0-alpha.8`**.

All changes land in `Directory.Packages.props` (centrally managed) + `Directory.Build.props`. No per-csproj pins overrode the central versions — verified by grep.

## AOT fallout — one in-scope fix

`Weasel.SqlServer` 9.0.0-alpha.6 tightened `ICommandBuilder.AddParameters(object)` with `[RequiresUnreferencedCode]` (weasel#266). `Polecat.Linq.Joins.AliasingCommandBuilder` implements `ICommandBuilder`, so its `AddParameters(object)` override now needs the same RUC annotation to keep the AOT audit lane clean — without it, `IL2046` (interface annotation mismatch) and `IL2026` (RUC member call without forwarding) surface in `src/Polecat/Polecat.csproj`'s build output. The override is a thin pass-through to `_inner.AddParameters(parameters)`, so mirroring Weasel's annotation message verbatim is correct and keeps the AOT-trim-clean guidance ("use the `IDictionary<string, T>` overload") in the right place.

```diff
+ [RequiresUnreferencedCode("AddParameters(object) reflects on the parameters object's public properties via Type.GetProperties(). Use the IDictionary<string, T> overload when publishing AOT-trim-clean.")]
  public void AddParameters(object parameters) => _inner.AddParameters(parameters);
```

After the annotation, the `Polecat.csproj` IL warning count returns to its pre-bump baseline (14 pre-existing warnings in `PolecatProjectionBatch` / `DocumentMapping` / `StreamCompacting`).

## Verification

Local docker-compose SQL Server 2025 instance:

```
Polecat.Tests              (net10.0): 1128 pass /   3 skip / 0 fail / 1131 total
Polecat.EntityFrameworkCore.Tests (net10.0):   37 pass /   0 skip / 0 fail /   37 total
Polecat.AotSmoke           (net10.0):  builds + runs clean — "Polecat AOT smoke OK."
LINQ slice (uses AliasingCommandBuilder): 135/135 pass
```

(3 skips in `event_loader_resiliency_tests` are pre-existing — unrelated to this PR.)

## Test plan

- [ ] CI green on `feature/bump-jfx-weasel`
- [ ] No regression in async daemon / SG-dispatched projection apply (covered by `Polecat.Tests.Daemon` slice + `projection_sg_dispatch_audit_tests`)
- [ ] `Polecat.AotSmoke` still builds + runs under WarningsAsErrors on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)