### PR TITLE
Fix GetProjectionStatusesAsync lifecycle reporting (#200)

### DIFF
--- a/src/Polecat.Tests/Diagnostics/event_store_explorer_tests.cs
+++ b/src/Polecat.Tests/Diagnostics/event_store_explorer_tests.cs
@@ -201,6 +201,36 @@ public class event_store_explorer_tests : IntegrationContext
     }
 
     [Fact]
+    public async Task get_projection_statuses_reports_real_lifecycle()
+    {
+        // #200 — GetProjectionStatusesAsync hardcoded every projection's
+        // lifecycle to "Unknown" instead of resolving it from the registered
+        // source. Register one Inline and one Async projection and assert the
+        // reported lifecycle strings (and unquoted names) are correct.
+        await StoreOptions(opts =>
+        {
+            opts.DatabaseSchemaName = "explorer_lifecycle";
+            opts.Projections.Add<SingleStreamProjection<QuestParty, Guid>>(ProjectionLifecycle.Inline);
+            opts.Projections.Add<QuestLogProjection>(ProjectionLifecycle.Async);
+        });
+
+        IEventStore es = theStore;
+        var statuses = await es.GetProjectionStatusesAsync(CancellationToken.None);
+
+        // Names must be reported unquoted — AllProjectionNames() wraps them in
+        // single quotes, which also broke shard matching.
+        statuses.ShouldAllBe(s => !s.ProjectionName.StartsWith("'"));
+
+        var inline = statuses.Where(s => s.ProjectionName == nameof(QuestParty)).ShouldHaveSingleItem();
+        inline.Lifecycle.ShouldBe(ProjectionLifecycle.Inline.ToString());
+
+        var async = statuses.Where(s => s.ProjectionName.EndsWith(nameof(QuestLogProjection))).ShouldHaveSingleItem();
+        async.Lifecycle.ShouldBe(ProjectionLifecycle.Async.ToString());
+
+        statuses.ShouldAllBe(s => s.Lifecycle != "Unknown");
+    }
+
+    [Fact]
     public async Task try_create_usage_populates_registered_event_types()
     {
         var store = await CreateStoreAsync();

--- a/src/Polecat/DocumentStore.EventStoreExplorer.cs
+++ b/src/Polecat/DocumentStore.EventStoreExplorer.cs
@@ -249,13 +249,14 @@ public partial class DocumentStore
             }
         }
 
-        var allShards = Options.Projections.AllShards();
+        // #200: drive off the registered projection sources (not
+        // AllProjectionNames(), which quote-wraps each name for SQL-list
+        // display). Each source exposes its real Lifecycle and ShardNames,
+        // mirroring Marten's DocumentStore.EventStoreExplorer.GetProjectionStatusesAsync.
         var statuses = new List<ProjectionStatus>();
-        foreach (var projectionName in Options.Projections.AllProjectionNames())
+        foreach (var source in Options.Projections.All)
         {
-            var lifecycle = "Unknown";
-            var shards = allShards
-                .Where(s => s.Name.Name.Equals(projectionName, StringComparison.Ordinal))
+            var shards = source.Shards()
                 .Select(shard =>
                 {
                     var shardName = shard.Name.Identity;
@@ -268,11 +269,11 @@ public partial class DocumentStore
             {
                 shards = new List<ShardStatus>
                 {
-                    new(projectionName, lifecycle, 0, highWater, Error: null!)
+                    new(source.Name, source.Lifecycle.ToString(), 0, highWater, Error: null!)
                 };
             }
 
-            statuses.Add(new ProjectionStatus(projectionName, lifecycle, shards));
+            statuses.Add(new ProjectionStatus(source.Name, source.Lifecycle.ToString(), shards));
         }
 
         return statuses;


### PR DESCRIPTION
Fixes #200.

## Problem

`DocumentStore.EventStoreExplorer.GetProjectionStatusesAsync` drove its loop off `Options.Projections.AllProjectionNames()`, which caused **two** defects:

1. **Lifecycle hardcoded `"Unknown"`** (the reported issue) — never resolved from the registered source, so consumers of the store-agnostic projections surface could never tell an Async projection from Inline/Live. CritterWatch's projection-list filtered on `Lifecycle == "Async"` and dropped every Polecat projection.

2. **Names single-quoted** (latent, found while fixing #1) — `AllProjectionNames()` returns each name wrapped in single quotes (`'MyProjection'`) for SQL-list display. So the reported `ProjectionName` was quoted, and the shard match `AllShards().Where(s => s.Name.Name == projectionName)` could *never* match (unquoted vs quoted) — it always fell into the placeholder-shard branch, so real shard/progression data was never attached either.

## Fix

Drive the loop off `Options.Projections.All` (the `IProjectionSource` list) instead, mirroring Marten's equivalent `GetProjectionStatusesAsync`:

- `source.Name` → correct **unquoted** name
- `source.Lifecycle.ToString()` → real `"Inline"` / `"Async"` / `"Live"`
- `source.Shards()` matched against the progression dictionary by `ShardName.Identity`

## Tests

Added `get_projection_statuses_reports_real_lifecycle` which registers one Inline and one Async projection and asserts the reported lifecycle strings (and that names are unquoted / never `"Unknown"`). All 12 tests in `event_store_explorer_tests` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)