### PR TITLE
#187: register Polecat store as a JasperFx ISystemPart so AddResourceSetupOnStartup() provisions the schema

### DIFF
--- a/src/Polecat.Tests/DependencyInjection/system_part_resource_tests.cs
+++ b/src/Polecat.Tests/DependencyInjection/system_part_resource_tests.cs
@@ -1,0 +1,119 @@
+using JasperFx.CommandLine.Descriptions;
+using JasperFx.Resources;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Polecat.Tests.Harness;
+using Weasel.Core.CommandLine;
+
+namespace Polecat.Tests.DependencyInjection;
+
+/// <summary>
+///     #187: AddPolecat must register the Polecat database with JasperFx's resource
+///     model (ISystemPart) so the idiomatic services.AddResourceSetupOnStartup()
+///     provisions the schema with no Polecat-specific call, matching Marten.
+/// </summary>
+public class system_part_resource_tests
+{
+    [Fact]
+    public void add_polecat_registers_a_polecat_system_part()
+    {
+        var services = new ServiceCollection();
+        services.AddPolecat(opts =>
+        {
+            opts.ConnectionString = ConnectionSource.ConnectionString;
+            opts.UseNativeJsonType = ConnectionSource.SupportsNativeJson;
+        });
+
+        using var provider = services.BuildServiceProvider();
+
+        var parts = provider.GetServices<ISystemPart>().ToArray();
+        parts.OfType<PolecatSystemPart>().ShouldNotBeEmpty();
+    }
+
+    [Fact]
+    public async Task find_resources_wraps_each_tenant_database_as_a_database_resource()
+    {
+        var services = new ServiceCollection();
+        services.AddPolecat(opts =>
+        {
+            opts.ConnectionString = ConnectionSource.ConnectionString;
+            opts.UseNativeJsonType = ConnectionSource.SupportsNativeJson;
+        });
+
+        using var provider = services.BuildServiceProvider();
+
+        var part = provider.GetServices<ISystemPart>().OfType<PolecatSystemPart>().Single();
+        var store = (DocumentStore)provider.GetRequiredService<IDocumentStore>();
+
+        var resources = await part.FindResources();
+
+        var resource = resources.ShouldHaveSingleItem().ShouldBeOfType<DatabaseResource>();
+        resource.Database.ShouldBeSameAs(store.Database);
+        resource.Name.ShouldBe(store.Database.Identifier);
+    }
+
+    [Fact]
+    public async Task add_resource_setup_on_startup_creates_the_polecat_schema()
+    {
+        const string schema = "resource_setup_187";
+        await DropSchemaAsync(schema);
+
+        // No .ApplyAllDatabaseChangesOnStartup() — rely solely on the generic
+        // JasperFx resource bootstrapping, the path Marten supports out of the box.
+        using var host = new HostBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddPolecat(opts =>
+                {
+                    opts.ConnectionString = ConnectionSource.ConnectionString;
+                    opts.UseNativeJsonType = ConnectionSource.SupportsNativeJson;
+                    opts.DatabaseSchemaName = schema;
+                });
+
+                services.AddResourceSetupOnStartup();
+            })
+            .Build();
+
+        await host.StartAsync();
+        try
+        {
+            var tables = await SchemaInspector.GetTableNamesAsync(schema);
+            tables.ShouldContain("pc_streams");
+            tables.ShouldContain("pc_events");
+            tables.ShouldContain("pc_event_progression");
+        }
+        finally
+        {
+            await host.StopAsync();
+        }
+    }
+
+    private static async Task DropSchemaAsync(string schema)
+    {
+        await using var conn = new SqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"""
+            IF SCHEMA_ID('{schema}') IS NOT NULL
+            BEGIN
+                DECLARE @fksql NVARCHAR(MAX) = '';
+                SELECT @fksql += 'ALTER TABLE ' + QUOTENAME(s.name) + '.' + QUOTENAME(t.name)
+                    + ' DROP CONSTRAINT ' + QUOTENAME(fk.name) + ';' + CHAR(13)
+                FROM sys.foreign_keys fk
+                JOIN sys.tables t ON fk.parent_object_id = t.object_id
+                JOIN sys.schemas s ON t.schema_id = s.schema_id
+                WHERE s.name = '{schema}';
+                IF LEN(@fksql) > 0 EXEC sp_executesql @fksql;
+
+                DECLARE @sql NVARCHAR(MAX) = '';
+                SELECT @sql += 'DROP TABLE IF EXISTS ' + QUOTENAME(s.name) + '.' + QUOTENAME(t.name) + ';' + CHAR(13)
+                FROM sys.tables t
+                JOIN sys.schemas s ON t.schema_id = s.schema_id
+                WHERE s.name = '{schema}';
+                EXEC sp_executesql @sql;
+            END
+            """;
+        await cmd.ExecuteNonQueryAsync();
+    }
+}

