### PR TITLE
docs: clarify the event parameter is identified by type, not name

### DIFF
--- a/docs/events/projections/event-projections.md
+++ b/docs/events/projections/event-projections.md
@@ -33,6 +33,8 @@ public class AuditLogProjection : EventProjection
 }
 ```
 
+The examples name the event parameter `@event`, but that is not required: Polecat identifies the event argument **by type**. In `Project(IEvent<OrderCreated> @event, IDocumentOperations ops)`, the `IEvent<OrderCreated>` parameter is the event regardless of its name (`IDocumentOperations` is an interface and is never treated as the event). You only need a conventional event parameter **name** — `@event`, `event`, `e`, or `ev` — to disambiguate a signature in which more than one parameter could be the event. This is the same rule used by aggregate projections; see [Identifying the Event Parameter](/events/projections/single-stream-projections#identifying-the-event-parameter).
+
 ## Registration
 
 ```cs

--- a/docs/events/projections/single-stream-projections.md
+++ b/docs/events/projections/single-stream-projections.md
@@ -66,6 +66,15 @@ public void Apply(IEvent<OrderCreated> @event)
 }
 ```
 
+## Identifying the Event Parameter
+
+Notice that the examples above name the event parameter `e` in some methods and `@event` in others — both work. Polecat identifies the event argument of a conventional `Create` / `Apply` / `ShouldDelete` method (and an [event projection](/events/projections/event-projections)'s `Project` / `Transform` methods) **by type, not by name**, using the same rule for every projection type:
+
+1. A parameter typed `IEvent<T>` is always the event, and `T` is the event type — use this when you need event metadata such as `Timestamp` or `Headers`.
+2. Otherwise the single **concrete** parameter that is not an interface (`IQuerySession`, `IDocumentOperations`), not `IEvent`, not `CancellationToken`, and not the aggregate type is the event.
+
+So `Apply(OrderShipped e)` and `Apply(OrderShipped shipped)` are equivalent — the parameter name is incidental. A conventional event parameter **name** is only consulted to disambiguate an unusual signature in which more than one parameter could be the event; the recognized names are `@event`, `event`, `e`, and `ev`.
+
 ## Live Aggregation
 
 Use a single stream projection for on-demand replay without persisting:

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -230,6 +230,8 @@ public partial class Quest
 }
 ```
 
+The event argument of those conventional methods is identified **by type, not by parameter name**: a parameter typed `IEvent<T>` is the event, otherwise the single concrete parameter that isn't an interface (`IQuerySession` / `IDocumentOperations`), `IEvent`, `CancellationToken`, or the aggregate type. You do **not** need to name it `@event` — `Apply(MembersJoined e)` and `Apply(MembersJoined joined)` are equivalent. A conventional name (`@event`, `event`, `e`, or `ev`) is only consulted to disambiguate a signature with more than one candidate parameter. See [Identifying the Event Parameter](/events/projections/single-stream-projections#identifying-the-event-parameter).
+
 Aggregate identity discovery follows the same convention rule as Marten — by default, the SG looks for a property literally named `Id` (or `<TypeName>Id`). If your aggregate's identity uses a different member name, annotate that member with `[Identity]` from **`JasperFx`** (the same `JasperFx.IdentityAttribute` Polecat uses for document identity — see the [rc dedup-wave relocations](#rc-dedup-wave-relocations) table; it moved out of `Polecat.Attributes` in [#135](https://github.com/JasperFx/polecat/issues/135)):
 
 ```csharp


### PR DESCRIPTION
Documentation-only. Companion to the JasperFx/marten event-parameter-naming clarification (JasperFx/marten#4562, JasperFx/marten#4563).

## Why

Several projection examples name the event parameter `@event`, which makes it look mandatory. It isn't — Polecat identifies the event argument **by type**. A parameter name only matters to disambiguate unusual signatures.

## What

Documents the shared rule used by `SingleStreamProjection`, `MultiStreamProjection`, and `EventProjection`:

1. an `IEvent<T>` parameter is the event (`T` is the event type);
2. otherwise the single **concrete** parameter that isn't an interface (`IQuerySession`/`IDocumentOperations`), isn't `IEvent`, isn't `CancellationToken`, and isn't the aggregate type;
3. only if ambiguous, a parameter **named** `@event`, `event`, `e`, or `ev`.

Changes:
- **`events/projections/single-stream-projections.md`** — new "Identifying the Event Parameter" section.
- **`events/projections/event-projections.md`** — matching note for `Project()`, linking to it.
- **`migration-guide.md`** — note alongside the existing `partial` / public-visibility convention guidance.

The `ev` name is being added to the accepted names upstream in JasperFx/jasperfx#369.

🤖 Generated with [Claude Code](https://claude.com/claude-code)