### PR TITLE
feat(events): populate ProjectionErrors / ProjectionRebuildErrors on TryCreateUsage

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,9 +9,13 @@
              partitioning surface (ShardName tenant grammar, nullable ShardState.TenantId /
              HighWaterStatistics.TenantId, tenant-aware JasperFxAsyncDaemon) plus
              IEventStoreInstrumentation (jasperfx#424) for CritterWatch monitoring.
-             Consumed by Polecat #163 (partitioning) and #166 (instrumentation). -->
-        <PackageVersion Include="JasperFx" Version="2.9.0" />
-        <PackageVersion Include="JasperFx.Events" Version="2.9.0" />
+             Consumed by Polecat #163 (partitioning) and #166 (instrumentation).
+             JasperFx 2.9.2: jasperfx#431 — ProjectionErrorHandlingDescriptor on
+             EventStoreUsage so monitoring tools (CritterWatch) can read the daemon
+             error-handling policy off the wire instead of presuming skip-and-DLQ
+             behaviour. See JasperFx/ProductSupport#3. -->
+        <PackageVersion Include="JasperFx" Version="2.9.2" />
+        <PackageVersion Include="JasperFx.Events" Version="2.9.2" />
         <!-- Pin the sibling JasperFx packages for parity with Marten 9's matrix
              even though Polecat doesn't currently reference them directly —
              keeps the lockstep matrix coherent when transitive resolution
@@ -19,7 +23,7 @@
              RuntimeCompiler 5.x line is the active continuation of the 4.x
              lineage; do not pin against the parallel stale 2.0.x series. -->
         <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.9.0" />
+        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.9.2" />
         <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
@@ -45,7 +49,7 @@
         <PackageVersion Include="StronglyTypedId" Version="1.0.0-beta08" />
 
         <!-- Source generators (matched to JasperFx.Events above) -->
-        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.9.0" />
+        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.9.2" />
 
         <!-- Build automation -->
         <PackageVersion Include="Nuke.Common" Version="9.0.4" />

--- a/src/Polecat.Tests/event_store_usage_integration_tests.cs
+++ b/src/Polecat.Tests/event_store_usage_integration_tests.cs
@@ -66,4 +66,35 @@ public class event_store_usage_integration_tests : IntegrationContext
         usage.ShouldNotBeNull();
         usage.MaxEventSequence.ShouldBeNull();
     }
+
+    [Fact]
+    public async Task projection_error_handling_descriptors_mirror_store_options()
+    {
+        // JasperFx/ProductSupport#3 — the projection error policy needs to ride
+        // along on EventStoreUsage so monitoring tools can render the right
+        // affordance (DLQ button vs "shard halts on error" indicator) without
+        // sniffing into Polecat internals. Asserts the descriptors carry the
+        // exact policy values configured on the store, rather than pinning
+        // specific defaults (which can drift across JasperFx.Events releases).
+        var usage = await ((IEventStore)theStore).TryCreateUsage(CancellationToken.None);
+
+        usage.ShouldNotBeNull();
+
+        // Both descriptors must be populated so monitoring tools can render
+        // policy-driven UI on every store.
+        usage.ProjectionErrors.ShouldNotBeNull();
+        usage.ProjectionRebuildErrors.ShouldNotBeNull();
+
+        // Mirror assertions — the descriptors must exactly reflect the
+        // ErrorHandlingOptions on the store, whatever the upstream defaults are.
+        var storeErrors = theStore.Options.Projections.Errors;
+        usage.ProjectionErrors.SkipApplyErrors.ShouldBe(storeErrors.SkipApplyErrors);
+        usage.ProjectionErrors.SkipUnknownEvents.ShouldBe(storeErrors.SkipUnknownEvents);
+        usage.ProjectionErrors.SkipSerializationErrors.ShouldBe(storeErrors.SkipSerializationErrors);
+
+        var storeRebuildErrors = theStore.Options.Projections.RebuildErrors;
+        usage.ProjectionRebuildErrors.SkipApplyErrors.ShouldBe(storeRebuildErrors.SkipApplyErrors);
+        usage.ProjectionRebuildErrors.SkipUnknownEvents.ShouldBe(storeRebuildErrors.SkipUnknownEvents);
+        usage.ProjectionRebuildErrors.SkipSerializationErrors.ShouldBe(storeRebuildErrors.SkipSerializationErrors);
+    }
 }

