### PR TITLE
#166: expose IEventStoreInstrumentation for extended progression monitoring

### DIFF
--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -120,3 +120,39 @@ await store.Advanced.CleanAllEventDataAsync();
 ::: warning
 These cleanup methods permanently delete data. They are intended for testing and development, not production use.
 :::
+
+## Projection Daemon Monitoring
+
+### Extended Progression Tracking
+
+Polecat can extend its event-progression table (`pc_event_progression`) with additional
+columns that the asynchronous projection daemon uses to report per-shard health — the same
+surface monitoring tools such as **CritterWatch** read to show heartbeat liveness, agent
+status, pause reasons, and per-shard alert thresholds.
+
+Opt in via the event store options:
+
+```cs
+var store = DocumentStore.For(opts =>
+{
+    opts.Connection("...");
+    opts.Events.EnableExtendedProgressionTracking = true;
+});
+```
+
+When enabled, the next schema apply adds six nullable columns to `pc_event_progression`
+(`heartbeat`, `agent_status`, `pause_reason`, `running_on_node`, `warning_behind_threshold`,
+`critical_behind_threshold`); the daemon writes its runtime agent state to them, and they are
+read back into `JasperFx.Events.Projections.ShardState`. The default is `false`, in which case
+no extra columns are created.
+
+`StoreOptions.Events` also implements the storage-agnostic
+`JasperFx.Events.IEventStoreInstrumentation` interface, whose `ExtendedProgressionEnabled`
+property is an alias for `EnableExtendedProgressionTracking`. This lets store-agnostic tooling
+toggle the same monitoring fidelity across Marten and Polecat without referencing store-specific
+types:
+
+```cs
+IEventStoreInstrumentation instrumentation = store.Options.Events;
+instrumentation.ExtendedProgressionEnabled = true;
+```

