### PR TITLE
feat: declaratively RANGE-partition document tables by a member (#211)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -50,8 +50,8 @@
         <PackageVersion Include="Shouldly" Version="4.3.0" />
         <PackageVersion Include="xunit" Version="2.9.3" />
         <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.4" />
-        <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.2.1" />
-        <PackageVersion Include="Weasel.SqlServer" Version="9.2.1" />
+        <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.3.0" />
+        <PackageVersion Include="Weasel.SqlServer" Version="9.3.0" />
 
         <!-- Strongly typed IDs -->
         <PackageVersion Include="StronglyTypedId" Version="1.0.0-beta08" />

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -92,6 +92,7 @@ const config: UserConfig<DefaultTheme.Config> = {
               ]
             },
             { text: 'Multi-Tenanted Documents', link: '/documents/multi-tenancy' },
+            { text: 'Table Partitioning', link: '/documents/partitioning' },
             { text: 'Initial Baseline Data', link: '/documents/initial-data' },
             { text: 'Optimistic Concurrency', link: '/documents/concurrency' },
             { text: 'Partial Updates/Patching', link: '/documents/partial-updates-patching' },

--- a/docs/documents/partitioning.md
+++ b/docs/documents/partitioning.md
@@ -1,0 +1,66 @@
+# Table Partitioning
+
+Polecat can declaratively **RANGE-partition a document table** on a member you choose — the SQL Server
+companion to Marten's `PartitionOn`. The classic use is a time-series retention table partitioned by
+month, so that old data can eventually be pruned by dropping a partition instead of issuing a large
+`DELETE`.
+
+::: tip
+This is built on SQL Server partition **functions** and **schemes** rather than the child-table model
+PostgreSQL/Marten uses, so the migration story differs. It requires `Weasel.SqlServer` 9.3.0 or later.
+:::
+
+## Partitioning by a date member
+
+Use `PartitionByRange` in `Schema.For<T>()`, passing the member and the RANGE RIGHT boundary values
+(`N` boundaries produce `N + 1` partitions):
+
+```csharp
+var store = DocumentStore.For(opts =>
+{
+    opts.Connection(connectionString);
+
+    opts.Schema.For<MetricsSample>()
+        .PartitionByRange(x => x.BucketEnd,
+            new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero),
+            new DateTimeOffset(2026, 2, 1, 0, 0, 0, TimeSpan.Zero),
+            new DateTimeOffset(2026, 3, 1, 0, 0, 0, TimeSpan.Zero));
+});
+```
+
+This creates a partition function and scheme for `pc_doc_metricssample` and places the table on the
+scheme. Supported member types are dates (`DateTimeOffset`, `DateTime`, `DateOnly`) and integers
+(`int`, `long`, `short`), plus `Guid`.
+
+### The promoted partition column
+
+Unless you partition directly on the identity, the member's value is promoted into a real column
+(`bucket_end` for `BucketEnd`) that Polecat writes on every upsert. SQL Server requires the partitioning
+column to be part of the table's unique (clustered) index, so this column is **added to the primary
+key** — meaning the document `Id` is unique together with the partition value. For the typical
+time-series case the partition value is derived from immutable document data, so this is transparent.
+
+## Rolling partitions forward
+
+Adding new boundaries over time is an in-place, online operation: Polecat (via Weasel) issues
+`ALTER PARTITION FUNCTION ... SPLIT RANGE` rather than rebuilding the table. Extend the boundary list and
+re-activate the schema (for example at application start-up):
+
+```csharp
+opts.Schema.For<MetricsSample>()
+    .PartitionByRange(x => x.BucketEnd,
+        /* existing months... */
+        new DateTimeOffset(2026, 3, 1, 0, 0, 0, TimeSpan.Zero),
+        new DateTimeOffset(2026, 4, 1, 0, 0, 0, TimeSpan.Zero)); // new
+```
+
+Schema migration adds the new partition with no data movement. Removing a boundary or changing the
+column/type is reported as a rebuild rather than performed silently.
+
+## Limitations
+
+- Supported for **single-tenant** document tables only; combining partitioning with conjoined
+  multi-tenancy throws at start-up.
+- Dropping aged partitions for retention (`SWITCH`/`MERGE RANGE`) and externally-managed partition
+  rolling are not yet wired into the document API — for now, manage those out of band, or keep pruning
+  with a predicate delete.