--- a/src/Polecat/DocumentStore.EventStore.cs
+++ b/src/Polecat/DocumentStore.EventStore.cs
@@ -204,6 +204,24 @@ public partial class DocumentStore : IEventStore<IDocumentSession, IQuerySession
         hilo.AddValue(nameof(Options.HiloSequenceDefaults.MaxAdvanceToNextHiAttempts), Options.HiloSequenceDefaults.MaxAdvanceToNextHiAttempts);
         usage.Children["HiloSequenceDefaults"] = hilo;
 
+        // JasperFx/ProductSupport#3 — surface the async-daemon error-handling
+        // policy on the wire so monitoring tools (CritterWatch) can render the
+        // right "shard halts on error" vs "view related dead letters" affordance.
+        // Mirror of the Marten companion so the descriptor is populated identically
+        // regardless of which store backs the monitored service.
+        usage.ProjectionErrors = new ProjectionErrorHandlingDescriptor
+        {
+            SkipApplyErrors = Options.Projections.Errors.SkipApplyErrors,
+            SkipUnknownEvents = Options.Projections.Errors.SkipUnknownEvents,
+            SkipSerializationErrors = Options.Projections.Errors.SkipSerializationErrors
+        };
+        usage.ProjectionRebuildErrors = new ProjectionErrorHandlingDescriptor
+        {
+            SkipApplyErrors = Options.Projections.RebuildErrors.SkipApplyErrors,
+            SkipUnknownEvents = Options.Projections.RebuildErrors.SkipUnknownEvents,
+            SkipSerializationErrors = Options.Projections.RebuildErrors.SkipSerializationErrors
+        };
+
         // DCB tag-type registrations — first-class typed list mirroring
         // Marten's plumbing. Polecat doesn't expose a GlobalAggregates surface
         // yet; that list stays empty until the equivalent lands.


### PR DESCRIPTION
## What

Companion to JasperFx/jasperfx#431 — populates the new descriptor fields on `EventStoreUsage` from `StoreOptions.Projections.Errors` and `.RebuildErrors` inside `DocumentStore.EventStore.TryCreateUsage`. Mirror of the Marten companion (JasperFx/marten#4708) so the descriptor populates identically regardless of which event store backs the monitored service.

| Wire field | Sourced from |
|---|---|
| `usage.ProjectionErrors` | `Options.Projections.Errors` (normal-run config) |
| `usage.ProjectionRebuildErrors` | `Options.Projections.RebuildErrors` (rebuild-mode config) |

Each descriptor mirrors `ErrorHandlingOptions`'s three flags: `SkipApplyErrors`, `SkipUnknownEvents`, `SkipSerializationErrors`.

## Why

JasperFx/ProductSupport#3 — CritterWatch's projection detail page renders a *"View Related Dead Letters"* affordance that assumes skip-and-DLQ behaviour. With the descriptors on the wire (this PR + jasperfx#431 + marten#4708), CritterWatch can read each store's actual policy and render the right operator affordance.

## Verification

- `dotnet test src/Polecat.Tests --filter "FullyQualifiedName~projection_error_handling_descriptors_mirror_store_options"` — passes on both net9.0 and net10.0 against a local-feed prerelease of JasperFx.Events.
- Assertion shape is **mirror-style** — descriptor values are compared to the live `theStore.Options.Projections.Errors` shape rather than pinned to specific upstream defaults, so the test shields itself from JasperFx.Events default drift.

## Coordination

- **Depends on:** JasperFx/jasperfx#431
- **Companion:** JasperFx/marten#4708
- **Consumer:** JasperFx/CritterWatch follow-up bumps pins + reads the new descriptors on the projection detail page

🤖 Generated with [Claude Code](https://claude.com/claude-code)