### PR TITLE
Add per-store reset/clean API to AdvancedOperations (ResetAllData / IDocumentCleaner) — #191

### DIFF
--- a/src/Polecat.Tests/Cleaning/reset_all_data_tests.cs
+++ b/src/Polecat.Tests/Cleaning/reset_all_data_tests.cs
@@ -1,0 +1,161 @@
+using JasperFx;
+using Polecat.Linq;
+using Polecat.Tests.Harness;
+using Shouldly;
+
+namespace Polecat.Tests.Cleaning;
+
+// polecat#191: a public, per-store reset/clean API on AdvancedOperations parallel to
+// Marten — Advanced.ResetAllData() plus an IDocumentCleaner (DeleteAllDocumentsAsync /
+// DeleteAllEventDataAsync / CompletelyRemoveAllAsync). The headline requirement is that
+// every operation is scoped to the owning store's schema, so an ancillary store
+// (AddPolecatStore<T> with its own schema) can reset its own data on boot without ever
+// touching the host application's data (CritterWatch.Embedded).
+
+public class ResetDoc
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+}
+
+public record ResetHappened(string Name);
+
+public class reset_all_data_tests
+{
+    // Build a store, ensure its full schema (event tables included) exists, and clear it to a
+    // known empty state regardless of rows left behind by prior runs in the fixed schema.
+    private static async Task<DocumentStore> NewStoreAsync(string schema)
+    {
+        var store = DocumentStore.For(opts =>
+        {
+            opts.Connection(ConnectionSource.ConnectionString);
+            opts.DatabaseSchemaName = schema;
+            opts.AutoCreateSchemaObjects = AutoCreate.All;
+            opts.UseNativeJsonType = ConnectionSource.SupportsNativeJson;
+        });
+        await store.Database.ApplyAllConfiguredChangesToDatabaseAsync();
+        await store.Advanced.CleanAllDocumentsAsync();
+        await store.Advanced.CleanAllEventDataAsync();
+        return store;
+    }
+
+    // Seed two documents and one event stream, returning (docCount, eventCount).
+    private static async Task SeedAsync(DocumentStore store)
+    {
+        await using var session = store.LightweightSession();
+        session.Store(new ResetDoc { Id = Guid.NewGuid(), Name = "a" });
+        session.Store(new ResetDoc { Id = Guid.NewGuid(), Name = "b" });
+        session.Events.StartStream(Guid.NewGuid(), new ResetHappened("started"));
+        await session.SaveChangesAsync();
+    }
+
+    private static async Task<int> DocCountAsync(DocumentStore store)
+    {
+        await using var query = store.QuerySession();
+        return (await query.Query<ResetDoc>().ToListAsync()).Count;
+    }
+
+    [Fact]
+    public async Task reset_all_data_clears_documents_and_events()
+    {
+        using var store = await NewStoreAsync("reset_all_basic");
+
+        await SeedAsync(store);
+        (await DocCountAsync(store)).ShouldBe(2);
+        (await store.Advanced.FetchEventStoreStatistics()).EventCount.ShouldBe(1);
+
+        await store.Advanced.ResetAllData();
+
+        (await DocCountAsync(store)).ShouldBe(0);
+        var stats = await store.Advanced.FetchEventStoreStatistics();
+        stats.EventCount.ShouldBe(0);
+        stats.StreamCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task document_cleaner_deletes_documents_and_events_independently()
+    {
+        using var store = await NewStoreAsync("reset_cleaner");
+        await SeedAsync(store);
+
+        // DeleteAllDocuments leaves event data alone.
+        await store.Advanced.Clean.DeleteAllDocumentsAsync();
+        (await DocCountAsync(store)).ShouldBe(0);
+        (await store.Advanced.FetchEventStoreStatistics()).EventCount.ShouldBe(1);
+
+        // DeleteAllEventData clears the events.
+        await store.Advanced.Clean.DeleteAllEventDataAsync();
+        (await store.Advanced.FetchEventStoreStatistics()).EventCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task reset_is_scoped_to_the_store_schema()
+    {
+        using var storeA = await NewStoreAsync("reset_iso_a");
+        using var storeB = await NewStoreAsync("reset_iso_b");
+        foreach (var s in new[] { storeA, storeB })
+        {
+            await SeedAsync(s);
+        }
+
+        // Resetting store A must NOT touch store B's data — the core CritterWatch.Embedded contract.
+        await storeA.Advanced.ResetAllData();
+
+        (await DocCountAsync(storeA)).ShouldBe(0);
+        (await storeA.Advanced.FetchEventStoreStatistics()).EventCount.ShouldBe(0);
+
+        (await DocCountAsync(storeB)).ShouldBe(2);
+        (await storeB.Advanced.FetchEventStoreStatistics()).EventCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task reset_all_data_reapplies_initial_data()
+    {
+        var seededId = Guid.NewGuid();
+        using var store = DocumentStore.For(opts =>
+        {
+            opts.Connection(ConnectionSource.ConnectionString);
+            opts.DatabaseSchemaName = "reset_initialdata";
+            opts.AutoCreateSchemaObjects = AutoCreate.All;
+            opts.UseNativeJsonType = ConnectionSource.SupportsNativeJson;
+            opts.InitialData.Add(async (s, ct) =>
+            {
+                await using var session = s.LightweightSession();
+                session.Store(new ResetDoc { Id = seededId, Name = "seed" });
+                await session.SaveChangesAsync(ct);
+            });
+        });
+        await store.Database.ApplyAllConfiguredChangesToDatabaseAsync();
+        await store.Advanced.CleanAllDocumentsAsync();
+        await store.Advanced.CleanAllEventDataAsync();
+
+        await SeedAsync(store); // 2 extra docs + an event
+        (await DocCountAsync(store)).ShouldBe(2);
+
+        await store.Advanced.ResetAllData();
+
+        // Only the InitialData-seeded document should remain after a reset.
+        await using var query = store.QuerySession();
+        var docs = await query.Query<ResetDoc>().ToListAsync();
+        docs.ShouldHaveSingleItem().Id.ShouldBe(seededId);
+    }
+
+    [Fact]
+    public async Task completely_remove_all_drops_the_tables()
+    {
+        const string schema = "reset_remove_all";
+        using var store = await NewStoreAsync(schema);
+        await SeedAsync(store);
+
+        // Tables exist after seeding.
+        var before = await SchemaInspector.GetTableNamesAsync(schema);
+        before.ShouldContain(t => t.StartsWith("pc_doc_"));
+        before.ShouldContain("pc_events");
+
+        await store.Advanced.Clean.CompletelyRemoveAllAsync();
+
+        // All pc_* tables are gone.
+        var after = await SchemaInspector.GetTableNamesAsync(schema);
+        after.ShouldNotContain(t => t.StartsWith("pc_"));
+    }
+}

--- a/src/Polecat/AdvancedOperations.cs
+++ b/src/Polecat/AdvancedOperations.cs
@@ -21,6 +21,7 @@ public class AdvancedOperations
 {
     private readonly DocumentStore _store;
     private readonly ResiliencePipeline _resilience;
+    private IDocumentCleaner? _cleaner;
 
     internal AdvancedOperations(DocumentStore store)
     {
@@ -29,6 +30,31 @@ public class AdvancedOperations
     }
 
     public HiloSettings HiloSequenceDefaults => _store.Options.HiloSequenceDefaults;
+
+    /// <summary>
+    ///     The schema-scoped clean/reset surface for this store. Mirrors Marten's
+    ///     <c>AdvancedOperations.Clean</c>. All operations target only this store's
+    ///     configured schema (<see cref="StoreOptions.DatabaseSchemaName" />).
+    /// </summary>
+    public IDocumentCleaner Clean => _cleaner ??= new Internal.PolecatDocumentCleaner(this);
+
+    /// <summary>
+    ///     Delete all current document and event data for this store (scoped to the store's
+    ///     configured schema), then re-apply any registered <see cref="StoreOptions.InitialData" />.
+    ///     Mirrors Marten's <c>AdvancedOperations.ResetAllData</c>. The per-store scoping is what
+    ///     lets an ancillary store (<c>AddPolecatStore&lt;T&gt;</c> with its own schema) reset its
+    ///     own data on boot without touching the host application's data (polecat#191).
+    /// </summary>
+    public async Task ResetAllData(CancellationToken cancellation = default)
+    {
+        await CleanAllDocumentsAsync(cancellation).ConfigureAwait(false);
+        await CleanAllEventDataAsync(cancellation).ConfigureAwait(false);
+
+        foreach (var initialData in _store.Options.InitialData)
+        {
+            await initialData.Populate(_store, cancellation).ConfigureAwait(false);
+        }
+    }
 
     /// <summary>
     ///     Bulk insert documents with default settings (InsertsOnly, batch size 200, default tenant).
@@ -466,6 +492,76 @@ public class AdvancedOperations
             }
 
             await DeleteFlatTablesAsync(conn, flatTableNames, ct);
+        }, (connStr, schema, flatTables), token);
+    }
+
+    /// <summary>
+    ///     Drop all Polecat schema objects in this store's configured schema — every
+    ///     <c>pc_*</c> table plus any <see cref="FlatTableProjection" /> table. Unlike the
+    ///     <c>CleanAll*</c> methods (which only delete rows), this removes the tables
+    ///     themselves. Mirrors Marten's <c>IDocumentCleaner.CompletelyRemoveAllAsync</c>
+    ///     (polecat#191). Foreign keys are dropped first so the tables can be removed in any
+    ///     order; missing tables are ignored so this is safe to call repeatedly.
+    /// </summary>
+    public async Task CompletelyRemoveAllAsync(CancellationToken token = default)
+    {
+        var schema = _store.Options.DatabaseSchemaName;
+        var connStr = _store.Options.ConnectionString;
+        var flatTables = CollectFlatTableNames();
+        await _resilience.ExecuteAsync(static async (state, ct) =>
+        {
+            var (connectionString, schemaName, flatTableNames) = state;
+            await using var conn = new SqlConnection(connectionString);
+            await conn.OpenAsync(ct);
+
+            // Drop every foreign key on pc_* tables first so the tables themselves can be
+            // dropped in any order ([_] escapes the LIKE wildcard to mean a literal underscore).
+            await using (var dropFks = conn.CreateCommand())
+            {
+                dropFks.CommandText = """
+                    DECLARE @sql nvarchar(max) = N'';
+                    SELECT @sql += N'ALTER TABLE [' + s.name + N'].[' + t.name + N'] DROP CONSTRAINT [' + fk.name + N'];'
+                    FROM sys.foreign_keys fk
+                    JOIN sys.tables t ON fk.parent_object_id = t.object_id
+                    JOIN sys.schemas s ON t.schema_id = s.schema_id
+                    WHERE s.name = @schema AND t.name LIKE 'pc[_]%';
+                    IF @sql <> N'' EXEC sp_executesql @sql;
+                    """;
+                dropFks.Parameters.AddWithValue("@schema", schemaName);
+                await dropFks.ExecuteNonQueryAsync(ct);
+            }
+
+            // Find every pc_* base table in the schema and drop it.
+            var tables = new List<string>();
+            await using (var findCmd = conn.CreateCommand())
+            {
+                findCmd.CommandText = """
+                    SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES
+                    WHERE TABLE_SCHEMA = @schema AND TABLE_TYPE = 'BASE TABLE' AND TABLE_NAME LIKE 'pc[_]%'
+                    ORDER BY TABLE_NAME;
+                    """;
+                findCmd.Parameters.AddWithValue("@schema", schemaName);
+                await using var reader = await findCmd.ExecuteReaderAsync(ct);
+                while (await reader.ReadAsync(ct))
+                {
+                    tables.Add(reader.GetString(0));
+                }
+            }
+
+            foreach (var table in tables)
+            {
+                await using var dropCmd = conn.CreateCommand();
+                dropCmd.CommandText = $"DROP TABLE IF EXISTS [{schemaName}].[{table}];";
+                await dropCmd.ExecuteNonQueryAsync(ct);
+            }
+
+            // FlatTableProjection tables may live outside the pc_ prefix; drop them explicitly.
+            foreach (var qualified in flatTableNames)
+            {
+                await using var dropCmd = conn.CreateCommand();
+                dropCmd.CommandText = $"IF OBJECT_ID('{qualified}', 'U') IS NOT NULL DROP TABLE {qualified};";
+                await dropCmd.ExecuteNonQueryAsync(ct);
+            }
         }, (connStr, schema, flatTables), token);
     }
 