--- a/src/Polecat.Tests/Storage/document_range_partitioning_tests.cs
+++ b/src/Polecat.Tests/Storage/document_range_partitioning_tests.cs
@@ -1,0 +1,186 @@
+using JasperFx;
+using Polecat.Tests.Harness;
+using Shouldly;
+
+namespace Polecat.Tests.Storage;
+
+public class MetricsSample
+{
+    public Guid Id { get; set; }
+    public DateTimeOffset BucketEnd { get; set; }
+    public string Metric { get; set; } = string.Empty;
+    public double Value { get; set; }
+}
+
+// Distinct type for the roll-forward test so its partition function (named from the table) does not
+// collide with the other tests' — SQL Server partition functions/schemes are database-scoped.
+public class RolledMetricsSample
+{
+    public Guid Id { get; set; }
+    public DateTimeOffset BucketEnd { get; set; }
+    public double Value { get; set; }
+}
+
+[Collection("integration")]
+public class document_range_partitioning_tests : IntegrationContext
+{
+    private const string Schema = "doc_partitioning";
+
+    private static readonly DateTimeOffset Jan = new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+    private static readonly DateTimeOffset Feb = new(2026, 2, 1, 0, 0, 0, TimeSpan.Zero);
+    private static readonly DateTimeOffset Mar = new(2026, 3, 1, 0, 0, 0, TimeSpan.Zero);
+
+    public document_range_partitioning_tests(DefaultStoreFixture fixture) : base(fixture)
+    {
+    }
+
+    private async Task<int> ScalarAsync(string sql)
+    {
+        await using var conn = await OpenConnectionAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = sql;
+        return (int)(await cmd.ExecuteScalarAsync())!;
+    }
+
+    // Drop the table and its (database-scoped) partition function/scheme so each test starts clean
+    // regardless of state left by a prior run.
+    private async Task ResetAsync(string table)
+    {
+        await using var conn = await OpenConnectionAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"""
+            IF OBJECT_ID('[{Schema}].[{table}]','U') IS NOT NULL DROP TABLE [{Schema}].[{table}];
+            IF EXISTS (SELECT 1 FROM sys.partition_schemes WHERE name='ps_{table}_bucket_end') DROP PARTITION SCHEME [ps_{table}_bucket_end];
+            IF EXISTS (SELECT 1 FROM sys.partition_functions WHERE name='pf_{table}_bucket_end') DROP PARTITION FUNCTION [pf_{table}_bucket_end];
+            """;
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    private Task<int> PartitionCountAsync(string table) => ScalarAsync(
+        $"""
+         SELECT COUNT(*) FROM sys.partitions p
+         JOIN sys.objects o ON p.object_id = o.object_id
+         JOIN sys.schemas s ON o.schema_id = s.schema_id
+         WHERE s.name = '{Schema}' AND o.name = '{table}' AND p.index_id IN (0, 1)
+         """);
+
+    [Fact]
+    public async Task creates_partition_function_scheme_and_partitions()
+    {
+        await ResetAsync("pc_doc_metricssample");
+        await StoreOptions(opts =>
+        {
+            opts.DatabaseSchemaName = Schema;
+            opts.Schema.For<MetricsSample>().PartitionByRange(x => x.BucketEnd, Jan, Feb, Mar);
+        });
+
+        (await ScalarAsync(
+            "SELECT COUNT(*) FROM sys.partition_functions WHERE name = 'pf_pc_doc_metricssample_bucket_end'"))
+            .ShouldBe(1);
+        (await ScalarAsync(
+            "SELECT COUNT(*) FROM sys.partition_schemes WHERE name = 'ps_pc_doc_metricssample_bucket_end'"))
+            .ShouldBe(1);
+
+        // 3 boundaries -> 4 partitions.
+        (await PartitionCountAsync("pc_doc_metricssample")).ShouldBe(4);
+
+        // The promoted partition column is part of the primary key.
+        (await ScalarAsync(
+            $"""
+             SELECT COUNT(*) FROM sys.index_columns ic
+             JOIN sys.indexes i ON i.object_id = ic.object_id AND i.index_id = ic.index_id
+             JOIN sys.columns c ON c.object_id = ic.object_id AND c.column_id = ic.column_id
+             WHERE i.is_primary_key = 1 AND c.name = 'bucket_end'
+               AND ic.object_id = OBJECT_ID('[{Schema}].[pc_doc_metricssample]')
+             """)).ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task stored_documents_populate_partition_column_and_land_in_distinct_partitions()
+    {
+        await ResetAsync("pc_doc_metricssample");
+        await StoreOptions(opts =>
+        {
+            opts.DatabaseSchemaName = Schema;
+            opts.Schema.For<MetricsSample>().PartitionByRange(x => x.BucketEnd, Jan, Feb, Mar);
+        });
+
+        var janDoc = new MetricsSample { Id = Guid.NewGuid(), BucketEnd = Jan.AddDays(14), Metric = "cpu", Value = 1 };
+        var febDoc = new MetricsSample { Id = Guid.NewGuid(), BucketEnd = Feb.AddDays(14), Metric = "cpu", Value = 2 };
+        var marDoc = new MetricsSample { Id = Guid.NewGuid(), BucketEnd = Mar.AddDays(14), Metric = "cpu", Value = 3 };
+
+        theSession.Store(janDoc, febDoc, marDoc);
+        await theSession.SaveChangesAsync();
+
+        // Documents round-trip through the JSON body unaffected by the duplicated column.
+        var loaded = await theSession.LoadAsync<MetricsSample>(febDoc.Id);
+        loaded.ShouldNotBeNull();
+        loaded!.BucketEnd.ShouldBe(febDoc.BucketEnd);
+        loaded.Value.ShouldBe(2);
+
+        // The promoted column mirrors the document value.
+        await using var conn = await OpenConnectionAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"SELECT bucket_end FROM [{Schema}].[pc_doc_metricssample] WHERE id = @id";
+        var p = cmd.CreateParameter();
+        p.ParameterName = "@id";
+        p.Value = febDoc.Id;
+        cmd.Parameters.Add(p);
+        var storedBucket = (DateTimeOffset)(await cmd.ExecuteScalarAsync())!;
+        storedBucket.ShouldBe(febDoc.BucketEnd);
+
+        // The three documents land in three different physical partitions.
+        (await ScalarAsync(
+            $"""
+             SELECT COUNT(DISTINCT $PARTITION.pf_pc_doc_metricssample_bucket_end(bucket_end))
+             FROM [{Schema}].[pc_doc_metricssample]
+             """)).ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task additive_boundary_rolls_a_new_partition_forward_without_losing_data()
+    {
+        await ResetAsync("pc_doc_rolledmetricssample");
+        await StoreOptions(opts =>
+        {
+            opts.DatabaseSchemaName = Schema;
+            opts.Schema.For<RolledMetricsSample>().PartitionByRange(x => x.BucketEnd, Jan, Feb);
+        });
+
+        var doc = new RolledMetricsSample { Id = Guid.NewGuid(), BucketEnd = Jan.AddDays(10), Value = 7 };
+        theSession.Store(doc);
+        await theSession.SaveChangesAsync();
+
+        (await PartitionCountAsync("pc_doc_rolledmetricssample")).ShouldBe(3); // 2 boundaries -> 3 partitions
+
+        // Roll March forward by re-applying the schema with an extra boundary.
+        await StoreOptions(opts =>
+        {
+            opts.DatabaseSchemaName = Schema;
+            opts.Schema.For<RolledMetricsSample>().PartitionByRange(x => x.BucketEnd, Jan, Feb, Mar);
+        });
+
+        (await PartitionCountAsync("pc_doc_rolledmetricssample")).ShouldBe(4); // SPLIT RANGE added one partition
+
+        // Pre-existing data survived the in-place split (no rebuild).
+        var reloaded = await theSession.LoadAsync<RolledMetricsSample>(doc.Id);
+        reloaded.ShouldNotBeNull();
+        reloaded!.Value.ShouldBe(7);
+    }
+
+    [Fact]
+    public async Task conjoined_tenancy_partitioning_is_rejected()
+    {
+        var ex = await Should.ThrowAsync<NotSupportedException>(async () =>
+        {
+            await StoreOptions(opts =>
+            {
+                opts.DatabaseSchemaName = "doc_partitioning_conjoined";
+                opts.Events.TenancyStyle = TenancyStyle.Conjoined;
+                opts.Schema.For<MetricsSample>().PartitionByRange(x => x.BucketEnd, Jan, Feb);
+            });
+        });
+
+        ex.Message.ShouldContain("conjoined");
+    }
+}

--- a/src/Polecat/DocumentStore.cs
+++ b/src/Polecat/DocumentStore.cs
@@ -39,6 +39,10 @@ public partial class DocumentStore : IDocumentStore
         // dead-letter count reads can LINQ-query it (jasperfx#356).
         _providers.GetProvider<DeadLetterEvent>();
 
+        // Validate + eagerly register RANGE-partitioned document types (#211) so their partition
+        // function/scheme and table are created and rolled forward by schema migration at activation.
+        _providers.ConfigurePartitionedDocuments();
+
         // Back-reference so the database can open sessions for the dead-letter
         // document store/queries (it has no store/session of its own otherwise).
         Database.Store = this;

--- a/src/Polecat/Internal/DocumentProviderRegistry.cs
+++ b/src/Polecat/Internal/DocumentProviderRegistry.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
+using JasperFx;
 using Polecat.Schema.Identity.Sequences;
 using Polecat.Storage;
 
@@ -115,8 +116,45 @@ internal class DocumentProviderRegistry
                     mapping.ForeignKeys.Add(fk);
                 }
             }
+
+            // Apply RANGE partitioning
+            var partitioningField = exprType.GetField("Partitioning", BindingFlags.NonPublic | BindingFlags.Instance);
+            if (partitioningField?.GetValue(expr) is Storage.DocumentPartitioning partitioning)
+            {
+                mapping.Partitioning = partitioning;
+            }
         }
     }
 
     public IEnumerable<DocumentProvider> AllProviders => _providers.Values;
