### PR TITLE
Upgrade JasperFx family 2.9.2 → 2.9.8

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,9 +13,10 @@
              JasperFx 2.9.2: jasperfx#431 — ProjectionErrorHandlingDescriptor on
              EventStoreUsage so monitoring tools (CritterWatch) can read the daemon
              error-handling policy off the wire instead of presuming skip-and-DLQ
-             behaviour. See JasperFx/ProductSupport#3. -->
-        <PackageVersion Include="JasperFx" Version="2.9.2" />
-        <PackageVersion Include="JasperFx.Events" Version="2.9.2" />
+             behaviour. See JasperFx/ProductSupport#3.
+             JasperFx 2.9.8: roll forward to the latest released 2.9.x line. -->
+        <PackageVersion Include="JasperFx" Version="2.9.8" />
+        <PackageVersion Include="JasperFx.Events" Version="2.9.8" />
         <!-- Pin the sibling JasperFx packages for parity with Marten 9's matrix
              even though Polecat doesn't currently reference them directly —
              keeps the lockstep matrix coherent when transitive resolution
@@ -23,7 +24,7 @@
              RuntimeCompiler 5.x line is the active continuation of the 4.x
              lineage; do not pin against the parallel stale 2.0.x series. -->
         <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.9.2" />
+        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.9.8" />
         <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
@@ -49,7 +50,7 @@
         <PackageVersion Include="StronglyTypedId" Version="1.0.0-beta08" />
 
         <!-- Source generators (matched to JasperFx.Events above) -->
-        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.9.2" />
+        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.9.8" />
 
         <!-- Build automation -->
         <PackageVersion Include="Nuke.Common" Version="9.0.4" />


### PR DESCRIPTION
Rolls the JasperFx package family forward to the latest released `2.9.x`:

- `JasperFx` 2.9.2 → 2.9.8
- `JasperFx.Events` 2.9.2 → 2.9.8
- `JasperFx.SourceGenerator` 2.9.2 → 2.9.8
- `JasperFx.Events.SourceGenerator` 2.9.2 → 2.9.8

`JasperFx.RuntimeCompiler` stays on 5.0.0; Weasel unchanged. No source changes were required — the solution builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)