### PR TITLE
Upgrade JasperFx family 2.9.13 → 2.10.0 (release 4.4.4)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>4.4.3</Version>
+        <Version>4.4.4</Version>
         <LangVersion>latest</LangVersion>
         <Authors>Jeremy D. Miller</Authors>
         <PackageIcon>logo.png</PackageIcon>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,8 +15,8 @@
              error-handling policy off the wire instead of presuming skip-and-DLQ
              behaviour. See JasperFx/ProductSupport#3.
              JasperFx 2.9.8/2.9.9/2.9.12/2.9.13: roll forward to the latest released 2.9.x line. -->
-        <PackageVersion Include="JasperFx" Version="2.9.13" />
-        <PackageVersion Include="JasperFx.Events" Version="2.9.13" />
+        <PackageVersion Include="JasperFx" Version="2.10.0" />
+        <PackageVersion Include="JasperFx.Events" Version="2.10.0" />
         <!-- Pin the sibling JasperFx packages for parity with Marten 9's matrix
              even though Polecat doesn't currently reference them directly —
              keeps the lockstep matrix coherent when transitive resolution
@@ -24,7 +24,7 @@
              RuntimeCompiler 5.x line is the active continuation of the 4.x
              lineage; do not pin against the parallel stale 2.0.x series. -->
         <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.9.13" />
+        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.10.0" />
         <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
@@ -50,7 +50,7 @@
         <PackageVersion Include="StronglyTypedId" Version="1.0.0-beta08" />
 
         <!-- Source generators (matched to JasperFx.Events above) -->
-        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.9.13" />
+        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.10.0" />
 
         <!-- Build automation -->
         <PackageVersion Include="Nuke.Common" Version="9.0.4" />


### PR DESCRIPTION
Bumps `JasperFx`, `JasperFx.Events`, `JasperFx.Events.SourceGenerator`, `JasperFx.SourceGenerator` → **2.10.0** and the package version to **4.4.4**.

**Why:** JasperFx.Events 2.10.0 (jasperfx #449 + #450) made the positional record `DeadLetterShardCount` 4-arg (`+ string? TenantId`), which is binary-breaking. Polecat 4.4.3 (compiled against the 3-arg ctor) throws `MissingMethodException` at runtime against 2.10.0. Rebuilding against 2.10.0 fixes the call site so downstream consumers (CritterWatch) can adopt 2.10.0.

Core build verified locally (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)