### PR TITLE
#163 Phase 0: consume JasperFx 2.5.0 + UseTenantPartitionedEvents flag

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,8 +5,13 @@
 
     <ItemGroup>
         <!-- Core dependencies -->
-        <PackageVersion Include="JasperFx" Version="2.2.0" />
-        <PackageVersion Include="JasperFx.Events" Version="2.2.0" />
+        <!-- JasperFx 2.5.0 brings the store-agnostic per-tenant event partitioning
+             surface (ShardName tenant grammar, nullable ShardState.TenantId /
+             HighWaterStatistics.TenantId, tenant-aware JasperFxAsyncDaemon).
+             Polecat #163 consumes it in phases — Phase 0 surfaces the flag,
+             Phase 1/2 land the SQL Server side. -->
+        <PackageVersion Include="JasperFx" Version="2.5.0" />
+        <PackageVersion Include="JasperFx.Events" Version="2.5.0" />
         <!-- Pin the sibling JasperFx packages for parity with Marten 9's matrix
              even though Polecat doesn't currently reference them directly —
              keeps the lockstep matrix coherent when transitive resolution
@@ -14,7 +19,7 @@
              RuntimeCompiler 5.x line is the active continuation of the 4.x
              lineage; do not pin against the parallel stale 2.0.x series. -->
         <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.2.0" />
+        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.5.0" />
         <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
@@ -39,8 +44,8 @@
         <!-- Strongly typed IDs -->
         <PackageVersion Include="StronglyTypedId" Version="1.0.0-beta08" />
 
-        <!-- Source generators -->
-        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.2.0" />
+        <!-- Source generators (matched to JasperFx.Events above) -->
+        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.5.0" />
 
         <!-- Build automation -->
         <PackageVersion Include="Nuke.Common" Version="9.0.4" />

--- a/src/Polecat/Events/EventGraph.cs
+++ b/src/Polecat/Events/EventGraph.cs
@@ -92,6 +92,27 @@ public class EventGraph : EventRegistry, IAggregationSourceFactory<IQuerySession
     public bool UseArchivedStreamPartitioning { get; set; }
 
     /// <summary>
+    ///     Master switch for per-tenant event partitioning (Polecat #163 / CritterWatch #209).
+    ///     When enabled, the SQL Server append path moves from a global
+    ///     <c>seq_id BIGINT IDENTITY</c> to per-tenant <c>pc_events_sequence_{suffix}</c>
+    ///     SEQUENCE objects, and the async daemon's high-water detector returns
+    ///     <see cref="JasperFx.Events.Daemon.HighWater.IHighWaterDetector.SupportsTenantPartitioning"/> = true
+    ///     so tenant-scoped rebuilds and high-water reads run bounded by a single
+    ///     tenant's sequence ceiling rather than the database-wide event-sequence scan.
+    ///     <para>
+    ///     <b>Default is false</b> — existing stores keep the global IDENTITY path
+    ///     byte-for-byte. The per-tenant SEQUENCE + tenant-registry + daemon-side
+    ///     surface land in subsequent phases (#163 Phase 1 + Phase 2); Phase 0 only
+    ///     introduces this flag so downstream phases can gate cleanly.
+    ///     </para>
+    ///     <para>
+    ///     Polecat is single-append-path (QuickAppend only — direct INSERTs, no stored
+    ///     procedures), so no append-mode compatibility guard is needed.
+    ///     </para>
+    /// </summary>
+    public bool UseTenantPartitionedEvents { get; set; }
+
+    /// <summary>
     ///     Process projection side effects (slice.PublishMessage) when running
     ///     projections under the Inline lifecycle. Off by default — flip on to
     ///     route inline-projection-emitted messages through the configured


### PR DESCRIPTION
## Summary

Phase 0 of polecat **#163** (per-tenant event partitioning + per-tenant async daemon), part of the **CritterWatch #209** master plan. Surface-only change with **zero behavior change** — Phase 1 (storage) and Phase 2 (daemon) follow in separate PRs.

**JasperFx 2.5.0** introduces the store-agnostic per-tenant event partitioning surface that Polecat will plug into:
- `ShardName` tenant grammar (`Compose` / `TryParse` / `ForTenant`)
- nullable `ShardState.TenantId` / `HighWaterStatistics.TenantId`
- a tenant-aware `JasperFxAsyncDaemon` base that picks up tenant-scoped rebuilds once a store's `IHighWaterDetector.SupportsTenantPartitioning` flips on

Polecat already inherits the daemon base — Phase 1/2 supply the SQL Server-side storage DDL and detector implementation; this PR makes the surface available so the flag can be wired without churning consumers.

## Changes

| File | Change |
|---|---|
| `Directory.Packages.props` | `JasperFx` / `JasperFx.Events` / `JasperFx.SourceGenerator` / `JasperFx.Events.SourceGenerator` **`2.2.0` → `2.5.0`**. `JasperFx.RuntimeCompiler` stays at `5.0.0` (no 2.5.0 sibling). |
| `src/Polecat/Events/EventGraph.cs` | New `UseTenantPartitionedEvents` (bool, default **false**) — master switch Phase 1/2 will gate on. |

**No append-mode compatibility guard needed** — Polecat is single-append-path (QuickAppend only, direct INSERTs, no stored procedures); confirmed and documented on the property's XML doc.

## Verification

```
Clean restore from nuget.org (no NU downgrade/conflict warnings)
dotnet build Debug + Release: 0 errors
Polecat.AotSmoke (Release): clean
Polecat.Tests (net10.0): 1160 pass / 3 pre-existing skips / 0 fail
Polecat.EntityFrameworkCore.Tests (net10.0): 37 pass / 0 fail
```

## Out of scope

- **Phase 1 (storage)** — `pc_tenant_partitions` registry, per-tenant `pc_events_sequence_{suffix}`, append-path rewrite under the flag, `ShardName.Identity` composed into `pc_event_progression.name`. Needs explicit call on whether to also do physical SQL Server per-tenant partitioning (recommendation: defer; per-tenant SEQUENCE alone delivers the bounded scan).
- **Phase 2 (daemon)** — `PolecatHighWaterDetector` vectorized per-tenant `DetectForTenantsAsync` / `DetectInSafeZoneForTenantsAsync` (via `sys.sequences.current_value` + the new registry), tenant-scoped event loader, per-tenant teardown for rebuild. Composite rebuild is an optional sub-phase after P2.
- **Weasel 9.0.2** is also available (currently pinned `9.0.1`) — out of scope for this JasperFx-only surface bump; flag for a separate patch.

Closes part of #163 (Phase 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
