### PR TITLE
Register JasperFx.Events IProjectionCoordinator base interface (jasperfx#430) + JasperFx 2.13.1 / Weasel 9.2.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,8 +22,8 @@
              IEventDatabase.QueryDeadLetterEventsAsync (dead-letter row drill-in), DeadLetterEvent.TenantId,
              and the tenant-aware daemon surface. Polecat implements the dead-letter row query + per-tenant
              FetchDeadLetterCountsAsync below. -->
-        <PackageVersion Include="JasperFx" Version="2.12.0" />
-        <PackageVersion Include="JasperFx.Events" Version="2.12.0" />
+        <PackageVersion Include="JasperFx" Version="2.13.1" />
+        <PackageVersion Include="JasperFx.Events" Version="2.13.1" />
         <!-- Pin the sibling JasperFx packages for parity with Marten 9's matrix
              even though Polecat doesn't currently reference them directly —
              keeps the lockstep matrix coherent when transitive resolution
@@ -31,7 +31,7 @@
              RuntimeCompiler 5.x line is the active continuation of the 4.x
              lineage; do not pin against the parallel stale 2.0.x series. -->
         <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.12.0" />
+        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.13.1" />
         <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
@@ -50,14 +50,14 @@
         <PackageVersion Include="Shouldly" Version="4.3.0" />
         <PackageVersion Include="xunit" Version="2.9.3" />
         <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.4" />
-        <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.1.0" />
-        <PackageVersion Include="Weasel.SqlServer" Version="9.1.0" />
+        <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.2.1" />
+        <PackageVersion Include="Weasel.SqlServer" Version="9.2.1" />
 
         <!-- Strongly typed IDs -->
         <PackageVersion Include="StronglyTypedId" Version="1.0.0-beta08" />
 
         <!-- Source generators (matched to JasperFx.Events above) -->
-        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.12.0" />
+        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.13.1" />
 
         <!-- Build automation -->
         <PackageVersion Include="Nuke.Common" Version="9.0.4" />

--- a/src/Polecat/PolecatConfigurationExpression.cs
+++ b/src/Polecat/PolecatConfigurationExpression.cs
@@ -91,6 +91,11 @@ public class PolecatConfigurationExpression
         });
         Services.AddSingleton<IHostedService>(sp =>
             sp.GetRequiredService<Polecat.Events.Daemon.Coordination.IProjectionCoordinator>());
+        // jasperfx#430 — also resolve the JasperFx.Events base interface, so a stock host can
+        // GetService<JasperFx.Events.Daemon.IProjectionCoordinator>() directly instead of walking
+        // the registered IHostedServices for one.
+        Services.AddSingleton<JasperFx.Events.Daemon.IProjectionCoordinator>(sp =>
+            sp.GetRequiredService<Polecat.Events.Daemon.Coordination.IProjectionCoordinator>());
         return this;
     }
 


### PR DESCRIPTION
## What

1. **jasperfx#430** — register the `JasperFx.Events.Daemon.IProjectionCoordinator` base interface alongside Polecat's store-specific `Polecat.Events.Daemon.Coordination.IProjectionCoordinator` subtype, so a stock host's `GetService<JasperFx.Events.Daemon.IProjectionCoordinator>()` resolves directly instead of returning `null` (which forced consumers like CritterWatch to walk the registered `IHostedService`s).

2. **Dependency upgrade** — `JasperFx` / `JasperFx.Events` / source generators `2.12.0 → 2.13.1` (RuntimeCompiler stays 5.0.0); `Weasel.SqlServer` / `Weasel.EntityFrameworkCore` `9.1.0 → 9.2.1`.

## Verification
`dotnet build src/Polecat/Polecat.csproj` is clean against the upgraded dependencies. Full suite via CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)