### PR TITLE
Update JasperFx.* dependencies to 2.2.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,8 +5,8 @@
 
     <ItemGroup>
         <!-- Core dependencies -->
-        <PackageVersion Include="JasperFx" Version="2.0.1" />
-        <PackageVersion Include="JasperFx.Events" Version="2.1.0" />
+        <PackageVersion Include="JasperFx" Version="2.2.0" />
+        <PackageVersion Include="JasperFx.Events" Version="2.2.0" />
         <!-- Pin the sibling JasperFx packages for parity with Marten 9's matrix
              even though Polecat doesn't currently reference them directly —
              keeps the lockstep matrix coherent when transitive resolution
@@ -14,7 +14,7 @@
              RuntimeCompiler 5.x line is the active continuation of the 4.x
              lineage; do not pin against the parallel stale 2.0.x series. -->
         <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.0.1" />
+        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.2.0" />
         <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
@@ -40,7 +40,7 @@
         <PackageVersion Include="StronglyTypedId" Version="1.0.0-beta08" />
 
         <!-- Source generators -->
-        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.1.0" />
+        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.2.0" />
 
         <!-- Build automation -->
         <PackageVersion Include="Nuke.Common" Version="9.0.4" />


### PR DESCRIPTION
## Summary

Bumps the JasperFx package matrix to **2.2.0**:

| Package | From | To |
|---------|------|-----|
| JasperFx | 2.0.1 | **2.2.0** |
| JasperFx.Events | 2.1.0 | **2.2.0** |
| JasperFx.SourceGenerator | 2.0.1 | **2.2.0** |
| JasperFx.Events.SourceGenerator | 2.1.0 | **2.2.0** |

`JasperFx.RuntimeCompiler` stays at **5.0.0** — it has no 2.2.0 release. Its 2.0.x series is the stale parallel line the matrix comment in `Directory.Packages.props` explicitly warns against; the 5.x line is the active continuation.

## Why

Picks up the latest core Critter Stack framework. Notably, JasperFx.Events 2.2.0 ships `IEventStore.AllDatabases()`, which unblocks #156.

## Verification (local, SQL Server 2025)

- `Polecat.Tests` — 1149 passed, 0 failed, 3 skipped
- `Polecat.EntityFrameworkCore.Tests` — 37 passed, 0 failed
- `Polecat.AspNetCore.Testing` — 14 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)