### PR TITLE
docs: multi-tenancy strategy overview for the new tenancy options

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -61,7 +61,7 @@ const config: UserConfig<DefaultTheme.Config> = {
             { text: 'Configuring Document Storage', link: '/configuration/storeoptions' },
             { text: 'JSON Serialization', link: '/configuration/json' },
             { text: 'Resiliency Policies', link: '/configuration/retries' },
-            { text: 'Multi-Tenancy with Database per Tenant', link: '/configuration/multitenancy' },
+            { text: 'Multi-Tenancy', link: '/configuration/multitenancy' },
             { text: 'MCP Server', link: '/configuration/mcp' },
             { text: 'Aspire Dashboard Commands', link: '/configuration/aspire-commands' },
           ]

--- a/docs/configuration/multitenancy.md
+++ b/docs/configuration/multitenancy.md
@@ -1,6 +1,24 @@
-# Multi-Tenancy with Database per Tenant
+# Multi-Tenancy
 
-Polecat supports multiple multi-tenancy strategies for isolating data between tenants.
+Polecat supports several multi-tenancy strategies for isolating data between tenants — from a single
+shared table to a database per tenant. They differ in **where** a tenant's data lives, **how** the
+tenant set is managed, and **how** the async projection daemon scales.
+
+## Choosing a Tenancy Strategy
+
+| Strategy | Isolation | Tenant set | Best for |
+| --- | --- | --- | --- |
+| [Single tenant](#single-tenant-default) | None (shared tables) | n/a | Single-tenant apps |
+| [Conjoined](#conjoined-tenancy) | `tenant_id` column, shared tables | Open (any id) | Many tenants, shared schema, simplest ops |
+| [Separate database (static)](#separate-database-tenancy) | One database per tenant | Fixed at startup (`AddTenant`) | Strong isolation, known tenant list |
+| [Master-table (dynamic)](#dynamic-tenant-management-master-table-tenancy) | One database per tenant | Managed at runtime via a control table | Strong isolation + add/remove/enable/disable tenants without a restart |
+| [Per-tenant event partitioning](/events/multitenancy#per-tenant-event-partitioning) | Conjoined + per-tenant event sequence | Open (any id) | Very large multi-tenant **event** stores needing bounded, isolated per-tenant projection rebuilds |
+
+Conjoined and the two separate-database strategies are mutually exclusive choices for **where data
+lives**. Per-tenant event partitioning is an **opt-in optimization layered on conjoined event
+tenancy** — see [Per-Tenant Event Partitioning](/events/multitenancy#per-tenant-event-partitioning).
+For event-store specifics (tenanted streams, the default tenant), see
+[Event Multi-Tenancy](/events/multitenancy).
 
 ## Tenancy Styles
 


### PR DESCRIPTION
Follow-up on the multi-tenancy work (#165 MasterTableTenancy, #163 per-tenant event partitioning) — adds coherent entry-point documentation tying all the tenancy options together.

## What

- A **"Choosing a Tenancy Strategy"** comparison table at the top of `configuration/multitenancy.md` covering every strategy (single, conjoined, separate-database static, master-table dynamic, and per-tenant event partitioning), with isolation/tenant-set/best-for columns and links to each section.
- Generalizes the page H1 + sidebar label from "Multi-Tenancy with Database per Tenant" to "Multi-Tenancy", since the page now documents conjoined and dynamic options too.

Complements the per-strategy docs already added with #165 (Master Table) and #163 (per-tenant partitioning + tenant-aware daemon). Docs-only; `docs.yml` is `workflow_dispatch`-only so this doesn't gate on the deploy job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)