### PR TITLE
#180: atomic, cleanly-cancellable per-tenant rebuild teardown

### DIFF
--- a/src/Polecat.Tests/Daemon/per_tenant_rebuild_tests.cs
+++ b/src/Polecat.Tests/Daemon/per_tenant_rebuild_tests.cs
@@ -115,6 +115,67 @@ public class per_tenant_rebuild_tests : IAsyncLifetime
         (await ProgressRowsForTenantAsync("Green")).ShouldBe(greenProgressBefore);
     }
 
+    // polecat#180 (item 2) — cancelling a per-tenant rebuild must leave pc_event_progression in a
+    // consistent state: other tenants untouched, and the cancelled tenant never advanced past the
+    // events that exist (progress + projected data are committed atomically per batch).
+    [Fact]
+    public async Task cancelling_a_per_tenant_rebuild_keeps_progression_consistent()
+    {
+        using var store = CreateStore();
+        await store.Database.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        // Red gets a longer stream so its rebuild has real work to interrupt.
+        const int redEventCount = 26; // QuestStarted + 25 MembersJoined
+        await using (var red = store.LightweightSession(new SessionOptions { TenantId = "Red" }))
+        {
+            var events = new List<object> { new QuestStarted("Red Quest") };
+            for (var i = 1; i <= 25; i++) events.Add(new MembersJoined(i, "Town", [$"H{i}"]));
+            red.Events.StartStream(Guid.NewGuid(), events.ToArray());
+            await red.SaveChangesAsync();
+        }
+
+        foreach (var tenant in new[] { "Blue", "Green" })
+        {
+            await using var s = store.LightweightSession(new SessionOptions { TenantId = tenant });
+            s.Events.StartStream(Guid.NewGuid(), new QuestStarted($"{tenant} Quest"));
+            await s.SaveChangesAsync();
+        }
+
+        var projectionName = store.Options.Projections.All.Single().Name;
+        using var daemon = (IProjectionDaemon)await store.BuildProjectionDaemonAsync();
+
+        foreach (var tenant in Tenants)
+        {
+            await daemon.RebuildProjectionAsync(projectionName, tenant, CancellationToken.None);
+        }
+
+        var blueBefore = await ProgressRowsForTenantAsync("Blue");
+        var greenBefore = await ProgressRowsForTenantAsync("Green");
+
+        // Cancel a rebuild of Red. The token may win the race (rebuild aborts) or lose it (rebuild
+        // completes) — either outcome must leave a consistent state, so the test tolerates both.
+        using var cts = new CancellationTokenSource();
+        cts.CancelAfter(TimeSpan.FromMilliseconds(20));
+        try
+        {
+            await daemon.RebuildProjectionAsync(projectionName, "Red", cts.Token);
+        }
+        catch (OperationCanceledException)
+        {
+        }
+
+        // Red's cancelled rebuild left the other tenants' progression completely untouched.
+        (await ProgressRowsForTenantAsync("Blue")).ShouldBe(blueBefore);
+        (await ProgressRowsForTenantAsync("Green")).ShouldBe(greenBefore);
+
+        // Red's progression is never advanced past the events that exist — a cancelled rebuild can only
+        // leave a valid intermediate (or fully reset) mark, never an over-advanced one.
+        foreach (var seq in (await ProgressRowsForTenantAsync("Red")).Values)
+        {
+            seq.ShouldBeLessThanOrEqualTo(redEventCount);
+        }
+    }
+
     // Progression rows (name -> last_seq_id) whose composed identity targets the given tenant.
     private static async Task<Dictionary<string, long>> ProgressRowsForTenantAsync(string tenantId)
     {

--- a/src/Polecat/DocumentStore.EventStore.cs
+++ b/src/Polecat/DocumentStore.EventStore.cs
@@ -431,31 +431,50 @@ public partial class DocumentStore : IEventStore<IDocumentSession, IQuerySession
                 .ToArray();
         }
 
