### PR TITLE
Fix AddPolecatStore<T> to generate a typed store proxy (4.5.0)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>4.4.5</Version>
+        <Version>4.5.0</Version>
         <LangVersion>latest</LangVersion>
         <Authors>Jeremy D. Miller</Authors>
         <PackageIcon>logo.png</PackageIcon>

--- a/src/Polecat.Tests/DependencyInjection/lazy_ancillary_store_registration_tests.cs
+++ b/src/Polecat.Tests/DependencyInjection/lazy_ancillary_store_registration_tests.cs
@@ -59,6 +59,37 @@ public class lazy_ancillary_store_registration_tests
         services.Any(d => d.ServiceType == typeof(Lazy<ILazyTestStore>)).ShouldBeTrue();
         services.Any(d => d.ServiceType == typeof(Lazy<IAnotherTestStore>)).ShouldBeTrue();
     }
+
+    [Fact]
+    public void resolves_the_marker_interface_to_a_working_document_store()
+    {
+        // Regression: AddPolecatStore<T> used to hard-cast a bare DocumentStore to the marker
+        // interface T (`(T)(IDocumentStore)store`), which threw InvalidCastException the moment T
+        // was actually resolved. The previous tests only asserted the Lazy<T> descriptor existed,
+        // so they never resolved T and never caught it. A runtime proxy subclass now implements T.
+        var services = new ServiceCollection();
+        services.AddPolecat(opts =>
+        {
+            opts.ConnectionString = ConnectionSource.ConnectionString;
+            opts.UseNativeJsonType = ConnectionSource.SupportsNativeJson;
+        });
+
+        services.AddPolecatStore<ILazyTestStore>(opts =>
+        {
+            opts.ConnectionString = ConnectionSource.ConnectionString;
+            opts.DatabaseSchemaName = "resolves_marker_ancillary";
+            opts.UseNativeJsonType = ConnectionSource.SupportsNativeJson;
+        });
+
+        using var provider = services.BuildServiceProvider();
+
+        var store = provider.GetRequiredService<ILazyTestStore>();
+        store.ShouldNotBeNull();
+        store.ShouldBeAssignableTo<IDocumentStore>();
+
+        // The same singleton instance flows through the Lazy<T> registration.
+        provider.GetRequiredService<Lazy<ILazyTestStore>>().Value.ShouldBeSameAs(store);
+    }
 }
 
 public interface IAnotherTestStore : IDocumentStore;

--- a/src/Polecat/Internal/SecondaryStoreProxyFactory.cs
+++ b/src/Polecat/Internal/SecondaryStoreProxyFactory.cs
@@ -1,0 +1,106 @@
+#nullable enable
+using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace Polecat.Internal;
+
+/// <summary>
+/// Builds a thin runtime subclass <c>class &lt;T&gt;Implementation : DocumentStore, T</c>
+/// per user-supplied secondary-store interface via <see cref="System.Reflection.Emit"/>.
+/// <c>T</c> here is a marker interface (<c>T : IDocumentStore</c>) with no extra abstract
+/// members, so the emitted type only needs a forwarding constructor. Mirrors Marten's
+/// <c>SecondaryStoreProxyFactory</c> so <see cref="PolecatStoreServiceCollectionExtensions.AddPolecatStore{T}(Microsoft.Extensions.DependencyInjection.IServiceCollection,System.Func{System.IServiceProvider,StoreOptions})"/>
+/// can resolve the marker interface instead of hard-casting a bare <see cref="DocumentStore"/>
+/// (which only implements <see cref="IDocumentStore"/>, not the user's sub-interface).
+/// </summary>
+[RequiresDynamicCode("Generates a runtime subclass per secondary-store interface via System.Reflection.Emit.")]
+internal static class SecondaryStoreProxyFactory
+{
+    // Lazy<Type> (not Type) is the value: ConcurrentDictionary.GetOrAdd does NOT
+    // guarantee the value-factory runs only once under contention, so caching the
+    // raw Type would let multiple threads run Build for the same key — each calling
+    // DefineType with the same name on the shared module and throwing
+    // "Duplicate type name within an assembly". Caching a Lazy makes Build run
+    // exactly once per key.
+    //
+    // Note: Lazy (ExecutionAndPublication) caches a thrown exception permanently,
+    // so a failed Build is no longer retried on the next call. Build only fails
+    // deterministically here (a non-marker interface that can't be implemented),
+    // so caching the failure is acceptable.
+    private static readonly ConcurrentDictionary<Type, Lazy<Type>> _cache = new();
+
+    // The ModuleBuilder is process-shared across every secondary-store interface,
+    // and ModuleBuilder.DefineType/CreateType are not thread-safe even for distinct
+    // type names. Serialise all emission through this gate.
+    private static readonly object _emitLock = new();
+
+    private static readonly Lazy<ModuleBuilder> _module = new(() =>
+    {
+        var asm = AssemblyBuilder.DefineDynamicAssembly(
+            new AssemblyName("Polecat.DynamicStores"),
+            AssemblyBuilderAccess.Run);
+        return asm.DefineDynamicModule("Polecat.DynamicStores");
+    });
+
+    // The emitted subclass always declares a public forwarding constructor (see BuildCore), so the
+    // returned Type is guaranteed to satisfy the PublicConstructors requirement of the
+    // Activator.CreateInstance(Type, object[]) call site in AddPolecatStore<T>.
+    [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+    [UnconditionalSuppressMessage("Trimming", "IL2073",
+        Justification = "BuildCore emits a public DocumentStore(StoreOptions) forwarding constructor on the returned type, so the PublicConstructors guarantee on the return value holds even though CreateType() is not statically annotated.")]
+    public static Type GetOrCreate(Type interfaceType)
+    {
+        if (!typeof(IDocumentStore).IsAssignableFrom(interfaceType))
+        {
+            throw new ArgumentException(
+                $"{interfaceType.FullName} must inherit from {nameof(IDocumentStore)} to be used as a secondary store interface.",
+                nameof(interfaceType));
+        }
+
+        return _cache.GetOrAdd(interfaceType, t => new Lazy<Type>(() => Build(t))).Value;
+    }
+
+    private static Type Build(Type interfaceType)
+    {
+        lock (_emitLock)
+        {
+            return BuildCore(interfaceType);
+        }
+    }
+
+    private static Type BuildCore(Type interfaceType)
+    {
+        var module = _module.Value;
+        var typeName = $"Polecat.DynamicStores.{interfaceType.Name}Implementation";
+
+        var tb = module.DefineType(
+            typeName,
+            TypeAttributes.Public | TypeAttributes.Class,
+            typeof(DocumentStore),
+            new[] { interfaceType });
+
+        var baseCtor = typeof(DocumentStore).GetConstructor(
+            BindingFlags.Public | BindingFlags.Instance,
+            binder: null,
+            types: new[] { typeof(StoreOptions) },
+            modifiers: null)
+            ?? throw new InvalidOperationException(
+                $"Could not find public DocumentStore(StoreOptions) constructor on {typeof(DocumentStore).FullName}.");
+
+        var ctor = tb.DefineConstructor(
+            MethodAttributes.Public | MethodAttributes.HideBySig | MethodAttributes.SpecialName | MethodAttributes.RTSpecialName,
+            CallingConventions.Standard,
+            new[] { typeof(StoreOptions) });
+
+        var il = ctor.GetILGenerator();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Call, baseCtor);
+        il.Emit(OpCodes.Ret);
+
+        return tb.CreateType()
+            ?? throw new InvalidOperationException($"Failed to materialize the secondary-store proxy for {interfaceType.FullName}.");
+    }
+}