+
+    /// <summary>
+    ///     Validates and eagerly registers explicitly RANGE-partitioned document types so their
+    ///     partition function/scheme and table are created (and rolled forward via SPLIT RANGE) by
+    ///     schema migration at activation time, rather than lazily on the first write. Fails fast when
+    ///     partitioning is combined with conjoined tenancy, which is not yet supported.
+    /// </summary>
+    public void ConfigurePartitionedDocuments()
+    {
+        foreach (var expr in _options.Schema.Expressions)
+        {
+            var exprType = expr.GetType();
+            if (!exprType.IsGenericType) continue;
+
+            var partitioningField = exprType.GetField("Partitioning", BindingFlags.NonPublic | BindingFlags.Instance);
+            if (partitioningField?.GetValue(expr) is not DocumentPartitioning) continue;
+
+            var docType = exprType.GetGenericArguments()[0];
+
+            if (_options.Events.TenancyStyle == TenancyStyle.Conjoined)
+            {
+                throw new NotSupportedException(
+                    "RANGE partitioning of document tables is currently supported for single-tenant tables " +
+                    $"only, but '{docType.Name}' uses conjoined tenancy.");
+            }
+
+            // Materialize the provider so DocumentFeatureSchema yields its (partitioned) table.
+            GetProvider(docType);
+        }
+    }
 }

