### PR TITLE
Upgrade JasperFx family 2.5.0 → 2.9.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,13 +5,13 @@
 
     <ItemGroup>
         <!-- Core dependencies -->
-        <!-- JasperFx 2.5.0 brings the store-agnostic per-tenant event partitioning
-             surface (ShardName tenant grammar, nullable ShardState.TenantId /
-             HighWaterStatistics.TenantId, tenant-aware JasperFxAsyncDaemon).
-             Polecat #163 consumes it in phases — Phase 0 surfaces the flag,
-             Phase 1/2 land the SQL Server side. -->
-        <PackageVersion Include="JasperFx" Version="2.5.0" />
-        <PackageVersion Include="JasperFx.Events" Version="2.5.0" />
+        <!-- JasperFx 2.9.0: released line carrying the store-agnostic per-tenant event
+             partitioning surface (ShardName tenant grammar, nullable ShardState.TenantId /
+             HighWaterStatistics.TenantId, tenant-aware JasperFxAsyncDaemon) plus
+             IEventStoreInstrumentation (jasperfx#424) for CritterWatch monitoring.
+             Consumed by Polecat #163 (partitioning) and #166 (instrumentation). -->
+        <PackageVersion Include="JasperFx" Version="2.9.0" />
+        <PackageVersion Include="JasperFx.Events" Version="2.9.0" />
         <!-- Pin the sibling JasperFx packages for parity with Marten 9's matrix
              even though Polecat doesn't currently reference them directly —
              keeps the lockstep matrix coherent when transitive resolution
@@ -19,7 +19,7 @@
              RuntimeCompiler 5.x line is the active continuation of the 4.x
              lineage; do not pin against the parallel stale 2.0.x series. -->
         <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.5.0" />
+        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.9.0" />
         <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
@@ -45,7 +45,7 @@
         <PackageVersion Include="StronglyTypedId" Version="1.0.0-beta08" />
 
         <!-- Source generators (matched to JasperFx.Events above) -->
-        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.5.0" />
+        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.9.0" />
 
         <!-- Build automation -->
         <PackageVersion Include="Nuke.Common" Version="9.0.4" />


### PR DESCRIPTION
Bumps the JasperFx package family from `2.5.0` to the released `2.9.0` line:

- `JasperFx` 2.5.0 → 2.9.0
- `JasperFx.Events` 2.5.0 → 2.9.0
- `JasperFx.SourceGenerator` 2.5.0 → 2.9.0
- `JasperFx.Events.SourceGenerator` 2.5.0 → 2.9.0

`JasperFx.RuntimeCompiler` stays on the 5.0.0 line; Weasel unchanged.

## Why

2.9.0 is the released line carrying:
- `IEventStoreInstrumentation` (jasperfx#424) — the storage-agnostic monitoring toggle surface needed by **#166**.
- The released per-tenant event partitioning surface (`SupportsTenantPartitioning`, `DetectForTenantsAsync`, tenant-aware daemon) needed by **#163**.

This is a prerequisite dependency bump for those two issues. No source changes were required — the solution builds clean (only pre-existing benign `CS8767` nullability warnings in test fixtures, which are not in the `WarningsAsErrors` set).

🤖 Generated with [Claude Code](https://claude.com/claude-code)