### PR TITLE
Fix flaky async-daemon catch-up test (treat shutdown-cancelled loads as benign)

### DIFF
--- a/src/Polecat/Events/Daemon/PolecatEventLoader.cs
+++ b/src/Polecat/Events/Daemon/PolecatEventLoader.cs
@@ -50,6 +50,24 @@ internal class PolecatEventLoader : IEventLoader
 
     public async Task<EventPage> LoadAsync(EventRequest request, CancellationToken token)
     {
+        try
+        {
+            return await LoadInternalAsync(request, token);
+        }
+        catch (Exception ex) when (token.IsCancellationRequested && ex is not OperationCanceledException)
+        {
+            // The daemon cancelled this load mid-flight — e.g. shutting the shard down after a
+            // CatchUpAsync reaches the high-water mark. SqlClient surfaces that cancellation as a
+            // SqlException ("Operation cancelled by user" / "the batch is aborted ... the session is
+            // busy") rather than a clean OperationCanceledException, and the async daemon's recorder
+            // would otherwise treat it as a real shard error. Translate it to a cooperative
+            // cancellation so the daemon ignores it as the benign shutdown it is.
+            throw new OperationCanceledException("Event loading was cancelled.", ex, token);
+        }
+    }
+
+    private async Task<EventPage> LoadInternalAsync(EventRequest request, CancellationToken token)
+    {
         var page = new EventPage(request.Floor);
 
         await using var conn = new SqlConnection(_connectionString);


### PR DESCRIPTION
Fixes the intermittent failure of `time_based_multi_stream_projection_tests.monthly_projection_works_with_async_daemon` (the flake that gated the docs PR #174 on the Azure SQL Edge runner).

## Root cause

When `CatchUpAsync` reaches the high-water mark it stops the shard, cancelling its in-flight event load. SqlClient surfaces that cancellation as a **`SqlException`** ("Operation cancelled by user" / "the batch is aborted … the session is busy") rather than a clean `OperationCanceledException`. The async daemon's recorder treats a clean cancellation as benign but logs the raw `SqlException` as a real shard error, so `CatchUpAsync` rethrew it. It's timing-sensitive — more likely on the slower edge container, and **pre-existing** (reproduces on the pre-#163 commit).

## Fix

`PolecatEventLoader.LoadAsync` now wraps the load; when the cancellation token is signalled it translates any non-`OperationCanceledException` into an `OperationCanceledException(…, token)` so the daemon treats it as the benign shutdown it is. The load body is moved verbatim into a private `LoadInternalAsync` — **the non-cancelled path is byte-for-byte identical**, so normal loading is unaffected.

## Verification

Locally against SQL Server 2025, running the affected test class repeatedly:
- **before:** 3/5 runs failed
- **after:** 0/8 runs failed

Daemon + projections suites otherwise green (the one unrelated `composite_projection_tests` blip in a 16-min combined run passes 3/3 in isolation and is a separate pre-existing flake, not touched by this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)