### PR TITLE
Bump Polecat to 4.1.1 + JasperFx 2.0.1 / Weasel 9.0.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>4.1.0</Version>
+        <Version>4.1.1</Version>
         <LangVersion>latest</LangVersion>
         <Authors>Jeremy D. Miller</Authors>
         <PackageIcon>logo.png</PackageIcon>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
 
     <ItemGroup>
         <!-- Core dependencies -->
-        <PackageVersion Include="JasperFx" Version="2.0.0" />
+        <PackageVersion Include="JasperFx" Version="2.0.1" />
         <PackageVersion Include="JasperFx.Events" Version="2.1.0" />
         <!-- Pin the sibling JasperFx packages for parity with Marten 9's matrix
              even though Polecat doesn't currently reference them directly —

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -33,8 +33,8 @@
         <PackageVersion Include="Shouldly" Version="4.3.0" />
         <PackageVersion Include="xunit" Version="2.9.3" />
         <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.4" />
-        <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.0.0" />
-        <PackageVersion Include="Weasel.SqlServer" Version="9.0.0" />
+        <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.0.1" />
+        <PackageVersion Include="Weasel.SqlServer" Version="9.0.1" />
 
         <!-- Strongly typed IDs -->
         <PackageVersion Include="StronglyTypedId" Version="1.0.0-beta08" />


### PR DESCRIPTION
## Summary

Patch release on the 4.1.x line — Critter Stack dependency/matrix bumps. CI-green on this branch → triggers the NuGet publish of **4.1.1**.

## Changes

| File | Change |
|---|---|
| `Directory.Packages.props` | **JasperFx `2.0.0` → `2.0.1`** |
| `Directory.Packages.props` | **Weasel.SqlServer `9.0.0` → `9.0.1`** |
| `Directory.Packages.props` | **Weasel.EntityFrameworkCore `9.0.0` → `9.0.1`** |
| `Directory.Build.props` | Version `4.1.0` → `4.1.1` |

- `JasperFx.Events` (`2.1.0`) and `JasperFx.SourceGenerator` (`2.0.1`) were already current — no change needed.
- First **released** package to carry the #151 matrix-pin rename (`JasperFx.SourceGeneration` → `JasperFx.SourceGenerator 2.0.1`), which merged to `main` after the 4.1.0 publish.

## Verification

```
Clean restore (no NU downgrade/conflict warnings) + full solution builds (Debug)
Polecat.AotSmoke builds clean (Release)
Polecat.Tests (net10.0): 1149 pass / 3 pre-existing skips / 0 fail
Polecat.EntityFrameworkCore.Tests (net10.0): 37 pass / 0 fail
```

No functional or schema changes — dependency/matrix bumps only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
