### PR TITLE
Vary IEventStore.Identity by StoreName so stores are distinct (#207)

### DIFF
--- a/src/Polecat.Tests/Documents/DocumentStoreTests.cs
+++ b/src/Polecat.Tests/Documents/DocumentStoreTests.cs
@@ -1,3 +1,5 @@
+using JasperFx.Events;
+using Microsoft.Extensions.DependencyInjection;
 using Polecat.Tests.Harness;
 
 namespace Polecat.Tests.Documents;
@@ -83,4 +85,46 @@ public class DocumentStoreTests
         var session = store.LightweightSession(new SessionOptions { TenantId = "tenant-a" });
         session.TenantId.ShouldBe("tenant-a");
     }
+
+    // polecat#207: IEventStore.Identity must vary by StoreName so multiple stores are distinguishable.
+    [Fact]
+    public void event_store_identity_defaults_to_store_name_main()
+    {
+        using var store = DocumentStore.For(ConnectionSource.ConnectionString);
+        var identity = ((IEventStore)store).Identity;
+        identity.Name.ShouldBe("main"); // "Main".ToLowerInvariant()
+        identity.Type.ShouldBe("SqlServer");
+    }
+
+    [Fact]
+    public void event_store_identity_varies_by_store_name()
+    {
+        using var primary = DocumentStore.For(ConnectionSource.ConnectionString);
+        using var named = DocumentStore.For(opts =>
+        {
+            opts.ConnectionString = ConnectionSource.ConnectionString;
+            opts.StoreName = "Invoicing";
+        });
+
+        var a = ((IEventStore)primary).Identity;
+        var b = ((IEventStore)named).Identity;
+
+        b.Name.ShouldBe("invoicing");
+        a.ToString().ShouldNotBe(b.ToString());
+    }
+
+    [Fact]
+    public void ancillary_store_takes_store_name_from_marker_type()
+    {
+        var services = new ServiceCollection();
+        services.AddPolecatStore<IInvoiceStore>(opts => opts.ConnectionString = ConnectionSource.ConnectionString);
+
+        using var provider = services.BuildServiceProvider();
+        var store = provider.GetRequiredService<IInvoiceStore>();
+
+        store.Options.StoreName.ShouldBe(nameof(IInvoiceStore));
+        ((IEventStore)store).Identity.Name.ShouldBe("iinvoicestore");
+    }
 }
+
+public interface IInvoiceStore : IDocumentStore;

--- a/src/Polecat/DocumentStore.DocumentStoreUsage.cs
+++ b/src/Polecat/DocumentStore.DocumentStoreUsage.cs
@@ -31,10 +31,9 @@ public partial class DocumentStore : IDocumentStoreUsageSource
                 Cardinality = DatabaseCardinality.Single,
                 MainDatabase = Database.Describe(),
             },
-            // Polecat doesn't carry a separate StoreName concept yet — fall back
-            // to the database identifier so the descriptor still has a stable
-            // identity.
-            StoreName = Database.Identifier,
+            // Per-store logical name (default "Main"; the marker type name for ancillary stores) so the
+            // descriptor is distinguishable across stores, mirroring Marten. See polecat#207.
+            StoreName = Options.StoreName,
             DatabaseSchemaName = Options.DatabaseSchemaName,
             AutoCreateSchemaObjects = Options.AutoCreateSchemaObjects.ToString(),
             // Polecat's serializer-resident EnumStorage isn't exposed at the

--- a/src/Polecat/DocumentStore.EventStore.cs
+++ b/src/Polecat/DocumentStore.EventStore.cs
@@ -57,7 +57,10 @@ public partial class DocumentStore : IEventStore<IDocumentSession, IQuerySession
         Options.Events.TenancyStyle == TenancyStyle.Conjoined
         || Options.Tenancy?.Cardinality == DatabaseCardinality.StaticMultiple;
 
