### PR TITLE
Exact-identity progression delete: DeleteProjectionProgressByShardNameAsync (#220)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,8 +22,8 @@
              IEventDatabase.QueryDeadLetterEventsAsync (dead-letter row drill-in), DeadLetterEvent.TenantId,
              and the tenant-aware daemon surface. Polecat implements the dead-letter row query + per-tenant
              FetchDeadLetterCountsAsync below. -->
-        <PackageVersion Include="JasperFx" Version="2.15.0" />
-        <PackageVersion Include="JasperFx.Events" Version="2.15.0" />
+        <PackageVersion Include="JasperFx" Version="2.16.0" />
+        <PackageVersion Include="JasperFx.Events" Version="2.16.0" />
         <!-- Pin the sibling JasperFx packages for parity with Marten 9's matrix
              even though Polecat doesn't currently reference them directly —
              keeps the lockstep matrix coherent when transitive resolution
@@ -31,7 +31,7 @@
              RuntimeCompiler 5.x line is the active continuation of the 4.x
              lineage; do not pin against the parallel stale 2.0.x series. -->
         <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.15.0" />
+        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.16.0" />
         <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
@@ -57,7 +57,7 @@
         <PackageVersion Include="StronglyTypedId" Version="1.0.0-beta08" />
 
         <!-- Source generators (matched to JasperFx.Events above) -->
-        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.15.0" />
+        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.16.0" />
 
         <!-- Build automation -->
         <PackageVersion Include="Nuke.Common" Version="9.0.4" />

--- a/src/Polecat.Tests/Daemon/delete_projection_progress_by_shard_name_tests.cs
+++ b/src/Polecat.Tests/Daemon/delete_projection_progress_by_shard_name_tests.cs
@@ -1,0 +1,153 @@
+using JasperFx.Events;
+using JasperFx.Events.Projections;
+using Polecat.Events.Daemon.Progress;
+using Polecat.Tests.Harness;
+
+namespace Polecat.Tests.Daemon;
+
+/// <summary>
+/// #220 (jasperfx#473/#474, JasperFx.Events 2.16.0): exact-identity progression delete via the
+/// store-agnostic <see cref="IEventDatabase.DeleteProjectionProgressByShardNameAsync"/> override.
+///
+/// Exercises every permutation of <see cref="ShardName.Identity"/>:
+///   - default key "All", version 1            → "Trip:All"
+///   - custom shard key, version 1             → "Trip:Lines"
+///   - versioned (V&gt;1), key "All"           → "claim_lines:V9:All"
+///   - versioned + custom key                  → "claim_lines:V9:Lines"
+///   - per-tenant, version 1                   → "Trip:All:acme"
+///   - per-tenant + versioned                  → "claim_lines:V9:All:acme"
+///   - per-tenant + versioned + custom key     → "claim_lines:V9:Lines:acme"
+///
+/// plus the two semantics the issue calls out: exact-equality (no prefix/tenant collateral) and a
+/// clean zero-row no-op for a non-existent identity.
+/// </summary>
+[Collection("integration")]
+public class delete_projection_progress_by_shard_name_tests : IntegrationContext
+{
+    public delete_projection_progress_by_shard_name_tests(DefaultStoreFixture fixture) : base(fixture)
+    {
+    }
+
+    public override async Task InitializeAsync()
+    {
+        await base.InitializeAsync();
+        // Clean progression table for each test
+        await using var conn = await OpenConnectionAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = "DELETE FROM [dbo].[pc_event_progression];";
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    public static IEnumerable<object[]> AllShardNamePermutations()
+    {
+        // name, shardKey, version, tenantId — expected Identity in the comment
+        yield return [new ShardName("Trip")];                                  // "Trip:All"
+        yield return [new ShardName("Trip", "Lines", 1)];                      // "Trip:Lines"
+        yield return [new ShardName("claim_lines", "All", 9)];                 // "claim_lines:V9:All"
+        yield return [new ShardName("claim_lines", "Lines", 9)];               // "claim_lines:V9:Lines"
+        yield return [new ShardName("Trip").ForTenant("acme")];                // "Trip:All:acme"
+        yield return [new ShardName("claim_lines", "All", 9).ForTenant("acme")];   // "claim_lines:V9:All:acme"
+        yield return [new ShardName("claim_lines", "Lines", 9).ForTenant("acme")]; // "claim_lines:V9:Lines:acme"
+    }
+
+    [Theory]
+    [MemberData(nameof(AllShardNamePermutations))]
+    public async Task deletes_the_exact_identity_for_every_permutation(ShardName shard)
+    {
+        await InsertProgressAsync(shard, 12);
+
+        // sanity: the row exists before the delete
+        (await theStore.Database.ProjectionProgressFor(shard)).ShouldBe(12);
+
+        // Reach it through the store-agnostic abstraction (issue requirement #2) — no reflection.
+        await ((IEventDatabase)theStore.Database)
+            .DeleteProjectionProgressByShardNameAsync(shard.Identity, CancellationToken.None);
+
+        (await theStore.Database.ProjectionProgressFor(shard)).ShouldBe(0);
+        var all = await theStore.Database.AllProjectionProgress();
+        all.ShouldNotContain(s => s.ShardName == shard.Identity);
+    }
+
+    [Fact]
+    public async Task exact_equality_does_not_drop_prefix_sibling()
+    {
+        // The issue's canonical hazard: deleting "claim_lines:V9:All" must NOT also drop
+        // "claim_lines:V9:AllOther", which a prefix LIKE 'name%' delete would wrongly catch.
+        var target = new ShardName("claim_lines", "All", 9);          // claim_lines:V9:All
+        var sibling = new ShardName("claim_lines", "AllOther", 9);    // claim_lines:V9:AllOther
+
+        await InsertProgressAsync(target, 10);
+        await InsertProgressAsync(sibling, 20);
+
+        await ((IEventDatabase)theStore.Database)
+            .DeleteProjectionProgressByShardNameAsync(target.Identity, CancellationToken.None);
+
+        (await theStore.Database.ProjectionProgressFor(target)).ShouldBe(0);
+        (await theStore.Database.ProjectionProgressFor(sibling)).ShouldBe(20); // survives
+    }
+
+    [Fact]
+    public async Task exact_equality_does_not_drop_tenant_scoped_sibling()
+    {
+        // A non-tenant identity is a strict prefix of the per-tenant one ("Trip:All" vs
+        // "Trip:All:acme"). Exact equality must leave the tenant row alone.
+        var shared = new ShardName("Trip");                  // Trip:All
+        var perTenant = new ShardName("Trip").ForTenant("acme"); // Trip:All:acme
+
+        await InsertProgressAsync(shared, 5);
+        await InsertProgressAsync(perTenant, 7);
+
+        await ((IEventDatabase)theStore.Database)
+            .DeleteProjectionProgressByShardNameAsync(shared.Identity, CancellationToken.None);
+
+        (await theStore.Database.ProjectionProgressFor(shared)).ShouldBe(0);
+        (await theStore.Database.ProjectionProgressFor(perTenant)).ShouldBe(7); // survives
+    }
+
+    [Fact]
+    public async Task nonexistent_identity_is_a_clean_no_op()
+    {
+        var keep = new ShardName("Trip");
+        await InsertProgressAsync(keep, 3);
+
+        // No matching row — must not throw and must not touch unrelated rows.
+        await Should.NotThrowAsync(((IEventDatabase)theStore.Database)
+            .DeleteProjectionProgressByShardNameAsync("does_not_exist:V3:All:nobody", CancellationToken.None));
+
+        (await theStore.Database.ProjectionProgressFor(keep)).ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task deletes_only_the_targeted_row_among_all_permutations()
+    {
+        var shards = AllShardNamePermutations().Select(o => (ShardName)o[0]).ToArray();
+        for (var i = 0; i < shards.Length; i++)
+        {
+            await InsertProgressAsync(shards[i], (i + 1) * 10);
+        }
+
+        var victim = shards[3]; // claim_lines:V9:Lines
+        await ((IEventDatabase)theStore.Database)
+            .DeleteProjectionProgressByShardNameAsync(victim.Identity, CancellationToken.None);
+
+        for (var i = 0; i < shards.Length; i++)
+        {
+            var expected = shards[i].Identity == victim.Identity ? 0 : (i + 1) * 10;
+            (await theStore.Database.ProjectionProgressFor(shards[i])).ShouldBe(expected);
+        }
+    }
+
+    private async Task InsertProgressAsync(ShardName shardName, long ceiling)
+    {
+        var op = new InsertProjectionProgress(
+            theStore.Database.Events,
+            new EventRange(shardName, 0, ceiling, null!));
+        await using var conn = await OpenConnectionAsync();
+        await using var batch = new Microsoft.Data.SqlClient.SqlBatch(conn);
+        var builder = new Weasel.SqlServer.BatchBuilder(batch);
+        op.ConfigureCommand(builder);
+        builder.Compile();
+        await using var reader = await batch.ExecuteReaderAsync(CancellationToken.None);
+        await op.PostprocessAsync(reader, new List<Exception>(), CancellationToken.None);
+    }
+}

--- a/src/Polecat/Storage/PolecatDatabase.cs
+++ b/src/Polecat/Storage/PolecatDatabase.cs
@@ -151,6 +151,28 @@ public class PolecatDatabase : DatabaseBase<SqlConnection>, IEventDatabase, IPro
         }, (_connectionString, _events.ProgressionTableName, name.Identity), token);
     }
 