--- a/src/Polecat/IDocumentCleaner.cs
+++ b/src/Polecat/IDocumentCleaner.cs
@@ -1,0 +1,32 @@
+namespace Polecat;
+
+/// <summary>
+///     Per-store clean/reset surface, scoped to the owning store's configured schema.
+///     Exposed via <see cref="AdvancedOperations.Clean" /> and parallels Marten's
+///     <c>Marten.Schema.IDocumentCleaner</c>. Every operation targets only the tables in
+///     this store's <see cref="StoreOptions.DatabaseSchemaName" /> — an ancillary store
+///     (e.g. <c>AddPolecatStore&lt;T&gt;</c> with its own schema) never touches the host
+///     application's data.
+/// </summary>
+public interface IDocumentCleaner
+{
+    /// <summary>
+    ///     Delete all rows from every document table (<c>pc_doc_*</c>) and any
+    ///     <c>FlatTableProjection</c> table in this store's schema. Schema objects are kept.
+    /// </summary>
+    Task DeleteAllDocumentsAsync(CancellationToken ct = default);
+
+    /// <summary>
+    ///     Delete all event and stream data (<c>pc_events</c>, <c>pc_streams</c>,
+    ///     <c>pc_event_progression</c>, natural-key and flat-table data) in this store's
+    ///     schema. Schema objects are kept.
+    /// </summary>
+    Task DeleteAllEventDataAsync(CancellationToken ct = default);
+
+    /// <summary>
+    ///     Drop all Polecat schema objects (the <c>pc_*</c> tables plus any
+    ///     <c>FlatTableProjection</c> tables) in this store's schema. Unlike the delete
+    ///     operations, this removes the tables themselves.
+    /// </summary>
+    Task CompletelyRemoveAllAsync(CancellationToken ct = default);
+}

