### PR TITLE
Propagate JasperFxOptions.EnableAdvancedTracking to Events.EnableExtendedProgressionTracking

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,9 +14,13 @@
              EventStoreUsage so monitoring tools (CritterWatch) can read the daemon
              error-handling policy off the wire instead of presuming skip-and-DLQ
              behaviour. See JasperFx/ProductSupport#3.
-             JasperFx 2.9.8/2.9.9/2.9.12/2.9.13: roll forward to the latest released 2.9.x line. -->
-        <PackageVersion Include="JasperFx" Version="2.10.0" />
-        <PackageVersion Include="JasperFx.Events" Version="2.10.0" />
+             JasperFx 2.9.8/2.9.9/2.9.12/2.9.13: roll forward to the latest released 2.9.x line.
+             JasperFx 2.10.0: rolled forward to the released 2.10.x line.
+             JasperFx 2.12.0: carries JasperFxOptions.EnableAdvancedTracking (the CritterWatch
+             advanced-tooling host opt-in). Polecat propagates it to every store's
+             Events.EnableExtendedProgressionTracking, mirroring Marten PR #4741. -->
+        <PackageVersion Include="JasperFx" Version="2.12.0" />
+        <PackageVersion Include="JasperFx.Events" Version="2.12.0" />
         <!-- Pin the sibling JasperFx packages for parity with Marten 9's matrix
              even though Polecat doesn't currently reference them directly —
              keeps the lockstep matrix coherent when transitive resolution
@@ -24,7 +28,7 @@
              RuntimeCompiler 5.x line is the active continuation of the 4.x
              lineage; do not pin against the parallel stale 2.0.x series. -->
         <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.10.0" />
+        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.12.0" />
         <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
@@ -50,7 +54,7 @@
         <PackageVersion Include="StronglyTypedId" Version="1.0.0-beta08" />
 
         <!-- Source generators (matched to JasperFx.Events above) -->
-        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.10.0" />
+        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.12.0" />
 
         <!-- Build automation -->
         <PackageVersion Include="Nuke.Common" Version="9.0.4" />