--- a/src/Polecat/Internal/Operations/InsertOperation.cs
+++ b/src/Polecat/Internal/Operations/InsertOperation.cs
@@ -37,13 +37,15 @@ internal class InsertOperation : IStorageOperation
     {
         var docTypeCol = _mapping.IsHierarchy() ? ", doc_type" : "";
         var docTypeVal = _mapping.IsHierarchy() ? ", @doc_type" : "";
+        var pCols = _mapping.PartitionInsertColumns;
+        var pVals = _mapping.PartitionInsertValues;
 
         if (_mapping.UseOptimisticConcurrency)
         {
             builder.Append($"""
-                INSERT INTO {_mapping.QualifiedTableName} (id, data, version, guid_version, last_modified, created_at, dotnet_type{docTypeCol}, tenant_id)
+                INSERT INTO {_mapping.QualifiedTableName} (id, data, version, guid_version, last_modified, created_at, dotnet_type{docTypeCol}, tenant_id{pCols})
                 OUTPUT inserted.version, inserted.guid_version
-                VALUES (@id, @data, 1, @new_guid_version, SYSDATETIMEOFFSET(), SYSDATETIMEOFFSET(), @dotnet_type{docTypeVal}, @tenant_id);
+                VALUES (@id, @data, 1, @new_guid_version, SYSDATETIMEOFFSET(), SYSDATETIMEOFFSET(), @dotnet_type{docTypeVal}, @tenant_id{pVals});
                 """);
 
             var parameters = new Dictionary<string, object?>
@@ -52,14 +54,15 @@ internal class InsertOperation : IStorageOperation
                 ["dotnet_type"] = _mapping.DotNetTypeName, ["tenant_id"] = _tenantId
             };
             if (_mapping.IsHierarchy()) parameters["doc_type"] = _mapping.AliasFor(_document.GetType());
+            if (_mapping.HasPartitionColumn) parameters["partition_value"] = _mapping.Partitioning!.GetValue(_document);
             builder.AddParameters(parameters);
         }
         else
         {
             builder.Append($"""
-                INSERT INTO {_mapping.QualifiedTableName} (id, data, version, last_modified, created_at, dotnet_type{docTypeCol}, tenant_id)
+                INSERT INTO {_mapping.QualifiedTableName} (id, data, version, last_modified, created_at, dotnet_type{docTypeCol}, tenant_id{pCols})
                 OUTPUT inserted.version
-                VALUES (@id, @data, 1, SYSDATETIMEOFFSET(), SYSDATETIMEOFFSET(), @dotnet_type{docTypeVal}, @tenant_id);
+                VALUES (@id, @data, 1, SYSDATETIMEOFFSET(), SYSDATETIMEOFFSET(), @dotnet_type{docTypeVal}, @tenant_id{pVals});
                 """);
 
             var parameters = new Dictionary<string, object?>
@@ -68,6 +71,7 @@ internal class InsertOperation : IStorageOperation
                 ["dotnet_type"] = _mapping.DotNetTypeName, ["tenant_id"] = _tenantId
             };
             if (_mapping.IsHierarchy()) parameters["doc_type"] = _mapping.AliasFor(_document.GetType());
+            if (_mapping.HasPartitionColumn) parameters["partition_value"] = _mapping.Partitioning!.GetValue(_document);
             builder.AddParameters(parameters);
         }
     }