+    // #220 (jasperfx#473 / #474, JasperFx.Events 2.16.0): exact-identity progression delete.
+    // The JasperFx.Events default throws NotSupportedException, so Polecat must override this or
+    // the operation is inert. Unlike the prefix-LIKE DeleteProjectionProgressAsync path on
+    // DocumentStore.EventStore.cs, this matches the *raw* ShardName.Identity with exact equality so
+    // ejecting (e.g.) "claim_lines:V9:All" cannot drop "claim_lines:V9:AllOther"-style siblings.
+    // No registration check by design: the abstraction targets orphaned/unregistered shards too
+    // (CritterWatch #476 "Eject Shard"). A non-existent identity is a clean zero-row no-op.
+    public async Task DeleteProjectionProgressByShardNameAsync(string shardIdentity, CancellationToken token = default)
+    {
+        await _resilience.ExecuteAsync(static async (state, ct) =>
+        {
+            var (connectionString, progressionTable, identity) = state;
+            await using var conn = new SqlConnection(connectionString);
+            await conn.OpenAsync(ct);
+
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = $"DELETE FROM {progressionTable} WHERE name = @identity;";
+            cmd.Parameters.AddWithValue("@identity", identity);
+            await cmd.ExecuteNonQueryAsync(ct);
+        }, (_connectionString, _events.ProgressionTableName, shardIdentity), token);
+    }
+
     public async Task<IReadOnlyList<ShardState>> AllProjectionProgress(CancellationToken token = default)
     {
         return await _resilience.ExecuteAsync(static async (state, ct) =>


### PR DESCRIPTION
Closes #220.

## What

Implements the store-agnostic `IEventDatabase.DeleteProjectionProgressByShardNameAsync(string shardIdentity, CancellationToken)` override added in **JasperFx.Events 2.16.0** ([jasperfx#473](https://github.com/JasperFx/jasperfx/issues/473) / [#474](https://github.com/JasperFx/jasperfx/pull/474)).

The JasperFx.Events default implementation **throws `NotSupportedException`** (a silent no-op on a delete is dangerous), so Polecat must override it or the operation is inert. `PolecatDatabase` now overrides it with **exact-equality** semantics:

```sql
DELETE FROM {progressionTable} WHERE name = @identity
```

## Why exact-equality (not the existing LIKE path)

Polecat already deletes by raw name via `DocumentStore.EventStore.cs` → `DeleteProjectionProgressAsync`, but that path uses a **prefix `LIKE 'name%'`** match. The new abstraction matches the **exact `ShardName.Identity`**, so ejecting `claim_lines:V9:All` cannot also drop:

- `claim_lines:V9:AllOther`-style **prefix siblings**, or
- `claim_lines:V9:All:acme`-style **per-tenant siblings** (a non-tenant identity is a strict prefix of the per-tenant one).

The prefix `DeleteProjectionProgressAsync` path is left untouched. No registration check by design — the abstraction targets orphaned/unregistered shards too.

## Acceptance (per the issue)
- `DeleteProjectionProgressByShardNameAsync("claim_lines:V9:All", ct)` drops exactly that row, no prefix collateral. ✅
- A non-existent identity is a clean no-op (zero rows), not an error. ✅
- Multi-tenant per-tenant progression rows: deleting the shared identity leaves `…:tenant` rows alone, and a per-tenant identity deletes exactly its own row. ✅

## Tests

New `delete_projection_progress_by_shard_name_tests` exercises **every permutation of `ShardName.Identity`**:

| Permutation | Example Identity |
|---|---|
| default key, v1 | `Trip:All` |
| custom key, v1 | `Trip:Lines` |
| versioned (V>1), key All | `claim_lines:V9:All` |
| versioned + custom key | `claim_lines:V9:Lines` |
| per-tenant, v1 | `Trip:All:acme` |
| per-tenant + versioned | `claim_lines:V9:All:acme` |
| per-tenant + versioned + custom key | `claim_lines:V9:Lines:acme` |

plus dedicated facts for prefix-sibling survival, tenant-sibling survival, the clean no-op, and "delete only the targeted row among all permutations." Each delete is invoked **through the `IEventDatabase` abstraction** (no reflection) to validate store-agnostic reachability. 11 tests, all green; existing `projection_progression_tests` still pass after the 2.16.0 bump.

## Downstream
Unblocks [CritterWatch#476](https://github.com/JasperFx/CritterWatch/issues/476) Part 1 ("Eject Shard"). Marten needs the symmetric override (filed separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)