### PR TITLE
Upgrade JasperFx family 2.9.9 -> 2.9.13 (latest)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,9 +14,9 @@
              EventStoreUsage so monitoring tools (CritterWatch) can read the daemon
              error-handling policy off the wire instead of presuming skip-and-DLQ
              behaviour. See JasperFx/ProductSupport#3.
-             JasperFx 2.9.8/2.9.9/2.9.12: roll forward to the latest released 2.9.x line. -->
-        <PackageVersion Include="JasperFx" Version="2.9.12" />
-        <PackageVersion Include="JasperFx.Events" Version="2.9.12" />
+             JasperFx 2.9.8/2.9.9/2.9.12/2.9.13: roll forward to the latest released 2.9.x line. -->
+        <PackageVersion Include="JasperFx" Version="2.9.13" />
+        <PackageVersion Include="JasperFx.Events" Version="2.9.13" />
         <!-- Pin the sibling JasperFx packages for parity with Marten 9's matrix
              even though Polecat doesn't currently reference them directly —
              keeps the lockstep matrix coherent when transitive resolution
@@ -24,7 +24,7 @@
              RuntimeCompiler 5.x line is the active continuation of the 4.x
              lineage; do not pin against the parallel stale 2.0.x series. -->
         <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.9.12" />
+        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.9.13" />
         <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
@@ -50,7 +50,7 @@
         <PackageVersion Include="StronglyTypedId" Version="1.0.0-beta08" />
 
         <!-- Source generators (matched to JasperFx.Events above) -->
-        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.9.12" />
+        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.9.13" />
 
         <!-- Build automation -->
         <PackageVersion Include="Nuke.Common" Version="9.0.4" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,9 +14,9 @@
              EventStoreUsage so monitoring tools (CritterWatch) can read the daemon
              error-handling policy off the wire instead of presuming skip-and-DLQ
              behaviour. See JasperFx/ProductSupport#3.
-             JasperFx 2.9.8/2.9.9: roll forward to the latest released 2.9.x line. -->
-        <PackageVersion Include="JasperFx" Version="2.9.9" />
-        <PackageVersion Include="JasperFx.Events" Version="2.9.9" />
+             JasperFx 2.9.8/2.9.9/2.9.12: roll forward to the latest released 2.9.x line. -->
+        <PackageVersion Include="JasperFx" Version="2.9.12" />
+        <PackageVersion Include="JasperFx.Events" Version="2.9.12" />
         <!-- Pin the sibling JasperFx packages for parity with Marten 9's matrix
              even though Polecat doesn't currently reference them directly —
              keeps the lockstep matrix coherent when transitive resolution
@@ -24,7 +24,7 @@
              RuntimeCompiler 5.x line is the active continuation of the 4.x
              lineage; do not pin against the parallel stale 2.0.x series. -->
         <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.9.9" />
+        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.9.12" />
         <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
@@ -50,7 +50,7 @@
         <PackageVersion Include="StronglyTypedId" Version="1.0.0-beta08" />
 
         <!-- Source generators (matched to JasperFx.Events above) -->
-        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.9.9" />
+        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.9.12" />
 
         <!-- Build automation -->
         <PackageVersion Include="Nuke.Common" Version="9.0.4" />


### PR DESCRIPTION
Rolls the JasperFx 2.9.x pins in `Directory.Packages.props` forward to the latest released **2.9.13** line:

| Package | Old | New |
|---|---|---|
| JasperFx | 2.9.9 | **2.9.13** |
| JasperFx.Events | 2.9.9 | **2.9.13** |
| JasperFx.SourceGenerator | 2.9.9 | **2.9.13** |
| JasperFx.Events.SourceGenerator | 2.9.9 | **2.9.13** |

`JasperFx.RuntimeCompiler` stays on **5.0.0** (latest of its line; the 2.9.x cadence does not apply to it).

> Updated from the initial 2.9.12 bump — 2.9.13 was released while this PR was open, so the pins were rolled straight to 2.9.13.

## Verification

- `dotnet restore` + full solution build: **green**
- `Polecat.Tests` (net10.0): **1189 passed, 0 failed**, 3 skipped
- `Polecat.EntityFrameworkCore.Tests` (net10.0): **37 passed, 0 failed**

No source changes were required — pure dependency bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)