--- a/src/Polecat/Internal/Operations/UpdateOperation.cs
+++ b/src/Polecat/Internal/Operations/UpdateOperation.cs
@@ -55,10 +55,11 @@ internal class UpdateOperation : IStorageOperation
     private void ConfigureStandardCommand(ICommandBuilder builder)
     {
         var docTypeSet = _mapping.IsHierarchy() ? ", doc_type = @doc_type" : "";
+        var pSet = _mapping.PartitionUpdateSet;
         builder.Append($"""
             UPDATE {_mapping.QualifiedTableName}
             SET data = @data, version = version + 1,
-                last_modified = SYSDATETIMEOFFSET(), dotnet_type = @dotnet_type{docTypeSet}
+                last_modified = SYSDATETIMEOFFSET(), dotnet_type = @dotnet_type{docTypeSet}{pSet}
             OUTPUT inserted.version
             WHERE id = @id AND tenant_id = @tenant_id;
             """);
@@ -69,10 +70,11 @@ internal class UpdateOperation : IStorageOperation
     private void ConfigureRevisionCommand(ICommandBuilder builder)
     {
         var docTypeSet = _mapping.IsHierarchy() ? ", doc_type = @doc_type" : "";
+        var pSet = _mapping.PartitionUpdateSet;
         builder.Append($"""
             UPDATE {_mapping.QualifiedTableName}
             SET data = @data, version = version + 1,
-                last_modified = SYSDATETIMEOFFSET(), dotnet_type = @dotnet_type{docTypeSet}
+                last_modified = SYSDATETIMEOFFSET(), dotnet_type = @dotnet_type{docTypeSet}{pSet}
             OUTPUT inserted.version
             WHERE id = @id AND tenant_id = @tenant_id
                 AND (@expected_version = 0 OR version = @expected_version);
@@ -85,10 +87,11 @@ internal class UpdateOperation : IStorageOperation
     private void ConfigureGuidVersionCommand(ICommandBuilder builder)
     {
         var docTypeSet = _mapping.IsHierarchy() ? ", doc_type = @doc_type" : "";
+        var pSet = _mapping.PartitionUpdateSet;
         builder.Append($"""
             UPDATE {_mapping.QualifiedTableName}
             SET data = @data, version = version + 1, guid_version = @new_guid_version,
-                last_modified = SYSDATETIMEOFFSET(), dotnet_type = @dotnet_type{docTypeSet}
+                last_modified = SYSDATETIMEOFFSET(), dotnet_type = @dotnet_type{docTypeSet}{pSet}
             OUTPUT inserted.version, inserted.guid_version
             WHERE id = @id AND tenant_id = @tenant_id
                 AND (@expected_guid_version IS NULL OR guid_version = @expected_guid_version);
@@ -151,6 +154,14 @@ internal class UpdateOperation : IStorageOperation
             builder.AddParameters(new Dictionary<string, object?>
             {
                 ["doc_type"] = _mapping.AliasFor(_document.GetType())
+            });
+        }
+
+        if (_mapping.HasPartitionColumn)
+        {
+            builder.AddParameters(new Dictionary<string, object?>
+            {
+                ["partition_value"] = _mapping.Partitioning!.GetValue(_document)
             });
         }
     }

--- a/src/Polecat/Internal/Operations/UpsertOperation.cs
+++ b/src/Polecat/Internal/Operations/UpsertOperation.cs
@@ -54,6 +54,10 @@ internal class UpsertOperation : IStorageOperation
 
     private void ConfigureStandardCommand(ICommandBuilder builder)
     {
+        var pCols = _mapping.PartitionInsertColumns;
+        var pVals = _mapping.PartitionInsertValues;
+        var pSet = _mapping.PartitionUpdateSet;
+
         if (_mapping.IsHierarchy())
         {
             builder.Append($"""
@@ -62,10 +66,10 @@ internal class UpsertOperation : IStorageOperation
                     ON target.id = source.id AND target.tenant_id = source.tenant_id
                 WHEN MATCHED THEN
                   UPDATE SET data = @data, version = target.version + 1,
-                    last_modified = SYSDATETIMEOFFSET(), dotnet_type = @dotnet_type, doc_type = @doc_type
+                    last_modified = SYSDATETIMEOFFSET(), dotnet_type = @dotnet_type, doc_type = @doc_type{pSet}
                 WHEN NOT MATCHED THEN
-                  INSERT (id, data, version, last_modified, created_at, dotnet_type, tenant_id, doc_type)
-                  VALUES (@id, @data, 1, SYSDATETIMEOFFSET(), SYSDATETIMEOFFSET(), @dotnet_type, @tenant_id, @doc_type)
+                  INSERT (id, data, version, last_modified, created_at, dotnet_type, tenant_id, doc_type{pCols})
+                  VALUES (@id, @data, 1, SYSDATETIMEOFFSET(), SYSDATETIMEOFFSET(), @dotnet_type, @tenant_id, @doc_type{pVals})
                 OUTPUT inserted.version;
                 """);
         }
@@ -77,10 +81,10 @@ internal class UpsertOperation : IStorageOperation
                     ON target.id = source.id AND target.tenant_id = source.tenant_id
                 WHEN MATCHED THEN
                   UPDATE SET data = @data, version = target.version + 1,
-                    last_modified = SYSDATETIMEOFFSET(), dotnet_type = @dotnet_type
+                    last_modified = SYSDATETIMEOFFSET(), dotnet_type = @dotnet_type{pSet}
                 WHEN NOT MATCHED THEN
-                  INSERT (id, data, version, last_modified, created_at, dotnet_type, tenant_id)
-                  VALUES (@id, @data, 1, SYSDATETIMEOFFSET(), SYSDATETIMEOFFSET(), @dotnet_type, @tenant_id)
+                  INSERT (id, data, version, last_modified, created_at, dotnet_type, tenant_id{pCols})
+                  VALUES (@id, @data, 1, SYSDATETIMEOFFSET(), SYSDATETIMEOFFSET(), @dotnet_type, @tenant_id{pVals})
                 OUTPUT inserted.version;
                 """);
         }
@@ -90,6 +94,10 @@ internal class UpsertOperation : IStorageOperation
 
     private void ConfigureRevisionCommand(ICommandBuilder builder)
     {
+        var pCols = _mapping.PartitionInsertColumns;
+        var pVals = _mapping.PartitionInsertValues;
+        var pSet = _mapping.PartitionUpdateSet;
+
         if (_mapping.IsHierarchy())
         {
             builder.Append($"""
@@ -98,10 +106,10 @@ internal class UpsertOperation : IStorageOperation
                     ON target.id = source.id AND target.tenant_id = source.tenant_id
                 WHEN MATCHED AND (@expected_version = 0 OR target.version = @expected_version) THEN
                   UPDATE SET data = @data, version = target.version + 1,
-                    last_modified = SYSDATETIMEOFFSET(), dotnet_type = @dotnet_type, doc_type = @doc_type
+                    last_modified = SYSDATETIMEOFFSET(), dotnet_type = @dotnet_type, doc_type = @doc_type{pSet}
                 WHEN NOT MATCHED THEN
-                  INSERT (id, data, version, last_modified, created_at, dotnet_type, tenant_id, doc_type)
-                  VALUES (@id, @data, 1, SYSDATETIMEOFFSET(), SYSDATETIMEOFFSET(), @dotnet_type, @tenant_id, @doc_type)
+                  INSERT (id, data, version, last_modified, created_at, dotnet_type, tenant_id, doc_type{pCols})
+                  VALUES (@id, @data, 1, SYSDATETIMEOFFSET(), SYSDATETIMEOFFSET(), @dotnet_type, @tenant_id, @doc_type{pVals})
                 OUTPUT inserted.version;
                 """);
         }
@@ -113,10 +121,10 @@ internal class UpsertOperation : IStorageOperation
                     ON target.id = source.id AND target.tenant_id = source.tenant_id
                 WHEN MATCHED AND (@expected_version = 0 OR target.version = @expected_version) THEN
                   UPDATE SET data = @data, version = target.version + 1,
-                    last_modified = SYSDATETIMEOFFSET(), dotnet_type = @dotnet_type
+                    last_modified = SYSDATETIMEOFFSET(), dotnet_type = @dotnet_type{pSet}
                 WHEN NOT MATCHED THEN
-                  INSERT (id, data, version, last_modified, created_at, dotnet_type, tenant_id)
-                  VALUES (@id, @data, 1, SYSDATETIMEOFFSET(), SYSDATETIMEOFFSET(), @dotnet_type, @tenant_id)
+                  INSERT (id, data, version, last_modified, created_at, dotnet_type, tenant_id{pCols})
+                  VALUES (@id, @data, 1, SYSDATETIMEOFFSET(), SYSDATETIMEOFFSET(), @dotnet_type, @tenant_id{pVals})
                 OUTPUT inserted.version;
                 """);
         }