--- a/src/Polecat/Internal/PolecatDocumentCleaner.cs
+++ b/src/Polecat/Internal/PolecatDocumentCleaner.cs
@@ -1,0 +1,25 @@
+namespace Polecat.Internal;
+
+/// <summary>
+///     Thin adapter exposing the schema-scoped clean operations on
+///     <see cref="AdvancedOperations" /> through the <see cref="IDocumentCleaner" />
+///     contract. Mirrors how Marten surfaces <c>IDocumentCleaner</c> off the store.
+/// </summary>
+internal sealed class PolecatDocumentCleaner : IDocumentCleaner
+{
+    private readonly AdvancedOperations _advanced;
+
+    internal PolecatDocumentCleaner(AdvancedOperations advanced)
+    {
+        _advanced = advanced;
+    }
+
+    public Task DeleteAllDocumentsAsync(CancellationToken ct = default)
+        => _advanced.CleanAllDocumentsAsync(ct);
+
+    public Task DeleteAllEventDataAsync(CancellationToken ct = default)
+        => _advanced.CleanAllEventDataAsync(ct);
+
+    public Task CompletelyRemoveAllAsync(CancellationToken ct = default)
+        => _advanced.CompletelyRemoveAllAsync(ct);
+}


### PR DESCRIPTION
Closes #191.

