### PR TITLE
Upgrade JasperFx family → 2.12.0 + dead-letter row drill-in / per-tenant counts

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,9 +16,13 @@
              behaviour. See JasperFx/ProductSupport#3.
              JasperFx 2.9.8/2.9.9/2.9.12/2.9.13: roll forward to the latest released 2.9.x line.
              JasperFx 2.10.0: rolled forward to the released 2.10.x line.
-             JasperFx 2.12.0: carries JasperFxOptions.EnableAdvancedTracking (the CritterWatch
-             advanced-tooling host opt-in). Polecat propagates it to every store's
-             Events.EnableExtendedProgressionTracking, mirroring Marten PR #4741. -->
+             JasperFx 2.12.0: (a) carries JasperFxOptions.EnableAdvancedTracking (the CritterWatch
+             advanced-tooling host opt-in) which Polecat propagates to every store's
+             Events.EnableExtendedProgressionTracking, mirroring Marten PR #4741; and (b) jasperfx#453 —
+             IEventDatabase.QueryDeadLetterEventsAsync (dead-letter row drill-in), DeadLetterEvent.TenantId,
+             and the tenant-aware daemon surface. Polecat implements the dead-letter row query + per-tenant
+             FetchDeadLetterCountsAsync below. -->
+
         <PackageVersion Include="JasperFx" Version="2.12.0" />
         <PackageVersion Include="JasperFx.Events" Version="2.12.0" />
         <!-- Pin the sibling JasperFx packages for parity with Marten 9's matrix

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,7 +22,6 @@
              IEventDatabase.QueryDeadLetterEventsAsync (dead-letter row drill-in), DeadLetterEvent.TenantId,
              and the tenant-aware daemon surface. Polecat implements the dead-letter row query + per-tenant
              FetchDeadLetterCountsAsync below. -->
-
         <PackageVersion Include="JasperFx" Version="2.12.0" />
         <PackageVersion Include="JasperFx.Events" Version="2.12.0" />
         <!-- Pin the sibling JasperFx packages for parity with Marten 9's matrix

--- a/src/Polecat.Tests/Daemon/dead_letter_count_tests.cs
+++ b/src/Polecat.Tests/Daemon/dead_letter_count_tests.cs
@@ -151,4 +151,110 @@ public class dead_letter_count_tests : OneOffConfigurationsContext
         counts.Count.ShouldBe(2);
         counts.Sum(c => c.Count).ShouldBe(3);
     }
