### PR TITLE
#181: clean FlatTableProjection tables via CleanAllDocuments/CleanAllEventData

### DIFF
--- a/src/Polecat.Tests/Projections/flat_table_projection_tests.cs
+++ b/src/Polecat.Tests/Projections/flat_table_projection_tests.cs
@@ -273,4 +273,41 @@ public class flat_table_projection_tests : IntegrationContext
         var memberCount = await ReadMetric<int>("member_count", streamId);
         memberCount.ShouldBe(2);
     }
+
+    // polecat#181 — flat-table projection data must be erasable via the Clean* admin helpers.
+    [Fact]
+    public async Task clean_all_documents_erases_flat_table_projection_data()
+    {
+        var store = await CreateStoreWithFlatTable();
+
+        await using (var session = store.LightweightSession())
+        {
+            session.Events.StartStream(Guid.NewGuid(), new QuestStarted("Cleanup Quest"));
+            await session.SaveChangesAsync();
+        }
+
+        (await CountMetrics()).ShouldBeGreaterThan(0);
+
+        await store.Advanced.CleanAllDocumentsAsync();
+
+        (await CountMetrics()).ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task clean_all_event_data_erases_flat_table_projection_data()
+    {
+        var store = await CreateStoreWithFlatTable();
+
+        await using (var session = store.LightweightSession())
+        {
+            session.Events.StartStream(Guid.NewGuid(), new QuestStarted("Cleanup Quest"));
+            await session.SaveChangesAsync();
+        }
+
+        (await CountMetrics()).ShouldBeGreaterThan(0);
+
+        await store.Advanced.CleanAllEventDataAsync();
+
+        (await CountMetrics()).ShouldBe(0);
+    }
 }

--- a/src/Polecat/AdvancedOperations.cs
+++ b/src/Polecat/AdvancedOperations.cs
@@ -6,6 +6,7 @@ using Polly;
 using Polecat.Events.TestSupport;
 using Polecat.Internal;
 using Polecat.Metadata;
+using Polecat.Projections.Flattened;
 using Polecat.Schema.Identity.Sequences;
 using Polecat.Storage;
 using Weasel.Core;
@@ -424,15 +425,18 @@ public class AdvancedOperations
     }
 
     /// <summary>
-    ///     Delete all rows from all pc_doc_* tables in the configured schema.
+    ///     Delete all rows from all pc_doc_* tables in the configured schema, plus the custom tables
+    ///     owned by any registered <see cref="FlatTableProjection" /> (their projected document-like
+    ///     data is not stored in pc_doc_* tables, so it is cleaned explicitly — polecat#181).
     /// </summary>
     public async Task CleanAllDocumentsAsync(CancellationToken token = default)
     {
         var schema = _store.Options.DatabaseSchemaName;
         var connStr = _store.Options.ConnectionString;
+        var flatTables = CollectFlatTableNames();
         await _resilience.ExecuteAsync(static async (state, ct) =>
         {
-            var (connectionString, schemaName) = state;
+            var (connectionString, schemaName, flatTableNames) = state;
             await using var conn = new SqlConnection(connectionString);
             await conn.OpenAsync(ct);
 
@@ -460,7 +464,33 @@ public class AdvancedOperations
                 deleteCmd.CommandText = $"DELETE FROM [{schemaName}].[{table}];";
                 await deleteCmd.ExecuteNonQueryAsync(ct);
             }
-        }, (connStr, schema), token);
+
+            await DeleteFlatTablesAsync(conn, flatTableNames, ct);
+        }, (connStr, schema, flatTables), token);
+    }
+
+    /// <summary>
+    ///     The schema-qualified tables owned by registered <see cref="FlatTableProjection" /> sources.
+    /// </summary>
+    private string[] CollectFlatTableNames()
+    {
+        return _store.Options.Projections.All
+            .OfType<FlatTableProjection>()
+            .Select(p => p.Table.Identifier.QualifiedName)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    private static async Task DeleteFlatTablesAsync(SqlConnection conn, string[] qualifiedNames,
+        CancellationToken ct)
+    {
+        foreach (var qualified in qualifiedNames)
+        {
+            await using var cmd = conn.CreateCommand();
+            // Guard against the table not existing yet (the projection ensures it lazily).
+            cmd.CommandText = $"IF OBJECT_ID('{qualified}', 'U') IS NOT NULL DELETE FROM {qualified};";
+            await cmd.ExecuteNonQueryAsync(ct);
+        }
     }
 
     /// <summary>
@@ -581,12 +611,17 @@ public class AdvancedOperations
         var eventsTable = events.EventsTableName;
         var streamsTable = events.StreamsTableName;
         var progressionTable = events.ProgressionTableName;
+        var flatTables = CollectFlatTableNames();
 
         await _resilience.ExecuteAsync(static async (state, ct) =>
         {
-            var (connectionString, schemaName, evtTable, strmTable, progTable) = state;
+            var (connectionString, schemaName, evtTable, strmTable, progTable, flatTableNames) = state;
             await using var conn = new SqlConnection(connectionString);
             await conn.OpenAsync(ct);
+
+            // Flat-table projection output is derived from events; clear it alongside the event data
+            // so a reset leaves no stale projected rows (mirrors the natural-key table cleanup below).
+            await DeleteFlatTablesAsync(conn, flatTableNames, ct);
 
             // Delete natural key tables first (they reference streams)
             await using (var findCmd = conn.CreateCommand())
@@ -635,7 +670,7 @@ public class AdvancedOperations
                 cmd.CommandText = $"IF OBJECT_ID('{progTable}', 'U') IS NOT NULL DELETE FROM {progTable};";
                 await cmd.ExecuteNonQueryAsync(ct);
             }
-        }, (connStr, schema, eventsTable, streamsTable, progressionTable), token);
+        }, (connStr, schema, eventsTable, streamsTable, progressionTable, flatTables), token);
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes #181 — `FlatTableProjection` data was not erased by `store.Advanced.CleanAllDocumentsAsync()` or `CleanAllEventDataAsync()`.

## Cause

A flat-table projection writes to its own **custom-named** table (e.g. `quest_metrics`), which is neither a `pc_doc_*` document table nor an event/stream/progression table — so neither admin cleaner touched it.

## Fix

Both `CleanAllDocumentsAsync` and `CleanAllEventDataAsync` now also `DELETE` the tables owned by every registered `FlatTableProjection` (enumerated from `Projections.All` via each projection's `Table.Identifier`), guarded with `IF OBJECT_ID(...)` since the projection creates its table lazily. This mirrors the existing behavior where `CleanAllEventDataAsync` already clears `pc_natural_key_*` projection tables.

For the issue's question — *"what's the recommended way to clear this data in a development situation?"* — `CleanAllDocumentsAsync()` is now the call for clearing projected document-like state (flat tables included); `CleanAllEventDataAsync()` additionally resets the event store and its derived projection tables.

## Tests

`clean_all_documents_erases_flat_table_projection_data` and `clean_all_event_data_erases_flat_table_projection_data` — populate a flat-table projection, run each cleaner, assert the table is empty.

Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)