### PR TITLE
#156: Override IEventStore.AllDatabases() on DocumentStore

### DIFF
--- a/src/Polecat.Tests/Daemon/all_databases_tests.cs
+++ b/src/Polecat.Tests/Daemon/all_databases_tests.cs
@@ -1,0 +1,36 @@
+using JasperFx.Events;
+using Polecat.Storage;
+using Polecat.Tests.Harness;
+
+namespace Polecat.Tests.Daemon;
+
+[Collection("integration")]
+public class all_databases_tests : IntegrationContext
+{
+    public all_databases_tests(DefaultStoreFixture fixture) : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task returns_one_event_database_for_single_database_store()
+    {
+        var databases = await ((IEventStore)theStore).AllDatabases();
+
+        databases.Count.ShouldBe(1);
+        databases.ShouldAllBe(db => db is PolecatDatabase);
+    }
+
+    [Fact]
+    public async Task each_database_can_serve_projection_progress()
+    {
+        // The whole point of the abstraction (jasperfx#387) is that store-agnostic tooling can
+        // reach an IEventDatabase and call the read members without referencing concrete types.
+        var databases = await ((IEventStore)theStore).AllDatabases();
+
+        foreach (var database in databases)
+        {
+            var progress = await database.AllProjectionProgress(CancellationToken.None);
+            progress.ShouldNotBeNull();
+        }
+    }
+}

--- a/src/Polecat.Tests/MultiTenancy/separate_database_tenancy_tests.cs
+++ b/src/Polecat.Tests/MultiTenancy/separate_database_tenancy_tests.cs
@@ -1,5 +1,6 @@
 using JasperFx;
 using JasperFx.Descriptors;
+using JasperFx.Events;
 using JasperFx.MultiTenancy;
 using Microsoft.Data.SqlClient;
 using Polecat.Storage;
@@ -197,6 +198,19 @@ public class separate_database_tenancy_tests : IAsyncLifetime
 
         var databases = store.Options.Tenancy!.AllDatabases();
         databases.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task event_store_all_databases_returns_one_per_configured_database()
+    {
+        using var store = CreateSeparateTenantStore();
+
+        // The store-agnostic IEventStore.AllDatabases() (jasperfx#387) must surface every
+        // configured database as an IEventDatabase, matching the tenancy accessor.
+        var databases = await ((IEventStore)store).AllDatabases();
+
+        databases.Count.ShouldBe(2);
+        databases.ShouldAllBe(db => db is PolecatDatabase);
     }
 
     [Fact]

--- a/src/Polecat/DocumentStore.EventStore.cs
+++ b/src/Polecat/DocumentStore.EventStore.cs
@@ -61,6 +61,15 @@ public partial class DocumentStore : IEventStore<IDocumentSession, IQuerySession
 
     Uri IEventStore.Subject => Database.DatabaseUri;
 
+    // Store-agnostic accessor for every IEventDatabase backing this store (jasperfx#387).
+    // Monitoring/tooling (e.g. CritterWatch) resolves IEventStore from DI and enumerates the
+    // databases through this member rather than referencing concrete store types. The tenancy
+    // accessor is synchronous and PolecatDatabase implements IEventDatabase, so we project and
+    // wrap in a completed ValueTask — mirroring the ProjectionCoordinator's IProjectionDatabase cast.
+    ValueTask<IReadOnlyList<IEventDatabase>> IEventStore.AllDatabases() =>
+        ValueTask.FromResult<IReadOnlyList<IEventDatabase>>(
+            Options.Tenancy?.AllDatabases().Cast<IEventDatabase>().ToList() ?? []);
+
     Type IEventStore<IDocumentSession, IQuerySession>.IdentityTypeForProjectedType(Type aggregateType) =>
         Events.StreamIdentity == StreamIdentity.AsGuid ? typeof(Guid) : typeof(string);
 


### PR DESCRIPTION
Closes #156.

## Summary

Overrides the store-agnostic `IEventStore.AllDatabases()` member that JasperFx.Events 2.2.0 ships (jasperfx#387), so monitoring/tooling (e.g. CritterWatch) can resolve `IEventStore` from DI and enumerate the backing `IEventDatabase` instances without referencing concrete store types.

```csharp
ValueTask<IReadOnlyList<IEventDatabase>> IEventStore.AllDatabases() =>
    ValueTask.FromResult<IReadOnlyList<IEventDatabase>>(
        Options.Tenancy?.AllDatabases().Cast<IEventDatabase>().ToList() ?? []);
```

The tenancy accessor is synchronous and `PolecatDatabase : IEventDatabase`, so we project and wrap in a completed `ValueTask` — mirroring the existing `ProjectionCoordinator` pattern that casts to `IProjectionDatabase`.

## Tests
- Single-database store returns exactly one `IEventDatabase`, and it can serve `AllProjectionProgress(...)`.
- Separate-database tenancy returns one `IEventDatabase` per configured tenant database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)