--- a/src/Polecat.Tests/Events/advanced_tracking_propagation_tests.cs
+++ b/src/Polecat.Tests/Events/advanced_tracking_propagation_tests.cs
@@ -1,0 +1,113 @@
+using JasperFx;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Polecat.Tests.Events;
+
+// Mirrors Marten PR #4741 (CoreTests/jasper_fx_mechanics.cs): when the JasperFx host
+// opts into advanced tracking (typically via CritterWatch configuration) by setting
+// JasperFxOptions.EnableAdvancedTracking, every Polecat DocumentStore in the container
+// — primary (AddPolecat) and ancillary (AddPolecatStore<T>) — opts into extended
+// progression tracking so downstream tooling sees the richer per-shard state.
+//
+// The single integration point is StoreOptions.ReadJasperFxOptions, called by both
+// registration paths after the IConfigurePolecat chain and before the IDocumentStore
+// singleton is constructed.
+
+public class advanced_tracking_propagation_tests
+{
+    [Fact]
+    public void enable_advanced_tracking_propagates_to_main_document_store()
+    {
+        var services = new ServiceCollection();
+        services.AddJasperFx(o => o.EnableAdvancedTracking = true);
+        services.AddPolecat(opts =>
+        {
+            opts.ConnectionString = ConnectionSource.ConnectionString;
+            opts.DatabaseSchemaName = "advanced_tracking_main";
+            opts.UseNativeJsonType = ConnectionSource.SupportsNativeJson;
+        });
+
+        using var provider = services.BuildServiceProvider();
+
+        var store = provider.GetRequiredService<IDocumentStore>();
+        store.Options.Events.EnableExtendedProgressionTracking.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void advanced_tracking_off_leaves_extended_progression_tracking_at_default()
+    {
+        // Sanity: when EnableAdvancedTracking is not set (default false), we do NOT
+        // flip EnableExtendedProgressionTracking on. Per-store opt-in is preserved.
+        var services = new ServiceCollection();
+        services.AddJasperFx();
+        services.AddPolecat(opts =>
+        {
+            opts.ConnectionString = ConnectionSource.ConnectionString;
+            opts.DatabaseSchemaName = "advanced_tracking_off_main";
+            opts.UseNativeJsonType = ConnectionSource.SupportsNativeJson;
+        });
+
+        using var provider = services.BuildServiceProvider();
+
+        var store = provider.GetRequiredService<IDocumentStore>();
+        store.Options.Events.EnableExtendedProgressionTracking.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void no_jasperfx_options_registered_leaves_extended_progression_tracking_at_default()
+    {
+        // When AddJasperFx is never called, ReadJasperFxOptions receives null and is a
+        // no-op — the per-store default (opt-out) stands.
+        var services = new ServiceCollection();
+        services.AddPolecat(opts =>
+        {
+            opts.ConnectionString = ConnectionSource.ConnectionString;
+            opts.DatabaseSchemaName = "advanced_tracking_none";
+            opts.UseNativeJsonType = ConnectionSource.SupportsNativeJson;
+        });
+
+        using var provider = services.BuildServiceProvider();
+
+        var store = provider.GetRequiredService<IDocumentStore>();
+        store.Options.Events.EnableExtendedProgressionTracking.ShouldBeFalse();
+    }
+
+    // Both AddPolecat and AddPolecatStore<T> funnel through the same
+    // StoreOptions.ReadJasperFxOptions integration point. Polecat's AddPolecatStore<T>
+    // resolution throws InvalidCastException (no dynamic store proxy — see
+    // event_store_instrumentation_di_tests.cs), so the ancillary path is exercised
+    // directly against the shared method instead of through container resolution.
+
+    [Fact]
+    public void read_jasperfx_options_propagates_advanced_tracking_when_enabled()
+    {
+        var options = new StoreOptions();
+        options.Events.EnableExtendedProgressionTracking.ShouldBeFalse();
+
+        options.ReadJasperFxOptions(new JasperFxOptions { EnableAdvancedTracking = true });
+
+        options.Events.EnableExtendedProgressionTracking.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void read_jasperfx_options_leaves_flag_alone_when_advanced_tracking_off()
+    {
+        var options = new StoreOptions();
+
+        options.ReadJasperFxOptions(new JasperFxOptions { EnableAdvancedTracking = false });
+
+        options.Events.EnableExtendedProgressionTracking.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void read_jasperfx_options_is_a_noop_for_null()
+    {
+        var options = new StoreOptions();
+        options.Events.EnableExtendedProgressionTracking = true;
+
+        options.ReadJasperFxOptions(null);
+
+        // Null host options must not disturb the existing per-store value.
+        options.Events.EnableExtendedProgressionTracking.ShouldBeTrue();
+    }
+}

--- a/src/Polecat/PolecatServiceCollectionExtensions.cs
+++ b/src/Polecat/PolecatServiceCollectionExtensions.cs
@@ -62,11 +62,19 @@ public static class PolecatServiceCollectionExtensions
         services.AddSingleton(sp =>
         {
             var options = optionSource(sp);
+
             var configures = sp.GetServices<IConfigurePolecat>();
             foreach (var configure in configures)
             {
                 configure.Configure(sp, options);
             }
+
+            // Apply host-level JasperFxOptions (e.g. EnableAdvancedTracking →
+            // Events.EnableExtendedProgressionTracking) before the IDocumentStore
+            // singleton is constructed. Runs after the IConfigurePolecat chain so the
+            // host opt-in is not clobbered by per-store instrumentation defaults.
+            // Mirrors Marten PR #4741.
+            options.ReadJasperFxOptions(sp.GetService<JasperFx.JasperFxOptions>());
 
             return options;
         });

--- a/src/Polecat/PolecatStoreServiceCollectionExtensions.cs
+++ b/src/Polecat/PolecatStoreServiceCollectionExtensions.cs
@@ -55,6 +55,12 @@ public static class PolecatStoreServiceCollectionExtensions
                 configure.Configure(sp, options);
             }
 
+            // Apply host-level JasperFxOptions (e.g. EnableAdvancedTracking →
+            // Events.EnableExtendedProgressionTracking) before the ancillary store is
+            // constructed. Runs after the IConfigurePolecat<T> chain so the host opt-in
+            // is not clobbered by per-store instrumentation defaults. Mirrors Marten PR #4741.
+            options.ReadJasperFxOptions(sp.GetService<JasperFx.JasperFxOptions>());
+
             var store = new DocumentStore(options);
             return (T)(IDocumentStore)store;
         });

--- a/src/Polecat/StoreOptions.cs
+++ b/src/Polecat/StoreOptions.cs
@@ -84,6 +84,27 @@ public class StoreOptions
     }
 
     /// <summary>