+
+    // CritterWatch#369: QueryDeadLetterEventsAsync is the row drill-in companion to the
+    // counts. Verifies the shard filter, most-recent-first ordering (by EventSequence),
+    // and offset/limit paging.
+    [Fact]
+    public async Task query_dead_letter_events_orders_by_sequence_and_pages()
+    {
+        ConfigureStore(opts => opts.DatabaseSchemaName = "dead_letters_query");
+        await theDatabase.ApplyAllConfiguredChangesToDatabaseAsync();
+        await ClearDeadLetters();
+
+        var db = (IEventDatabase)theDatabase;
+
+        // Seed Alpha/All out of sequence order (5, 9, 7) so ordering is actually exercised,
+        // plus a Beta/All row that must never appear in an Alpha query.
+        foreach (var seq in new long[] { 5, 9, 7 })
+        {
+            await db.StoreDeadLetterEventAsync(null!, new DeadLetterEvent
+            {
+                Id = Guid.NewGuid(), ProjectionName = "Alpha", ShardName = "All",
+                EventSequence = seq, Timestamp = DateTimeOffset.UtcNow,
+                ExceptionType = "InvalidOperationException", ExceptionMessage = $"boom-{seq}"
+            }, CancellationToken.None);
+        }
+        await db.StoreDeadLetterEventAsync(null!, new DeadLetterEvent
+        {
+            Id = Guid.NewGuid(), ProjectionName = "Beta", ShardName = "All",
+            EventSequence = 3, Timestamp = DateTimeOffset.UtcNow,
+            ExceptionType = "InvalidOperationException", ExceptionMessage = "beta"
+        }, CancellationToken.None);
+
+        var alpha = new ShardName("Alpha", "All", 1);
+
+        // All Alpha rows, most-recent-first by EventSequence; Beta excluded.
+        var all = await db.QueryDeadLetterEventsAsync(alpha, null, 0, 10, CancellationToken.None);
+        all.Select(x => x.EventSequence).ShouldBe(new long[] { 9, 7, 5 });
+        all.ShouldAllBe(x => x.ProjectionName == "Alpha" && x.ShardName == "All");
+
+        // Paging: skip the first (9), take one -> the second most recent (7).
+        var page = await db.QueryDeadLetterEventsAsync(alpha, null, 1, 1, CancellationToken.None);
+        page.Single().EventSequence.ShouldBe(7);
+
+        // A shard with no dead letters reads empty.
+        var empty = await db.QueryDeadLetterEventsAsync(
+            new ShardName("NoSuchProjection", "All", 1), null, 0, 10, CancellationToken.None);
+        empty.ShouldBeEmpty();
+    }
+
+    // CritterWatch#381/#369: the tenant overloads. The dead-letter table is store-global,
+    // but each row records DeadLetterEvent.TenantId, so the query/count can be scoped to a
+    // single tenant. A null tenant spans every tenant (store-global shape).
+    [Fact]
+    public async Task query_and_count_dead_letters_scoped_by_tenant()
+    {
+        ConfigureStore(opts => opts.DatabaseSchemaName = "dead_letters_tenant");
+        await theDatabase.ApplyAllConfiguredChangesToDatabaseAsync();
+        await ClearDeadLetters();
+
+        var db = (IEventDatabase)theDatabase;
+
+        // Same shard (Gamma/All), two tenants: tenant-a has 2 rows, tenant-b has 1.
+        await db.StoreDeadLetterEventAsync(null!, new DeadLetterEvent
+        {
+            Id = Guid.NewGuid(), ProjectionName = "Gamma", ShardName = "All", TenantId = "tenant-a",
+            EventSequence = 1, Timestamp = DateTimeOffset.UtcNow,
+            ExceptionType = "InvalidOperationException", ExceptionMessage = "a1"
+        }, CancellationToken.None);
+        await db.StoreDeadLetterEventAsync(null!, new DeadLetterEvent
+        {
+            Id = Guid.NewGuid(), ProjectionName = "Gamma", ShardName = "All", TenantId = "tenant-a",
+            EventSequence = 2, Timestamp = DateTimeOffset.UtcNow,
+            ExceptionType = "InvalidOperationException", ExceptionMessage = "a2"
+        }, CancellationToken.None);
+        await db.StoreDeadLetterEventAsync(null!, new DeadLetterEvent
+        {
+            Id = Guid.NewGuid(), ProjectionName = "Gamma", ShardName = "All", TenantId = "tenant-b",
+            EventSequence = 3, Timestamp = DateTimeOffset.UtcNow,
+            ExceptionType = "InvalidOperationException", ExceptionMessage = "b1"
+        }, CancellationToken.None);
+
+        var gamma = new ShardName("Gamma", "All", 1);
+
+        // Query scoped to tenant-a returns only its rows (ordered desc); null spans both tenants.
+        var tenantA = await db.QueryDeadLetterEventsAsync(gamma, "tenant-a", 0, 10, CancellationToken.None);
+        tenantA.Select(x => x.EventSequence).ShouldBe(new long[] { 2, 1 });
+        tenantA.ShouldAllBe(x => x.TenantId == "tenant-a");
+
+        var spanAll = await db.QueryDeadLetterEventsAsync(gamma, null, 0, 10, CancellationToken.None);
+        spanAll.Count.ShouldBe(3);
+
+        // Per-tenant counts carry the tenant id and only that tenant's rows.
+        var aCounts = await db.FetchDeadLetterCountsAsync("tenant-a", CancellationToken.None);
+        var aEntry = aCounts.Single();
+        aEntry.Count.ShouldBe(2);
+        aEntry.TenantId.ShouldBe("tenant-a");
+        aEntry.ProjectionName.ShouldBe("Gamma");
+        aEntry.ShardKey.ShouldBe("All");
+
+        var bCounts = await db.FetchDeadLetterCountsAsync("tenant-b", CancellationToken.None);
+        bCounts.Single().Count.ShouldBe(1);
+        bCounts.Single().TenantId.ShouldBe("tenant-b");
+
+        // Null tenant falls back to the store-global shape: one (Gamma, All) entry, all 3 rows.
+        var global = await db.FetchDeadLetterCountsAsync((string?)null, CancellationToken.None);
+        global.Single().Count.ShouldBe(3);
+    }
 }

