### PR TITLE
#163 Phase 1: per-tenant event sequencing (storage)

### DIFF
--- a/docs/events/multitenancy.md
+++ b/docs/events/multitenancy.md
@@ -63,3 +63,63 @@ With separate database tenancy:
 ## Default Tenant
 
 When no tenant ID is specified, events are stored with `tenant_id = 'DEFAULT'`. In single-tenant mode, all queries use this default value.
+
+## Per-Tenant Event Partitioning <Badge type="tip" text="4.2" />
+
+::: tip
+This is an advanced, opt-in option for large multi-tenanted event stores where a single shared
+event sequence becomes a scalability bottleneck. It builds on conjoined event tenancy by giving each
+tenant its own event numbering, so a tenant-scoped projection rebuild doesn't have to pay for a
+database-wide event-sequence scan. Tracked in
+[polecat#163](https://github.com/JasperFx/polecat/issues/163) /
+[CritterStack #209](https://github.com/JasperFx/CritterWatch/issues/209).
+:::
+
+By default every tenant shares the global `seq_id BIGINT IDENTITY` on `pc_events`. With
+**per-tenant event partitioning**, each tenant instead gets its own event sequence:
+
+```cs
+var store = DocumentStore.For(opts =>
+{
+    opts.Connection("...");
+
+    // Per-tenant partitioning builds on conjoined event tenancy
+    opts.Events.TenancyStyle = TenancyStyle.Conjoined;
+
+    // Opt into per-tenant event numbering
+    opts.EventGraph.UseTenantPartitionedEvents = true;
+});
+```
+
+When enabled, Polecat:
+
+* **Maintains a tenant registry** — `pc_tenant_partitions` maps each `tenant_id` to a compact
+  `partition_id`, populated the first time a tenant appends events.
+* **Gives each tenant its own sequence** — `seq_id` is drawn from a per-tenant
+  `pc_events_sequence_{partition_id}` object (created on demand) via `NEXT VALUE FOR`, rather than a
+  single global `IDENTITY`. `seq_id` is therefore unique only *within* a tenant, so the `pc_events`
+  primary key becomes composite `(tenant_id, seq_id)`.
+
+```cs
+// Each tenant's seq_id starts at 1 and advances independently
+await using var red = store.LightweightSession(new SessionOptions { TenantId = "Red" });
+red.Events.StartStream(redStream, new QuestStarted("Red"));   // Red seq_id 1
+await red.SaveChangesAsync();
+
+await using var blue = store.LightweightSession(new SessionOptions { TenantId = "Blue" });
+blue.Events.StartStream(blueStream, new QuestStarted("Blue")); // Blue seq_id 1 — independent
+await blue.SaveChangesAsync();
+```
+
+::: warning
+`UseTenantPartitionedEvents` defaults to `false`; existing stores keep the global `IDENTITY` append
+path byte-for-byte. The flag **requires** `TenancyStyle.Conjoined` (there is nothing to partition by
+otherwise) and is currently incompatible with `UseArchivedStreamPartitioning` — a SQL Server table
+supports only one partition scheme; both raise an error at store construction.
+
+This first phase delivers per-tenant **sequencing** (the bounded-scan win). The tenant-aware async
+daemon (per-tenant high-water + per-tenant rebuild) and physical per-tenant table partitioning land
+in follow-ups — [polecat#163](https://github.com/JasperFx/polecat/issues/163) and
+[polecat#171](https://github.com/JasperFx/polecat/issues/171). Until the daemon phase ships, treat
+the flag as experimental for asynchronous projections.
+:::

--- a/src/Polecat.Tests/Events/per_tenant_event_sequence_tests.cs
+++ b/src/Polecat.Tests/Events/per_tenant_event_sequence_tests.cs
@@ -1,0 +1,242 @@
+using JasperFx;
+using JasperFx.Events;
+using Microsoft.Data.SqlClient;
+using Polecat.Tests.Harness;
+using Polecat.TestUtils;
+
+namespace Polecat.Tests.Events;
+
+/// <summary>
+///     Covers #163 Phase 1 — per-tenant event sequencing (UseTenantPartitionedEvents): config guards,
+///     the pc_tenant_partitions registry + per-tenant pc_events_sequence objects, per-tenant sequence
+///     isolation, append/read round-trip under the flag, and off-flag regression.
+/// </summary>
+public class per_tenant_event_sequence_tests : IAsyncLifetime
+{
+    private const string PartitionedSchema = "pt_on";
+    private const string DefaultSchema = "pt_off";
+
+    public async Task InitializeAsync()
+    {
+        await DropSchemaTablesAsync(PartitionedSchema);
+        await DropSchemaTablesAsync(DefaultSchema);
+        await DropSequencesAsync(PartitionedSchema);
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    private static DocumentStore CreatePartitionedStore(string schema = PartitionedSchema)
+    {
+        return DocumentStore.For(opts =>
+        {
+            opts.ConnectionString = ConnectionSource.ConnectionString;
+            opts.DatabaseSchemaName = schema;
+            opts.AutoCreateSchemaObjects = AutoCreate.All;
+            opts.UseNativeJsonType = ConnectionSource.SupportsNativeJson;
+            opts.Events.TenancyStyle = TenancyStyle.Conjoined;
+            opts.EventGraph.UseTenantPartitionedEvents = true;
+        });
+    }
+
+    [Fact]
+    public void requires_conjoined_tenancy()
+    {
+        var ex = Should.Throw<InvalidOperationException>(() => DocumentStore.For(opts =>
+        {
+            opts.ConnectionString = ConnectionSource.ConnectionString;
+            // TenancyStyle left at the default (Single)
+            opts.EventGraph.UseTenantPartitionedEvents = true;
+        }));
+
+        ex.Message.ShouldContain("Conjoined");
+    }
+
+    [Fact]
+    public void incompatible_with_archived_stream_partitioning()
+    {
+        var ex = Should.Throw<InvalidOperationException>(() => DocumentStore.For(opts =>
+        {
+            opts.ConnectionString = ConnectionSource.ConnectionString;
+            opts.Events.TenancyStyle = TenancyStyle.Conjoined;
+            opts.EventGraph.UseTenantPartitionedEvents = true;
+            opts.EventGraph.UseArchivedStreamPartitioning = true;
+        }));
+
+        ex.Message.ShouldContain("UseArchivedStreamPartitioning");
+    }
+
+    [Fact]
+    public async Task off_flag_keeps_identity_and_creates_no_registry_table()
+    {
+        using var store = DocumentStore.For(opts =>
+        {
+            opts.ConnectionString = ConnectionSource.ConnectionString;
+            opts.DatabaseSchemaName = DefaultSchema;
+            opts.AutoCreateSchemaObjects = AutoCreate.All;
+            opts.UseNativeJsonType = ConnectionSource.SupportsNativeJson;
+            opts.Events.TenancyStyle = TenancyStyle.Conjoined;
+            // UseTenantPartitionedEvents left false
+        });
+        await store.Database.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        // seq_id stays a global IDENTITY column...
+        (await IsIdentityAsync(DefaultSchema, "pc_events", "seq_id")).ShouldBeTrue();
+        // ...and no per-tenant registry table is created.
+        (await TableExistsAsync(DefaultSchema, "pc_tenant_partitions")).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task enabling_drops_identity_and_creates_registry_table()
+    {
+        using var store = CreatePartitionedStore();
+        await store.Database.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        (await IsIdentityAsync(PartitionedSchema, "pc_events", "seq_id")).ShouldBeFalse();
+        (await TableExistsAsync(PartitionedSchema, "pc_tenant_partitions")).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task per_tenant_sequences_are_isolated()
+    {
+        using var store = CreatePartitionedStore();
+        await store.Database.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        var redStream = Guid.NewGuid();
+        var blueStream = Guid.NewGuid();
+
+        // Tenant Red: 2 events.
+        await using (var red = store.LightweightSession(new SessionOptions { TenantId = "Red" }))
+        {
+            red.Events.StartStream(redStream,
+                new QuestStarted("Red Quest"),
+                new MembersJoined(1, "Red Town", ["RedHero"]));
+            await red.SaveChangesAsync();
+        }
+
+        // Tenant Blue: 3 events.
+        await using (var blue = store.LightweightSession(new SessionOptions { TenantId = "Blue" }))
+        {
+            blue.Events.StartStream(blueStream,
+                new QuestStarted("Blue Quest"),
+                new MembersJoined(1, "Blue Town", ["BlueHero"]),
+                new MonsterSlain("Grendel", 10));
+            await blue.SaveChangesAsync();
+        }
+
+        // The registry assigned a distinct partition id to each tenant.
+        var partitionIds = await QueryAsync(
+            $"SELECT tenant_id, partition_id FROM [{PartitionedSchema}].[pc_tenant_partitions] ORDER BY tenant_id");
+        partitionIds.Count.ShouldBe(2);
+        partitionIds.Select(r => r[1]).Distinct().Count().ShouldBe(2);
+
+        // Each tenant has its OWN sequence starting at 1 — so seq_ids overlap across tenants, which is
+        // exactly the per-tenant sequencing guarantee (and impossible under a single global IDENTITY).
+        var redSeqs = await SeqIdsForTenantAsync("Red");
+        var blueSeqs = await SeqIdsForTenantAsync("Blue");
+
+        redSeqs.ShouldBe(new long[] { 1, 2 });
+        blueSeqs.ShouldBe(new long[] { 1, 2, 3 });
+
+        // Round-trip: each tenant reads its own stream; cross-tenant is invisible.
+        await using var redQuery = store.QuerySession(new SessionOptions { TenantId = "Red" });
+        (await redQuery.Events.FetchStreamAsync(redStream)).Count.ShouldBe(2);
+        (await redQuery.Events.FetchStreamAsync(blueStream)).Count.ShouldBe(0);
+
+        await using var blueQuery = store.QuerySession(new SessionOptions { TenantId = "Blue" });
+        (await blueQuery.Events.FetchStreamAsync(blueStream)).Count.ShouldBe(3);
+    }
+
+    private static async Task<long[]> SeqIdsForTenantAsync(string tenantId)
+    {
+        await using var conn = new SqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText =
+            $"SELECT seq_id FROM [{PartitionedSchema}].[pc_events] WHERE tenant_id = @t ORDER BY seq_id";
+        cmd.Parameters.AddWithValue("@t", tenantId);
+        var list = new List<long>();
+        await using var reader = await cmd.ExecuteReaderAsync();
+        while (await reader.ReadAsync()) list.Add(reader.GetInt64(0));
+        return list.ToArray();
+    }
+
+    private static async Task<bool> IsIdentityAsync(string schema, string table, string column)
+    {
+        await using var conn = new SqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText =
+            $"SELECT COLUMNPROPERTY(OBJECT_ID('[{schema}].[{table}]'), @col, 'IsIdentity')";
+        cmd.Parameters.AddWithValue("@col", column);
+        var result = await cmd.ExecuteScalarAsync();
+        return result is int i && i == 1;
+    }
+
+    private static async Task<bool> TableExistsAsync(string schema, string table)
+    {
+        await using var conn = new SqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = "SELECT OBJECT_ID(@name, 'U')";
+        cmd.Parameters.AddWithValue("@name", $"[{schema}].[{table}]");
+        var result = await cmd.ExecuteScalarAsync();
+        return result is not (null or DBNull);
+    }
+
+    private static async Task<List<object[]>> QueryAsync(string sql)
+    {
+        await using var conn = new SqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = sql;
+        var rows = new List<object[]>();
+        await using var reader = await cmd.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            var values = new object[reader.FieldCount];
+            reader.GetValues(values);
+            rows.Add(values);
+        }
+        return rows;
+    }
+
+    private static async Task DropSchemaTablesAsync(string schema)
+    {
+        await using var conn = new SqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = """
+            DECLARE @sql nvarchar(max) = N'';
+            SELECT @sql = @sql + 'ALTER TABLE [' + s.name + '].[' + t.name + '] DROP CONSTRAINT [' + fk.name + '];'
+            FROM sys.foreign_keys fk
+            JOIN sys.tables t ON fk.parent_object_id = t.object_id
+            JOIN sys.schemas s ON t.schema_id = s.schema_id
+            WHERE s.name = @schema;
+
+            SELECT @sql = @sql + 'DROP TABLE [' + s.name + '].[' + t.name + '];'
+            FROM sys.tables t
+            JOIN sys.schemas s ON t.schema_id = s.schema_id
+            WHERE s.name = @schema;
+            EXEC sp_executesql @sql;
+            """;
+        cmd.Parameters.AddWithValue("@schema", schema);
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    private static async Task DropSequencesAsync(string schema)
+    {
+        await using var conn = new SqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = """
+            DECLARE @sql nvarchar(max) = N'';
+            SELECT @sql = @sql + 'DROP SEQUENCE [' + s.name + '].[' + sq.name + '];'
+            FROM sys.sequences sq
+            JOIN sys.schemas s ON sq.schema_id = s.schema_id
+            WHERE s.name = @schema;
+            EXEC sp_executesql @sql;
+            """;
+        cmd.Parameters.AddWithValue("@schema", schema);
+        await cmd.ExecuteNonQueryAsync();
+    }
+}

--- a/src/Polecat/DocumentStore.cs
+++ b/src/Polecat/DocumentStore.cs
@@ -49,6 +49,9 @@ public partial class DocumentStore : IDocumentStore
         // Auto-discover aggregate types with source-generated evolvers
         options.Projections.DiscoverGeneratedEvolvers(AppDomain.CurrentDomain.GetAssemblies());
 
+        // Fail fast on an incoherent per-tenant partitioning configuration (#163 Phase 1).
+        options.EventGraph.AssertTenantPartitioningValidity();
+
         // Initialize projection graph - builds async shard registry
         options.Projections.AssertValidity(options);
 

--- a/src/Polecat/Events/EventGraph.cs
+++ b/src/Polecat/Events/EventGraph.cs
@@ -124,6 +124,44 @@ public class EventGraph : EventRegistry, IAggregationSourceFactory<IQuerySession
     internal string StreamsTableName => $"[{DatabaseSchemaName}].[pc_streams]";
     internal string EventsTableName => $"[{DatabaseSchemaName}].[pc_events]";
     internal string ProgressionTableName => $"[{DatabaseSchemaName}].[pc_event_progression]";
+    internal string TenantPartitionsTableName => $"[{DatabaseSchemaName}].[pc_tenant_partitions]";
+
+    private TenantEventSequenceRegistry? _tenantSequences;
+
+    /// <summary>
+    ///     Resolves (and lazily provisions) per-tenant event sequences when
+    ///     <see cref="UseTenantPartitionedEvents" /> is enabled. Conjoined tenancy is a precondition,
+    ///     so all tenants share the one configured connection.
+    /// </summary>
+    internal TenantEventSequenceRegistry TenantSequences =>
+        _tenantSequences ??= new TenantEventSequenceRegistry(
+            _options.ConnectionString, DatabaseSchemaName, _options.ResiliencePipeline);
+
+    /// <summary>
+    ///     Validate the per-tenant partitioning configuration (#163 Phase 1). Per-tenant event
+    ///     sequencing only makes sense with conjoined event tenancy (there must be a tenant to slice
+    ///     by), and Phase 1 does not yet combine it with the physical <c>is_archived</c> partitioning
+    ///     scheme (a SQL Server table can carry only one partition scheme — tracked by polecat#171).
+    /// </summary>
+    internal void AssertTenantPartitioningValidity()
+    {
+        if (!UseTenantPartitionedEvents) return;
+
+        if (TenancyStyle != TenancyStyle.Conjoined)
+        {
+            throw new InvalidOperationException(
+                "Events.UseTenantPartitionedEvents requires Events.TenancyStyle = TenancyStyle.Conjoined " +
+                "— there is nothing to partition by when every event lives in the default tenant.");
+        }
+
+        if (UseArchivedStreamPartitioning)
+        {
+            throw new InvalidOperationException(
+                "Events.UseTenantPartitionedEvents cannot currently be combined with " +
+                "Events.UseArchivedStreamPartitioning — a SQL Server table supports only one partition " +
+                "scheme. Physical per-tenant partitioning is tracked separately in polecat#171.");
+        }
+    }
 
     public override EventAppendMode AppendMode
     {
@@ -223,6 +261,11 @@ public class EventGraph : EventRegistry, IAggregationSourceFactory<IQuerySession
     internal EventProgressionTable BuildEventProgressionTable()
     {
         return new EventProgressionTable(this);
+    }
+
+    internal TenantPartitionsTable BuildTenantPartitionsTable()
+    {
+        return new TenantPartitionsTable(this);
     }
 
     public ITagTypeRegistration RegisterTagType<TTag>() where TTag : notnull

--- a/src/Polecat/Events/Schema/EventStoreFeatureSchema.cs
+++ b/src/Polecat/Events/Schema/EventStoreFeatureSchema.cs
@@ -34,6 +34,14 @@ internal class EventStoreFeatureSchema : FeatureSchemaBase
         yield return _events.BuildEventsTable();
         yield return _events.BuildEventProgressionTable();
 
+        // Per-tenant partitioning registry (#163 Phase 1). Only materialized when the feature is on,
+        // so off-flag stores see no schema delta. The per-tenant pc_events_sequence_{id} objects are
+        // created on demand at first append (TenantEventSequenceRegistry), not here.
+        if (_events.UseTenantPartitionedEvents)
+        {
+            yield return _events.BuildTenantPartitionsTable();
+        }
+
         // Tag tables for DCB support
         foreach (var tagRegistration in _events.TagTypes)
         {

--- a/src/Polecat/Events/Schema/EventsTable.cs
+++ b/src/Polecat/Events/Schema/EventsTable.cs
@@ -15,8 +15,19 @@ internal class EventsTable : Table
     public EventsTable(EventGraph events)
         : base(new SqlServerObjectName(events.DatabaseSchemaName, TableName))
     {
-        // Global sequence — auto-incrementing primary key
-        AddColumn("seq_id", "bigint").AsPrimaryKey().AutoNumber();
+        // Event position. By default a global auto-incrementing IDENTITY primary key. When per-tenant
+        // partitioning is enabled (#163 Phase 1) seq_id is instead supplied from that tenant's
+        // pc_events_sequence_{id} (NEXT VALUE FOR in the append path), so it is no longer IDENTITY and
+        // no longer globally unique — the primary key becomes composite (tenant_id, seq_id) below.
+        var seqColumn = AddColumn("seq_id", "bigint");
+        if (events.UseTenantPartitionedEvents)
+        {
+            seqColumn.NotNull().AsPrimaryKey();
+        }
+        else
+        {
+            seqColumn.AsPrimaryKey().AutoNumber();
+        }
 
         // Event identity
         AddColumn("id", "uniqueidentifier").NotNull();
@@ -42,9 +53,16 @@ internal class EventsTable : Table
             .DefaultValueByExpression("SYSDATETIMEOFFSET()");
 
         // Tenant id
-        AddColumn(JasperFx.StorageConstants.TenantIdColumn, "varchar(250)")
+        var tenantColumn = AddColumn(JasperFx.StorageConstants.TenantIdColumn, "varchar(250)")
             .NotNull()
             .DefaultValueByString(JasperFx.StorageConstants.DefaultTenantId);
+
+        // Per-tenant partitioning makes seq_id unique only within a tenant, so the tenant id joins the
+        // primary key to keep (tenant_id, seq_id) globally unique.
+        if (events.UseTenantPartitionedEvents)
+        {
+            tenantColumn.AsPrimaryKey();
+        }
 
         // .NET type for deserialization
         AddColumn("dotnet_type", "varchar(500)").AllowNulls();

--- a/src/Polecat/Events/Schema/TenantEventSequenceRegistry.cs
+++ b/src/Polecat/Events/Schema/TenantEventSequenceRegistry.cs
@@ -1,0 +1,87 @@
+using System.Collections.Concurrent;
+using Microsoft.Data.SqlClient;
+using Polly;
+
+namespace Polecat.Events.Schema;
+
+/// <summary>
+///     Resolves (and lazily provisions) the per-tenant event sequence used by the append path when
+///     <see cref="EventGraph.UseTenantPartitionedEvents" /> is enabled (#163 Phase 1).
+///
+///     The first time a tenant appends events, this registers the tenant in
+///     <see cref="TenantPartitionsTable" /> (assigning a compact <c>partition_id</c>) and creates the
+///     tenant's <c>pc_events_sequence_{partition_id}</c> SEQUENCE object. Subsequent appends hit the
+///     in-memory cache. The provisioning step is its own short transaction (idempotent, serialized per
+///     tenant via <c>sp_getapplock</c>) so it never depends on, or rolls back with, the caller's append
+///     transaction — and it runs entirely through the store's resilience pipeline per the project's
+///     "all command execution goes through ResiliencePipeline" rule.
+/// </summary>
+internal sealed class TenantEventSequenceRegistry
+{
+    private readonly string _connectionString;
+    private readonly string _schemaName;
+    private readonly ResiliencePipeline _resilience;
+    private readonly ConcurrentDictionary<string, string> _cache = new(StringComparer.Ordinal);
+
+    public TenantEventSequenceRegistry(string connectionString, string schemaName, ResiliencePipeline resilience)
+    {
+        _connectionString = connectionString;
+        _schemaName = schemaName;
+        _resilience = resilience;
+    }
+
+    /// <summary>
+    ///     Returns the fully-qualified per-tenant sequence name (e.g. <c>[dbo].[pc_events_sequence_3]</c>),
+    ///     provisioning the registry row and sequence object on first use for the tenant.
+    /// </summary>
+    public async ValueTask<string> ResolveSequenceNameAsync(string tenantId, CancellationToken token)
+    {
+        if (_cache.TryGetValue(tenantId, out var cached)) return cached;
+
+        var partitionId = await _resilience.ExecuteAsync(static async (state, ct) =>
+        {
+            var (connectionString, schema, tenantId) = state;
+
+            await using var conn = new SqlConnection(connectionString);
+            await conn.OpenAsync(ct).ConfigureAwait(false);
+
+            await using var cmd = conn.CreateCommand();
+            // Serialize per-tenant so concurrent first-appends don't race on the INSERT / CREATE SEQUENCE.
+            cmd.CommandText = $"""
+                SET NOCOUNT ON;
+                DECLARE @pid int;
+                BEGIN TRANSACTION;
+                EXEC sp_getapplock @Resource = @lock, @LockMode = 'Exclusive', @LockOwner = 'Transaction';
+
+                MERGE [{schema}].[pc_tenant_partitions] WITH (HOLDLOCK) AS target
+                USING (SELECT @tenant AS tenant_id) AS source ON target.tenant_id = source.tenant_id
+                WHEN NOT MATCHED THEN INSERT (tenant_id) VALUES (@tenant);
+
+                SELECT @pid = partition_id FROM [{schema}].[pc_tenant_partitions] WHERE tenant_id = @tenant;
+
+                DECLARE @seq sysname = N'pc_events_sequence_' + CAST(@pid AS varchar(20));
+                IF NOT EXISTS (
+                    SELECT 1 FROM sys.sequences sq
+                    JOIN sys.schemas sc ON sq.schema_id = sc.schema_id
+                    WHERE sq.name = @seq AND sc.name = @schema)
+                BEGIN
+                    DECLARE @ddl nvarchar(max) =
+                        N'CREATE SEQUENCE [' + @schema + N'].[' + @seq + N'] AS bigint START WITH 1 INCREMENT BY 1;';
+                    EXEC sp_executesql @ddl;
+                END
+
+                COMMIT TRANSACTION;
+                SELECT @pid;
+                """;
+            cmd.Parameters.AddWithValue("@tenant", tenantId);
+            cmd.Parameters.AddWithValue("@schema", schema);
+            cmd.Parameters.AddWithValue("@lock", $"pc_tenant_partition_{tenantId}");
+
+            var result = await cmd.ExecuteScalarAsync(ct).ConfigureAwait(false);
+            return Convert.ToInt32(result);
+        }, (_connectionString, _schemaName, tenantId), token).ConfigureAwait(false);
+
+        var sequenceName = $"[{_schemaName}].[pc_events_sequence_{partitionId}]";
+        return _cache.GetOrAdd(tenantId, sequenceName);
+    }
+}

--- a/src/Polecat/Events/Schema/TenantPartitionsTable.cs
+++ b/src/Polecat/Events/Schema/TenantPartitionsTable.cs
@@ -1,0 +1,35 @@
+using Weasel.SqlServer;
+using Weasel.SqlServer.Tables;
+
+namespace Polecat.Events.Schema;
+
+/// <summary>
+///     Registry mapping each tenant id to a compact integer partition id, used to name that tenant's
+///     per-tenant event sequence (<c>pc_events_sequence_{partition_id}</c>). Only created when
+///     <see cref="EventGraph.UseTenantPartitionedEvents" /> is enabled (#163 Phase 1). The per-tenant
+///     sequence objects themselves are created on demand the first time a tenant appends events.
+/// </summary>
+internal class TenantPartitionsTable : Table
+{
+    public const string TableName = "pc_tenant_partitions";
+
+    public TenantPartitionsTable(EventGraph eventGraph)
+        : base(new SqlServerObjectName(eventGraph.DatabaseSchemaName, TableName))
+    {
+        AddColumn("tenant_id", "varchar(250)").AsPrimaryKey().NotNull();
+
+        // Compact, stable per-tenant ordinal assigned on first append. IDENTITY keeps allocation
+        // server-side and contention-free; the value names the tenant's pc_events_sequence_{id}.
+        AddColumn("partition_id", "int").NotNull().AutoNumber();
+
+        AddColumn("created", "datetimeoffset")
+            .NotNull()
+            .DefaultValueByExpression("SYSDATETIMEOFFSET()");
+
+        Indexes.Add(new IndexDefinition("ix_pc_tenant_partitions_partition_id")
+        {
+            IsUnique = true,
+            Columns = ["partition_id"]
+        });
+    }
+}

--- a/src/Polecat/Internal/DocumentSessionBase.cs
+++ b/src/Polecat/Internal/DocumentSessionBase.cs
@@ -742,6 +742,18 @@ internal abstract class DocumentSessionBase : QuerySession, IDocumentSession
         var columns = "id, stream_id, version, data, type, timestamp, tenant_id, dotnet_type";
         var values = "@id, @stream_id, @version, @data, @type, SYSDATETIMEOFFSET(), @tenant_id, @dotnet_type";
 
+        // Per-tenant partitioning (#163 Phase 1): seq_id is no longer a global IDENTITY — it is drawn
+        // from this tenant's own pc_events_sequence_{id} (provisioned on first use). Off-flag this whole
+        // block is skipped and seq_id keeps its IDENTITY default, leaving the append path byte-for-byte.
+        if (_eventGraph.UseTenantPartitionedEvents)
+        {
+            var eventTenantId = @event.TenantId ?? TenantId;
+            var sequenceName = await _eventGraph.TenantSequences
+                .ResolveSequenceNameAsync(eventTenantId, token);
+            columns = "seq_id, " + columns;
+            values = $"NEXT VALUE FOR {sequenceName}, " + values;
+        }
+
         if (eventOptions.EnableCorrelationId)
         {
             columns += ", correlation_id";


### PR DESCRIPTION
Implements **Phase 1 (storage)** of per-tenant event partitioning — JasperFx/polecat#163, the SQL Server track of CritterWatch #209. Scoped per the maintainer's call: per-tenant **sequencing** now (the bounded-scan win), physical partitioning and the tenant-aware daemon as follow-ups.

## What

Everything is gated behind `EventGraph.UseTenantPartitionedEvents` (default `false` → the global `IDENTITY` append path is unchanged byte-for-byte).

When enabled (requires conjoined event tenancy):

- **`pc_tenant_partitions` registry** — maps each `tenant_id` to a compact `partition_id`. Created through the event store's Weasel feature schema, and only materialized when the flag is on (off-flag stores see no schema delta).
- **Per-tenant `pc_events_sequence_{partition_id}`** — provisioned on demand the first time a tenant appends, by `TenantEventSequenceRegistry`: idempotent, serialized per tenant via `sp_getapplock`, in its own short transaction (so it never rolls back with the caller's append tx), entirely through the store's `ResiliencePipeline`, cached after first use.
- **Append path** draws `seq_id` from the tenant's sequence via `NEXT VALUE FOR` instead of a global `IDENTITY`. Because `seq_id` is now unique only *within* a tenant, the `pc_events` primary key becomes composite `(tenant_id, seq_id)`.
- **Config guards** fail fast at store construction: `UseTenantPartitionedEvents` requires `TenancyStyle.Conjoined`, and is incompatible with `UseArchivedStreamPartitioning` (a SQL Server table supports only one partition scheme).

## Deferred (follow-ups)

- **Physical per-tenant table partitioning** → JasperFx/polecat#171, blocked on a managed per-tenant partitioning API in Weasel.SqlServer → **JasperFx/weasel#301** (Weasel.SqlServer only ships static `RangePartitioning`; it has no `ManagedListPartitions` equivalent).
- **Tenant-aware async daemon** (per-tenant high-water + per-tenant rebuild) → #163 Phase 2. Until then, treat the flag as experimental for async projections.

## Tests (`per_tenant_event_sequence_tests`)

- conjoined-tenancy guard, archived-partitioning incompatibility guard,
- off-flag regression (seq_id stays IDENTITY; no registry table),
- flag-on schema shape (seq_id non-identity; registry table present),
- per-tenant sequence isolation (Red `{1,2}` / Blue `{1,2,3}` — overlapping seq_ids prove independent sequences) + append/read round-trip with cross-tenant isolation.

All green locally; the off-flag regression subset (86 existing event/daemon tests) also passes unchanged.

Refs #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)