### PR TITLE
#165: MasterTableTenancy — dynamic separate-database multi-tenancy

### DIFF
--- a/docs/configuration/multitenancy.md
+++ b/docs/configuration/multitenancy.md
@@ -70,6 +70,67 @@ With separate database tenancy:
 - Sessions automatically route to the correct database based on tenant ID
 - The async daemon runs independently per tenant database
 
+### Dynamic Tenant Management (Master Table Tenancy)
+
+`MultiTenantedDatabases` above is **static** — the full tenant list is fixed when the store is
+configured. When you need to add, remove, enable, or disable tenants **at runtime** without
+restarting the service, use the **master table** strategy. A control-plane table (`pc_tenants`)
+maps each `tenant_id` to its connection string, and Polecat reads from it dynamically:
+
+```cs
+var store = DocumentStore.For(opts =>
+{
+    // Default/fallback connection
+    opts.Connection("...");
+
+    // The control-plane database that holds the pc_tenants registry
+    opts.MultiTenantedMasterTable("Server=localhost;Database=control_plane;...");
+});
+```
+
+`MultiTenantedMasterTable` returns a `MasterTableTenancy` you can drive from operational code (for
+example, a CritterWatch tenant-management handler). The master table is created automatically on
+first use:
+
+```cs
+var tenancy = (MasterTableTenancy)store.Options.Tenancy!;
+
+// Register a tenant -> connection string mapping at runtime (idempotent upsert)
+await tenancy.AddDatabaseRecordAsync("tenant-a", "Server=localhost;Database=tenant_a;...");
+
+// Temporarily take a tenant offline without losing its record...
+await tenancy.DisableTenantAsync("tenant-a");
+// ...and bring it back
+await tenancy.EnableTenantAsync("tenant-a");
+
+// Inspect which tenants are currently disabled
+IReadOnlyList<string> disabled = await tenancy.AllDisabledAsync();
+
+// Remove a tenant record entirely (the tenant database itself is left untouched)
+await tenancy.DeleteDatabaseRecordAsync("tenant-a");
+
+// Materialize the full set of currently-enabled tenant databases
+// (e.g. to apply schema to each)
+foreach (var db in await tenancy.BuildDatabasesAsync())
+{
+    await db.ApplyAllConfiguredChangesToDatabaseAsync();
+}
+```
+
+Notes:
+
+- The master table is `pc_tenants` (`tenant_id`, `connection_string`, `is_disabled`) and lives in the
+  schema you pass to `MultiTenantedMasterTable` (defaults to `StoreOptions.DatabaseSchemaName`).
+- `AddDatabaseRecordAsync` records the mapping and re-enables a previously-disabled tenant; it does
+  **not** create the tenant database — provision that separately (the connection string must point at
+  an existing database).
+- Disabled or unknown tenants raise `UnknownTenantIdException` when a session is opened for them,
+  exactly like static separate-database tenancy.
+- All master-table access flows through `StoreOptions.ResiliencePipeline`.
+
+This is the Polecat (SQL Server) equivalent of Marten's `MultiTenantedDatabasesViaMasterTable` /
+`MasterTableTenancy`.
+
 ## Setting the Tenant ID
 
 The tenant ID is set when opening a session:

