### PR TITLE
#154: Translate LINQ DistinctBy() to SQL Server

### DIFF
--- a/linq.md
+++ b/linq.md
@@ -146,6 +146,14 @@ var uniqueNames = await session.Query<User>()
     .Select(x => x.Name)
     .Distinct()
     .ToListAsync();
+
+// DistinctBy — one row per distinct key
+// SQL Server has no DISTINCT ON, so this becomes a ROW_NUMBER() windowed subquery
+// partitioned by the key. Any OrderBy() decides which row survives per key.
+var onePerGroup = await session.Query<User>()
+    .Select(x => new { x.GroupId, x.Name })
+    .DistinctBy(x => x.GroupId)
+    .ToListAsync();
 ```
 
 ### Collection Queries (OPENJSON)

--- a/src/Polecat.Tests/Linq/distinct_by_operator.cs
+++ b/src/Polecat.Tests/Linq/distinct_by_operator.cs
@@ -1,0 +1,137 @@
+using Polecat.Linq;
+using Polecat.Tests.Harness;
+
+namespace Polecat.Tests.Linq;
+
+public class distinct_by_operator : OneOffConfigurationsContext
+{
+    private async Task StoreSeedDataAsync()
+    {
+        ConfigureStore(_ => { });
+
+        await using var session = theStore.LightweightSession();
+        // "Alice" appears twice (ages 25 and 40) so DistinctBy(Name) must collapse to one row.
+        session.Store(new LinqTarget { Id = Guid.NewGuid(), Name = "Alice", Age = 25, Score = 9.0 });
+        session.Store(new LinqTarget { Id = Guid.NewGuid(), Name = "Bob", Age = 35, Score = 8.0 });
+        session.Store(new LinqTarget { Id = Guid.NewGuid(), Name = "Charlie", Age = 30, Score = 7.0 });
+        session.Store(new LinqTarget { Id = Guid.NewGuid(), Name = "Alice", Age = 40, Score = 6.0 });
+        await session.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task distinct_by_document_member_returns_one_full_document_per_key()
+    {
+        await StoreSeedDataAsync();
+
+        await using var query = theStore.QuerySession();
+        var results = await query.Query<LinqTarget>()
+            .DistinctBy(x => x.Name)
+            .ToListAsync();
+
+        results.Count.ShouldBe(3);
+        results.Select(x => x.Name).OrderBy(x => x)
+            .ShouldBe(["Alice", "Bob", "Charlie"]);
+    }
+
+    [Fact]
+    public async Task distinct_by_after_anonymous_projection()
+    {
+        await StoreSeedDataAsync();
+
+        // Mirrors the issue's example: Select(...) then DistinctBy(projectedKey).
+        await using var query = theStore.QuerySession();
+        var results = await query.Query<LinqTarget>()
+            .Select(x => new { x.Name, x.Age })
+            .DistinctBy(x => x.Name)
+            .ToListAsync();
+
+        results.Count.ShouldBe(3);
+        results.Select(x => x.Name).OrderBy(x => x)
+            .ShouldBe(["Alice", "Bob", "Charlie"]);
+    }
+
+    [Fact]
+    public async Task distinct_by_after_dto_projection()
+    {
+        await StoreSeedDataAsync();
+
+        await using var query = theStore.QuerySession();
+        var results = await query.Query<LinqTarget>()
+            .Select(x => new NameAge { Name = x.Name, Age = x.Age })
+            .DistinctBy(x => x.Name)
+            .ToListAsync();
+
+        results.Count.ShouldBe(3);
+        results.Select(x => x.Name).OrderBy(x => x)
+            .ShouldBe(["Alice", "Bob", "Charlie"]);
+    }
+
+    [Fact]
+    public async Task distinct_by_applies_where_filter_before_dedup()
+    {
+        await StoreSeedDataAsync();
+
+        await using var query = theStore.QuerySession();
+        var results = await query.Query<LinqTarget>()
+            .Where(x => x.Age >= 30)
+            .Select(x => new { x.Name, x.Age })
+            .DistinctBy(x => x.Name)
+            .ToListAsync();
+
+        // Age >= 30: Bob(35), Charlie(30), Alice(40) -> distinct Name -> 3
+        results.Count.ShouldBe(3);
+        results.Select(x => x.Name).OrderBy(x => x)
+            .ShouldBe(["Alice", "Bob", "Charlie"]);
+    }
+
+    [Fact]
+    public async Task order_by_decides_surviving_row_per_key_ascending()
+    {
+        await StoreSeedDataAsync();
+
+        await using var query = theStore.QuerySession();
+        var results = await query.Query<LinqTarget>()
+            .OrderBy(x => x.Age)
+            .DistinctBy(x => x.Name)
+            .ToListAsync();
+
+        results.Count.ShouldBe(3);
+        // The lowest-age row survives per name, and the final list is ordered by age.
+        results[0].Name.ShouldBe("Alice");
+        results[0].Age.ShouldBe(25);
+        results.Select(x => x.Age).ShouldBe([25, 30, 35]);
+    }
+
+    [Fact]
+    public async Task order_by_descending_decides_surviving_row_per_key()
+    {
+        await StoreSeedDataAsync();
+
+        await using var query = theStore.QuerySession();
+        var results = await query.Query<LinqTarget>()
+            .OrderByDescending(x => x.Age)
+            .DistinctBy(x => x.Name)
+            .ToListAsync();
+
+        results.Count.ShouldBe(3);
+        // The highest-age Alice (40) survives this time.
+        results.Single(x => x.Name == "Alice").Age.ShouldBe(40);
+    }
+
+    [Fact]
+    public async Task distinct_by_computed_projection_key_throws_actionable_error()
+    {
+        await StoreSeedDataAsync();
+
+        await using var query = theStore.QuerySession();
+
+        // "Doubled" is a computed expression, not a member of the document — cannot translate.
+        var ex = await Should.ThrowAsync<NotSupportedException>(async () =>
+            await query.Query<LinqTarget>()
+                .Select(x => new { Doubled = x.Age * 2 })
+                .DistinctBy(x => x.Doubled)
+                .ToListAsync());
+
+        ex.Message.ShouldContain("DistinctBy");
+    }
+}

--- a/src/Polecat/Linq/Parsing/LinqQueryParser.cs
+++ b/src/Polecat/Linq/Parsing/LinqQueryParser.cs
@@ -233,6 +233,9 @@ internal class LinqQueryParser : ExpressionVisitor
             case "Distinct":
                 IsDistinct = true;
                 break;
+            case "DistinctBy":
+                HandleDistinctBy(node);
+                break;
             case "AnyTenant" when node.Method.DeclaringType == typeof(LinqExtensions):
                 IsAnyTenant = true;
                 break;
@@ -431,6 +434,83 @@ internal class LinqQueryParser : ExpressionVisitor
     ///     Whether the Select is a simple scalar member access.
     /// </summary>
     public bool IsScalarSelect { get; private set; }
+
+    private void HandleDistinctBy(MethodCallExpression node)
+    {
+        // DistinctBy(keySelector). SQL Server has no DISTINCT ON, so we resolve the key to a SQL
+        // locator and let Statement emit a ROW_NUMBER() windowed subquery. The source visit
+        // (Arguments[0]) ran before this case, so a preceding Select(...) has already populated
+        // SelectExpression and we can map the projected key back to its document member.
+        var keyLambda = GetLambda(node.Arguments[1]);
+        var keyBody = StripConvert(keyLambda.Body);
+
+        var documentMember = ResolveDistinctByKeyMember(keyBody);
+        var member = _memberFactory.ResolveMember(documentMember);
+        Statement.DistinctByLocator = member.TypedLocator;
+    }
+
+    private MemberExpression ResolveDistinctByKeyMember(Expression keyBody)
+    {
+        if (keyBody is not MemberExpression memberExpr)
+        {
+            throw new NotSupportedException(
+                $"DistinctBy() requires a member key selector (e.g. x => x.GroupId), got: {keyBody}");
+        }
+
+        // Called directly on the document collection: resolve the member access as-is.
+        if (SelectExpression == null)
+        {
+            if (IsDocumentMember(memberExpr)) return memberExpr;
+
+            throw new NotSupportedException(
+                $"DistinctBy() could not translate the key selector: {keyBody}");
+        }
+
+        // Called after a Select(...) projection: map the projected member name back to the
+        // underlying document member expression the projection assigned it from.
+        return MapProjectedMemberToDocument(memberExpr.Member.Name)
+               ?? throw new NotSupportedException(
+                   $"DistinctBy() key '{memberExpr.Member.Name}' must reference a member of the preceding " +
+                   "Select(...) projection (anonymous type or object initializer).");
+    }
+
+    private MemberExpression? MapProjectedMemberToDocument(string projectedMemberName)
+    {
+        var body = SelectExpression!.Body;
+        if (body is UnaryExpression { NodeType: ExpressionType.Convert } convert)
+        {
+            body = convert.Operand;
+        }
+
+        switch (body)
+        {
+            // Select(x => new { x.GroupId, x.Name }) — anonymous type
+            case NewExpression newExpr when newExpr.Members != null:
+                for (var i = 0; i < newExpr.Members.Count; i++)
+                {
+                    if (newExpr.Members[i].Name == projectedMemberName)
+                    {
+                        return StripConvert(newExpr.Arguments[i]) as MemberExpression;
+                    }
+                }
+
+                break;
+
+            // Select(x => new Dto { GroupId = x.GroupId }) — object initializer
+            case MemberInitExpression memberInit:
+                foreach (var binding in memberInit.Bindings)
+                {
+                    if (binding is MemberAssignment assignment && assignment.Member.Name == projectedMemberName)
+                    {
+                        return StripConvert(assignment.Expression) as MemberExpression;
+                    }
+                }
+
+                break;
+        }
+
+        return null;
+    }
 
     private void HandleSingleValue(MethodCallExpression node, SingleValueMode mode)
     {

--- a/src/Polecat/Linq/SqlGeneration/Statement.cs
+++ b/src/Polecat/Linq/SqlGeneration/Statement.cs
@@ -18,6 +18,13 @@ internal class Statement
     public List<string> GroupByColumns { get; } = [];
     public List<ISqlFragment> HavingClauses { get; } = [];
 
+    /// <summary>
+    ///     When set, the SQL locator for the LINQ DistinctBy() key. SQL Server has no
+    ///     PostgreSQL-style DISTINCT ON, so the query is wrapped in a ROW_NUMBER() windowed
+    ///     subquery partitioned by this locator, keeping one row per distinct key.
+    /// </summary>
+    public string? DistinctByLocator { get; set; }
+
     public void Apply(ICommandBuilder builder)
     {
         if (IsExistsWrapper)
@@ -33,6 +40,12 @@ internal class Statement
 
     private void ApplyInner(ICommandBuilder builder)
     {
+        if (DistinctByLocator != null)
+        {
+            ApplyDistinctBy(builder);
+            return;
+        }
+
         builder.Append("SELECT ");
 
         if (IsDistinct) builder.Append("DISTINCT ");
@@ -47,15 +60,7 @@ internal class Statement
         builder.Append(" FROM ");
         builder.Append(FromTable);
 
-        if (Wheres.Count > 0)
-        {
-            builder.Append(" WHERE ");
-            for (var i = 0; i < Wheres.Count; i++)
-            {
-                if (i > 0) builder.Append(" AND ");
-                Wheres[i].Apply(builder);
-            }
-        }
+        AppendWheres(builder);
 
         if (GroupByColumns.Count > 0)
         {
@@ -81,12 +86,7 @@ internal class Statement
         if (OrderBys.Count > 0 && !IsAggregateSelect())
         {
             builder.Append(" ORDER BY ");
-            for (var i = 0; i < OrderBys.Count; i++)
-            {
-                if (i > 0) builder.Append(", ");
-                builder.Append(OrderBys[i].Locator);
-                if (OrderBys[i].Descending) builder.Append(" DESC");
-            }
+            AppendOrderByList(builder);
         }
 
         // OFFSET/FETCH pagination (requires ORDER BY)
@@ -102,6 +102,94 @@ internal class Statement
             {
                 builder.Append($" FETCH NEXT {Limit.Value} ROWS ONLY");
             }
+        }
+    }
+
+    /// <summary>
+    ///     Emits a DistinctBy() query as a ROW_NUMBER() windowed subquery. The inner query keeps the
+    ///     original SELECT columns plus a row number partitioned by the key locator; the outer query
+    ///     returns only the first row of each partition. The inner window orders by any supplied
+    ///     ORDER BY (so it decides which row survives per key), falling back to an arbitrary order.
+    ///     The outer query re-applies ORDER BY / pagination to the de-duplicated result set.
+    /// </summary>
+    private void ApplyDistinctBy(ICommandBuilder builder)
+    {
+        var skipOrderBy = IsAggregateSelect();
+
+        builder.Append("SELECT ");
+
+        // TOP applies to the de-duplicated outer result when there's no offset.
+        if (Limit.HasValue && !Offset.HasValue)
+        {
+            builder.Append($"TOP({Limit.Value}) ");
+        }
+
+        builder.Append(SelectColumns);
+
+        builder.Append(" FROM (SELECT ");
+        builder.Append(SelectColumns);
+        builder.Append(", ROW_NUMBER() OVER (PARTITION BY ");
+        builder.Append(DistinctByLocator!);
+        builder.Append(" ORDER BY ");
+        builder.Append(WindowOrderBy());
+        builder.Append(") AS __pc_distinct_rn FROM ");
+        builder.Append(FromTable);
+
+        AppendWheres(builder);
+
+        builder.Append(") AS __pc_distinct WHERE __pc_distinct_rn = 1");
+
+        if (OrderBys.Count > 0 && !skipOrderBy)
+        {
+            builder.Append(" ORDER BY ");
+            AppendOrderByList(builder);
+        }
+
+        if (Offset.HasValue)
+        {
+            if (OrderBys.Count == 0 || skipOrderBy)
+            {
+                builder.Append(" ORDER BY (SELECT NULL)");
+            }
+
+            builder.Append($" OFFSET {Offset.Value} ROWS");
+            if (Limit.HasValue)
+            {
+                builder.Append($" FETCH NEXT {Limit.Value} ROWS ONLY");
+            }
+        }
+    }
+
+    private string WindowOrderBy()
+    {
+        if (OrderBys.Count == 0)
+        {
+            // No deterministic representative requested; any row in the partition is acceptable.
+            return "(SELECT NULL)";
+        }
+
+        return string.Join(", ", OrderBys.Select(o => o.Descending ? $"{o.Locator} DESC" : o.Locator));
+    }
+
+    private void AppendWheres(ICommandBuilder builder)
+    {
+        if (Wheres.Count == 0) return;
+
+        builder.Append(" WHERE ");
+        for (var i = 0; i < Wheres.Count; i++)
+        {
+            if (i > 0) builder.Append(" AND ");
+            Wheres[i].Apply(builder);
+        }
+    }
+
+    private void AppendOrderByList(ICommandBuilder builder)
+    {
+        for (var i = 0; i < OrderBys.Count; i++)
+        {
+            if (i > 0) builder.Append(", ");
+            builder.Append(OrderBys[i].Locator);
+            if (OrderBys[i].Descending) builder.Append(" DESC");
         }
     }
 


### PR DESCRIPTION
Closes #154.

## Summary

Adds native translation of the LINQ `DistinctBy(keySelector)` operator (parity with [marten#4565](https://github.com/JasperFx/marten/issues/4565)). SQL Server has no PostgreSQL-style `DISTINCT ON`, so the query is emitted as a `ROW_NUMBER()` windowed subquery partitioned by the key locator, keeping one row per distinct key:

```sql
SELECT <cols> FROM (
    SELECT <cols>, ROW_NUMBER() OVER (PARTITION BY <key> ORDER BY <order>) AS rn
    FROM <table> WHERE <filters>
) sub WHERE rn = 1 [ORDER BY ...] [OFFSET/FETCH]
```

## Behavior
- **Key resolution** happens in the parser. When `DistinctBy()` follows a `Select(...)` projection (anonymous type or object initializer), the projected key is mapped back to its underlying document member; called directly on the document, the member is resolved as-is.
- **Representative row**: any `OrderBy()` the query supplies decides which row survives per key (used as the window `ORDER BY`) and the final result ordering. With no `OrderBy`, the representative is arbitrary — matching `DistinctBy` semantics.
- **Pagination/`Where`** compose: `Where` filters before dedup; `Skip`/`Take`/`TOP` apply to the de-duplicated result.
- A computed projection key that can't be mapped to a document member throws an actionable `NotSupportedException`.

No provider changes were needed — the locator is set on `Statement`, so all build paths (execute, `ToCommand`, `ToSql`) pick it up.

## Tests
Direct/anonymous/DTO projections, `Where`-before-dedup, ascending & descending representative selection, and the unsupported-key error. Existing LINQ + pagination suites (155 tests) still pass.

Docs: `linq.md` updated with a `DistinctBy` example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)