### PR TITLE
Release Polecat 4.0.0 (Critter Stack 2026)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>4.0.0-rc.2</Version>
+        <Version>4.0.0</Version>
         <LangVersion>latest</LangVersion>
         <Authors>Jeremy D. Miller</Authors>
         <PackageIcon>logo.png</PackageIcon>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,16 +5,16 @@
 
     <ItemGroup>
         <!-- Core dependencies -->
-        <PackageVersion Include="JasperFx" Version="2.0.0-rc.3" />
-        <PackageVersion Include="JasperFx.Events" Version="2.0.0-rc.3" />
+        <PackageVersion Include="JasperFx" Version="2.0.0" />
+        <PackageVersion Include="JasperFx.Events" Version="2.0.0" />
         <!-- Pin the sibling JasperFx packages for parity with Marten 9's matrix
              even though Polecat doesn't currently reference them directly —
              keeps the lockstep matrix coherent when transitive resolution
              surfaces them through JasperFx / JasperFx.Events updates. The
              RuntimeCompiler 5.x line is the active continuation of the 4.x
              lineage; do not pin against the parallel stale 2.0.x series. -->
-        <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0-rc.3" />
-        <PackageVersion Include="JasperFx.SourceGeneration" Version="2.0.0-rc.3" />
+        <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
+        <PackageVersion Include="JasperFx.SourceGeneration" Version="2.0.0" />
         <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
@@ -33,14 +33,14 @@
         <PackageVersion Include="Shouldly" Version="4.3.0" />
         <PackageVersion Include="xunit" Version="2.9.3" />
         <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.4" />
-        <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.0.0-alpha.8" />
-        <PackageVersion Include="Weasel.SqlServer" Version="9.0.0-alpha.8" />
+        <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.0.0" />
+        <PackageVersion Include="Weasel.SqlServer" Version="9.0.0" />
 
         <!-- Strongly typed IDs -->
         <PackageVersion Include="StronglyTypedId" Version="1.0.0-beta08" />
 
         <!-- Source generators -->
-        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.0.0-rc.3" />
+        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.0.0" />
 
         <!-- Build automation -->
         <PackageVersion Include="Nuke.Common" Version="9.0.4" />


### PR DESCRIPTION
Foundation upgrade to final + version bump rc.2 → final.

| Package | From | To |
|---|---|---|
| JasperFx (+ Events / SourceGeneration / Events.SourceGenerator) | 2.0.0-rc.3 | **2.0.0** |
| JasperFx.RuntimeCompiler | 5.0.0-rc.3 | **5.0.0** |
| Weasel.EntityFrameworkCore / Weasel.SqlServer | 9.0.0-alpha.8 | **9.0.0** |
| Polecat.* | 4.0.0-rc.2 | **4.0.0** |

JasperFx 2.0.0 + Weasel 9.0.0 are live on nuget.org. Polecat builds clean against them (0 errors). Ships in lockstep with Marten 9.0.

After merge: tag `V4.0.0`, GitHub release, then trigger NuGet publish + docs deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)