-        await Options.ResiliencePipeline.ExecuteAsync(static async (state, ct) =>
+        try
         {
-            var (connString, progressionTable, identities, tableNames, tenant) = state;
-            await using var conn = new SqlConnection(connString);
-            await conn.OpenAsync(ct);
-
-            foreach (var identity in identities)
+            await Options.ResiliencePipeline.ExecuteAsync(static async (state, ct) =>
             {
-                await using var delProg = conn.CreateCommand();
-                delProg.CommandText = $"DELETE FROM {progressionTable} WHERE name = @id;";
-                delProg.Parameters.AddWithValue("@id", identity);
-                await delProg.ExecuteNonQueryAsync(ct);
-            }
+                var (connString, progressionTable, identities, tableNames, tenant) = state;
+                await using var conn = new SqlConnection(connString);
+                await conn.OpenAsync(ct);
 
-            foreach (var tableName in tableNames)
-            {
-                await using var delDocs = conn.CreateCommand();
-                // The projection's doc table is created lazily on first write, so on a first-ever
-                // rebuild it may not exist yet — guard the tenant-scoped delete accordingly.
-                delDocs.CommandText =
-                    $"IF OBJECT_ID('{tableName}', 'U') IS NOT NULL DELETE FROM {tableName} WHERE tenant_id = @tenant;";
-                delDocs.Parameters.AddWithValue("@tenant", tenant);
-                await delDocs.ExecuteNonQueryAsync(ct);
-            }
-        }, (connStr, Events.ProgressionTableName, shardIdentities, publishedTableNames, tenantId), token);
+                // #180: do the whole tenant teardown in one transaction so a cancellation can only leave
+                // it fully applied or fully rolled back — never a half-reset (progression deleted but
+                // docs kept, or vice versa). pc_event_progression therefore stays consistent on cancel.
+                await using var tx = (SqlTransaction)await conn.BeginTransactionAsync(ct);
+
+                foreach (var identity in identities)
+                {
+                    await using var delProg = conn.CreateCommand();
+                    delProg.Transaction = tx;
+                    delProg.CommandText = $"DELETE FROM {progressionTable} WHERE name = @id;";
+                    delProg.Parameters.AddWithValue("@id", identity);
+                    await delProg.ExecuteNonQueryAsync(ct);
+                }
+
+                foreach (var tableName in tableNames)
+                {
+                    await using var delDocs = conn.CreateCommand();
+                    delDocs.Transaction = tx;
+                    // The projection's doc table is created lazily on first write, so on a first-ever
+                    // rebuild it may not exist yet — guard the tenant-scoped delete accordingly.
+                    delDocs.CommandText =
+                        $"IF OBJECT_ID('{tableName}', 'U') IS NOT NULL DELETE FROM {tableName} WHERE tenant_id = @tenant;";
+                    delDocs.Parameters.AddWithValue("@tenant", tenant);
+                    await delDocs.ExecuteNonQueryAsync(ct);
+                }
+
+                await tx.CommitAsync(ct);
+            }, (connStr, Events.ProgressionTableName, shardIdentities, publishedTableNames, tenantId), token);
+        }
+        catch (Exception ex) when (token.IsCancellationRequested && ex is not OperationCanceledException)
+        {
+            // SqlClient surfaces a cancelled command as a raw SqlException ("Operation cancelled by
+            // user" / "a severe error occurred"); translate it so a cancelled rebuild reports clean
+            // cancellation. The transaction above has already rolled back, leaving state consistent.
+            throw new OperationCanceledException("Per-tenant projection teardown was cancelled.", ex, token);
+        }
     }
 
     // ISubscriptionRunner<ISubscription>


### PR DESCRIPTION
Addresses **item 2** of #180 — per-cell (per-tenant) rebuild cancellation consistency for `pc_event_progression` (the Polecat-parity test CritterWatch#309 needs).

## Problem found

The per-tenant `DeleteProjectionProgressAsync` (the teardown the base daemon runs at the start of `RebuildProjectionAsync(name, tenantId, ct)`) deleted the tenant's progression rows and its projected docs as **separate, un-transacted** commands. Verifying the cancellation behavior surfaced two real gaps:

1. **Non-atomic teardown** — a cancel mid-teardown could leave a half-reset state (progression deleted but docs kept, or vice versa).
2. **Raw exception leak** — SqlClient surfaces a cancelled command as a raw `SqlException` ("Operation cancelled by user" / "a severe error occurred") rather than a clean `OperationCanceledException`, so a cancelled rebuild threw an opaque DB error.

## Fix

- The teardown now runs in **one transaction**, so a cancellation can only leave it fully applied or fully rolled back — `pc_event_progression` stays consistent.
- A cancellation-induced `SqlException` is translated to `OperationCanceledException` (same pattern as the event-loader fix, #175), so a cancelled rebuild reports clean cancellation.

## Test

`cancelling_a_per_tenant_rebuild_keeps_progression_consistent` — cancels a per-tenant rebuild and asserts (a) other tenants' progression rows are untouched and (b) the cancelled tenant is never advanced past the events that exist. Ran 6× locally with the fix: green every time (flaky before the fix).

## Out of scope (still blocked)

**Item 1** — populating `MaxConcurrentRebuildsPerDatabase` on the descriptor — remains blocked on **jasperfx#434**: that `EventStoreUsage` field is not present in JasperFx.Events 2.9.8. It will follow once the field ships (the `ProjectionErrorHandlingDescriptor` population in #179 is the pattern to mirror).

Refs #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)