### PR TITLE
Verify SubscriptionDescriptor carries ImplementationType/AggregateType (#203)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,8 +22,8 @@
              IEventDatabase.QueryDeadLetterEventsAsync (dead-letter row drill-in), DeadLetterEvent.TenantId,
              and the tenant-aware daemon surface. Polecat implements the dead-letter row query + per-tenant
              FetchDeadLetterCountsAsync below. -->
-        <PackageVersion Include="JasperFx" Version="2.13.1" />
-        <PackageVersion Include="JasperFx.Events" Version="2.13.1" />
+        <PackageVersion Include="JasperFx" Version="2.13.2" />
+        <PackageVersion Include="JasperFx.Events" Version="2.13.2" />
         <!-- Pin the sibling JasperFx packages for parity with Marten 9's matrix
              even though Polecat doesn't currently reference them directly —
              keeps the lockstep matrix coherent when transitive resolution
@@ -31,7 +31,7 @@
              RuntimeCompiler 5.x line is the active continuation of the 4.x
              lineage; do not pin against the parallel stale 2.0.x series. -->
         <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.13.1" />
+        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.13.2" />
         <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
@@ -57,7 +57,7 @@
         <PackageVersion Include="StronglyTypedId" Version="1.0.0-beta08" />
 
         <!-- Source generators (matched to JasperFx.Events above) -->
-        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.13.1" />
+        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.13.2" />
 
         <!-- Build automation -->
         <PackageVersion Include="Nuke.Common" Version="9.0.4" />

--- a/src/Polecat.Tests/event_store_usage_integration_tests.cs
+++ b/src/Polecat.Tests/event_store_usage_integration_tests.cs
@@ -1,5 +1,9 @@
+using JasperFx.Descriptors;
 using JasperFx.Events;
+using JasperFx.Events.Projections;
+using Polecat.Projections;
 using Polecat.Tests.Harness;
+using Polecat.Tests.Projections;
 
 namespace Polecat.Tests;
 
@@ -96,5 +100,38 @@ public class event_store_usage_integration_tests : IntegrationContext
         usage.ProjectionRebuildErrors.SkipApplyErrors.ShouldBe(storeRebuildErrors.SkipApplyErrors);
         usage.ProjectionRebuildErrors.SkipUnknownEvents.ShouldBe(storeRebuildErrors.SkipUnknownEvents);
         usage.ProjectionRebuildErrors.SkipSerializationErrors.ShouldBe(storeRebuildErrors.SkipSerializationErrors);
+    }
+
+    [Fact]
+    public async Task subscription_descriptors_carry_implementation_and_aggregate_types()
+    {
+        // polecat#203 — JasperFx.Events enriched SubscriptionDescriptor with ImplementationType
+        // (the CLR type that implements the projection/subscription) and, for self-aggregating
+        // projections, AggregateType (the document type). Polecat projections funnel through the
+        // shared SubscriptionDescriptor(ISubscriptionSource, IEventStore) ctor via
+        // ProjectionGraph.Describe, so this should populate with no Polecat production change —
+        // this guards parity with Marten.
+        await StoreOptions(opts =>
+        {
+            opts.DatabaseSchemaName = "descriptor_enrichment";
+            opts.Projections.Add<SingleStreamProjection<QuestParty, Guid>>(ProjectionLifecycle.Inline);
+            opts.Projections.Add<QuestLogProjection>(ProjectionLifecycle.Async);
+        });
+
+        var usage = await ((IEventStore)theStore).TryCreateUsage(CancellationToken.None);
+        usage.ShouldNotBeNull();
+
+        // Single-stream (self-aggregating) projection: ImplementationType is the projection class,
+        // AggregateType is the document type.
+        var singleStream = usage.Subscriptions
+            .Single(x => x.Name == nameof(QuestParty));
+        singleStream.ImplementationType.ShouldBe(TypeDescriptor.For(typeof(SingleStreamProjection<QuestParty, Guid>)));
+        singleStream.AggregateType.ShouldBe(TypeDescriptor.For(typeof(QuestParty)));
+
+        // Event projection: ImplementationType set, but it is not an aggregation so AggregateType is null.
+        var eventProjection = usage.Subscriptions
+            .Single(x => x.Name.EndsWith(nameof(QuestLogProjection)));
+        eventProjection.ImplementationType.ShouldBe(TypeDescriptor.For(typeof(QuestLogProjection)));
+        eventProjection.AggregateType.ShouldBeNull();
     }
 }


### PR DESCRIPTION
Closes #203.

## What
- Bump the JasperFx family pin **2.13.1 → 2.13.2** (now released), which adds `ImplementationType` + `AggregateType` (`TypeDescriptor`) to `SubscriptionDescriptor`.
- Add a regression test in `event_store_usage_integration_tests.cs`.

## Why no production change
Polecat projections funnel through the shared `SubscriptionDescriptor(ISubscriptionSource, IEventStore)` ctor via `ProjectionGraph.Describe` (`DocumentStore.EventStore.cs` → `Options.Projections.Describe`), so the enrichment is populated automatically. This guards Polecat parity with Marten.

## Test
`subscription_descriptors_carry_implementation_and_aggregate_types` asserts:
- A `SingleStreamProjection<QuestParty, Guid>` descriptor has `ImplementationType` set and `AggregateType == TypeDescriptor.For(typeof(QuestParty))`.
- A `QuestLogProjection` (EventProjection) descriptor has `ImplementationType` set with a null `AggregateType` (not an aggregation).

Locally green, plus the usage/explorer (23) and projection (102) suites pass on the version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)