### PR TITLE
Bundle JasperFx.Events.SourceGenerator into the Polecat package (#196)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>4.5.0</Version>
+        <Version>4.5.1</Version>
         <LangVersion>latest</LangVersion>
         <Authors>Jeremy D. Miller</Authors>
         <PackageIcon>logo.png</PackageIcon>

--- a/src/Polecat/Polecat.csproj
+++ b/src/Polecat/Polecat.csproj
@@ -27,11 +27,46 @@
     <ItemGroup>
         <PackageReference Include="JasperFx" />
         <PackageReference Include="JasperFx.Events" />
+        <!-- #196: Reference the projection-dispatcher source generator so it runs over
+             Polecat itself, and (via the bundling target below) so it is forwarded to
+             downstream consumers inside the published Polecat package. PrivateAssets=all
+             keeps it a development-only dependency that does NOT flow as a normal
+             transitive PackageReference. -->
+        <PackageReference Include="JasperFx.Events.SourceGenerator" GeneratePathProperty="true">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
         <PackageReference Include="Microsoft.Data.SqlClient" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
         <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
         <PackageReference Include="Polly.Core" />
         <PackageReference Include="Weasel.SqlServer" />
     </ItemGroup>
+
+    <!-- #196 (mirrors JasperFx/marten#4557): Bundle the JasperFx.Events.SourceGenerator
+         analyzer into Polecat's own NuGet package (analyzers/dotnet/cs) so it is applied
+         to every consuming project automatically. The 2.0 wave source-generates projection
+         dispatch with no runtime reflection fallback — a convention-method projection
+         subclass must be partial or it fail-fasts at registration with
+         "No source-generated dispatcher found ...". The generator ships as a
+         DevelopmentDependency that does NOT flow transitively, so a consumer that only
+         references the Polecat package never ran it. Carrying the analyzer DLL inside
+         Polecat's package is the self-contained fix. -->
+    <PropertyGroup>
+        <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_BundleEventsSourceGeneratorAnalyzer</TargetsForTfmSpecificContentInPackage>
+    </PropertyGroup>
+
+    <!-- Runs per-TFM (where the $(Pkg...) path property is resolved, unlike the outer
+         pack evaluation). The analyzer is TFM-agnostic and goes to analyzers/dotnet/cs,
+         so it must be contributed exactly once — guard on a single TFM to avoid a
+         duplicate-package-file conflict. -->
+    <Target Name="_BundleEventsSourceGeneratorAnalyzer"
+            Condition="'$(TargetFramework)' == 'net9.0' And '$(PkgJasperFx_Events_SourceGenerator)' != ''">
+        <ItemGroup>
+            <TfmSpecificPackageFile Include="$(PkgJasperFx_Events_SourceGenerator)\analyzers\dotnet\cs\JasperFx.Events.SourceGenerator.dll">
+                <PackagePath>analyzers/dotnet/cs</PackagePath>
+            </TfmSpecificPackageFile>
+        </ItemGroup>
+    </Target>
 
 </Project>


### PR DESCRIPTION
Closes #196.

## Problem
The published `Polecat` package did **not** forward the `JasperFx.Events.SourceGenerator` analyzer to downstream consumers. In the 2.0 wave, projection dispatch is source-generated with **no runtime reflection fallback** — a convention-method projection subclass must be `partial` or it fail-fasts at registration with `InvalidProjectionException: No source-generated dispatcher found ...`.

Only Polecat's own test/smoke projects referenced the generator explicitly; `src/Polecat/Polecat.csproj` did not reference it at all. So a third-party app that referenced only the `Polecat` package never ran the generator and would hit that exception.

## Fix
Mirror Marten exactly (JasperFx/marten#4557):

1. Reference `JasperFx.Events.SourceGenerator` with `PrivateAssets=all` + `GeneratePathProperty="true"` (development-only, does not flow as a normal transitive PackageReference).
2. Add a `_BundleEventsSourceGeneratorAnalyzer` MSBuild target that carries the analyzer DLL into `analyzers/dotnet/cs` of the produced nupkg — contributed exactly once, guarded on `net9.0` (one of Polecat's two TFMs) to avoid a duplicate-package-file conflict.

Downstream consumers now get a `[GeneratedEvolver]` for convention-based projections transitively from a plain `<PackageReference Include="Polecat" />`.

Version bumped 4.5.0 → 4.5.1.

## Verification
- `dotnet pack` succeeds (only pre-existing AOT/nullable warnings).
- The packed nupkg contains `analyzers/dotnet/cs/JasperFx.Events.SourceGenerator.dll`, contributed once (not duplicated per-TFM).
- `PrivateAssets=all` stops the analyzer flowing transitively across the project reference into the test projects, so their existing explicit references remain valid with no conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)