--- a/src/Polecat.Tests/Events/event_store_instrumentation_tests.cs
+++ b/src/Polecat.Tests/Events/event_store_instrumentation_tests.cs
@@ -1,0 +1,175 @@
+using JasperFx;
+using JasperFx.Events;
+using Microsoft.Data.SqlClient;
+using Polecat.Events;
+using Polecat.Events.Daemon.Progress;
+using Polecat.Tests.Harness;
+using Polecat.TestUtils;
+using Weasel.SqlServer;
+
+namespace Polecat.Tests.Events;
+
+/// <summary>
+///     Covers issue #166 — Polecat's <see cref="IEventStoreInstrumentation" /> surface plus the
+///     6-column extended progression tracking it toggles (schema, daemon write, shard-state read,
+///     and opt-out).
+/// </summary>
+public class event_store_instrumentation_tests : IAsyncLifetime
+{
+    private const string OnSchema = "instr_on";
+    private const string OffSchema = "instr_off";
+
+    private static readonly string[] ExtendedColumns =
+    [
+        "heartbeat", "agent_status", "pause_reason", "running_on_node",
+        "warning_behind_threshold", "critical_behind_threshold"
+    ];
+
+    public async Task InitializeAsync()
+    {
+        await DropSchemaTablesAsync(OnSchema);
+        await DropSchemaTablesAsync(OffSchema);
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    private static DocumentStore CreateStore(string schema, bool extended)
+    {
+        return DocumentStore.For(opts =>
+        {
+            opts.ConnectionString = ConnectionSource.ConnectionString;
+            opts.DatabaseSchemaName = schema;
+            opts.AutoCreateSchemaObjects = AutoCreate.All;
+            opts.UseNativeJsonType = ConnectionSource.SupportsNativeJson;
+            opts.Events.EnableExtendedProgressionTracking = extended;
+        });
+    }
+
+    [Fact]
+    public void events_options_implement_instrumentation_and_toggle_is_shared()
+    {
+        var options = new StoreOptions();
+
+        // The .Events options surface is the IEventStoreInstrumentation, mirroring how Marten
+        // exposes it via EventGraph on StoreOptions.Events.
+        options.Events.ShouldBeAssignableTo<IEventStoreInstrumentation>();
+
+        var instrumentation = (IEventStoreInstrumentation)options.Events;
+
+        // Default is opt-out.
+        instrumentation.ExtendedProgressionEnabled.ShouldBeFalse();
+        options.Events.EnableExtendedProgressionTracking.ShouldBeFalse();
+
+        // Setting through the storage-agnostic interface flips the Polecat-named flag...
+        instrumentation.ExtendedProgressionEnabled = true;
+        options.Events.EnableExtendedProgressionTracking.ShouldBeTrue();
+
+        // ...and vice versa — they are one setting.
+        options.Events.EnableExtendedProgressionTracking = false;
+        instrumentation.ExtendedProgressionEnabled.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task enabling_adds_the_six_columns_on_schema_apply()
+    {
+        using var store = CreateStore(OnSchema, extended: true);
+        await store.Database.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        var columns = (await SchemaInspector.GetColumnInfoAsync("pc_event_progression", OnSchema))
+            .Select(c => c.Name).ToList();
+
+        foreach (var col in ExtendedColumns)
+        {
+            columns.ShouldContain(col);
+        }
+    }
+
+    [Fact]
+    public async Task opting_out_produces_no_schema_delta()
+    {
+        using var store = CreateStore(OffSchema, extended: false);
+        await store.Database.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        var columns = (await SchemaInspector.GetColumnInfoAsync("pc_event_progression", OffSchema))
+            .Select(c => c.Name).ToList();
+
+        // Base columns present...
+        columns.ShouldContain("name");
+        columns.ShouldContain("last_seq_id");
+        columns.ShouldContain("last_updated");
+
+        // ...but none of the extended monitoring columns.
+        foreach (var col in ExtendedColumns)
+        {
+            columns.ShouldNotContain(col);
+        }
+    }
+
+    [Fact]
+    public async Task daemon_write_is_read_back_into_shard_state()
+    {
+        using var store = CreateStore(OnSchema, extended: true);
+        await store.Database.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        var heartbeat = DateTimeOffset.UtcNow;
+
+        // Simulate the projection daemon writing its runtime agent state for a shard.
+        var op = new MarkExtendedProjectionProgress(
+            store.Database.Events,
+            shardName: "Instrumented:All",
+            sequenceCeiling: 42,
+            heartbeat: heartbeat,
+            agentStatus: "Running",
+            pauseReason: null,
+            runningOnNode: 7);
+
+        await ExecuteAsync(op);
+
+        // The shard-state selector reads the extended columns back into ShardState.
+        var all = await store.Database.AllProjectionProgress();
+        var state = all.ShouldHaveSingleItem();
+
+        state.ShardName.ShouldBe("Instrumented:All");
+        state.Sequence.ShouldBe(42);
+        state.AgentStatus.ShouldBe("Running");
+        state.RunningOnNode.ShouldBe(7);
+        state.LastHeartbeat.ShouldNotBeNull();
+    }
+
+    private static async Task ExecuteAsync(Internal.IStorageOperation op)
+    {
+        await using var conn = new SqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        await using var batch = new SqlBatch(conn);
+        var builder = new BatchBuilder(batch);
+        op.ConfigureCommand(builder);
+        builder.Compile();
+        await using var reader = await batch.ExecuteReaderAsync(CancellationToken.None);
+        await op.PostprocessAsync(reader, new List<Exception>(), CancellationToken.None);
+    }
+
+    private static async Task DropSchemaTablesAsync(string schema)
+    {
+        await using var conn = new SqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        // Drop every base table in the schema so each run migrates from a clean slate.
+        cmd.CommandText = $"""
+            DECLARE @sql nvarchar(max) = N'';
+            -- Drop foreign keys first so tables can be dropped in any order.
+            SELECT @sql = @sql + 'ALTER TABLE [' + s.name + '].[' + t.name + '] DROP CONSTRAINT [' + fk.name + '];'
+            FROM sys.foreign_keys fk
+            JOIN sys.tables t ON fk.parent_object_id = t.object_id
+            JOIN sys.schemas s ON t.schema_id = s.schema_id
+            WHERE s.name = @schema;
+
+            SELECT @sql = @sql + 'DROP TABLE [' + s.name + '].[' + t.name + '];'
+            FROM sys.tables t
+            JOIN sys.schemas s ON t.schema_id = s.schema_id
+            WHERE s.name = @schema;
+            EXEC sp_executesql @sql;
+            """;
+        cmd.Parameters.AddWithValue("@schema", schema);
+        await cmd.ExecuteNonQueryAsync();
+    }
+}

--- a/src/Polecat/StoreOptions.cs
+++ b/src/Polecat/StoreOptions.cs
@@ -315,7 +315,7 @@ public class StoreOptions
 /// <summary>
 ///     Configuration specific to the event store.
 /// </summary>
-public class EventStoreOptions
+public class EventStoreOptions : IEventStoreInstrumentation
 {
     internal EventGraph? EventGraph { get; set; }
 
@@ -354,9 +354,23 @@ public class EventStoreOptions
 
     /// <summary>
     ///     Opt into extended columns on the event progression table for CritterWatch alerting.
-    ///     Adds nullable heartbeat, agent_status, pause_reason, and running_on_node columns.
+    ///     Adds nullable heartbeat, agent_status, pause_reason, running_on_node,
+    ///     warning_behind_threshold, and critical_behind_threshold columns. This is the
+    ///     Polecat-named alias for <see cref="IEventStoreInstrumentation.ExtendedProgressionEnabled" />;
+    ///     both read and write the same setting.
     /// </summary>
     public bool EnableExtendedProgressionTracking { get; set; }
+
+    /// <summary>
+    ///     <see cref="JasperFx.Events.IEventStoreInstrumentation" /> surface (jasperfx#424). The
+    ///     storage-agnostic toggle CritterWatch uses to enable extended projection-daemon monitoring
+    ///     without referencing Polecat types. Backed by <see cref="EnableExtendedProgressionTracking" />.
+    /// </summary>
+    bool IEventStoreInstrumentation.ExtendedProgressionEnabled
+    {
+        get => EnableExtendedProgressionTracking;
+        set => EnableExtendedProgressionTracking = value;
+    }
 
     /// <summary>
     ///     Outbox factory the projection daemon asks for an


### PR DESCRIPTION
Implements `JasperFx.Events.IEventStoreInstrumentation` (jasperfx#424) on Polecat's event store options, closing issue #166. Depends on the JasperFx 2.9.0 upgrade (#169, merged) that introduced the interface.

## What

- **`EventStoreOptions` now implements `IEventStoreInstrumentation`.** Its `ExtendedProgressionEnabled` property is an explicit-interface alias for the existing `EnableExtendedProgressionTracking` flag — a single shared setting. `store.Options.Events is IEventStoreInstrumentation`, mirroring how Marten exposes it via `EventGraph` on `StoreOptions.Events`, so storage-agnostic tooling (CritterWatch) can toggle the same monitoring fidelity without referencing Polecat types.
- **Docs**: a "Projection Daemon Monitoring" section in `diagnostics.md`.

The 6-column extended-progression machinery already existed in Polecat and is unchanged:
- conditional schema columns in `EventProgressionTable` (`heartbeat`, `agent_status`, `pause_reason`, `running_on_node`, `warning_behind_threshold`, `critical_behind_threshold`),
- daemon runtime writes via `MarkExtendedProjectionProgress`,
- shard-state read in `PolecatDatabase.AllProjectionProgress`,
- opt-out gating in the progress merge/update operations.

This PR adds the standardized interface on top + tests.

## Tests (`event_store_instrumentation_tests`)

- interface toggle is shared with the flag (both directions),
- enabling adds the six columns on schema apply,
- opting out produces no schema delta,
- a simulated daemon write round-trips into `ShardState` (`AgentStatus`, `RunningOnNode`, `LastHeartbeat`).

All green locally against SQL Server 2025.

## Acceptance criteria

- [x] Polecat exposes `IEventStoreInstrumentation` on its options
- [x] `ExtendedProgressionEnabled = true` adds the 6 columns on next schema apply
- [x] default/`false` causes no schema delta
- [x] daemon writes the columns from runtime state
- [x] shard-state selector reads them into `ShardState`
- [x] integration tests covering schema migration, daemon write, shard-state read, opt-out

Closes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)