--- a/src/Polecat.Tests/MultiTenancy/master_table_tenancy_tests.cs
+++ b/src/Polecat.Tests/MultiTenancy/master_table_tenancy_tests.cs
@@ -1,0 +1,231 @@
+using JasperFx;
+using JasperFx.Descriptors;
+using JasperFx.MultiTenancy;
+using Microsoft.Data.SqlClient;
+using Polecat.Storage;
+using Polecat.TestUtils;
+
+namespace Polecat.Tests.MultiTenancy;
+
+public class master_table_tenancy_tests : IAsyncLifetime
+{
+    private const string TenantA = "tenant_a";
+    private const string TenantB = "tenant_b";
+    private const string ControlDb = "polecat_mt_control";
+    private const string DbA = "polecat_mt_tenant_a";
+    private const string DbB = "polecat_mt_tenant_b";
+
+    private static readonly string MasterConnectionString =
+        ConnectionSource.ConnectionString.Replace("Initial Catalog=master", "Database=master");
+
+    private static string Db(string name) =>
+        ConnectionSource.ConnectionString.Replace("Initial Catalog=master", $"Database={name}");
+
+    public async Task InitializeAsync()
+    {
+        await using var conn = new SqlConnection(MasterConnectionString);
+        await conn.OpenAsync();
+
+        foreach (var db in new[] { ControlDb, DbA, DbB })
+        {
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = $"IF DB_ID('{db}') IS NULL CREATE DATABASE [{db}];";
+            await cmd.ExecuteNonQueryAsync();
+        }
+    }
+
+    public async Task DisposeAsync()
+    {
+        await using var conn = new SqlConnection(MasterConnectionString);
+        await conn.OpenAsync();
+
+        foreach (var db in new[] { ControlDb, DbA, DbB })
+        {
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = $"""
+                IF DB_ID('{db}') IS NOT NULL
+                BEGIN
+                    ALTER DATABASE [{db}] SET SINGLE_USER WITH ROLLBACK IMMEDIATE;
+                    DROP DATABASE [{db}];
+                END
+                """;
+            await cmd.ExecuteNonQueryAsync();
+        }
+    }
+
+    private (DocumentStore Store, MasterTableTenancy Tenancy) CreateStore()
+    {
+        MasterTableTenancy? tenancy = null;
+        var store = DocumentStore.For(opts =>
+        {
+            // The default connection just needs to be valid; routing goes through the tenancy.
+            opts.ConnectionString = Db(ControlDb);
+            opts.AutoCreateSchemaObjects = AutoCreate.All;
+            opts.UseNativeJsonType = ConnectionSource.SupportsNativeJson;
+
+            tenancy = opts.MultiTenantedMasterTable(Db(ControlDb));
+        });
+
+        return (store, tenancy!);
+    }
+
+    private static async Task ApplySchemaAsync(MasterTableTenancy tenancy)
+    {
+        foreach (var db in await tenancy.BuildDatabasesAsync())
+        {
+            await db.ApplyAllConfiguredChangesToDatabaseAsync();
+        }
+    }
+
+    [Fact]
+    public async Task cardinality_is_dynamic_multiple()
+    {
+        var (store, _) = CreateStore();
+        using (store)
+        {
+            store.Options.Tenancy!.Cardinality.ShouldBe(DatabaseCardinality.DynamicMultiple);
+        }
+    }
+
+    [Fact]
+    public async Task add_records_and_route_to_separate_databases()
+    {
+        var (store, tenancy) = CreateStore();
+        using (store)
+        {
+            await tenancy.AddDatabaseRecordAsync(TenantA, Db(DbA));
+            await tenancy.AddDatabaseRecordAsync(TenantB, Db(DbB));
+            await ApplySchemaAsync(tenancy);
+
+            var docId = Guid.NewGuid();
+
+            await using (var session = store.LightweightSession(new SessionOptions { TenantId = TenantA }))
+            {
+                session.Store(new TestDoc { Id = docId, Name = "Tenant A Doc" });
+                await session.SaveChangesAsync();
+            }
+
+            await using (var query = store.QuerySession(new SessionOptions { TenantId = TenantA }))
+            {
+                (await query.LoadAsync<TestDoc>(docId))!.Name.ShouldBe("Tenant A Doc");
+            }
+
+            // Separate database — tenant B cannot see tenant A's document.
+            await using (var query = store.QuerySession(new SessionOptions { TenantId = TenantB }))
+            {
+                (await query.LoadAsync<TestDoc>(docId)).ShouldBeNull();
+            }
+        }
+    }
+
+    [Fact]
+    public async Task unknown_tenant_throws()
+    {
+        var (store, _) = CreateStore();
+        using (store)
+        {
+            // Touch the tenancy so the master table is created, but never add this tenant.
+            await Should.ThrowAsync<UnknownTenantIdException>(async () =>
+            {
+                await using var _ = store.LightweightSession(new SessionOptions { TenantId = "nonexistent" });
+            });
+        }
+    }
+
+    [Fact]
+    public async Task build_databases_returns_only_enabled_tenants()
+    {
+        var (store, tenancy) = CreateStore();
+        using (store)
+        {
+            await tenancy.AddDatabaseRecordAsync(TenantA, Db(DbA));
+            await tenancy.AddDatabaseRecordAsync(TenantB, Db(DbB));
+
+            (await tenancy.BuildDatabasesAsync()).Count.ShouldBe(2);
+
+            await tenancy.DisableTenantAsync(TenantB);
+
+            // A fresh tenancy reads purely from the master table — no stale cache.
+            var (store2, tenancy2) = CreateStore();
+            using (store2)
+            {
+                (await tenancy2.BuildDatabasesAsync()).Count.ShouldBe(1);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task disable_then_enable_toggles_routing()
+    {
+        var (store, tenancy) = CreateStore();
+        using (store)
+        {
+            await tenancy.AddDatabaseRecordAsync(TenantA, Db(DbA));
+            await ApplySchemaAsync(tenancy);
+
+            // Routable while enabled.
+            await using (var _ = store.LightweightSession(new SessionOptions { TenantId = TenantA }))
+            {
+            }
+
+            await tenancy.DisableTenantAsync(TenantA);
+
+            (await tenancy.AllDisabledAsync()).ShouldContain(TenantA);
+            await Should.ThrowAsync<UnknownTenantIdException>(async () =>
+            {
+                await using var _ = store.LightweightSession(new SessionOptions { TenantId = TenantA });
+            });
+
+            await tenancy.EnableTenantAsync(TenantA);
+
+            (await tenancy.AllDisabledAsync()).ShouldNotContain(TenantA);
+            // Routable again.
+            await using (var _ = store.LightweightSession(new SessionOptions { TenantId = TenantA }))
+            {
+            }
+        }
+    }
+
+    [Fact]
+    public async Task delete_record_removes_tenant()
+    {
+        var (store, tenancy) = CreateStore();
+        using (store)
+        {
+            await tenancy.AddDatabaseRecordAsync(TenantA, Db(DbA));
+            (await tenancy.BuildDatabasesAsync()).Count.ShouldBe(1);
+
+            await tenancy.DeleteDatabaseRecordAsync(TenantA);
+
+            (await tenancy.BuildDatabasesAsync()).Count.ShouldBe(0);
+            await Should.ThrowAsync<UnknownTenantIdException>(async () =>
+            {
+                await using var _ = store.LightweightSession(new SessionOptions { TenantId = TenantA });
+            });
+        }
+    }
+
+    [Fact]
+    public async Task add_is_idempotent_and_reenables_disabled_tenant()
+    {
+        var (store, tenancy) = CreateStore();
+        using (store)
+        {
+            await tenancy.AddDatabaseRecordAsync(TenantA, Db(DbA));
+            await tenancy.DisableTenantAsync(TenantA);
+            (await tenancy.AllDisabledAsync()).ShouldContain(TenantA);
+
+            // Re-adding the same tenant is an upsert that clears the disabled flag.
+            await tenancy.AddDatabaseRecordAsync(TenantA, Db(DbA));
+
+            (await tenancy.AllDisabledAsync()).ShouldNotContain(TenantA);
+            (await tenancy.BuildDatabasesAsync()).Count.ShouldBe(1);
+        }
+    }
+
+    public class TestDoc
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; } = "";
+    }
+}

--- a/src/Polecat/Storage/MasterTableTenancy.cs
+++ b/src/Polecat/Storage/MasterTableTenancy.cs
@@ -1,0 +1,327 @@
+using System.Collections.Concurrent;
+using JasperFx;
+using JasperFx.Descriptors;
+using JasperFx.MultiTenancy;
+using Microsoft.Data.SqlClient;
+using Polecat.Internal;
+using Polly;
+
+namespace Polecat.Storage;
+
+/// <summary>
+///     Dynamic separate-database multi-tenancy backed by a master "control plane" table that maps
+///     <c>tenant_id</c> &rarr; connection string. Unlike <see cref="SeparateDatabaseTenancy" /> (whose
+///     tenant list is fixed at registration time), tenants can be added, removed, enabled, and disabled
+///     at runtime without restarting the service. This is the Polecat (SQL Server) equivalent of
+///     Marten's <c>MasterTableTenancy</c> and the surface CritterWatch uses for dynamic tenant
+///     management.
+/// </summary>
+public class MasterTableTenancy : ITenancy
+{
+    /// <summary>
+    ///     The master tenant-registry table name (unqualified).
+    /// </summary>
+    public const string TableName = "pc_tenants";
+
+    private readonly StoreOptions _options;
+    private readonly string _masterConnectionString;
+    private readonly string _schemaName;
+    private readonly ResiliencePipeline _resilience;
+
+    private readonly ConcurrentDictionary<string, Entry> _cache =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    private volatile bool _masterTableEnsured;
+    private readonly SemaphoreSlim _ensureLock = new(1, 1);
+
+    internal MasterTableTenancy(StoreOptions options, string masterConnectionString, string schemaName)
+    {
+        _options = options;
+        _masterConnectionString = masterConnectionString
+            ?? throw new ArgumentNullException(nameof(masterConnectionString));
+        _schemaName = string.IsNullOrWhiteSpace(schemaName) ? options.DatabaseSchemaName : schemaName;
+        _resilience = options.ResiliencePipeline;
+    }
+
+    /// <summary>
+    ///     The fully-qualified master table name, e.g. <c>[dbo].[pc_tenants]</c>.
+    /// </summary>
+    public string QualifiedTableName => $"[{_schemaName}].[{TableName}]";
+
+    DatabaseCardinality ITenancy.Cardinality => DatabaseCardinality.DynamicMultiple;
+    string ITenancy.DefaultTenantId => StorageConstants.DefaultTenantId;
+
+    ConnectionFactory ITenancy.GetConnectionFactory(string tenantId)
+    {
+        return ResolveEntry(tenantId).Factory;
+    }
+
+    PolecatDatabase ITenancy.GetDatabase(string tenantId)
+    {
+        return ResolveEntry(tenantId).Database;
+    }
+
+    IReadOnlyList<PolecatDatabase> ITenancy.AllDatabases()
+    {
+        // Prime the cache from the master table if nothing has been loaded yet so the
+        // resource model / daemon coordinator sees the current tenant set.
+        if (_cache.IsEmpty)
+        {
+            BuildDatabasesAsync().GetAwaiter().GetResult();
+        }
+
+        return _cache.Values.Select(x => x.Database).ToList();
+    }
+
+    private Entry ResolveEntry(string tenantId)
+    {
+        if (_cache.TryGetValue(tenantId, out var cached)) return cached;
+
+        // It is deliberately important *not* to silently swallow the lookup here — an unknown or
+        // disabled tenant must surface as UnknownTenantIdException, same as SeparateDatabaseTenancy.
+        var connectionString = LookupConnectionStringAsync(tenantId).GetAwaiter().GetResult()
+            ?? throw new UnknownTenantIdException(tenantId);
+
+        return _cache.GetOrAdd(tenantId, id => CreateEntry(id, connectionString));
+    }
+
+    private Entry CreateEntry(string tenantId, string connectionString)
+    {
+        var factory = new ConnectionFactory(connectionString);
+        var database = new PolecatDatabase(_options, connectionString, $"Polecat_{tenantId}");
+        return new Entry(factory, database);
+    }
+
+    /// <summary>
+    ///     Read every enabled tenant from the master table, (re)building the in-memory database cache,
+    ///     and return the full set of tenant databases the tenancy currently knows about. Mirrors
+    ///     Marten's <c>BuildDatabases()</c>.
+    /// </summary>
+    public async Task<IReadOnlyList<PolecatDatabase>> BuildDatabasesAsync(CancellationToken token = default)
+    {
+        await EnsureMasterTableAsync(token).ConfigureAwait(false);
+
+        var rows = await _resilience.ExecuteAsync(static async (state, ct) =>
+        {
+            var (connectionString, table) = state;
+            var list = new List<(string TenantId, string ConnectionString)>();
+
+            await using var conn = new SqlConnection(connectionString);
+            await conn.OpenAsync(ct).ConfigureAwait(false);
+
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = $"SELECT tenant_id, connection_string FROM {table} WHERE is_disabled = 0;";
+
+            await using var reader = await cmd.ExecuteReaderAsync(ct).ConfigureAwait(false);
+            while (await reader.ReadAsync(ct).ConfigureAwait(false))
+            {
+                list.Add((reader.GetString(0), reader.GetString(1)));
+            }
+
+            return list;
+        }, (_masterConnectionString, QualifiedTableName), token).ConfigureAwait(false);
+
+        foreach (var (tenantId, connectionString) in rows)
+        {
+            _cache.AddOrUpdate(
+                tenantId,
+                id => CreateEntry(id, connectionString),
+                (id, existing) => existing.Factory.ConnectionString == connectionString
+                    ? existing
+                    : CreateEntry(id, connectionString));
+        }
+
+        return _cache.Values.Select(x => x.Database).ToList();
+    }
+
+    /// <summary>
+    ///     Add (or update) a tenant record mapping <paramref name="tenantId" /> to
+    ///     <paramref name="connectionString" />. The tenant is immediately available to new sessions.
+    /// </summary>
+    public async Task AddDatabaseRecordAsync(string tenantId, string connectionString,
+        CancellationToken token = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(tenantId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
+
+        await EnsureMasterTableAsync(token).ConfigureAwait(false);
+
+        await _resilience.ExecuteAsync(static async (state, ct) =>
+        {
+            var (masterConn, table, tenantId, connectionString) = state;
+            await using var conn = new SqlConnection(masterConn);
+            await conn.OpenAsync(ct).ConfigureAwait(false);
+
+            await using var cmd = conn.CreateCommand();
+            // Upsert: keep AddDatabaseRecordAsync idempotent and re-enable on re-add.
+            cmd.CommandText = $"""
+                MERGE {table} AS target
+                USING (SELECT @id AS tenant_id) AS source
+                ON target.tenant_id = source.tenant_id
+                WHEN MATCHED THEN
+                    UPDATE SET connection_string = @conn, is_disabled = 0
+                WHEN NOT MATCHED THEN
+                    INSERT (tenant_id, connection_string, is_disabled) VALUES (@id, @conn, 0);
+                """;
+            cmd.Parameters.AddWithValue("@id", tenantId);
+            cmd.Parameters.AddWithValue("@conn", connectionString);
+            await cmd.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+        }, (_masterConnectionString, QualifiedTableName, tenantId, connectionString), token).ConfigureAwait(false);
+
+        // Eagerly cache so the tenant is usable immediately.
+        _cache[tenantId] = CreateEntry(tenantId, connectionString);
+    }
+
+    /// <summary>
+    ///     Remove a tenant record entirely. The tenant's database is left untouched.
+    /// </summary>
+    public async Task DeleteDatabaseRecordAsync(string tenantId, CancellationToken token = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(tenantId);
+
+        await EnsureMasterTableAsync(token).ConfigureAwait(false);
+        await ExecuteByTenantAsync(
+            $"DELETE FROM {QualifiedTableName} WHERE tenant_id = @id;", tenantId, token).ConfigureAwait(false);
+
+        _cache.TryRemove(tenantId, out _);
+    }
+
+    /// <summary>
+    ///     Enable a previously-disabled tenant. The tenant becomes routable again on next access.
+    /// </summary>
+    public async Task EnableTenantAsync(string tenantId, CancellationToken token = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(tenantId);
+
+        await EnsureMasterTableAsync(token).ConfigureAwait(false);
+        await ExecuteByTenantAsync(
+            $"UPDATE {QualifiedTableName} SET is_disabled = 0 WHERE tenant_id = @id;", tenantId, token)
+            .ConfigureAwait(false);
+
+        // Lazily reloaded into the cache on next access.
+    }
+
+    /// <summary>
+    ///     Disable a tenant without deleting its record. Disabled tenants are evicted from the cache
+    ///     and rejected (as <see cref="UnknownTenantIdException" />) until re-enabled.
+    /// </summary>
+    public async Task DisableTenantAsync(string tenantId, CancellationToken token = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(tenantId);
+
+        await EnsureMasterTableAsync(token).ConfigureAwait(false);
+        await ExecuteByTenantAsync(
+            $"UPDATE {QualifiedTableName} SET is_disabled = 1 WHERE tenant_id = @id;", tenantId, token)
+            .ConfigureAwait(false);
+
+        _cache.TryRemove(tenantId, out _);
+    }
+
+    /// <summary>
+    ///     The tenant ids that are currently disabled.
+    /// </summary>
+    public async Task<IReadOnlyList<string>> AllDisabledAsync(CancellationToken token = default)
+    {
+        await EnsureMasterTableAsync(token).ConfigureAwait(false);
+
+        return await _resilience.ExecuteAsync(static async (state, ct) =>
+        {
+            var (connectionString, table) = state;
+            var list = new List<string>();
+
+            await using var conn = new SqlConnection(connectionString);
+            await conn.OpenAsync(ct).ConfigureAwait(false);
+
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = $"SELECT tenant_id FROM {table} WHERE is_disabled = 1;";
+
+            await using var reader = await cmd.ExecuteReaderAsync(ct).ConfigureAwait(false);
+            while (await reader.ReadAsync(ct).ConfigureAwait(false))
+            {
+                list.Add(reader.GetString(0));
+            }
+
+            return (IReadOnlyList<string>)list;
+        }, (_masterConnectionString, QualifiedTableName), token).ConfigureAwait(false);
+    }
+
+    private async Task<string?> LookupConnectionStringAsync(string tenantId, CancellationToken token = default)
+    {
+        await EnsureMasterTableAsync(token).ConfigureAwait(false);
+
+        return await _resilience.ExecuteAsync(static async (state, ct) =>
+        {
+            var (connectionString, table, tenantId) = state;
+            await using var conn = new SqlConnection(connectionString);
+            await conn.OpenAsync(ct).ConfigureAwait(false);
+
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText =
+                $"SELECT connection_string FROM {table} WHERE tenant_id = @id AND is_disabled = 0;";
+            cmd.Parameters.AddWithValue("@id", tenantId);
+
+            return await cmd.ExecuteScalarAsync(ct).ConfigureAwait(false) as string;
+        }, (_masterConnectionString, QualifiedTableName, tenantId), token).ConfigureAwait(false);
+    }
+
+    private async Task ExecuteByTenantAsync(string sql, string tenantId, CancellationToken token)
+    {
+        await _resilience.ExecuteAsync(static async (state, ct) =>
+        {
+            var (connectionString, sql, tenantId) = state;
+            await using var conn = new SqlConnection(connectionString);
+            await conn.OpenAsync(ct).ConfigureAwait(false);
+
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = sql;
+            cmd.Parameters.AddWithValue("@id", tenantId);
+            await cmd.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+        }, (_masterConnectionString, sql, tenantId), token).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    ///     Create the master tenant-registry table on first use. This is a one-time control-plane
+    ///     DDL operation (same documented exception as <c>DocumentTableEnsurer</c>) and is wrapped in
+    ///     the resilience pipeline.
+    /// </summary>
+    private async Task EnsureMasterTableAsync(CancellationToken token)
+    {
+        if (_masterTableEnsured) return;
+
+        await _ensureLock.WaitAsync(token).ConfigureAwait(false);
+        try
+        {
+            if (_masterTableEnsured) return;
+
+            await _resilience.ExecuteAsync(static async (state, ct) =>
+            {
+                var (connectionString, schema, table) = state;
+                await using var conn = new SqlConnection(connectionString);
+                await conn.OpenAsync(ct).ConfigureAwait(false);
+
+                await using var cmd = conn.CreateCommand();
+                cmd.CommandText = $"""
+                    IF SCHEMA_ID(@schema) IS NULL
+                        EXEC('CREATE SCHEMA [' + @schema + ']');
+                    IF OBJECT_ID(@qualified, 'U') IS NULL
+                        CREATE TABLE {table} (
+                            tenant_id NVARCHAR(200) NOT NULL CONSTRAINT pk_pc_tenants PRIMARY KEY,
+                            connection_string NVARCHAR(MAX) NOT NULL,
+                            is_disabled BIT NOT NULL CONSTRAINT df_pc_tenants_is_disabled DEFAULT 0
+                        );
+                    """;
+                cmd.Parameters.AddWithValue("@schema", schema);
+                cmd.Parameters.AddWithValue("@qualified", table);
+                await cmd.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+            }, (_masterConnectionString, _schemaName, QualifiedTableName), token).ConfigureAwait(false);
+
+            _masterTableEnsured = true;
+        }
+        finally
+        {
+            _ensureLock.Release();
+        }
+    }
+
+    private readonly record struct Entry(ConnectionFactory Factory, PolecatDatabase Database);
+}

--- a/src/Polecat/StoreOptions.cs
+++ b/src/Polecat/StoreOptions.cs
@@ -243,6 +243,25 @@ public class StoreOptions
     }
 
     /// <summary>
+    ///     Configure dynamic separate-database multi-tenancy backed by a master "control plane" table.
+    ///     The master table on <paramref name="masterConnectionString" /> maps each tenant id to its
+    ///     connection string, and tenants can be added/removed/enabled/disabled at runtime via the
+    ///     returned <see cref="MasterTableTenancy" />. This is the Polecat equivalent of Marten's
+    ///     <c>MultiTenantedDatabasesViaMasterTable</c>.
+    /// </summary>
+    /// <param name="masterConnectionString">Connection string to the control-plane database that holds the tenant registry.</param>
+    /// <param name="schemaName">Schema for the master table; defaults to <see cref="DatabaseSchemaName" />.</param>
+    /// <param name="configure">Optional hook to configure the tenancy before it is assigned.</param>
+    public MasterTableTenancy MultiTenantedMasterTable(string masterConnectionString,
+        string? schemaName = null, Action<MasterTableTenancy>? configure = null)
+    {
+        var tenancy = new MasterTableTenancy(this, masterConnectionString, schemaName ?? DatabaseSchemaName);
+        configure?.Invoke(tenancy);
+        Tenancy = tenancy;
+        return tenancy;
+    }
+
+    /// <summary>
     ///     Configure the serialization settings for the document store.
     /// </summary>
     public void ConfigureSerialization(


### PR DESCRIPTION
Adds a `MasterTableTenancy` to Polecat — the SQL Server equivalent of Marten's `MasterTableTenancy` — closing the dynamic multi-tenant management parity gap (issue #165). Unlike the existing static `SeparateDatabaseTenancy`, tenants can be added/removed/enabled/disabled **at runtime** without restarting the service.

## What

- **`MasterTableTenancy : ITenancy`** (`Cardinality => DatabaseCardinality.DynamicMultiple`) backed by a control-plane `pc_tenants` table (`tenant_id`, `connection_string`, `is_disabled`). The master table is created automatically on first use, and all access flows through `StoreOptions.ResiliencePipeline` per the project's resilience rule.
- **API parity with Marten:**
  - `AddDatabaseRecordAsync` — idempotent upsert that also re-enables a disabled tenant
  - `DeleteDatabaseRecordAsync` — removes the record (tenant DB untouched)
  - `EnableTenantAsync` / `DisableTenantAsync` — toggle without deleting
  - `AllDisabledAsync` — list disabled tenant ids
  - `BuildDatabasesAsync` — materialize all currently-enabled tenant databases
  - Unknown/disabled tenants raise `UnknownTenantIdException` on session open, like static separate-DB tenancy.
- **`StoreOptions.MultiTenantedMasterTable(masterConnectionString, schemaName?, configure?)`** registration helper that returns the tenancy.
- **Docs** recipe in `configuration/multitenancy.md`.

## Tests

7 integration tests (`master_table_tenancy_tests`): routing/isolation across databases, unknown-tenant rejection, enable/disable toggle, delete, `BuildDatabasesAsync` returning enabled-only, and idempotent re-add re-enabling. All green locally against SQL Server 2025.

Mirrors Marten's `MasterTableTenancy` behavior, adapted to Polecat's concrete `ITenancy`/`PolecatDatabase` surface (Polecat has no `IPolecatDatabase` interface). Auto-creation of the per-tenant database is intentionally left to the caller, matching Marten's reference implementation.

Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)