--- a/src/Polecat/PolecatServiceCollectionExtensions.cs
+++ b/src/Polecat/PolecatServiceCollectionExtensions.cs
@@ -1,3 +1,4 @@
+using JasperFx.CommandLine.Descriptions;
 using JasperFx.Events;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -75,6 +76,13 @@ public static class PolecatServiceCollectionExtensions
             var options = sp.GetRequiredService<StoreOptions>();
             return new DocumentStore(options);
         });
+
+        // #187: expose the Polecat database(s) to JasperFx's resource model so the
+        // idiomatic services.AddResourceSetupOnStartup() provisions the Polecat
+        // schema with no Polecat-specific call (matching Marten's MartenSystemPart).
+        // The "resources" CLI commands also discover the Polecat database through this.
+        services.AddSingleton<ISystemPart>(sp =>
+            new PolecatSystemPart(sp.GetRequiredService<IDocumentStore>()));
 
         // Bridge so monitoring tools (CritterWatch / Wolverine
         // ServiceCapabilities.readDocumentStores) can discover this store via

--- a/src/Polecat/PolecatStoreServiceCollectionExtensions.cs
+++ b/src/Polecat/PolecatStoreServiceCollectionExtensions.cs
@@ -61,6 +61,12 @@ public static class PolecatStoreServiceCollectionExtensions
 
         services.AddSingleton<Lazy<T>>(sp => new Lazy<T>(() => sp.GetRequiredService<T>()));
 
+        // #187: contribute this ancillary store's database(s) to JasperFx's resource
+        // model so AddResourceSetupOnStartup() / the "resources" CLI provision its
+        // schema. Mirrors AddMartenStore<T>'s MartenSystemPart<T> registration.
+        services.AddSingleton<JasperFx.CommandLine.Descriptions.ISystemPart>(sp =>
+            new PolecatSystemPart<T>(sp.GetRequiredService<T>()));
+
         // Bridge so monitoring tools discover the ancillary store via
         // GetServices<IDocumentStoreUsageSource>(). Mirrors the bridge in
         // PolecatServiceCollectionExtensions.AddPolecat for the primary store.

--- a/src/Polecat/PolecatSystemPart.cs
+++ b/src/Polecat/PolecatSystemPart.cs
@@ -1,0 +1,64 @@
+using System.Diagnostics.CodeAnalysis;
+using JasperFx.CommandLine;
+using JasperFx.CommandLine.Descriptions;
+using JasperFx.Descriptors;
+using JasperFx.Resources;
+using Weasel.Core.CommandLine;
+
+namespace Polecat;
+
+/// <summary>
+///     Exposes the Polecat store's database(s) to JasperFx's resource model so the
+///     idiomatic <c>services.AddResourceSetupOnStartup()</c> (and the <c>resources</c>
+///     CLI commands) provision the Polecat schema with no Polecat-specific call.
+///     Mirrors Marten's <c>MartenSystemPart</c>: <c>FindResources()</c> wraps each
+///     tenant database in a Weasel <see cref="DatabaseResource" />.
+/// </summary>
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "WriteToConsole reflects over the store options for the dev-time 'describe' CLI command only; the resource-setup path (FindResources/Setup) is reflection-free. AOT consumers run resource setup, not describe.")]
+[UnconditionalSuppressMessage("Trimming", "IL2046",
+    Justification = "Class-level: override RUC mismatch — the base WriteToConsole does not yet carry RequiresUnreferencedCode. Suppressed locally to match Marten's MartenSystemPart.")]
+internal class PolecatSystemPart : SystemPartBase
+{
+    public static Uri PolecatStoreUri { get; } = new("polecat://store");
+
+    private readonly IDocumentStore _store;
+
+    protected PolecatSystemPart(IDocumentStore store, string title, Uri subjectUri) : base(title, subjectUri)
+    {
+        _store = store;
+    }
+
+    public PolecatSystemPart(IDocumentStore store) : this(store, "Polecat", PolecatStoreUri)
+    {
+    }
+
+    public override Task WriteToConsole()
+    {
+        var description = OptionsDescription.For(_store);
+        OptionDescriptionWriter.Write(description);
+        return Task.CompletedTask;
+    }
+
+    public override async ValueTask<IReadOnlyList<IStatefulResource>> FindResources()
+    {
+        // Await the tenancy build so dynamic (master-table / separate-database)
+        // tenancies enumerate every tenant database, exactly like MartenSystemPart.
+        var databases = await _store.Options.Tenancy!.BuildDatabasesAsync().ConfigureAwait(false);
+        return databases.Select(x => new DatabaseResource(x, SubjectUri)).ToArray();
+    }
+}
+
+/// <summary>
+///     Marker-typed variant of <see cref="PolecatSystemPart" /> for ancillary store
+///     registrations (multi-store apps where each <typeparamref name="T" /> store
+///     contributes its own databases to the resource model). Mirrors
+///     <c>MartenSystemPart&lt;T&gt;</c>.
+/// </summary>
+internal class PolecatSystemPart<T> : PolecatSystemPart where T : IDocumentStore
+{
+    public PolecatSystemPart(T store)
+        : base(store, $"Polecat {typeof(T).Name}", new Uri("polecat://" + typeof(T).Name.ToLowerInvariant()))
+    {
+    }
+}

