### PR TITLE
Route remaining direct-SQL execution through the resilience pipeline (#148)

### DIFF
--- a/src/Polecat/DocumentStore.EventStoreExplorer.cs
+++ b/src/Polecat/DocumentStore.EventStoreExplorer.cs
@@ -33,9 +33,10 @@ public partial class DocumentStore
 
         var results = new List<StreamSummary>(capacity: count);
 
-        await using var conn = new SqlConnection(Options.ConnectionString);
-        await conn.OpenAsync(ct);
-        await using var cmd = conn.CreateCommand();
+        // #148: run through a QuerySession so the command is covered by
+        // Options.ResiliencePipeline (Polly) like the rest of the read path.
+        await using var session = (Internal.QuerySession)QuerySession();
+        await using var cmd = new SqlCommand();
         // #57: share the column projection + row read with FetchStreamStateAsync
         // and GetStreamMetadataAsync via PcStreamsRowReader so all three sites
         // stay aligned when pc_streams' shape evolves.
@@ -46,7 +47,7 @@ public partial class DocumentStore
             """;
         cmd.Parameters.AddWithValue("@count", count);
 
-        await using var reader = await cmd.ExecuteReaderAsync(ct);
+        await using var reader = await session.ExecuteReaderAsync(cmd, ct);
         while (await reader.ReadAsync(ct))
         {
             results.Add(PcStreamsRowReader.ReadStreamSummary(reader, JasperFx.StorageConstants.DefaultTenantId));
@@ -65,9 +66,11 @@ public partial class DocumentStore
             ? Guid.Parse(streamId)
             : streamId;
 
-        await using var conn = new SqlConnection(Options.ConnectionString);
-        await conn.OpenAsync(ct);
-        await using var cmd = conn.CreateCommand();
+        // #148: run through a QuerySession so the command is covered by
+        // Options.ResiliencePipeline (Polly). The session is kept alive for the
+        // duration of the enumeration via await using.
+        await using var session = (Internal.QuerySession)QuerySession();
+        await using var cmd = new SqlCommand();
 
         // #57 pc_events half: share the column projection + row hydration
         // with QueryEventStore.FetchStreamAsync via PcEventsRowReader. The
@@ -94,7 +97,7 @@ public partial class DocumentStore
         // Explorer path doesn't need EventTypeCache (no EventMappingFor call).
         var slots = MetadataSlots.Compute(Events.EventOptions);
 
-        await using var reader = await cmd.ExecuteReaderAsync(ct);
+        await using var reader = await session.ExecuteReaderAsync(cmd, ct);
         while (await reader.ReadAsync(ct))
         {
             yield return PcEventsRowReader.ReadEventRecord(reader, ctx, slots);
@@ -110,9 +113,10 @@ public partial class DocumentStore
             ? Guid.Parse(streamId)
             : streamId;
 
-        await using var conn = new SqlConnection(Options.ConnectionString);
-        await conn.OpenAsync(ct);
-        await using var cmd = conn.CreateCommand();
+        // #148: run through a QuerySession so the command is covered by
+        // Options.ResiliencePipeline (Polly).
+        await using var session = (Internal.QuerySession)QuerySession();
+        await using var cmd = new SqlCommand();
         // #57: share the pc_streams column projection + row read with the
         // other two stream-reading sites via PcStreamsRowReader. The JOIN'd
         // first_event_at column is appended after the canonical projection
@@ -127,7 +131,7 @@ public partial class DocumentStore
             """;
         cmd.Parameters.AddWithValue("@id", resolvedStreamId);
 
-        await using var reader = await cmd.ExecuteReaderAsync(ct);
+        await using var reader = await session.ExecuteReaderAsync(cmd, ct);
         if (!await reader.ReadAsync(ct))
         {
             return null;
@@ -223,12 +227,13 @@ public partial class DocumentStore
         var progress = new Dictionary<string, long>(StringComparer.OrdinalIgnoreCase);
         long highWater = 0;
 
-        await using (var conn = new SqlConnection(Options.ConnectionString))
+        // #148: run through a QuerySession so the command is covered by
+        // Options.ResiliencePipeline (Polly).
+        await using (var session = (Internal.QuerySession)QuerySession())
         {
-            await conn.OpenAsync(ct);
-            await using var cmd = conn.CreateCommand();
+            await using var cmd = new SqlCommand();
             cmd.CommandText = $"SELECT name, last_seq_id FROM {Events.ProgressionTableName};";
-            await using var reader = await cmd.ExecuteReaderAsync(ct);
+            await using var reader = await session.ExecuteReaderAsync(cmd, ct);
             while (await reader.ReadAsync(ct))
             {
                 var name = reader.GetString(0);

--- a/src/Polecat/Linq/PolecatLinqQueryProvider.cs
+++ b/src/Polecat/Linq/PolecatLinqQueryProvider.cs
@@ -1131,47 +1131,57 @@ internal class PolecatLinqQueryProvider : IPolecatAsyncQueryProvider
         {
             token.ThrowIfCancellationRequested();
 
-            // Use auto-closing connections for polling (independent of session lifetime)
-            await using var conn = new SqlConnection(options.ConnectionString);
-            await conn.OpenAsync(token);
-
-            // Get high water mark
-            long highWater;
-            await using (var cmd = conn.CreateCommand())
+            // #148: poll on a fresh connection (independent of the session lifetime),
+            // but route each probe through Options.ResiliencePipeline so the staleness
+            // check is covered like the rest of the database access. Returns true once
+            // the registered async shards have caught up to the high-water mark.
+            var nonStale = await options.ResiliencePipeline.ExecuteAsync(static async (state, ct) =>
             {
-                cmd.CommandText = $"SELECT ISNULL(MAX(seq_id), 0) FROM {eventGraph.EventsTableName};";
-                var result = await cmd.ExecuteScalarAsync(token);
-                highWater = result is long seq ? seq : 0;
-            }
+                var (connectionString, eventGraph, asyncShardNames) = state;
 
-            if (highWater == 0) return;
+                await using var conn = new SqlConnection(connectionString);
+                await conn.OpenAsync(ct);
 
-            // Check only the registered async projection shards
-            var allCaughtUp = true;
-            await using (var cmd = conn.CreateCommand())
-            {
-                cmd.CommandText = $"SELECT name, last_seq_id FROM {eventGraph.ProgressionTableName};";
-                await using var reader = await cmd.ExecuteReaderAsync(token);
-                var foundShards = new HashSet<string>();
-                while (await reader.ReadAsync(token))
+                // Get high water mark
+                long highWater;
+                await using (var cmd = conn.CreateCommand())
                 {
-                    var name = reader.GetString(0);
-                    if (name == "HighWaterMark") continue;
-                    // Only check shards registered in this store
-                    if (!asyncShardNames.Contains(name)) continue;
-
-                    foundShards.Add(name);
-                    var seq = reader.GetInt64(1);
-                    if (seq < highWater)
-                    {
-                        allCaughtUp = false;
-                        break;
-                    }
+                    cmd.CommandText = $"SELECT ISNULL(MAX(seq_id), 0) FROM {eventGraph.EventsTableName};";
+                    var result = await cmd.ExecuteScalarAsync(ct);
+                    highWater = result is long seq ? seq : 0;
                 }
 
-                // All registered shards must exist and be caught up
-                if (allCaughtUp && foundShards.SetEquals(asyncShardNames)) return;
-            }
+                if (highWater == 0) return true;
+
+                // Check only the registered async projection shards
+                var allCaughtUp = true;
+                await using (var cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = $"SELECT name, last_seq_id FROM {eventGraph.ProgressionTableName};";
+                    await using var reader = await cmd.ExecuteReaderAsync(ct);
+                    var foundShards = new HashSet<string>();
+                    while (await reader.ReadAsync(ct))
+                    {
+                        var name = reader.GetString(0);
+                        if (name == "HighWaterMark") continue;
+                        // Only check shards registered in this store
+                        if (!asyncShardNames.Contains(name)) continue;
+
+                        foundShards.Add(name);
+                        var seq = reader.GetInt64(1);
+                        if (seq < highWater)
+                        {
+                            allCaughtUp = false;
+                            break;
+                        }
+                    }
+
+                    // All registered shards must exist and be caught up
+                    return allCaughtUp && foundShards.SetEquals(asyncShardNames);
+                }
+            }, (options.ConnectionString, eventGraph, asyncShardNames), token);
+
+            if (nonStale) return;
 
             await Task.Delay(100, token);
         }

--- a/src/Polecat/Schema/Identity/Sequences/HiloSequence.cs
+++ b/src/Polecat/Schema/Identity/Sequences/HiloSequence.cs
@@ -78,21 +78,27 @@ internal class HiloSequence : HiloSequenceBase
 
     protected override void AdvanceToNextHiSync()
     {
-        using var conn = _connectionFactory.Create();
-        conn.Open();
-
-        EnsureHiloTableSync(conn);
-
-        for (var attempts = 0; attempts < Settings.MaxAdvanceToNextHiAttempts; attempts++)
+        // #148: the async AdvanceToNextHi wraps its work in the resilience
+        // pipeline; the synchronous path must do the same (via the pipeline's
+        // synchronous Execute) so all pc_hilo access is covered.
+        _resilience.Execute(() =>
         {
-            var result = TryGetNextHiSync(conn);
-            if (TrySetCurrentHi(result))
-            {
-                return;
-            }
-        }
+            using var conn = _connectionFactory.Create();
+            conn.Open();
 
-        throw new HiloSequenceAdvanceToNextHiAttemptsExceededException();
+            EnsureHiloTableSync(conn);
+
+            for (var attempts = 0; attempts < Settings.MaxAdvanceToNextHiAttempts; attempts++)
+            {
+                var result = TryGetNextHiSync(conn);
+                if (TrySetCurrentHi(result))
+                {
+                    return;
+                }
+            }
+
+            throw new HiloSequenceAdvanceToNextHiAttemptsExceededException();
+        });
     }
 
     private async Task EnsureHiloTableAsync(SqlConnection conn, CancellationToken ct)

--- a/src/Polecat/Storage/PolecatDatabase.cs
+++ b/src/Polecat/Storage/PolecatDatabase.cs
@@ -12,6 +12,7 @@ using Polecat.Events;
 using Polecat.Events.Daemon;
 using Polecat.Events.Schema;
 using Polecat.Linq;
+using Polly;
 using Weasel.Core.Migrations;
 using Weasel.SqlServer;
 
@@ -27,6 +28,7 @@ public class PolecatDatabase : DatabaseBase<SqlConnection>, IEventDatabase, IPro
     private readonly StoreOptions _options;
     private readonly EventGraph _events;
     private readonly string _connectionString;
+    private readonly ResiliencePipeline _resilience;
 
     public PolecatDatabase(StoreOptions options)
         : this(options, options.ConnectionString, "Polecat")
@@ -44,6 +46,7 @@ public class PolecatDatabase : DatabaseBase<SqlConnection>, IEventDatabase, IPro
         _options = options;
         _events = options.EventGraph;
         _connectionString = connectionString;
+        _resilience = options.ResiliencePipeline;
         Tracker = new ShardStateTracker(NullLogger.Instance);
         // Mutates Skipped ShardStates in-place to set SkippedEventsCount.
         // Must be subscribed before any downstream consumers so the augmented
@@ -126,91 +129,105 @@ public class PolecatDatabase : DatabaseBase<SqlConnection>, IEventDatabase, IPro
 
     public async Task<long> ProjectionProgressFor(ShardName name, CancellationToken token = default)
     {
-        await using var conn = new SqlConnection(_connectionString);
-        await conn.OpenAsync(token);
+        // #148: route through Options.ResiliencePipeline like the rest of the
+        // database access. PolecatDatabase owns its own connection (it has no
+        // session), so it wraps the work in the pipeline directly.
+        return await _resilience.ExecuteAsync(static async (state, ct) =>
+        {
+            var (connectionString, progressionTable, identity) = state;
+            await using var conn = new SqlConnection(connectionString);
+            await conn.OpenAsync(ct);
 
-        await using var cmd = conn.CreateCommand();
-        cmd.CommandText = $"""
-            SELECT last_seq_id FROM {_events.ProgressionTableName}
-            WHERE name = @name;
-            """;
-        cmd.Parameters.AddWithValue("@name", name.Identity);
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = $"""
+                SELECT last_seq_id FROM {progressionTable}
+                WHERE name = @name;
+                """;
+            cmd.Parameters.AddWithValue("@name", identity);
 
-        var result = await cmd.ExecuteScalarAsync(token);
-        return result is long seq ? seq : 0;
+            var result = await cmd.ExecuteScalarAsync(ct);
+            return result is long seq ? seq : 0;
+        }, (_connectionString, _events.ProgressionTableName, name.Identity), token);
     }
 
     public async Task<IReadOnlyList<ShardState>> AllProjectionProgress(CancellationToken token = default)
     {
-        var list = new List<ShardState>();
-
-        await using var conn = new SqlConnection(_connectionString);
-        await conn.OpenAsync(token);
-
-        await using var cmd = conn.CreateCommand();
-        if (_events.EnableExtendedProgressionTracking)
+        return await _resilience.ExecuteAsync(static async (state, ct) =>
         {
-            cmd.CommandText = $"SELECT name, last_seq_id, heartbeat, agent_status, pause_reason, running_on_node, warning_behind_threshold, critical_behind_threshold FROM {_events.ProgressionTableName};";
-        }
-        else
-        {
-            cmd.CommandText = $"SELECT name, last_seq_id FROM {_events.ProgressionTableName};";
-        }
+            var (connectionString, events) = state;
+            var list = new List<ShardState>();
 
-        await using var reader = await cmd.ExecuteReaderAsync(token);
-        while (await reader.ReadAsync(token))
-        {
-            var name = reader.GetString(0);
-            var seq = reader.GetInt64(1);
-            var state = new ShardState(name, seq);
+            await using var conn = new SqlConnection(connectionString);
+            await conn.OpenAsync(ct);
 
-            if (_events.EnableExtendedProgressionTracking)
+            await using var cmd = conn.CreateCommand();
+            if (events.EnableExtendedProgressionTracking)
             {
-                if (!reader.IsDBNull(2)) state.LastHeartbeat = reader.GetDateTimeOffset(2);
-                if (!reader.IsDBNull(3)) state.AgentStatus = reader.GetString(3);
-                if (!reader.IsDBNull(4)) state.PauseReason = reader.GetString(4);
-                if (!reader.IsDBNull(5)) state.RunningOnNode = reader.GetInt32(5);
-                if (!reader.IsDBNull(6)) state.WarningBehindThreshold = reader.GetInt64(6);
-                if (!reader.IsDBNull(7)) state.CriticalBehindThreshold = reader.GetInt64(7);
+                cmd.CommandText = $"SELECT name, last_seq_id, heartbeat, agent_status, pause_reason, running_on_node, warning_behind_threshold, critical_behind_threshold FROM {events.ProgressionTableName};";
+            }
+            else
+            {
+                cmd.CommandText = $"SELECT name, last_seq_id FROM {events.ProgressionTableName};";
             }
 
-            list.Add(state);
-        }
+            await using var reader = await cmd.ExecuteReaderAsync(ct);
+            while (await reader.ReadAsync(ct))
+            {
+                var name = reader.GetString(0);
+                var seq = reader.GetInt64(1);
+                var shardState = new ShardState(name, seq);
 
-        return list;
+                if (events.EnableExtendedProgressionTracking)
+                {
+                    if (!reader.IsDBNull(2)) shardState.LastHeartbeat = reader.GetDateTimeOffset(2);
+                    if (!reader.IsDBNull(3)) shardState.AgentStatus = reader.GetString(3);
+                    if (!reader.IsDBNull(4)) shardState.PauseReason = reader.GetString(4);
+                    if (!reader.IsDBNull(5)) shardState.RunningOnNode = reader.GetInt32(5);
+                    if (!reader.IsDBNull(6)) shardState.WarningBehindThreshold = reader.GetInt64(6);
+                    if (!reader.IsDBNull(7)) shardState.CriticalBehindThreshold = reader.GetInt64(7);
+                }
+
+                list.Add(shardState);
+            }
+
+            return (IReadOnlyList<ShardState>)list;
+        }, (_connectionString, _events), token);
     }
 
     public async Task<long> FetchHighestEventSequenceNumber(CancellationToken token)
     {
-        await using var conn = new SqlConnection(_connectionString);
-        await conn.OpenAsync(token);
+        return await _resilience.ExecuteAsync(static async (state, ct) =>
+        {
+            var (connectionString, eventsTable) = state;
+            await using var conn = new SqlConnection(connectionString);
+            await conn.OpenAsync(ct);
 
-        await using var cmd = conn.CreateCommand();
-        cmd.CommandText = $"SELECT ISNULL(MAX(seq_id), 0) FROM {_events.EventsTableName};";
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = $"SELECT ISNULL(MAX(seq_id), 0) FROM {eventsTable};";
 
-        var result = await cmd.ExecuteScalarAsync(token);
-        return result is long seq ? seq : 0;
+            var result = await cmd.ExecuteScalarAsync(ct);
+            return result is long seq ? seq : 0;
+        }, (_connectionString, _events.EventsTableName), token);
     }
 
     public async Task<long?> FindEventStoreFloorAtTimeAsync(DateTimeOffset timestamp, CancellationToken token)
     {
-        await using var conn = new SqlConnection(_connectionString);
-        await conn.OpenAsync(token);
-
-        await using var cmd = conn.CreateCommand();
-        cmd.CommandText = $"""
-            SELECT MAX(seq_id) FROM {_events.EventsTableName}
-            WHERE timestamp <= @ts;
-            """;
-        cmd.Parameters.AddWithValue("@ts", timestamp);
-
-        var result = await cmd.ExecuteScalarAsync(token);
-        if (result is long seq)
+        return await _resilience.ExecuteAsync(static async (state, ct) =>
         {
-            return seq;
-        }
+            var (connectionString, eventsTable, ts) = state;
+            await using var conn = new SqlConnection(connectionString);
+            await conn.OpenAsync(ct);
 
-        return null;
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = $"""
+                SELECT MAX(seq_id) FROM {eventsTable}
+                WHERE timestamp <= @ts;
+                """;
+            cmd.Parameters.AddWithValue("@ts", ts);
+
+            var result = await cmd.ExecuteScalarAsync(ct);
+            return result is long seq ? (long?)seq : null;
+        }, (_connectionString, _events.EventsTableName, timestamp), token);
     }
 
     public async Task StoreDeadLetterEventAsync(object storage, DeadLetterEvent deadLetterEvent,


### PR DESCRIPTION
## Summary

Follow-up to PR #147. Brings the remaining direct-SQL sites that bypassed Polly into compliance with the rule adopted in #147 (now in `CLAUDE.md` → Engineering Principles):

> **All database command execution must be covered by `StoreOptions.ResiliencePipeline` (Polly)** — via a session (`QuerySession`/`IDocumentSession`), or via `Options.ResiliencePipeline.ExecuteAsync(...)` for components that own their own connection/transaction.

The #147 review audited `src/Polecat` and bucketed every execution site. Most already comply (through a session, or wrapping a self-owned connection in the pipeline directly — daemon HWM detector, projection batch, event loader, bulk insert, HiLo async). This PR fixes the **Category C** sites that had *no* resilience coverage at all.

## Changes

| Site | Fix |
|---|---|
| **`Storage/PolecatDatabase.cs`** — `ProjectionProgressFor`, `AllProjectionProgress`, `FetchHighestEventSequenceNumber`, `FindEventStoreFloorAtTimeAsync` | `PolecatDatabase` gains a `_resilience` field (`Options.ResiliencePipeline`); each method wraps its self-owned connection in `_resilience.ExecuteAsync` with a static state-tuple lambda (matches the daemon pattern). |
| **`DocumentStore.EventStoreExplorer.cs`** — `GetRecentStreamsAsync`, `ReadStreamAsync`, `GetStreamMetadataAsync`, `GetProjectionStatusesAsync` | Now run through a `QuerySession` (Polly-wrapped `ExecuteReaderAsync`) instead of an ad-hoc `SqlConnection`. The `ReadStreamAsync` iterator keeps the session alive for the enumeration via `await using`. |
| **`Schema/Identity/Sequences/HiloSequence.cs`** — `AdvanceToNextHiSync` | Synchronous `pc_hilo` path now runs through `_resilience.Execute` (the async path was already wrapped). |
| **`Linq/PolecatLinqQueryProvider.cs`** — `WaitForNonStaleDataAsync` | Each poll iteration now runs through `Options.ResiliencePipeline` (still on a fresh connection, independent of the session lifetime, as before). |

## Accepted exceptions (unchanged, per #148)

- **`Internal/DocumentTableEnsurer.cs`** — one-time DDL at startup, managed alongside Weasel migration.
- **`Events/TestSupport/ProjectionScenario.cs`** — test-support harness.

## Verification

```
Full solution builds clean (Debug); Polecat.AotSmoke builds clean (Release)
Polecat.Tests (net10.0): 1149 pass / 3 pre-existing skips / 0 fail
  — including Daemon, Diagnostics/event_store_explorer, Linq/non_stale_data, HiLo slices
```

No public API or schema change; no version bump (behavioral resilience fix only).

Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)