## Summary

Adds a public, **per-store** reset/clean surface on `AdvancedOperations`, parallel to Marten's `AdvancedOperations.ResetAllData` / `IDocumentCleaner`. Every operation is **scoped to the owning store's configured schema** (`StoreOptions.DatabaseSchemaName`), so an ancillary store (`AddPolecatStore<T>` with its own schema) can reset its own data on boot **without touching the host application's data** — the CritterWatch.Embedded contract (CritterWatch#414).

## API

- **`IDocumentCleaner`** (new, `Polecat` namespace) — `DeleteAllDocumentsAsync` / `DeleteAllEventDataAsync` / `CompletelyRemoveAllAsync`, exposed via **`AdvancedOperations.Clean`** (mirrors Marten's `Clean` property).
- **`AdvancedOperations.ResetAllData(CancellationToken)`** — clears all documents + event data for the store, then re-applies any registered `StoreOptions.InitialData` (parallels Marten).
- **`AdvancedOperations.CompletelyRemoveAllAsync(CancellationToken)`** — drops all `pc_*` tables plus `FlatTableProjection` tables in the store's schema (foreign keys dropped first so tables can be removed in any order; missing tables ignored, so it's safe to call repeatedly).

The two delete paths reuse the pre-existing, already schema-scoped `CleanAllDocumentsAsync` / `CleanAllEventDataAsync`, so behavior (pc_doc_*, events/streams/progression, natural-key tables, flat-table output) is consistent with the rest of the cleaning surface.

## Tests

`src/Polecat.Tests/Cleaning/reset_all_data_tests.cs` (5 tests):

- `reset_all_data_clears_documents_and_events`
- `document_cleaner_deletes_documents_and_events_independently`
- `reset_is_scoped_to_the_store_schema` — **the headline**: resetting store A (schema `reset_iso_a`) leaves store B (schema `reset_iso_b`) fully intact
- `reset_all_data_reapplies_initial_data` — after a reset, only the `InitialData`-seeded document remains
- `completely_remove_all_drops_the_tables`

All 5 pass locally on net10.0; `dotnet build polecat.slnx` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)