--- a/src/Polecat/Storage/ITenancy.cs
+++ b/src/Polecat/Storage/ITenancy.cs
@@ -15,6 +15,16 @@ public interface ITenancy
     ConnectionFactory GetConnectionFactory(string tenantId);
     PolecatDatabase GetDatabase(string tenantId);
     IReadOnlyList<PolecatDatabase> AllDatabases();
+
+    /// <summary>
+    ///     Asynchronously resolve every tenant database. Dynamic tenancies
+    ///     (e.g. <see cref="MasterTableTenancy" />) query their control table
+    ///     here; static tenancies just return <see cref="AllDatabases" />. Mirrors
+    ///     Marten's <c>ITenancy.BuildDatabases()</c> and is used by
+    ///     <c>PolecatSystemPart.FindResources()</c> so JasperFx's
+    ///     <c>AddResourceSetupOnStartup()</c> can provision every tenant schema.
+    /// </summary>
+    Task<IReadOnlyList<PolecatDatabase>> BuildDatabasesAsync(CancellationToken token = default);
 }
 
 /// <summary>
@@ -37,6 +47,9 @@ internal class DefaultTenancy : ITenancy
     public ConnectionFactory GetConnectionFactory(string tenantId) => _factory;
     public PolecatDatabase GetDatabase(string tenantId) => _database;
     public IReadOnlyList<PolecatDatabase> AllDatabases() => [_database];
+
+    public Task<IReadOnlyList<PolecatDatabase>> BuildDatabasesAsync(CancellationToken token = default) =>
+        Task.FromResult(AllDatabases());
 }
 
 /// <summary>
@@ -96,4 +109,7 @@ public class SeparateDatabaseTenancy : ITenancy
 
         return _databases.Values.ToList();
     }
+
+    Task<IReadOnlyList<PolecatDatabase>> ITenancy.BuildDatabasesAsync(CancellationToken token) =>
+        Task.FromResult(((ITenancy)this).AllDatabases());
 }


### PR DESCRIPTION
Closes #187.

## Problem

Polecat's event-store schema (`pc_streams`, `pc_events`, `pc_event_progression`, `pc_doc_*`) was **not** created when an app relied on JasperFx's generic `services.AddResourceSetupOnStartup()` for schema bootstrapping — the idiomatic JasperFx/Wolverine pattern that Marten supports out of the box. Apps had to call `.ApplyAllDatabaseChangesOnStartup()` explicitly or every event append failed with `Invalid object name '...pc_streams'`.

Root cause: Polecat registered no `ISystemPart` / `SystemPartBase` and exposed no `DatabaseResource`, so `AddResourceSetupOnStartup()` never discovered the Polecat database.

## Fix

- **`PolecatSystemPart : SystemPartBase`** (new) mirrors `MartenSystemPart`. `FindResources()` awaits the tenancy build and wraps each tenant `PolecatDatabase` in a Weasel `DatabaseResource`. A `PolecatSystemPart<T>` marker variant covers ancillary stores.
- **Registered** from `AddPolecat(...)` and `AddPolecatStore<T>(...)` as `ISystemPart`.
- **`ITenancy.BuildDatabasesAsync()`** (new) — `DefaultTenancy` / `SeparateDatabaseTenancy` return `AllDatabases()`; `MasterTableTenancy` already had an async build, so multi-tenancy enumerates every tenant database (acceptance criterion).

## Acceptance

- [x] `AddPolecat(...)` registers an `ISystemPart` exposing the Polecat database(s) as `IStatefulResource`.
- [x] An app calling only `AddResourceSetupOnStartup()` (no `.ApplyAllDatabaseChangesOnStartup()`) gets the schema created on startup.
- [x] `resources setup` / `resources list` discover the Polecat database (via the registered `ISystemPart` → `DatabaseResource`).
- [x] Multi-tenancy: `FindResources()` enumerates all tenant databases (awaits the tenancy build).

## Tests

New `system_part_resource_tests`:
1. `AddPolecat` registers a `PolecatSystemPart`.
2. `FindResources()` returns a `DatabaseResource` wrapping the store's database.
3. A host using **only** `AddResourceSetupOnStartup()` creates `pc_streams` / `pc_events` / `pc_event_progression` on startup.

All DI + multi-tenancy tests pass (42 total).

🤖 Generated with [Claude Code](https://claude.com/claude-code)