+    ///     Apply host-level <see cref="JasperFxOptions" /> (registered via
+    ///     <c>AddJasperFx</c>) to this store before the <see cref="DocumentStore" /> is
+    ///     constructed. Called from both the primary (<c>AddPolecat</c>) and ancillary
+    ///     (<c>AddPolecatStore&lt;T&gt;</c>) registration paths. Mirrors Marten's
+    ///     <c>StoreOptions.ReadJasperFxOptions</c>.
+    /// </summary>
+    internal void ReadJasperFxOptions(JasperFxOptions? options)
+    {
+        if (options == null) return;
+
+        // CritterWatch / advanced-tooling opt-in: when the JasperFx host turns on
+        // EnableAdvancedTracking, every Polecat DocumentStore in the container
+        // (primary + ancillary) opts into extended progression tracking so downstream
+        // tools (CritterWatch in particular) see the richer per-shard state.
+        if (options.EnableAdvancedTracking)
+        {
+            Events.EnableExtendedProgressionTracking = true;
+        }
+    }
+
+    /// <summary>
     ///     Default command timeout in seconds.
     /// </summary>
     public int CommandTimeout { get; set; } = DefaultTimeout;


### PR DESCRIPTION
## Summary

Mirrors Marten [PR #4741](https://github.com/JasperFx/marten/pull/4741) for Polecat.

When `JasperFxOptions.EnableAdvancedTracking == true` is set on the container (typically via CritterWatch configuration), every Polecat `DocumentStore` — the main one registered via `AddPolecat` and any ancillary stores registered via `AddPolecatStore<T>` — opts into `Events.EnableExtendedProgressionTracking`. Downstream tooling (CritterWatch in particular) then sees the richer per-shard progression state.

## Implementation

The single integration point is the new `StoreOptions.ReadJasperFxOptions` (mirroring Marten's `StoreOptions.ReadJasperFxOptions`):

```csharp
internal void ReadJasperFxOptions(JasperFxOptions? options)
{
    if (options == null) return;

    if (options.EnableAdvancedTracking)
    {
        Events.EnableExtendedProgressionTracking = true;
    }
}
```

Both registration paths call it from inside their `StoreOptions`/store singleton factory, **after** the `IConfigurePolecat` chain and **before** the `DocumentStore` is constructed:

- **Main store:** `PolecatServiceCollectionExtensions.AddPolecat`
- **Ancillary stores:** `PolecatStoreServiceCollectionExtensions.AddPolecatStore<T>`

Ordering matters: it runs after the `IConfigurePolecat` chain so the host opt-in is not clobbered by the per-store `SetEventStoreInstrumentation` default (which writes `EnableExtendedProgressionTracking = ExtendedProgressionEnabled`). This matches Marten, which also calls `ReadJasperFxOptions` after the `IConfigureMarten` chain.

The flip is one-directional: when `EnableAdvancedTracking` is `true`, we force `EnableExtendedProgressionTracking` on. When it's `false` (default), the per-store value is untouched and per-store opt-in semantics are preserved.

## JasperFx upgrade

Upgrades the JasperFx family `2.10.0 → 2.12.0` (`JasperFx`, `JasperFx.Events`, `JasperFx.SourceGenerator`, `JasperFx.Events.SourceGenerator`), which is the release line carrying `JasperFxOptions.EnableAdvancedTracking`. `JasperFx.RuntimeCompiler` stays at `5.0.0`.

## Test plan

`src/Polecat.Tests/Events/advanced_tracking_propagation_tests.cs` (6 tests):

- [x] `enable_advanced_tracking_propagates_to_main_document_store` — `AddJasperFx(o => o.EnableAdvancedTracking = true)` + `AddPolecat` ⇒ main store gets `EnableExtendedProgressionTracking = true`
- [x] `advanced_tracking_off_leaves_extended_progression_tracking_at_default` — `AddJasperFx()` (default) ⇒ flag stays `false`
- [x] `no_jasperfx_options_registered_leaves_extended_progression_tracking_at_default` — no `AddJasperFx` ⇒ `ReadJasperFxOptions(null)` is a no-op
- [x] `read_jasperfx_options_propagates_advanced_tracking_when_enabled` / `..._leaves_flag_alone_when_advanced_tracking_off` / `..._is_a_noop_for_null` — direct coverage of the shared integration point

> **Note on the ancillary path:** Marten's PR resolves `IFirstStore`/`ISecondStore` ancillary stores end-to-end. Polecat's `AddPolecatStore<T>` does `(T)(IDocumentStore)store` with no dynamic proxy, so resolving an ancillary store throws `InvalidCastException` (documented in `event_store_instrumentation_di_tests.cs`). Since both paths funnel through the same `ReadJasperFxOptions`, the ancillary behavior is covered by exercising that method directly rather than through container resolution.

- [x] Full test suite green on net10.0: **1195 passed, 0 failed, 3 pre-existing skips**
- [x] `dotnet build polecat.slnx` clean (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)