### PR TITLE
feat: populate structured partitioning in DocumentMappingDescriptor (#209)

### DIFF
--- a/src/Polecat.Tests/document_store_usage_tests.cs
+++ b/src/Polecat.Tests/document_store_usage_tests.cs
@@ -176,6 +176,46 @@ public class document_store_usage_tests
         eventUsage.TagTypes.ShouldContain(t => t.TagType.Contains(nameof(TestTag)));
     }
 
+    [Fact]
+    public async Task mapping_descriptor_carries_structured_range_partitioning()
+    {
+        await using var store = BuildStore(opts =>
+        {
+            opts.DatabaseSchemaName = "doc_usage";
+            opts.Schema.For<PartitionedUsageDoc>()
+                .PartitionByRange(x => x.BucketEnd,
+                    new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero),
+                    new DateTimeOffset(2026, 2, 1, 0, 0, 0, TimeSpan.Zero));
+        });
+
+        var usage = await GetUsageAsync(store);
+        var mapping = usage.Documents.First(d => d.DocumentType.Name == nameof(PartitionedUsageDoc));
+
+        // Structured partitioning lets CritterWatch render the actual partitions (#209/#211).
+        mapping.PartitioningStrategy.ShouldBe("Range");
+        mapping.Partitioning.ShouldNotBeNull();
+        mapping.Partitioning!.Strategy.ShouldBe("Range");
+        mapping.Partitioning.PartitionNames.Count().ShouldBe(2);
+        // ...and the DDL surfaces the partition function/scheme too.
+        mapping.Ddl.ShouldContain("PARTITION FUNCTION", Case.Insensitive);
+    }
+
+    [Fact]
+    public async Task mapping_descriptor_partitioning_is_null_when_not_partitioned()
+    {
+        await using var store = BuildStore(opts =>
+        {
+            opts.DatabaseSchemaName = "doc_usage";
+            opts.Schema.For<AdvSqlDoc>();
+        });
+
+        var usage = await GetUsageAsync(store);
+        var mapping = usage.Documents.First(d => d.DocumentType.Name == nameof(AdvSqlDoc));
+
+        mapping.PartitioningStrategy.ShouldBeNull();
+        mapping.Partitioning.ShouldBeNull();
+    }
+
     private static DocumentStore BuildStore(Action<StoreOptions> configure)
     {
         var options = new StoreOptions
@@ -206,3 +246,13 @@ public class document_store_usage_tests
 /// canonical shape.
 /// </summary>
 public readonly record struct TestTag(Guid Value);
+
+/// <summary>
+/// A range-partitioned document used to assert the structured partitioning descriptor (#209/#211).
+/// </summary>
+public class PartitionedUsageDoc
+{
+    public Guid Id { get; set; }
+    public DateTimeOffset BucketEnd { get; set; }
+    public double Value { get; set; }
+}

--- a/src/Polecat/DocumentStore.DocumentStoreUsage.cs
+++ b/src/Polecat/DocumentStore.DocumentStoreUsage.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.IO;
 using JasperFx.Descriptors;
 using JasperFx.Events;
@@ -145,11 +146,29 @@ public partial class DocumentStore : IDocumentStoreUsageSource
             UseNumericRevisions = mapping.UseNumericRevisions,
             SubClassCount = mapping.SubClasses.Count,
             SubClasses = mapping.SubClasses.Select(x => TypeDescriptor.For(x.DocumentType)).ToArray(),
-            // Polecat doesn't have a partition strategy today — leave both null.
-            PartitioningStrategy = null,
-            Partitioning = null,
+            PartitioningStrategy = mapping.Partitioning == null ? null : "Range",
+            Partitioning = BuildPartitioning(mapping.Partitioning),
             Ddl = ddl,
         };
+    }
+
+    /// <summary>
+    ///     Project Polecat's declarative RANGE partitioning (#211) into the structured
+    ///     <see cref="PartitioningDescriptor" /> CritterWatch renders. SQL Server partitions are
+    ///     anonymous, so the boundary values stand in for the partition names.
+    /// </summary>
+    private static PartitioningDescriptor? BuildPartitioning(Storage.DocumentPartitioning? partitioning)
+    {
+        if (partitioning == null)
+        {
+            return null;
+        }
+
+        var names = partitioning.Boundaries
+            .Select(b => Convert.ToString(b, CultureInfo.InvariantCulture) ?? string.Empty)
+            .ToArray();
+
+        return new PartitioningDescriptor { Strategy = "Range", PartitionNames = names };
     }
 
     private static string WriteSchemaCreationDdl(


### PR DESCRIPTION
Finishes the last open item of #209.

The core of #209 (the `IDocumentStoreDiagnostics` implementation + `SubClasses` enrichment) already shipped in `f3683b0`. The one piece left was the **structured `Partitioning`** on `DocumentMappingDescriptor`, which was stubbed `null` with the comment *"Polecat doesn't have a partition strategy today"*. That's no longer true since #211 added declarative document range-partitioning.

`BuildMappingDescriptor` now sets `PartitioningStrategy = "Range"` and a structured `PartitioningDescriptor` (Strategy `"Range"`, `PartitionNames` = the boundary values, since SQL Server partitions are anonymous) — mirroring Marten's `BuildPartitioning`. This lets CritterWatch (#544/#545) render the actual partitions, not just a strategy label.

## Tests

Two unit tests in `document_store_usage_tests` (no SQL Server required): a range-partitioned mapping carries the structured descriptor + partition function in DDL; a non-partitioned mapping leaves it null.

🤖 Generated with [Claude Code](https://claude.com/claude-code)