### PR TITLE
Repoint JasperFx.SourceGeneration → JasperFx.SourceGenerator 2.0.1 (matrix pin)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,7 +14,7 @@
              RuntimeCompiler 5.x line is the active continuation of the 4.x
              lineage; do not pin against the parallel stale 2.0.x series. -->
         <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-        <PackageVersion Include="JasperFx.SourceGeneration" Version="2.0.0" />
+        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.0.1" />
         <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />


### PR DESCRIPTION
Updates the retired `JasperFx.SourceGeneration` (noun) central-package-management pin to the merged **`JasperFx.SourceGenerator`** (singular) `2.0.1`, per [JasperFx/jasperfx#365](https://github.com/JasperFx/jasperfx/issues/365).

Unlike Marten/Wolverine, Polecat does **not** reference the generator directly — this is a parity pin (the adjacent comment: _"Pin the sibling JasperFx packages for parity with Marten 9's matrix even though Polecat doesn't currently reference them directly"_). Marten now pins `JasperFx.SourceGenerator 2.0.1`, so renaming this entry keeps the lockstep matrix coherent and avoids a dangling pin for a retired package.

## Changes
- `Directory.Packages.props` — `JasperFx.SourceGeneration` `2.0.0` → `JasperFx.SourceGenerator` `2.0.1`

## Verification
`dotnet build src/Polecat/Polecat.csproj` succeeds with **0 errors**. The pin is unused directly (no `PackageReference` resolves it), so there's no build or runtime behavior change — this is matrix-hygiene only.

Closes #150.
