### PR TITLE
Run transaction participants when SaveChangesAsync has only participants pending

### DIFF
--- a/src/Polecat.Tests/Bug_save_changes_runs_participants_only.cs
+++ b/src/Polecat.Tests/Bug_save_changes_runs_participants_only.cs
@@ -1,0 +1,48 @@
+using Microsoft.Data.SqlClient;
+using Polecat.Tests.Harness;
+using Shouldly;
+
+namespace Polecat.Tests;
+
+// Regression for the Wolverine GH-2941 root cause: DocumentSessionBase.SaveChangesAsync used to
+// early-return when _workTracker.HasOutstandingWork() was false. _workTracker only tracks
+// document operations and event streams, not ITransactionParticipants - so a session that has
+// ONLY registered participants (no doc ops, no streams) had SaveChangesAsync skip the entire
+// pipeline, including the participants' BeforeCommitAsync. Adding the participant-count check to
+// the early-return guard ensures the transaction runs and participants fire.
+public class Bug_save_changes_runs_participants_only : OneOffConfigurationsContext
+{
+    [Fact]
+    public async Task save_changes_runs_participants_when_only_participants_are_pending()
+    {
+        ConfigureStore(_ => { });
+        await theStore.Database.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        var participant = new RecordingParticipant();
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.AddTransactionParticipant(participant);
+            await session.SaveChangesAsync();
+        }
+
+        // Before the fix the participant was silently skipped (BeforeCommitAsync never ran).
+        participant.BeforeCommitInvocations.ShouldBe(1);
+        participant.LastTransactionWasNotNull.ShouldBeTrue(
+            "The participant must run inside an active SQL transaction so BeforeCommitAsync can attach commands to the same commit.");
+    }
+
+    private sealed class RecordingParticipant : ITransactionParticipant
+    {
+        public int BeforeCommitInvocations { get; private set; }
+
+        public bool LastTransactionWasNotNull { get; private set; }
+
+        public Task BeforeCommitAsync(SqlConnection connection, SqlTransaction transaction, CancellationToken token)
+        {
+            BeforeCommitInvocations++;
+            LastTransactionWasNotNull = transaction is not null;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Polecat/Internal/DocumentSessionBase.cs
+++ b/src/Polecat/Internal/DocumentSessionBase.cs
@@ -309,7 +309,17 @@ internal abstract class DocumentSessionBase : QuerySession, IDocumentSession
 
     public async Task SaveChangesAsync(CancellationToken token = default)
     {
-        if (!_workTracker.HasOutstandingWork()) return;
+        // _workTracker tracks document operations and event streams - it does NOT include
+        // ITransactionParticipants registered via AddTransactionParticipant. Skipping the entire
+        // SaveChangesAsync pipeline when _workTracker is empty therefore silently drops queued
+        // participants whose BeforeCommitAsync would otherwise run inside the same SQL transaction.
+        //
+        // This bit Wolverine.Polecat's scheduled-cascade outbox path (JasperFx/wolverine GH-2941):
+        // a handler that emits only a DeliveryMessage<T>.DelayedFor(...) cascade has Wolverine
+        // call Session.StoreIncoming(...), which registers a StoreIncomingEnvelopeParticipant
+        // whose BeforeCommitAsync inserts the scheduled envelope row. With no doc ops on the
+        // session, SaveChangesAsync early-returned and the row never got written.
+        if (!_workTracker.HasOutstandingWork() && _transactionParticipants.Count == 0) return;
 
         using var activity = OpenTelemetry.TracingSessionDecorator.StartSessionActivity(
             "polecat.save_changes", TenantId, Options.OpenTelemetry);


### PR DESCRIPTION
## The bug

`DocumentSessionBase.SaveChangesAsync` early-returns when `_workTracker.HasOutstandingWork()` is false. `_workTracker` tracks document operations + event streams — it does **not** include `ITransactionParticipant`s registered via `AddTransactionParticipant`. A session that has only registered participants (no doc ops, no streams) therefore had `SaveChangesAsync` skip the entire pipeline; the SQL transaction was never begun, and every queued participant's `BeforeCommitAsync` silently never ran.

## How it surfaced

Wolverine's [GH-2941](https://github.com/JasperFx/wolverine/issues/2941). `Wolverine.Polecat`'s outbox path for scheduled cascades (a `DeliveryMessage<T>.DelayedFor(...)` emitted by a `[ReadAggregate]` or `[DocumentExists]`-decorated handler with no document writes) hits `Session.StoreIncoming(...)`, which registers a `StoreIncomingEnvelopeParticipant` whose `BeforeCommitAsync` inserts the scheduled envelope row into `wolverine_incoming_envelopes`. With no document ops on the session, that participant never ran and the scheduled message was silently lost.

## Fix

Extend the early-return guard to also account for queued transaction participants. Listeners and other commit-time side effects continue to run via the normal pipeline once the transaction is begun.

```csharp
- if (!_workTracker.HasOutstandingWork()) return;
+ if (!_workTracker.HasOutstandingWork() && _transactionParticipants.Count == 0) return;
```

## Test

New regression test `Bug_save_changes_runs_participants_only` pins the contract that `ITransactionParticipant.BeforeCommitAsync` runs (and runs with a real `SqlTransaction`) when only a participant is registered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)