--- a/src/Polecat/PolecatStoreServiceCollectionExtensions.cs
+++ b/src/Polecat/PolecatStoreServiceCollectionExtensions.cs
@@ -61,8 +61,13 @@ public static class PolecatStoreServiceCollectionExtensions
             // is not clobbered by per-store instrumentation defaults. Mirrors Marten PR #4741.
             options.ReadJasperFxOptions(sp.GetService<JasperFx.JasperFxOptions>());
 
-            var store = new DocumentStore(options);
-            return (T)(IDocumentStore)store;
+            // T is a user-supplied marker interface (T : IDocumentStore) that the concrete
+            // DocumentStore does NOT implement, so a direct (T)store cast would throw
+            // InvalidCastException. Build a thin runtime subclass `class TImplementation :
+            // DocumentStore, T` and instantiate that instead. Mirrors Marten's
+            // SecondaryStoreConfig<T>.Build / SecondaryStoreProxyFactory.
+            var storeType = SecondaryStoreProxyFactory.GetOrCreate(typeof(T));
+            return (T)Activator.CreateInstance(storeType, options)!;
         });
 
         services.AddSingleton<Lazy<T>>(sp => new Lazy<T>(() => sp.GetRequiredService<T>()));


### PR DESCRIPTION
## Problem

`AddPolecatStore<T>()` registered the ancillary store as `(T)(IDocumentStore)new DocumentStore(options)` — a hard cast of a concrete `Polecat.DocumentStore` to the user's marker interface `T`. Since `DocumentStore` implements only `IDocumentStore` (not the user's sub-interface), resolving `T` threw:

```
System.InvalidCastException : Unable to cast object of type 'Polecat.DocumentStore' to type 'IMyStore'.
```

This was true in **every** shipped version. It was never caught because the existing `lazy_ancillary_store_registration_tests` only asserted the `Lazy<T>` service *descriptor* was registered — they never actually resolved `T`.

This blocks the Wolverine ancillary-Polecat-store integration (wolverine#3109), which needs `AddPolecatStore<T>().IntegrateWithWolverine()` to produce a working typed store.

## Fix

Mirror Marten's approach: port `SecondaryStoreProxyFactory`, which emits a thin runtime subclass `class TImplementation : DocumentStore, T` (via `System.Reflection.Emit`) with a forwarding `DocumentStore(StoreOptions)` constructor. Marker interfaces (`T : IDocumentStore` with no extra members) only need the forwarding ctor. `AddPolecatStore<T>` now instantiates that proxy instead of hard-casting.

Adds a regression test that **resolves** the marker interface to a working `IDocumentStore` (and asserts the `Lazy<T>` returns the same instance).

Minor version bump to **4.5.0** since `AddPolecatStore<T>` typed stores now actually function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)