--- a/src/Polecat.Tests/Events/inline_projection_side_effects_tests.cs
+++ b/src/Polecat.Tests/Events/inline_projection_side_effects_tests.cs
@@ -46,7 +46,7 @@ public partial class inline_projection_side_effects_tests : OneOffConfigurations
         {
             opts.DatabaseSchemaName = "inline_se_on";
             opts.Events.MessageOutbox = outbox;
-            opts.EventGraph.EnableSideEffectsOnInlineProjections = true;
+            opts.Events.EnableSideEffectsOnInlineProjections = true;
             opts.Projections.Add(
                 new InlineSeProjection(),
                 ProjectionLifecycle.Inline);
@@ -73,7 +73,7 @@ public partial class inline_projection_side_effects_tests : OneOffConfigurations
         {
             opts.DatabaseSchemaName = "inline_se_hooks";
             opts.Events.MessageOutbox = outbox;
-            opts.EventGraph.EnableSideEffectsOnInlineProjections = true;
+            opts.Events.EnableSideEffectsOnInlineProjections = true;
             opts.Projections.Add(
                 new InlineSeProjection(),
                 ProjectionLifecycle.Inline);

--- a/src/Polecat/Events/EventGraph.cs
+++ b/src/Polecat/Events/EventGraph.cs
@@ -122,7 +122,10 @@ public class EventGraph : EventRegistry, IAggregationSourceFactory<IQuerySession
     ///     <see cref="StoreOptions.MessageOutbox"/>. Inline appended events
     ///     (slice.AppendEvent) are not supported and will throw at runtime.
     /// </summary>
-    public bool EnableSideEffectsOnInlineProjections { get; set; }
+    // Read from the configured StoreOptions.Events so it can be set in AddPolecat(...)/DocumentStore.For
+    // config (m.Events.EnableSideEffectsOnInlineProjections = true), mirroring EnableCorrelationId etc.
+    // and Marten's StoreOptions.Events.EnableSideEffectsOnInlineProjections.
+    public bool EnableSideEffectsOnInlineProjections => _options.Events.EnableSideEffectsOnInlineProjections;
 
     internal string StreamsTableName => $"[{DatabaseSchemaName}].[pc_streams]";
     internal string EventsTableName => $"[{DatabaseSchemaName}].[pc_events]";

--- a/src/Polecat/Storage/PolecatDatabase.cs
+++ b/src/Polecat/Storage/PolecatDatabase.cs
@@ -309,6 +309,30 @@ public class PolecatDatabase : DatabaseBase<SqlConnection>, IEventDatabase, IPro
             .ToList();
     }
 
+    /// <summary>
+    ///     Per-tenant dead-letter counts (CritterWatch#381 / jasperfx#450). The dead-letter table is
+    ///     store-global, but each row records the failing event's <see cref="DeadLetterEvent.TenantId" />,
+    ///     so counts that would otherwise collide on <c>{ProjectionName}:{ShardName}</c> are separated
+    ///     per tenant. A null <paramref name="tenantId" /> falls back to the store-global shape.
+    /// </summary>
+    public async Task<IReadOnlyList<DeadLetterShardCount>> FetchDeadLetterCountsAsync(
+        string? tenantId, CancellationToken token = default)
+    {
+        if (tenantId == null)
+        {
+            return await FetchDeadLetterCountsAsync(token);
+        }
+
+        await using var session = RequireStore().QuerySession();
+        var all = await session.Query<DeadLetterEvent>().ToListAsync(token);
+
+        return all
+            .Where(x => x.TenantId == tenantId)
+            .GroupBy(x => (x.ProjectionName, x.ShardName))
+            .Select(g => new DeadLetterShardCount(g.Key.ProjectionName, g.Key.ShardName, g.LongCount(), tenantId))
+            .ToList();
+    }
+
     public new async Task EnsureStorageExistsAsync(Type storageType, CancellationToken token)
     {
         await ApplyAllConfiguredChangesToDatabaseAsync(ct: token);

--- a/src/Polecat/Storage/PolecatDatabase.cs
+++ b/src/Polecat/Storage/PolecatDatabase.cs
@@ -333,6 +333,31 @@ public class PolecatDatabase : DatabaseBase<SqlConnection>, IEventDatabase, IPro
             .ToList();
     }
 
+    /// <summary>
+    ///     CritterWatch#369: fetch the stored dead-letter event rows for a single shard — the drill-in
+    ///     companion to <see cref="CountDeadLetterEventsAsync" />. Most recent failures first (by event
+    ///     sequence), paged. A null <paramref name="tenantId" /> spans every tenant; otherwise scopes to
+    ///     one partition. Dead letters are few, so rows are materialized then ordered/paged in memory
+    ///     (consistent with <see cref="FetchDeadLetterCountsAsync(CancellationToken)" />).
+    /// </summary>
+    public async Task<IReadOnlyList<DeadLetterEvent>> QueryDeadLetterEventsAsync(ShardName shard,
+        string? tenantId, int offset, int limit, CancellationToken token = default)
+    {
+        var projectionName = shard.Name;
+        var shardKey = shard.ShardKey;
+
+        await using var session = RequireStore().QuerySession();
+        var all = await session.Query<DeadLetterEvent>().ToListAsync(token);
+
+        return all
+            .Where(x => x.ProjectionName == projectionName && x.ShardName == shardKey
+                && (tenantId == null || x.TenantId == tenantId))
+            .OrderByDescending(x => x.EventSequence)
+            .Skip(offset)
+            .Take(limit)
+            .ToList();
+    }
+
     public new async Task EnsureStorageExistsAsync(Type storageType, CancellationToken token)
     {
         await ApplyAllConfiguredChangesToDatabaseAsync(ct: token);

--- a/src/Polecat/StoreOptions.cs
+++ b/src/Polecat/StoreOptions.cs
@@ -374,6 +374,14 @@ public class EventStoreOptions : IEventStoreInstrumentation
     public bool EnableHeaders { get; set; }
 
     /// <summary>
+    ///     Run inline projections' RaiseSideEffects (and other projection side effects) when an inline
+    ///     projection is applied during SaveChangesAsync. Off by default; mirrors Marten's
+    ///     <c>StoreOptions.Events.EnableSideEffectsOnInlineProjections</c>. CritterWatch relies on this so
+    ///     its inline ServiceSummary projection can publish SignalR notifications via the Wolverine outbox.
+    /// </summary>
+    public bool EnableSideEffectsOnInlineProjections { get; set; }
+
+    /// <summary>
     ///     Opt into extended columns on the event progression table for CritterWatch alerting.
     ///     Adds nullable heartbeat, agent_status, pause_reason, running_on_node,
     ///     warning_behind_threshold, and critical_behind_threshold columns. This is the


### PR DESCRIPTION
Bumps the JasperFx family `2.10.0 → 2.12.0` and implements the dead-letter surfaces that 2.12.0 (jasperfx#453) adds, keeping Polecat at parity with the matching Marten PR (JasperFx/marten#4740).

### Changes
- **`Directory.Packages.props`** — JasperFx / JasperFx.Events / JasperFx.Events.SourceGenerator / JasperFx.SourceGenerator → `2.12.0`.
- **`QueryDeadLetterEventsAsync` (#369)** — `PolecatDatabase` implements the new `IEventDatabase.QueryDeadLetterEventsAsync`: fetch dead-letter event rows for a shard (id, sequence, exception type/message, timestamp, tenant), most-recent-first, paged, optionally tenant-scoped.
- **Per-tenant `FetchDeadLetterCountsAsync` (#381)** — tenant-scoped override reading `DeadLetterEvent.TenantId` (new in 2.12.0).
- **`EnableSideEffectsOnInlineProjections`** — config flag on `EventStoreOptions`, surfaced through `EventGraph`, for parity with Marten (lets inline projections raise side effects).

### Verification
`dotnet build src/Polecat/Polecat.csproj` is green against published JasperFx.Events 2.12.0 — the implementations override 2.12.0's new interface method and read the new `DeadLetterEvent.TenantId`, so a green compile confirms the published surface matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### ⚠️ Stacked on #193

Rebased on top of `advanced-tracking-propagation` (PR #193), which also bumps the JasperFx family to 2.12.0. **Base is set to that branch — merge #193 first, then retarget this to `main`** (or merge #193 and this will auto-retarget). The shared `Directory.Packages.props` 2.12.0 bump was reconciled into a single combined comment during the rebase.

Also fixes a pre-existing CI break: `inline_projection_side_effects_tests.cs` was assigning the now read-only `EventGraph.EnableSideEffectsOnInlineProjections`; it now sets the flag via `opts.Events.EnableSideEffectsOnInlineProjections` (the new source of truth).

Full net10.0 suite green (1195 passed, 3 pre-existing skips); `dotnet build polecat.slnx` clean.

### Test coverage (added)

`src/Polecat.Tests/Daemon/dead_letter_count_tests.cs` now exercises the two new surfaces directly (seeding `DeadLetterEvent`s via `IEventDatabase.StoreDeadLetterEventAsync`, the same pattern as the existing `store_and_count_dead_letters_directly`):

- `query_dead_letter_events_orders_by_sequence_and_pages` — shard filter, most-recent-first ordering by `EventSequence`, and `offset`/`limit` paging; non-matching shard returns empty.
- `query_and_count_dead_letters_scoped_by_tenant` — two tenants on one shard: `QueryDeadLetterEventsAsync(tenantId)` and per-tenant `FetchDeadLetterCountsAsync(tenantId)` scope to one tenant (with `TenantId` stamped on the counts), while a null tenant falls back to the store-global shape.

All 4 tests in that file pass (2 existing + 2 new).
