### PR TITLE
Fix two DCB defects: cross-tag-type queries and boundary append to existing stream

### DIFF
--- a/src/Polecat.Tests/Events/dcb_tag_query_and_consistency_tests.cs
+++ b/src/Polecat.Tests/Events/dcb_tag_query_and_consistency_tests.cs
@@ -131,6 +131,39 @@ public class dcb_tag_query_and_consistency_tests : IntegrationContext
     }
 
     [Fact]
+    public async Task can_query_events_across_distinct_tag_types_with_or()
+    {
+        // The core DCB boundary case: events on different streams carry DIFFERENT single tags, and the
+        // query OR-combines distinct tag types. Each matching event carries only one of the queried tag
+        // types — a regression guard against the INNER JOIN bug that required every event to carry all
+        // queried tag types (which collapsed this query to zero rows).
+        var studentId = new StudentId(Guid.NewGuid());
+        var courseId = new CourseId(Guid.NewGuid());
+
+        // Tagged with ONLY the student
+        var enrolled = theSession.Events.BuildEvent(new StudentEnrolled("Alice", "Math"));
+        enrolled.WithTag(studentId);
+        theSession.Events.Append(Guid.NewGuid(), enrolled);
+
+        // Tagged with ONLY the course
+        var submitted = theSession.Events.BuildEvent(new AssignmentSubmitted("HW1", 95));
+        submitted.WithTag(courseId);
+        theSession.Events.Append(Guid.NewGuid(), submitted);
+
+        await theSession.SaveChangesAsync();
+
+        await using var session2 = theStore.LightweightSession();
+        var query = new EventTagQuery()
+            .Or<StudentId>(studentId)
+            .Or<CourseId>(courseId);
+
+        var events = await session2.Events.QueryByTagsAsync(query);
+        events.Count.ShouldBe(2);
+        events.ShouldContain(e => e.Data is StudentEnrolled);
+        events.ShouldContain(e => e.Data is AssignmentSubmitted);
+    }
+
+    [Fact]
     public async Task can_query_events_by_tag_with_event_type_filter()
     {
         var studentId = new StudentId(Guid.NewGuid());

--- a/src/Polecat.Tests/Events/dcb_tag_query_and_consistency_tests.cs
+++ b/src/Polecat.Tests/Events/dcb_tag_query_and_consistency_tests.cs
@@ -287,6 +287,35 @@ public class dcb_tag_query_and_consistency_tests : IntegrationContext
     }
 
     [Fact]
