### PR TITLE
Bump version to 4.2.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>4.1.1</Version>
+        <Version>4.2.0</Version>
         <LangVersion>latest</LangVersion>
         <Authors>Jeremy D. Miller</Authors>
         <PackageIcon>logo.png</PackageIcon>


### PR DESCRIPTION
## Summary

Bumps the package version to **4.2.0** for the next minor release.

Covers everything merged since 4.1.1:
- #157 — JasperFx.* dependencies updated to 2.2.0
- #158 — `IEventStore.AllDatabases()` override on `DocumentStore` (closes #156)
- #159 — LINQ `DistinctBy()` translated to SQL Server `ROW_NUMBER()` (closes #154)

On merge, a GitHub release `v4.2.0` will be tagged, which triggers the NuGet publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)