@@ -127,6 +135,10 @@ internal class UpsertOperation : IStorageOperation
 
     private void ConfigureGuidVersionCommand(ICommandBuilder builder)
     {
+        var pCols = _mapping.PartitionInsertColumns;
+        var pVals = _mapping.PartitionInsertValues;
+        var pSet = _mapping.PartitionUpdateSet;
+
         if (_mapping.IsHierarchy())
         {
             builder.Append($"""
@@ -135,10 +147,10 @@ internal class UpsertOperation : IStorageOperation
                     ON target.id = source.id AND target.tenant_id = source.tenant_id
                 WHEN MATCHED AND (@expected_guid_version IS NULL OR target.guid_version = @expected_guid_version) THEN
                   UPDATE SET data = @data, version = target.version + 1, guid_version = @new_guid_version,
-                    last_modified = SYSDATETIMEOFFSET(), dotnet_type = @dotnet_type, doc_type = @doc_type
+                    last_modified = SYSDATETIMEOFFSET(), dotnet_type = @dotnet_type, doc_type = @doc_type{pSet}
                 WHEN NOT MATCHED THEN
-                  INSERT (id, data, version, guid_version, last_modified, created_at, dotnet_type, tenant_id, doc_type)
-                  VALUES (@id, @data, 1, @new_guid_version, SYSDATETIMEOFFSET(), SYSDATETIMEOFFSET(), @dotnet_type, @tenant_id, @doc_type)
+                  INSERT (id, data, version, guid_version, last_modified, created_at, dotnet_type, tenant_id, doc_type{pCols})
+                  VALUES (@id, @data, 1, @new_guid_version, SYSDATETIMEOFFSET(), SYSDATETIMEOFFSET(), @dotnet_type, @tenant_id, @doc_type{pVals})
                 OUTPUT inserted.version, inserted.guid_version;
                 """);
         }
@@ -150,10 +162,10 @@ internal class UpsertOperation : IStorageOperation
                     ON target.id = source.id AND target.tenant_id = source.tenant_id
                 WHEN MATCHED AND (@expected_guid_version IS NULL OR target.guid_version = @expected_guid_version) THEN
                   UPDATE SET data = @data, version = target.version + 1, guid_version = @new_guid_version,
-                    last_modified = SYSDATETIMEOFFSET(), dotnet_type = @dotnet_type
+                    last_modified = SYSDATETIMEOFFSET(), dotnet_type = @dotnet_type{pSet}
                 WHEN NOT MATCHED THEN
-                  INSERT (id, data, version, guid_version, last_modified, created_at, dotnet_type, tenant_id)
-                  VALUES (@id, @data, 1, @new_guid_version, SYSDATETIMEOFFSET(), SYSDATETIMEOFFSET(), @dotnet_type, @tenant_id)
+                  INSERT (id, data, version, guid_version, last_modified, created_at, dotnet_type, tenant_id{pCols})
+                  VALUES (@id, @data, 1, @new_guid_version, SYSDATETIMEOFFSET(), SYSDATETIMEOFFSET(), @dotnet_type, @tenant_id{pVals})
                 OUTPUT inserted.version, inserted.guid_version;
                 """);
         }
@@ -215,6 +227,14 @@ internal class UpsertOperation : IStorageOperation
             builder.AddParameters(new Dictionary<string, object?>
             {
                 ["doc_type"] = _mapping.AliasFor(_document.GetType())
+            });
+        }
+
+        if (_mapping.HasPartitionColumn)
+        {
+            builder.AddParameters(new Dictionary<string, object?>
+            {
+                ["partition_value"] = _mapping.Partitioning!.GetValue(_document)
             });
         }
     }

--- a/src/Polecat/Storage/DocumentMapping.cs
+++ b/src/Polecat/Storage/DocumentMapping.cs
@@ -161,6 +161,25 @@ internal class DocumentMapping
     public List<DocumentForeignKey> ForeignKeys { get; } = new();
 
     /// <summary>
+    ///     Declarative SQL Server RANGE partitioning for this document's table, or null when the table
+    ///     is not partitioned. Configured via <see cref="DocumentMappingExpression{T}.PartitionByRange" />.
+    /// </summary>
+    public DocumentPartitioning? Partitioning { get; set; }
+
+    /// <summary>True when a promoted partition column must be written on every upsert.</summary>
+    public bool HasPartitionColumn => Partitioning is { RequiresDuplicatedColumn: true };
+
+    /// <summary>SQL fragment appended to an INSERT column list for the partition column (or empty).</summary>
+    public string PartitionInsertColumns => HasPartitionColumn ? $", {Partitioning!.ColumnName}" : string.Empty;
+
+    /// <summary>SQL fragment appended to an INSERT VALUES list for the partition column (or empty).</summary>
+    public string PartitionInsertValues => HasPartitionColumn ? ", @partition_value" : string.Empty;
+
+    /// <summary>SQL fragment appended to an UPDATE SET clause for the partition column (or empty).</summary>
+    public string PartitionUpdateSet =>
+        HasPartitionColumn ? $", {Partitioning!.ColumnName} = @partition_value" : string.Empty;
+
+    /// <summary>
     ///     The alias used in the doc_type discriminator column for the base type.
     /// </summary>
     public string Alias { get; set; } = "base";

--- a/src/Polecat/Storage/DocumentMappingExpression.cs
+++ b/src/Polecat/Storage/DocumentMappingExpression.cs
@@ -15,6 +15,7 @@ public class DocumentMappingExpression<T>
     internal readonly List<(Type SubClass, string? Alias)> SubClasses = new();
     internal readonly List<DocumentIndex> Indexes = new();
     internal readonly List<DocumentForeignKey> ForeignKeys = new();
+    internal DocumentPartitioning? Partitioning;
 
     /// <summary>
     ///     Register a subclass of T for document hierarchy (single-table inheritance).
@@ -106,6 +107,27 @@ public class DocumentMappingExpression<T>
     public DocumentMappingExpression<T> AddForeignKey(DocumentForeignKey foreignKey)
     {
         ForeignKeys.Add(foreignKey);
+        return this;
+    }
+
+    /// <summary>
+    ///     Declaratively RANGE-partition this document's table on a member — the SQL Server companion to
+    ///     Marten's <c>PartitionOn</c>. The classic use is a date member (e.g. <c>x =&gt; x.BucketEnd</c>)
+    ///     partitioned monthly so old data can be pruned by dropping a partition. The boundaries are the
+    ///     RANGE RIGHT split points (N boundaries → N+1 partitions); add new boundaries over time and
+    ///     Weasel rolls them forward in place via <c>SPLIT RANGE</c>.
+    /// </summary>
+    /// <remarks>
+    ///     Unless the member is the identity, its value is promoted into a real column written on every
+    ///     upsert and added to the primary key (SQL Server requires the partition column in the table's
+    ///     unique index). Currently supported for single-tenant document tables only.
+    /// </remarks>
+    public DocumentMappingExpression<T> PartitionByRange<TValue>(
+        Expression<Func<T, TValue>> member,
+        params TValue[] boundaries)
+    {
+        var idMemberName = DocumentMapping.FindIdProperty(typeof(T))?.Name ?? "Id";
+        Partitioning = DocumentPartitioning.For(member, boundaries, idMemberName);
         return this;
     }
 }

--- a/src/Polecat/Storage/DocumentPartitioning.cs
+++ b/src/Polecat/Storage/DocumentPartitioning.cs
@@ -1,0 +1,145 @@
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Text;
+
+namespace Polecat.Storage;
+
+/// <summary>
+///     Describes declarative SQL Server RANGE partitioning for a document table on a caller-chosen
+///     member (the SQL Server companion to Marten's <c>PartitionOn</c>). When the member is not the
+///     identity, its value is promoted into a real "duplicated" column written on every upsert so the
+///     row lands in the correct partition; that column is added to the primary key because SQL Server
+///     requires the partitioning column to participate in the table's unique (clustered) index.
+/// </summary>
+internal sealed class DocumentPartitioning
+{
+    private readonly Func<object, object?>? _getter;
+
+    private DocumentPartitioning(string columnName, string sqlDataType, bool partitionOnId,
+        IReadOnlyList<object> boundaries, Func<object, object?>? getter)
+    {
+        ColumnName = columnName;
+        SqlDataType = sqlDataType;
+        PartitionOnId = partitionOnId;
+        Boundaries = boundaries;
+        _getter = getter;
+    }
+
+    /// <summary>The partition column name. <c>id</c> when <see cref="PartitionOnId" /> is true.</summary>
+    public string ColumnName { get; }
+
+    /// <summary>The SQL Server data type of the partition column / function parameter.</summary>
+    public string SqlDataType { get; }
+
+    /// <summary>
+    ///     True when partitioning directly on the identity column — no duplicated column is needed
+    ///     and nothing extra is written, the existing <c>id</c> column is the partition column.
+    /// </summary>
+    public bool PartitionOnId { get; }
+
+    /// <summary>The RANGE boundary values, as typed objects, in ascending order.</summary>
+    public IReadOnlyList<object> Boundaries { get; }
+
+    /// <summary>True when a real duplicated column must be created and written on upsert.</summary>
+    public bool RequiresDuplicatedColumn => !PartitionOnId;
+
+    /// <summary>Extract the partition value from a document instance for the write path.</summary>
+    public object GetValue(object document)
+    {
+        if (PartitionOnId)
+        {
+            throw new InvalidOperationException(
+                "Partitioning is on the identity column; the id parameter is used directly.");
+        }
+
+        return _getter!(document)
+               ?? throw new InvalidOperationException(
+                   $"The partition column '{ColumnName}' resolved to null. A range-partition column is " +
+                   "part of the primary key and must always have a value.");
+    }
+
+    /// <summary>
+    ///     Resolve a member expression into a partitioning descriptor: the column name, its SQL Server
+    ///     data type, whether it is the identity, a compiled value getter, and the typed boundaries.
+    /// </summary>
+    public static DocumentPartitioning For<T, TValue>(
+        Expression<Func<T, TValue>> member,
+        IReadOnlyList<TValue> boundaries,
+        string idMemberName)
+    {
+        var memberInfo = ResolveMember(member);
+        var sqlType = ToSqlServerType(typeof(TValue));
+        var boxed = boundaries.Select(b => (object)b!).ToArray();
+
+        if (string.Equals(memberInfo.Name, idMemberName, StringComparison.Ordinal))
+        {
+            return new DocumentPartitioning("id", sqlType, partitionOnId: true, boxed, getter: null);
+        }
+
+        var column = ToSnakeCase(memberInfo.Name);
+        var compiled = member.Compile();
+        Func<object, object?> getter = doc => compiled((T)doc);
+
+        return new DocumentPartitioning(column, sqlType, partitionOnId: false, boxed, getter);
+    }
+
+    private static MemberInfo ResolveMember<T, TValue>(Expression<Func<T, TValue>> member)
+    {
+        var body = member.Body;
+
+        // Unwrap a Convert/ConvertChecked the compiler may insert (e.g. for object-typed lambdas).
+        if (body is UnaryExpression { NodeType: ExpressionType.Convert or ExpressionType.ConvertChecked } unary)
+        {
+            body = unary.Operand;
+        }
+
+        if (body is MemberExpression memberExpression)
+        {
+            return memberExpression.Member;
+        }
+
+        throw new ArgumentException(
+            "PartitionByRange requires a simple member expression such as 'x => x.BucketEnd'.", nameof(member));
+    }
+
+    internal static string ToSqlServerType(Type type)
+    {
+        var t = Nullable.GetUnderlyingType(type) ?? type;
+
+        if (t == typeof(DateTimeOffset)) return "datetimeoffset";
+        if (t == typeof(DateTime)) return "datetime2";
+        if (t == typeof(DateOnly)) return "date";
+        if (t == typeof(int)) return "int";
+        if (t == typeof(long)) return "bigint";
+        if (t == typeof(short)) return "smallint";
+        if (t == typeof(Guid)) return "uniqueidentifier";
+
+        throw new NotSupportedException(
+            $"Range partitioning a document table on a '{t.Name}' column is not supported. " +
+            "Use a date (DateTimeOffset/DateTime/DateOnly) or integer member.");
+    }
+
+    internal static string ToSnakeCase(string name)
+    {
+        var builder = new StringBuilder(name.Length + 8);
+        for (var i = 0; i < name.Length; i++)
+        {
+            var c = name[i];
+            if (char.IsUpper(c))
+            {
+                if (i > 0 && (!char.IsUpper(name[i - 1]) || (i + 1 < name.Length && char.IsLower(name[i + 1]))))
+                {
+                    builder.Append('_');
+                }
+
+                builder.Append(char.ToLowerInvariant(c));
+            }
+            else
+            {
+                builder.Append(c);
+            }
+        }
+
+        return builder.ToString();
+    }
+}

--- a/src/Polecat/Storage/DocumentTable.cs
+++ b/src/Polecat/Storage/DocumentTable.cs
@@ -69,5 +69,28 @@ internal class DocumentTable : Table
                 .NotNull()
                 .DefaultValueByString(JasperFx.StorageConstants.DefaultTenantId);
         }
+
+        // Declarative SQL Server RANGE partitioning (#211). The partition column must be part of the
+        // table's unique (clustered) index, so a promoted member joins the primary key.
+        if (mapping.Partitioning is { } partitioning)
+        {
+            if (mapping.TenancyStyle == TenancyStyle.Conjoined)
+            {
+                throw new NotSupportedException(
+                    "RANGE partitioning of document tables is currently supported for single-tenant tables " +
+                    $"only, but '{mapping.DocumentType.Name}' uses conjoined tenancy.");
+            }
+
+            if (partitioning.RequiresDuplicatedColumn)
+            {
+                AddColumn(partitioning.ColumnName, partitioning.SqlDataType).AsPrimaryKey().NotNull();
+            }
+
+            var range = PartitionByRange(partitioning.ColumnName, partitioning.SqlDataType);
+            foreach (var boundary in partitioning.Boundaries)
+            {
+                range.AddBoundary(boundary);
+            }
+        }
     }
 }


### PR DESCRIPTION
Closes #211.

The SQL Server companion to Marten's `PartitionOn` (marten#4779): a document table can be declaratively RANGE-partitioned on a caller-chosen member — the classic case being a monthly date column for time-series retention.

## API

```csharp
opts.Schema.For<MetricsSample>()
    .PartitionByRange(x => x.BucketEnd, jan2026, feb2026, mar2026);
```

`N` boundaries → `N+1` partitions (RANGE RIGHT). Supported member types: dates (`DateTimeOffset`/`DateTime`/`DateOnly`), integers, and `Guid`.

## How it works

- **Promoted column.** Unless you partition on the identity, the member's value is promoted into a real column (`bucket_end` for `BucketEnd`) written on every `Insert`/`Update`/`Upsert`, and **added to the primary key** — SQL Server requires the partitioning column to participate in the table's unique (clustered) index. For non-partitioned documents the write path is byte-for-byte unchanged (the fragments are empty).
- **Eager activation.** Partitioned types are eagerly registered so their partition function/scheme and table are created — and rolled forward via `ALTER PARTITION FUNCTION ... SPLIT RANGE` — by schema migration at activation, not lazily on first write. Built on the round-trip + SPLIT migration shipped in Weasel.SqlServer 9.3.0 (weasel#319).
- **Roll-forward.** Adding boundaries over time is an in-place online `SPLIT` (no data movement); removing a boundary or changing the column/type is reported as a rebuild rather than performed silently.

## Scope / limitations

- **Single-tenant only** for now; combining with conjoined tenancy fails fast at startup.
- Dropping aged partitions for retention (`SWITCH`/`MERGE RANGE`) and externally-managed partition rolling are **not** yet wired into the document API — explicitly called out as follow-ups (they need further Weasel.SqlServer runtime support).

## Commits

1. `build: upgrade Weasel to 9.3.0` — the prerequisite (full suite green against it: 1209 passed).
2. `feat: …PartitionByRange…` — the feature, tests, and docs.

## Tests

New `document_range_partitioning_tests`: partition fn/scheme + partition count + PK membership; partition-column population, document round-trip, and three docs landing in three distinct physical partitions (`$PARTITION`); additive boundary roll-forward without data loss; conjoined-tenancy guard. Targeted regression set across storage/CRUD/concurrency/hierarchy/soft-delete/revision/versioned (162 tests) green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)