### PR TITLE
Docs: document [BoundaryAggregate] for identity-less DCB aggregates (#122)

### DIFF
--- a/docs/events/dcb.md
+++ b/docs/events/dcb.md
@@ -73,6 +73,58 @@ Then aggregate across streams by tag query:
 
 Returns `null` if no matching events are found.
 
+### Identity-less Boundary Aggregates
+
+The `StudentCourseEnrollment` aggregate above carries an `Id` property, so Polecat's source generator emits its evolver automatically and no extra annotation is needed.
+
+Some DCB aggregates, though, are *pure boundary aggregates*: they span streams only by tag and have **no single-stream identity** -- no `Id` property and no `[AggregateIdentity]`. For these, mark the aggregate type with `[BoundaryAggregate]` (from `JasperFx.Events.Aggregation`) so the source generator emits an evolver for it:
+
+```csharp
+using JasperFx.Events.Aggregation;
+
+[BoundaryAggregate]
+public partial class CourseEnrollmentSummary
+{
+    public int EnrolledCount { get; private set; }
+    public List<string> Students { get; } = new();
+
+    public void Apply(StudentEnrolled e)
+    {
+        Students.Add(e.StudentName);
+        EnrolledCount++;
+    }
+
+    public void Apply(StudentDropped e)
+    {
+        EnrolledCount--;
+    }
+}
+```
+
+Register it exactly like any other DCB aggregate -- the registration API is unchanged:
+
+```csharp
+opts.Events.RegisterTagType<CourseId>("course")
+    .ForAggregate<CourseEnrollmentSummary>();
+```
+
+**Why the marker is required.** Without a single-stream identity the source generator can't infer a `TId`, so it *intentionally* emits nothing. A bare no-`Id` aggregate is far more often a forgotten `Id` property than a deliberate boundary aggregate, and silently generating an evolver would mask that mistake -- so `[BoundaryAggregate]` is the explicit opt-in. Without it, the DCB fetch/aggregate path fails fast at runtime:
+
+```
+InvalidProjectionException: No source-generated dispatcher found
+for SingleStreamProjection<CourseEnrollmentSummary, string>
+```
+
+(The `string` type argument is vestigial -- it matches the `SingleStreamProjection<T, string>` the DCB aggregator builds and is never used by boundary-aggregate dispatch.)
+
+**Placement.** Put `[BoundaryAggregate]` on the aggregate type itself, and keep the type `partial` so the generator can attach the emitted dispatcher. The attribute must sit on the type **in its own defining assembly** -- that is the compilation the generator emits the `[assembly: GeneratedEvolver]` into, and it is the assembly the runtime scans (`typeof(T).Assembly`) when resolving the evolver.
+
+**Aggregates with an `Id` need no marker** and keep working unchanged -- `[BoundaryAggregate]` is only for the identity-less case.
+
+::: tip
+`[BoundaryAggregate]` requires JasperFx.Events 2.0.0-alpha.21 / JasperFx.Events.SourceGenerator 2.0.0-alpha.13 or later. The marker is a JasperFx.Events source-generator concern, so its behavior is backend-agnostic -- it works identically across the Critter Stack event stores; only the surrounding `RegisterTagType<...>().ForAggregate<T>()` registration is Polecat's SQL Server-backed API.
+:::
+
 ## Fetch for Writing (Consistency Boundary)
 
 `FetchForWritingByTags` loads the aggregate and establishes a consistency boundary. At `SaveChangesAsync` time, Polecat checks whether any new events matching the query have been appended since the read, throwing `DcbConcurrencyException` if so:


### PR DESCRIPTION
## Summary

Closes #122. Documents the `[BoundaryAggregate]` marker (`JasperFx.Events.Aggregation`, [jasperfx#324](https://github.com/JasperFx/jasperfx/issues/324)) in `docs/events/dcb.md`, for **pure boundary aggregates** — aggregates with `Apply`/`Create` methods but no `Id` property and no `[AggregateIdentity]`, spanning streams only by tag.

Docs-only. No source or package changes.

## What's added

A new **"Identity-less Boundary Aggregates"** subsection under "Aggregating by Tags" (next to the `ForAggregate<T>()` registration material), covering the four points from the issue:

- **When the marker is required** — identity-less aggregate; the marker is the explicit opt-in. A bare no-`Id` aggregate is intentionally *not* auto-detected so a forgotten `Id` fails fast rather than silently generating an evolver. Without the marker the DCB fetch/aggregate path throws `InvalidProjectionException: No source-generated dispatcher found for SingleStreamProjection<T, string>`.
- **Placement** — on the `partial` aggregate type in its own defining assembly (the compilation the SG emits `[assembly: GeneratedEvolver]` into, and the assembly the runtime scans via `typeof(T).Assembly`).
- **A short example** mirroring Polecat's SQL Server-backed API surface — `RegisterTagType<CourseId>("course").ForAggregate<CourseEnrollmentSummary>()` — reusing the doc's existing `StudentEnrolled` / `StudentDropped` event narrative.
- **Note that `Id`-carrying aggregates need no marker** and keep working unchanged.

## Why inline examples instead of test-backed snippets

The rest of `dcb.md` uses `<!-- snippet -->` markers populated from compiled tests. `[BoundaryAggregate]` ships in **JasperFx.Events 2.0.0-alpha.21 / JasperFx.Events.SourceGenerator 2.0.0-alpha.13**, and Polecat is currently pinned at **alpha.20 / alpha.12** — so a compiled snippet test can't be added until the alpha bump lands (a separate foundation re-pin wave, per the polecat#119 reference in the issue). The new section uses inline fenced code blocks and carries a version-requirement `:::tip` so readers on the current pin know what they need. The example can be promoted to a test-backed snippet once the bump lands.

## Refs

- [jasperfx#324](https://github.com/JasperFx/jasperfx/issues/324) — the SG/attribute change
- [polecat#119](https://github.com/JasperFx/polecat/issues/119) — distributor-concrete adoption (same JasperFx.Events alpha bump wave that will carry alpha.21)

## Test plan

- [ ] Docs render review — new `### Identity-less Boundary Aggregates` subsection appears under "Aggregating by Tags" with correctly highlighted C# fenced blocks and the `:::tip` callout
- [ ] No mdsnippets breakage (no new snippet markers introduced — plain fenced blocks only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)