+    public async Task fetch_for_writing_appends_to_existing_tag_derived_stream_without_collision()
+    {
+        // Seed the student's stream using the tag value as the stream id, so the boundary's
+        // tag-derived routing targets this PRE-EXISTING stream on save. Before the fix the boundary
+        // used StreamAction.Start here (TryFindStream only sees the current session's pending work),
+        // throwing ExistingStreamIdCollisionException.
+        var studentId = new StudentId(Guid.NewGuid());
+
+        var enrolled = theSession.Events.BuildEvent(new StudentEnrolled("Alice", "Math"));
+        enrolled.WithTag(studentId);
+        theSession.Events.Append(studentId.Value, enrolled);
+        await theSession.SaveChangesAsync();
+
+        await using var session2 = theStore.LightweightSession();
+        var query = new EventTagQuery().Or<StudentId>(studentId);
+        var boundary = await session2.Events.FetchForWritingByTags<StudentCourseEnrollment>(query);
+
+        var submitted = session2.Events.BuildEvent(new AssignmentSubmitted("HW1", 95));
+        submitted.WithTag(studentId);
+        boundary.AppendOne(submitted);
+
+        await Should.NotThrowAsync(async () => await session2.SaveChangesAsync());
+
+        await using var session3 = theStore.LightweightSession();
+        var events = await session3.Events.QueryByTagsAsync(new EventTagQuery().Or<StudentId>(studentId));
+        events.ShouldContain(e => e.Data is AssignmentSubmitted);
+    }
+
+    [Fact]
     public async Task fetch_for_writing_by_tags_detects_concurrency_violation()
     {
         var studentId = new StudentId(Guid.NewGuid());

--- a/src/Polecat/Events/Dcb/EventBoundary.cs
+++ b/src/Polecat/Events/Dcb/EventBoundary.cs
@@ -87,7 +87,10 @@ internal class EventBoundary<T> : IEventBoundary<T> where T : class
                     stream!.AddEvent(wrapped);
                 else
                 {
-                    stream = StreamAction.Start(guidId, [wrapped]);
+                    // Append, not Start: the tag-derived stream for an aggregate ordinarily already
+                    // exists in the database (TryFindStream only sees this session's pending work).
+                    // StreamAction.Start would throw ExistingStreamIdCollisionException on save.
+                    stream = StreamAction.Append(guidId, [wrapped]);
                     stream.AggregateType = registration.AggregateType;
                     stream.TenantId = _session.TenantId;
                     _session.WorkTracker.AddStream(stream);
@@ -99,7 +102,10 @@ internal class EventBoundary<T> : IEventBoundary<T> where T : class
                     stream!.AddEvent(wrapped);
                 else
                 {
-                    stream = StreamAction.Start(stringId, [wrapped]);
+                    // Append, not Start: the tag-derived stream for an aggregate ordinarily already
+                    // exists in the database (TryFindStream only sees this session's pending work).
+                    // StreamAction.Start would throw ExistingStreamIdCollisionException on save.
+                    stream = StreamAction.Append(stringId, [wrapped]);
                     stream.AggregateType = registration.AggregateType;
                     stream.TenantId = _session.TenantId;
                     _session.WorkTracker.AddStream(stream);

--- a/src/Polecat/Events/EventOperations.cs
+++ b/src/Polecat/Events/EventOperations.cs
@@ -868,7 +868,11 @@ internal class EventOperations : QueryEventStore, IEventOperations
         var sb = new StringBuilder();
         sb.Append($"SELECT {selectColumns} FROM [{schema}].[pc_events] e");
 
-        // INNER JOINs to tag tables
+        // LEFT JOINs to tag tables. The WHERE clause OR-combines the per-condition tag predicates,
+        // so an event that carries only one of several queried tag types (the normal DCB case where
+        // different streams emit differently-tagged events) must still be returned. An INNER JOIN to
+        // every distinct tag table would instead require each event to carry *all* queried tag types,
+        // collapsing any cross-tag-type OR query to zero rows.
         for (var i = 0; i < distinctTagTypes.Count; i++)
         {
             var tagType = distinctTagTypes[i];
@@ -876,7 +880,7 @@ internal class EventOperations : QueryEventStore, IEventOperations
                                ?? throw new InvalidOperationException(
                                    $"Tag type '{tagType.Name}' is not registered.");
 
-            sb.Append($" INNER JOIN [{schema}].[pc_event_tag_{registration.TableSuffix}] t{i} ON e.seq_id = t{i}.seq_id");
+            sb.Append($" LEFT JOIN [{schema}].[pc_event_tag_{registration.TableSuffix}] t{i} ON e.seq_id = t{i}.seq_id");
         }
 
         // WHERE clause
@@ -1058,6 +1062,10 @@ internal class EventOperations : QueryEventStore, IEventOperations
 
         builder.Append($"SELECT {selectColumns} FROM [{schema}].[pc_events] e");
 
+        // LEFT JOIN (not INNER) so an event carrying only one of several queried tag types still
+        // matches the OR'd WHERE clause below. INNER JOIN would require each event to carry *all*
+        // queried tag types, collapsing any cross-tag-type OR query (the normal DCB boundary case)
+        // to zero rows.
         for (var i = 0; i < distinctTagTypes.Count; i++)
         {
             var tagType = distinctTagTypes[i];
@@ -1065,7 +1073,7 @@ internal class EventOperations : QueryEventStore, IEventOperations
                                ?? throw new InvalidOperationException(
                                    $"Tag type '{tagType.Name}' is not registered.");
 
-            builder.Append($" INNER JOIN [{schema}].[pc_event_tag_{registration.TableSuffix}] t{i} ON e.seq_id = t{i}.seq_id");
+            builder.Append($" LEFT JOIN [{schema}].[pc_event_tag_{registration.TableSuffix}] t{i} ON e.seq_id = t{i}.seq_id");
         }
 
         builder.Append(" WHERE (");


### PR DESCRIPTION
Two related DCB defects, both surfaced while building Wolverine ↔ Polecat boundary-model parity tests against the Wolverine + Marten suite. Both are fixed to match Marten's behavior, with regression tests.

## 1. Cross-tag-type tag queries returned zero rows

`QueryByTagsAsync` and `WriteTagQuerySql` (the `FetchForWritingByTags<T>` path) `INNER JOIN`ed every distinct tag-type table, requiring each matched event to carry **all** queried tag types. In the normal DCB boundary case — events on different streams carrying different single tags, OR-combined across tag types — no event carries every tag, so the joins eliminated all rows.

**Fix:** `INNER JOIN` → `LEFT JOIN` in those two return-matching-events builders (matching Marten's `FetchForWritingByTagsHandler`). The existence-check builders (`EventsExist`, `AssertDcbConsistency`) keep `INNER JOIN`, also matching Marten.

Why it was missed: existing tests only used a single tag type, multiple conditions of the *same* type, or events tagged with all queried types at once — never differently-tagged events OR-queried across distinct types.

## 2. Boundary append to an existing tag-derived stream collided

`IEventBoundary.RouteEventByTags` routed an appended event to the stream derived from its first aggregate-bound tag using `StreamAction.Start`. `WorkTracker.TryFindStream` only sees the current session's pending work, so when that stream already exists in the database (the normal case — it's the aggregate's stream), the save threw `ExistingStreamIdCollisionException`.

**Fix:** use `StreamAction.Append` for the tag-derived stream (matching Marten's `EventBoundary`); `StreamAction.Start` remains only for the orphan-stream fallback.

## Tests

- `can_query_events_across_distinct_tag_types_with_or` — differently-tagged events OR-queried across distinct tag types.
- `fetch_for_writing_appends_to_existing_tag_derived_stream_without_collision` — boundary append to a pre-existing tag-derived stream.

All 26 DCB tests green (net9.0 + net10.0). End-to-end, these two fixes flip the full Wolverine + Polecat DCB boundary-model parity suite (5 cases) from 1/5 to 5/5, matching the Wolverine + Marten side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)