-    EventStoreIdentity IEventStore.Identity => new("Polecat", "SqlServer");
+    // Vary the identity Name by the logical store name so multiple Polecat stores (primary + ancillary)
+    // are distinguishable — mirrors Marten's `new(Options.StoreName.ToLowerInvariant(), "marten")`. The
+    // Type stays the provider ("SqlServer"). See polecat#207.
+    EventStoreIdentity IEventStore.Identity => new(Options.StoreName.ToLowerInvariant(), "SqlServer");
 
     Uri IEventStore.Subject => Database.DatabaseUri;
 

--- a/src/Polecat/PolecatStoreServiceCollectionExtensions.cs
+++ b/src/Polecat/PolecatStoreServiceCollectionExtensions.cs
@@ -49,6 +49,12 @@ public static class PolecatStoreServiceCollectionExtensions
         {
             var options = optionSource(sp);
 
+            // polecat#207: give this ancillary store a distinct logical StoreName (its marker type) so its
+            // IEventStore.Identity / usage descriptor are distinguishable from the primary and other
+            // ancillary stores. Mirrors Marten's SecondaryStoreConfig (options.StoreName = typeof(T).Name).
+            // Set before the IConfigurePolecat<T> chain so a user override still wins.
+            options.StoreName = typeof(T).Name;
+
             var configures = sp.GetServices<IConfigurePolecat<T>>();
             foreach (var configure in configures)
             {

--- a/src/Polecat/StoreOptions.cs
+++ b/src/Polecat/StoreOptions.cs
@@ -74,6 +74,14 @@ public class StoreOptions
     }
 
     /// <summary>
+    ///     A logical name for this store, used to build a distinct <see cref="JasperFx.Events.IEventStore" />
+    ///     identity (and the store-usage descriptor) so multiple Polecat stores in one application are
+    ///     distinguishable. Defaults to "Main"; ancillary stores registered via <c>AddPolecatStore&lt;T&gt;</c>
+    ///     set this to the marker type name. Mirrors Marten's <c>StoreOptions.StoreName</c>.
+    /// </summary>
+    public string StoreName { get; set; } = "Main";
+
+    /// <summary>
     ///     Whether Polecat should attempt to create or update database schema objects at runtime.
     ///     Defaults to CreateOrUpdate for development convenience.
     /// </summary>


### PR DESCRIPTION
Closes #207.

`IEventStore.Identity` was hardcoded to `new("Polecat", "SqlServer")`, so **every** Polecat store — primary and every ancillary (`AddPolecatStore<T>`) store — reported the **same** `EventStoreIdentity`. Consumers that key on `Identity` (e.g. Wolverine's `EventSubscriptionAgentFamily`, which keys its store map by `Identity.ToString()`) collide and treat multiple Polecat stores as one. Marten instead varies the identity `Name` per store.

## Mimic Marten
- `StoreOptions` gains a `StoreName` property (default `"Main"`) — like Marten's `StoreOptions.StoreName`.
- `IEventStore.Identity => new(Options.StoreName.ToLowerInvariant(), "SqlServer")` — mirrors Marten's `new(Options.StoreName.ToLowerInvariant(), "marten")`.
- `AddPolecatStore<T>` sets `options.StoreName = typeof(T).Name` (before the `IConfigurePolecat<T>` chain, so a user override still wins) — mirrors Marten's `SecondaryStoreConfig`.
- The `DocumentStoreUsage` descriptor now reports `Options.StoreName` instead of the `Database.Identifier` fallback, again matching Marten.

So a default store is `main:SqlServer` and an ancillary `IInvoiceStore` is `iinvoicestore:SqlServer` — distinct.

## Tests
`DocumentStoreTests`: identity defaults to `main`, varies by `StoreName`, and an ancillary store takes its `StoreName`/identity from the marker type.

Found while fixing JasperFx/wolverine#3219 (ancillary Polecat stores weren't registered as `IEventStore`); this resolves the residual identity collision noted there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)