### PR TITLE
#177: Copy IEventStoreInstrumentation DI mechanics from Marten

### DIFF
--- a/src/Polecat.Tests/Events/event_store_instrumentation_di_tests.cs
+++ b/src/Polecat.Tests/Events/event_store_instrumentation_di_tests.cs
@@ -1,0 +1,91 @@
+using JasperFx.Events;
+using Microsoft.Extensions.DependencyInjection;
+using Polecat.Tests.Harness;
+
+namespace Polecat.Tests.Events;
+
+// Issue #177: the DI registration mechanic that lets external tooling (e.g. CritterWatch)
+// resolve IEventStoreInstrumentation from the container, flip ExtendedProgressionEnabled,
+// and have the toggle land on the store BEFORE first IDocumentStore resolution. Mirrors
+// Marten's CoreTests.Events.EventGraph_IEventStoreInstrumentation. The storage-side
+// effects of the flag (schema delta, daemon write, shard-state read) are covered by
+// event_store_instrumentation_tests.cs — these tests focus purely on the wiring.
+
+public interface IInvoicingStore : IDocumentStore;
+
+public class event_store_instrumentation_di_tests
+{
+    [Fact]
+    public void build_store_with_progression_tracking_override()
+    {
+        var services = new ServiceCollection();
+        services.AddPolecat(opts =>
+        {
+            opts.ConnectionString = ConnectionSource.ConnectionString;
+            opts.UseNativeJsonType = ConnectionSource.SupportsNativeJson;
+        });
+
+        using var provider = services.BuildServiceProvider();
+
+        var instrumentation = provider.GetRequiredService<IEventStoreInstrumentation>();
+        instrumentation.ShouldNotBeNull();
+        // Defaults to opt-out — same as Marten and Polecat's StoreOptions default.
+        instrumentation.ExtendedProgressionEnabled.ShouldBeFalse();
+
+        // External tooling flips the toggle BEFORE first IDocumentStore resolution.
+        instrumentation.ExtendedProgressionEnabled = true;
+
+        // First IDocumentStore resolution drains the IConfigurePolecat chain, which
+        // includes the SetEventStoreInstrumentation instance — so the toggle lands
+        // on options.Events.EnableExtendedProgressionTracking.
+        var store = provider.GetRequiredService<IDocumentStore>();
+        store.Options.Events.EnableExtendedProgressionTracking.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void registers_one_instrumentation_per_store_and_primary_toggle_lands()
+    {
+        // Mirrors the shape of Marten's
+        // build_store_with_progression_tracking_override_with_ancillary_store: each of
+        // AddPolecat / AddPolecatStore<T> contributes its own IEventStoreInstrumentation,
+        // so GetServices<IEventStoreInstrumentation>() yields one per store and external
+        // tooling can flip them all in one pass.
+        //
+        // Polecat's AddPolecatStore<T> does (T)(IDocumentStore)store at runtime, which
+        // requires DocumentStore to actually implement T — Polecat does not emit dynamic
+        // proxies for ancillary stores the way Marten does, so resolving IInvoicingStore
+        // here would throw InvalidCastException. That's a separate concern from #177; this
+        // test verifies the instrumentation registration shape + the primary-store toggle
+        // landing, both of which are entirely the #177 wiring.
+
+        var services = new ServiceCollection();
+        services.AddPolecat(opts =>
+        {
+            opts.ConnectionString = ConnectionSource.ConnectionString;
+            opts.UseNativeJsonType = ConnectionSource.SupportsNativeJson;
+        });
+        services.AddPolecatStore<IInvoicingStore>(opts =>
+        {
+            opts.ConnectionString = ConnectionSource.ConnectionString;
+            opts.DatabaseSchemaName = "invoices_177";
+            opts.UseNativeJsonType = ConnectionSource.SupportsNativeJson;
+        });
+
+        // Two IEventStoreInstrumentation registrations exist before BuildServiceProvider.
+        services.Count(d => d.ServiceType == typeof(IEventStoreInstrumentation)).ShouldBe(2);
+
+        using var provider = services.BuildServiceProvider();
+
+        var instruments = provider.GetServices<IEventStoreInstrumentation>().ToList();
+        instruments.Count.ShouldBe(2);
+        instruments.ShouldAllBe(i => !i.ExtendedProgressionEnabled);
+
+        foreach (var i in instruments)
+        {
+            i.ExtendedProgressionEnabled = true;
+        }
+
+        var store = provider.GetRequiredService<IDocumentStore>();
+        store.Options.Events.EnableExtendedProgressionTracking.ShouldBeTrue();
+    }
+}

--- a/src/Polecat/PolecatServiceCollectionExtensions.cs
+++ b/src/Polecat/PolecatServiceCollectionExtensions.cs
@@ -1,3 +1,4 @@
+using JasperFx.Events;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Polecat.Internal;
@@ -47,6 +48,16 @@ public static class PolecatServiceCollectionExtensions
     public static PolecatConfigurationExpression AddPolecat(
         this IServiceCollection services, Func<IServiceProvider, StoreOptions> optionSource)
     {
+        // #177: register IEventStoreInstrumentation so external tooling (CritterWatch)
+        // can resolve it from the container, flip ExtendedProgressionEnabled BEFORE
+        // first IDocumentStore resolution, and have the toggle land on the store. The
+        // same instance also enters the IConfigurePolecat chain below, which copies
+        // the toggle into options.Events.EnableExtendedProgressionTracking on build.
+        // Mirrors Marten's SetEventStoreInstrumentation wiring (jasperfx#424).
+        var instrument = new SetEventStoreInstrumentation();
+        services.AddSingleton<IConfigurePolecat>(instrument);
+        services.AddSingleton<IEventStoreInstrumentation>(instrument);
+
         services.AddSingleton(sp =>
         {
             var options = optionSource(sp);
@@ -82,4 +93,32 @@ public static class PolecatServiceCollectionExtensions
 
         return new PolecatConfigurationExpression(services);
     }
+}
+
+// #177: paired (IConfigurePolecat + IEventStoreInstrumentation) connector classes
+// — co-located here per Marten's pattern (SetEventStoreInstrumentation lives next
+// to AddMarten / AddMartenStore<T> in MartenServiceCollectionExtensions). External
+// tooling resolves IEventStoreInstrumentation from the container and flips
+// ExtendedProgressionEnabled; on first store resolution the IConfigurePolecat[<T>]
+// chain runs Configure(), which copies the flag onto options.Events.
+
+internal class SetEventStoreInstrumentation : IConfigurePolecat, IEventStoreInstrumentation
+{
+    public void Configure(IServiceProvider serviceProvider, StoreOptions options)
+    {
+        options.Events.EnableExtendedProgressionTracking = ExtendedProgressionEnabled;
+    }
+
+    public bool ExtendedProgressionEnabled { get; set; }
+}
+
+internal class SetEventStoreInstrumentation<T> : IConfigurePolecat<T>, IEventStoreInstrumentation
+    where T : IDocumentStore
+{
+    public void Configure(IServiceProvider serviceProvider, StoreOptions options)
+    {
+        options.Events.EnableExtendedProgressionTracking = ExtendedProgressionEnabled;
+    }
+
+    public bool ExtendedProgressionEnabled { get; set; }
 }

--- a/src/Polecat/PolecatStoreServiceCollectionExtensions.cs
+++ b/src/Polecat/PolecatStoreServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using JasperFx.Events;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Polecat.Internal;
@@ -36,6 +37,14 @@ public static class PolecatStoreServiceCollectionExtensions
         this IServiceCollection services, Func<IServiceProvider, StoreOptions> optionSource)
         where T : class, IDocumentStore
     {
+        // #177: register IEventStoreInstrumentation alongside the per-T IConfigurePolecat<T>
+        // chain so external tooling can resolve every store's instrumentation through
+        // GetServices<IEventStoreInstrumentation>() and toggle them in one pass. Mirrors
+        // SetEventStoreInstrumentation<T> wiring in Marten's AddMartenStore<T>.
+        var instrument = new SetEventStoreInstrumentation<T>();
+        services.AddSingleton<IConfigurePolecat<T>>(instrument);
+        services.AddSingleton<IEventStoreInstrumentation>(instrument);
+
         services.AddSingleton<T>(sp =>
         {
             var options = optionSource(sp);


### PR DESCRIPTION
## Summary

Closes #177. Adds the `IEventStoreInstrumentation` DI registration mechanic — a 1:1 port of Marten's `SetEventStoreInstrumentation` pattern (jasperfx#424 / marten#4687) — so external tooling like CritterWatch can resolve `IEventStoreInstrumentation` from the container, flip `ExtendedProgressionEnabled` **before** first `IDocumentStore` resolution, and have the toggle land on the store.

## Why this was the only gap

Polecat already had *everything else* `IEventStoreInstrumentation` needs:

| Piece | Status before this PR |
|---|---|
| `StoreOptions` implements `IEventStoreInstrumentation` (alias to `Events.EnableExtendedProgressionTracking`) | ✅ |
| 6-column extended progression schema on `pc_event_progression` | ✅ |
| Read path: `PolecatDatabase.AllProjectionProgress` hydrates extended `ShardState` columns | ✅ |
| Write paths: `MarkExtendedProjectionProgress` + `heartbeat = SYSDATETIMEOFFSET()` on every base progression write | ✅ |
| `IConfigurePolecat[<T>]` chain drained by `AddPolecat` / `AddPolecatStore<T>` | ✅ |
| **DI registration of `IEventStoreInstrumentation` so external tooling can find it** | ❌ — this PR |

**Threshold parity confirmed**: both Marten and Polecat treat `warning_behind_threshold` / `critical_behind_threshold` as **read-only daemon side**. Neither store writes them — they're nullable columns left for external tooling. No parity gap.

## Changes (3 files, +48/-0 on production, +90 on tests)

| File | Change |
|---|---|
| `src/Polecat/PolecatServiceCollectionExtensions.cs` | `using JasperFx.Events`; register `IConfigurePolecat` + `IEventStoreInstrumentation` from the same `SetEventStoreInstrumentation` instance inside the `AddPolecat` Func overload; both `Set` / `Set<T>` classes co-located at the bottom of the file (mirroring Marten). |
| `src/Polecat/PolecatStoreServiceCollectionExtensions.cs` | `using JasperFx.Events`; register `IConfigurePolecat<T>` + `IEventStoreInstrumentation` from the same `SetEventStoreInstrumentation<T>` instance inside `AddPolecatStore<T>`. |
| `src/Polecat.Tests/Events/event_store_instrumentation_di_tests.cs` *(new)* | Two tests mirroring Marten's `EventGraph_IEventStoreInstrumentation`: primary-store override-via-instrumentation, and the multi-store registration shape. |

The two `Set` classes are trivial:
```csharp
internal class SetEventStoreInstrumentation : IConfigurePolecat, IEventStoreInstrumentation
{
    public void Configure(IServiceProvider sp, StoreOptions options)
        => options.Events.EnableExtendedProgressionTracking = ExtendedProgressionEnabled;
    public bool ExtendedProgressionEnabled { get; set; }
}
// + the <T> generic for ancillary stores
```

## A note on the ancillary-store test

Marten's mirror test resolves `IInvoicingStore` end-to-end (`provider.GetRequiredService<IInvoicingStore>().Options...`). Polecat's `AddPolecatStore<T>` currently does `(T)(IDocumentStore)store` at runtime, which only works when `T == IDocumentStore` — Polecat does not emit dynamic proxies the way Marten does for the ancillary path. That's a **separate concern from #177**.

So Polecat's second DI test verifies what the #177 wiring is responsible for:
- two `IEventStoreInstrumentation` descriptors are registered (one per store);
- `provider.GetServices<IEventStoreInstrumentation>()` yields both;
- setting both lands the toggle on the primary store on resolution.

The test's XML comment makes the limitation explicit so the next reader doesn't think this is by-design Marten-divergence.

## Verification

```
dotnet build Debug + Release: 0 errors; Polecat.AotSmoke (Release): clean
Polecat.Tests (net10.0): 1182 pass / 3 pre-existing skips / 0 fail   (+2 new DI tests)
Polecat.EntityFrameworkCore.Tests (net10.0): 37 pass / 0 fail
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
