### PR TITLE
Fix: make Index() computed-column indexes usable by the LINQ translator + persistable DateTimeOffset (#223)

### DIFF
--- a/src/Polecat.Tests/Storage/computed_column_index_usability_tests.cs
+++ b/src/Polecat.Tests/Storage/computed_column_index_usability_tests.cs
@@ -1,0 +1,235 @@
+using Polecat.Linq;
+using Polecat.Storage;
+using Polecat.Tests.Harness;
+
+namespace Polecat.Tests.Storage;
+
+/// <summary>
+/// #223: Index(...) computed-column indexes must be usable by the LINQ translator, and a
+/// DateTimeOffset member must be indexable at all.
+///
+/// Before this fix:
+///   - the translator emitted a different expression per member type than the index column used
+///     (bare JSON_VALUE for strings, CAST(... AS datetimeoffset) for dates), so the persisted
+///     computed column never matched the predicate and the index was dead weight; and
+///   - a DateTimeOffset index failed at schema-apply ("computed column ... cannot be persisted
+///     because the column is non-deterministic") because CAST(string AS datetimeoffset) is
+///     non-deterministic.
+///
+/// Now a single shared expression builder feeds both the index DDL and the translator, dates use a
+/// deterministic CONVERT(..., 126) (persistable), and each column is typed from its CLR member type.
+/// </summary>
+public class computed_column_index_usability_tests : OneOffConfigurationsContext
+{
+    public class IndexedMetric
+    {
+        public Guid Id { get; set; }
+        public string ServiceName { get; set; } = string.Empty;
+        public DateTimeOffset BucketEnd { get; set; }
+        public int Count { get; set; }
+    }
+
+    private const string Table = "pc_doc_indexedmetric";
+
+    private static string SqlFor<T>(IQuerySession session, IQueryable<T> query)
+    {
+        var provider = (PolecatLinqQueryProvider)query.Provider;
+        return provider.BuildSql(query.Expression, session.TenantId);
+    }
+
+    // ---- unit: the shared expression builder ----------------------------------------------------
+
+    [Fact]
+    public void datetimeoffset_uses_deterministic_convert_so_it_can_be_persisted()
+    {
+        DocumentIndex.ComputedColumnExpression("$.bucketEnd", "datetimeoffset", IndexCasing.Default)
+            .ShouldBe("CONVERT(datetimeoffset, JSON_VALUE(data, '$.bucketEnd'), 126)");
+    }
+
+    [Fact]
+    public void string_uses_cast_to_the_bounded_type()
+    {
+        DocumentIndex.ComputedColumnExpression("$.serviceName", "varchar(250)", IndexCasing.Default)
+            .ShouldBe("CAST(JSON_VALUE(data, '$.serviceName') AS varchar(250))");
+    }
+
+    [Fact]
+    public void resolve_sql_type_precedence_per_path_then_index_then_clr()
+    {
+        var index = new DocumentIndex(["$.bucketEnd"]);
+        // CLR-derived when nothing set
+        index.ResolveSqlType("$.bucketEnd", typeof(DateTimeOffset)).ShouldBe("datetimeoffset");
+        index.ResolveSqlType("$.count", typeof(int)).ShouldBe("int");
+        index.ResolveSqlType("$.serviceName", typeof(string)).ShouldBe("varchar(250)");
+
+        // index-wide override wins over CLR
+        index.SqlType = "varchar(500)";
+        index.ResolveSqlType("$.bucketEnd", typeof(DateTimeOffset)).ShouldBe("varchar(500)");
+
+        // per-path override wins over everything
+        index.SqlTypeByPath["$.bucketEnd"] = "datetime2";
+        index.ResolveSqlType("$.bucketEnd", typeof(DateTimeOffset)).ShouldBe("datetime2");
+    }
+
+    // ---- gap 2: DateTimeOffset index can be created + persisted ----------------------------------
+
+    [Fact]
+    public async Task datetimeoffset_index_applies_cleanly_and_is_persisted()
+    {
+        ConfigureStore(opts =>
+        {
+            opts.Schema.For<IndexedMetric>().Index(x => x.BucketEnd);
+        });
+
+        // Storing a doc triggers AutoCreate of the table + persisted computed column + index.
+        // Previously this threw: "computed column 'cc_bucketend' ... cannot be persisted because
+        // the column is non-deterministic." Must now succeed.
+        await Should.NotThrowAsync(async () =>
+        {
+            await using var session = theStore.LightweightSession();
+            session.Store(new IndexedMetric
+            {
+                Id = Guid.NewGuid(), ServiceName = "svc", BucketEnd = DateTimeOffset.UtcNow, Count = 1
+            });
+            await session.SaveChangesAsync();
+        });
+
+        await using var conn = await OpenConnectionAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"""
+            SELECT cc.is_persisted, TYPE_NAME(cc.user_type_id)
+            FROM sys.computed_columns cc
+            WHERE cc.object_id = OBJECT_ID('[{_schema()}].[{Table}]') AND cc.name = 'cc_bucketend';
+            """;
+        await using var reader = await cmd.ExecuteReaderAsync();
+        (await reader.ReadAsync()).ShouldBeTrue();
+        reader.GetBoolean(0).ShouldBeTrue();       // PERSISTED
+        reader.GetString(1).ShouldBe("datetimeoffset");
+    }
+
+    // ---- gap 1: the translator targets the computed column --------------------------------------
+
+    [Fact]
+    public async Task string_equality_predicate_targets_the_computed_column()
+    {
+        ConfigureStore(opts => opts.Schema.For<IndexedMetric>().Index(x => x.ServiceName));
+        await theDatabase.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        await using var session = theStore.QuerySession();
+        var query = session.Query<IndexedMetric>().Where(x => x.ServiceName == "svc-A");
+
+        // Bare JSON_VALUE (the old behavior) could never match the varchar(250) computed column.
+        SqlFor(session, query)
+            .ShouldContain("CAST(JSON_VALUE(data, '$.serviceName') AS varchar(250))");
+    }
+
+    [Fact]
+    public async Task datetimeoffset_range_predicate_targets_the_computed_column()
+    {
+        ConfigureStore(opts => opts.Schema.For<IndexedMetric>().Index(x => x.BucketEnd));
+        await theDatabase.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        var cutoff = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        await using var session = theStore.QuerySession();
+        var query = session.Query<IndexedMetric>().Where(x => x.BucketEnd >= cutoff);
+
+        SqlFor(session, query)
+            .ShouldContain("CONVERT(datetimeoffset, JSON_VALUE(data, '$.bucketEnd'), 126)");
+    }
+
+    [Fact]
+    public async Task non_indexed_member_keeps_its_plain_locator()
+    {
+        // Only indexed members are rewritten; everything else is untouched.
+        ConfigureStore(opts => opts.Schema.For<IndexedMetric>().Index(x => x.ServiceName));
+        await theDatabase.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        await using var session = theStore.QuerySession();
+        var query = session.Query<IndexedMetric>().Where(x => x.Count == 5);
+
+        var sql = SqlFor(session, query);
+        sql.ShouldContain("CAST(JSON_VALUE(data, '$.count') AS int)");
+        sql.ShouldNotContain("cc_"); // no computed column reference, no rewrite of unrelated members
+    }
+
+    // ---- gap 3: composite index types each column independently ----------------------------------
+
+    [Fact]
+    public async Task composite_index_types_string_and_date_columns_independently()
+    {
+        ConfigureStore(opts =>
+            opts.Schema.For<IndexedMetric>().Index(x => new { x.ServiceName, x.BucketEnd }));
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Store(new IndexedMetric
+            {
+                Id = Guid.NewGuid(), ServiceName = "svc", BucketEnd = DateTimeOffset.UtcNow, Count = 1
+            });
+            await session.SaveChangesAsync();
+        }
+
+        await using var conn = await OpenConnectionAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"""
+            SELECT cc.name, TYPE_NAME(cc.user_type_id)
+            FROM sys.computed_columns cc
+            WHERE cc.object_id = OBJECT_ID('[{_schema()}].[{Table}]')
+            ORDER BY cc.name;
+            """;
+        var types = new Dictionary<string, string>();
+        await using (var reader = await cmd.ExecuteReaderAsync())
+        {
+            while (await reader.ReadAsync()) types[reader.GetString(0)] = reader.GetString(1);
+        }
+
+        types["cc_servicename"].ShouldBe("varchar");
+        types["cc_bucketend"].ShouldBe("datetimeoffset");
+    }
+
+    // ---- end-to-end: the issue's MetricsSample scenario -----------------------------------------
+
+    [Fact]
+    public async Task end_to_end_query_and_delete_over_string_and_datetimeoffset()
+    {
+        ConfigureStore(opts =>
+            opts.Schema.For<IndexedMetric>().Index(x => new { x.ServiceName, x.BucketEnd }));
+
+        var t0 = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Store(new IndexedMetric { Id = Guid.NewGuid(), ServiceName = "svc-A", BucketEnd = t0, Count = 1 });
+            session.Store(new IndexedMetric { Id = Guid.NewGuid(), ServiceName = "svc-A", BucketEnd = t0.AddHours(2), Count = 2 });
+            session.Store(new IndexedMetric { Id = Guid.NewGuid(), ServiceName = "svc-A", BucketEnd = t0.AddHours(5), Count = 3 });
+            session.Store(new IndexedMetric { Id = Guid.NewGuid(), ServiceName = "svc-B", BucketEnd = t0.AddHours(5), Count = 9 });
+            await session.SaveChangesAsync();
+        }
+
+        var cutoff = t0.AddHours(1);
+        await using (var session = theStore.QuerySession())
+        {
+            // WHERE ServiceName = 'svc-A' AND BucketEnd >= cutoff
+            var rows = await session.Query<IndexedMetric>()
+                .Where(x => x.ServiceName == "svc-A" && x.BucketEnd >= cutoff)
+                .ToListAsync();
+            rows.Count.ShouldBe(2);
+            rows.ShouldAllBe(x => x.ServiceName == "svc-A" && x.BucketEnd >= cutoff);
+        }
+
+        // DeleteWhere(x => x.BucketEnd < cutoff) — the pruning path from the issue.
+        await using (var session = theStore.LightweightSession())
+        {
+            session.DeleteWhere<IndexedMetric>(x => x.BucketEnd < cutoff);
+            await session.SaveChangesAsync();
+        }
+
+        await using (var session = theStore.QuerySession())
+        {
+            var remaining = await session.Query<IndexedMetric>().ToListAsync();
+            remaining.Count.ShouldBe(3); // the single BucketEnd == t0 row was pruned
+            remaining.ShouldAllBe(x => x.BucketEnd >= cutoff);
+        }
+    }
+
+    private string _schema() => GetType().Name.ToLowerInvariant();
+}

--- a/src/Polecat/Linq/Members/MemberFactory.cs
+++ b/src/Polecat/Linq/Members/MemberFactory.cs
@@ -17,12 +17,14 @@ internal class MemberFactory : IMemberResolver
     private readonly EnumStorage _enumStorage;
     private readonly Type _idType;
     private readonly ValueTypeInfo? _valueTypeId;
+    private readonly DocumentMapping _mapping;
 
     public MemberFactory(StoreOptions options, DocumentMapping mapping)
     {
         _enumStorage = options.Serializer.EnumStorage;
         _idType = mapping.IdType;
         _valueTypeId = mapping.ValueTypeId;
+        _mapping = mapping;
 
         if (options.Serializer is Serializer s)
         {
@@ -67,7 +69,32 @@ internal class MemberFactory : IMemberResolver
             ? $"CAST({rawLocator} AS {sqlType})"
             : rawLocator;
 
+        // #223: if a Default-casing Index(...) covers this member, emit the EXACT computed-column
+        // expression the index defines instead of the bare/uncast locator. SQL Server then matches
+        // the predicate to the persisted computed column and can seek the index. Without this the
+        // translator's expression (e.g. bare JSON_VALUE for a string, CAST(... AS datetimeoffset)
+        // for a date) never lines up with the index column, so the index is dead weight.
+        if (TryGetIndexedLocator(jsonPath, underlying, out var indexedLocator))
+        {
+            typedLocator = indexedLocator;
+        }
+
         return new QueryableMember(rawLocator, typedLocator, memberType);
+    }
+
+    private bool TryGetIndexedLocator(string jsonPath, Type underlying, out string locator)
+    {
+        locator = string.Empty;
+
+        // Only Default-casing indexes are predicate-transparent. Upper/Lower computed columns
+        // fold case, so a plain equality/range predicate must not be rewritten onto them.
+        var index = _mapping.Indexes.FirstOrDefault(i =>
+            i.Casing == IndexCasing.Default && Array.IndexOf(i.JsonPaths, jsonPath) >= 0);
+        if (index == null) return false;
+
+        var sqlType = index.ResolveSqlType(jsonPath, underlying);
+        locator = DocumentIndex.ComputedColumnExpression(jsonPath, sqlType, IndexCasing.Default);
+        return true;
     }
 
     private string BuildJsonPath(MemberExpression expression)
@@ -105,15 +132,6 @@ internal class MemberFactory : IMemberResolver
 
     private static string? GetSqlType(Type type)
     {
-        if (type == typeof(int)) return "int";
-        if (type == typeof(long)) return "bigint";
-        if (type == typeof(short)) return "smallint";
-        if (type == typeof(double)) return "float";
-        if (type == typeof(decimal)) return "decimal(18,6)";
-        if (type == typeof(float)) return "real";
-        if (type == typeof(Guid)) return "uniqueidentifier";
-        if (type == typeof(DateTime)) return "datetime2";
-        if (type == typeof(DateTimeOffset)) return "datetimeoffset";
-        return null; // string, bool, etc. — no CAST needed
+        return SqlTypeMap.For(type);
     }
 }

--- a/src/Polecat/Storage/DocumentIndex.cs
+++ b/src/Polecat/Storage/DocumentIndex.cs
@@ -41,9 +41,19 @@ public class DocumentIndex
     public string? Predicate { get; set; }
 
     /// <summary>
-    ///     SQL type hint for the indexed value (default: varchar(250) for string paths).
+    ///     SQL type hint applied to every path in the index. When null, the type is derived from
+    ///     each member's CLR type (so an int member indexes as int, a DateTimeOffset as
+    ///     datetimeoffset, a string as varchar(250)). A non-null value overrides every path.
+    ///     For per-path control in a composite index, use <see cref="SqlTypeByPath" />.
     /// </summary>
     public string? SqlType { get; set; }
+
+    /// <summary>
+    ///     #223: per-path SQL type overrides for composite indexes, keyed by JSON path
+    ///     (e.g. "$.bucketEnd"). Lets a composite over a string + a date type each column
+    ///     correctly. Takes precedence over <see cref="SqlType" /> and the CLR-derived type.
+    /// </summary>
+    public Dictionary<string, string> SqlTypeByPath { get; } = new();
 
     /// <summary>
     ///     Sort order for the index columns.
@@ -79,6 +89,40 @@ public class DocumentIndex
     }
 
     /// <summary>
+    ///     #223: resolves the SQL type for a single indexed path. Precedence:
+    ///     per-path override → index-wide <see cref="SqlType" /> → CLR-derived type → varchar(250).
+    /// </summary>
+    internal string ResolveSqlType(string jsonPath, Type? clrType)
+    {
+        if (SqlTypeByPath.TryGetValue(jsonPath, out var perPath)) return perPath;
+        if (SqlType != null) return SqlType;
+        if (clrType != null && SqlTypeMap.For(clrType) is { } derived) return derived;
+        return "varchar(250)";
+    }
+
+    /// <summary>
+    ///     #223: builds the computed-column / predicate expression for a path. This single method
+    ///     feeds both the index DDL and the LINQ translator (via MemberFactory), which is what lets
+    ///     SQL Server match a predicate to the persisted computed column and seek the index.
+    ///     Date/time types use a deterministic CONVERT(..., 126) so the column can be PERSISTED
+    ///     (a CAST of a string to a date/time type is non-deterministic and rejected by PERSISTED).
+    /// </summary>
+    internal static string ComputedColumnExpression(string jsonPath, string sqlType, IndexCasing casing)
+    {
+        var json = $"JSON_VALUE(data, '{jsonPath}')";
+        var expr = SqlTypeMap.IsDateTimeFamily(sqlType)
+            ? $"CONVERT({sqlType}, {json}, 126)"
+            : $"CAST({json} AS {sqlType})";
+
+        return casing switch
+        {
+            IndexCasing.Upper => $"UPPER({expr})",
+            IndexCasing.Lower => $"LOWER({expr})",
+            _ => expr
+        };
+    }
+
+    /// <summary>
     ///     Gets the index name (explicit or derived).
     /// </summary>
     internal string GetIndexName(string tableName)
@@ -97,7 +141,6 @@ public class DocumentIndex
         var qualifiedTable = $"[{schema}].[{table}]";
         var name = GetIndexName(table);
         var unique = IsUnique ? "UNIQUE " : "";
-        var sqlType = SqlType ?? "varchar(250)";
 
         var statements = new List<string>();
 
@@ -105,15 +148,8 @@ public class DocumentIndex
         foreach (var path in JsonPaths)
         {
             var colName = ColumnNameForPath(path, Casing);
-            var jsonValueExpr = $"JSON_VALUE(data, '{path}')";
-
-            // Apply case transformation for string-typed columns
-            var castedExpr = Casing switch
-            {
-                IndexCasing.Upper => $"UPPER(CAST({jsonValueExpr} AS {sqlType}))",
-                IndexCasing.Lower => $"LOWER(CAST({jsonValueExpr} AS {sqlType}))",
-                _ => $"CAST({jsonValueExpr} AS {sqlType})"
-            };
+            var sqlType = ResolveSqlType(path, mapping.ResolveClrMemberType(path));
+            var castedExpr = ComputedColumnExpression(path, sqlType, Casing);
 
             statements.Add($"""
                 IF COL_LENGTH('{schema}.{table}', '{colName}') IS NULL

--- a/src/Polecat/Storage/DocumentMapping.cs
+++ b/src/Polecat/Storage/DocumentMapping.cs
@@ -102,6 +102,30 @@ internal class DocumentMapping
     public Type IdType { get; }
 
     /// <summary>
+    ///     #223: resolves an index JSON path (e.g. "$.serviceName", "$.address.city") back to the
+    ///     CLR member type so a computed-column index can be typed from the member rather than
+    ///     defaulting every column to varchar(250). Nullable types are unwrapped. Returns null when
+    ///     the path can't be walked to a simple property (caller falls back to varchar(250)).
+    /// </summary>
+    internal Type? ResolveClrMemberType(string jsonPath)
+    {
+        if (!jsonPath.StartsWith("$.", StringComparison.Ordinal)) return null;
+
+        var current = _documentType;
+        foreach (var segment in jsonPath[2..].Split('.'))
+        {
+            // Index paths are camelCased property names; match case-insensitively since
+            // camelCasing only changes the first character.
+            var prop = current.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                .FirstOrDefault(p => string.Equals(p.Name, segment, StringComparison.OrdinalIgnoreCase));
+            if (prop == null) return null;
+            current = prop.PropertyType;
+        }
+
+        return Nullable.GetUnderlyingType(current) ?? current;
+    }
+
+    /// <summary>
     ///     The unwrapped inner type for SQL column mapping.
     ///     For strongly typed IDs (e.g., OrderId wrapping Guid), returns the inner type.
     ///     For plain IDs, returns IdType.

--- a/src/Polecat/Storage/SqlTypeMap.cs
+++ b/src/Polecat/Storage/SqlTypeMap.cs
@@ -1,0 +1,42 @@
+namespace Polecat.Storage;
+
+/// <summary>
+///     Single source of truth mapping a CLR member type to the SQL Server type used both by the
+///     LINQ translator's CAST/CONVERT locators and by computed-column index definitions. Keeping
+///     one map is what lets an Index(...) computed column line up with the predicate the translator
+///     emits, so SQL Server can actually seek the index (#223).
+/// </summary>
+internal static class SqlTypeMap
+{
+    /// <summary>
+    ///     The SQL type for a CLR type, or null for types the translator leaves uncast
+    ///     (string, bool — JSON_VALUE already returns nvarchar for these).
+    /// </summary>
+    public static string? For(Type type)
+    {
+        if (type == typeof(int)) return "int";
+        if (type == typeof(long)) return "bigint";
+        if (type == typeof(short)) return "smallint";
+        if (type == typeof(double)) return "float";
+        if (type == typeof(decimal)) return "decimal(18,6)";
+        if (type == typeof(float)) return "real";
+        if (type == typeof(Guid)) return "uniqueidentifier";
+        if (type == typeof(DateTime)) return "datetime2";
+        if (type == typeof(DateTimeOffset)) return "datetimeoffset";
+        if (type == typeof(DateOnly)) return "date";
+        if (type == typeof(TimeOnly)) return "time";
+        return null; // string, bool, etc. — no CAST needed
+    }
+
+    /// <summary>
+    ///     True when the SQL type is a date/time family that needs a deterministic CONVERT(..., 126)
+    ///     (rather than CAST) to be usable in a PERSISTED computed column. CAST of a string to a
+    ///     date/time type is non-deterministic and cannot be persisted.
+    /// </summary>
+    public static bool IsDateTimeFamily(string sqlType)
+    {
+        var t = sqlType.Trim().ToLowerInvariant();
+        return t is "datetimeoffset" or "datetime2" or "datetime" or "smalldatetime"
+            or "date" or "time";
+    }
+}


### PR DESCRIPTION
Closes #223 (gaps 1–3; gap 4 deferred — see below).

## The bug

`Schema.For<T>().Index(...)` created a `PERSISTED` computed column + nonclustered index, but the LINQ translator emitted a *different* expression per member type than the column was defined with, so SQL Server's persisted-computed-column auto-matching never engaged — the index was dead weight. And `DateTimeOffset` members couldn't be indexed at all: `CAST(string AS datetimeoffset)` is non-deterministic and rejected by `PERSISTED`.

## Root cause

The DDL (`DocumentIndex`) and the translator (`MemberFactory`) computed their expressions independently and diverged:
- strings: column `CAST(... AS varchar(250))` vs predicate bare `JSON_VALUE(...)`;
- numbers: column defaulted to `varchar(250)` regardless of CLR type vs predicate `CAST(... AS int)`;
- dates: column `CAST(... AS datetimeoffset)` (un-persistable) vs predicate `CAST(... AS datetimeoffset)`.

`JSON_VALUE` returns `nvarchar(4000)` (un-indexable), so a string index *must* use a bounded computed column — which means the predicate has to match that bounded expression. The only correct fix is to make both sides produce the **same** expression.

## Fix

A single shared expression builder feeds both the DDL and the translator:

- **`SqlTypeMap`** — one CLR→SQL type map used by both the translator's CAST locators and the index columns.
- **`DocumentIndex.ComputedColumnExpression`** — the canonical expression. Date/time types use a deterministic `CONVERT(<type>, JSON_VALUE(...), 126)` (persistable); everything else uses `CAST`.
- **`DocumentIndex.ResolveSqlType`** — per-path override → index-wide `SqlType` → CLR-derived → `varchar(250)`.
- **`MemberFactory`** — for a member covered by a **Default-casing** index, emits the index's exact expression as the predicate locator, so SQL Server matches the persisted computed column and can seek.

Mapped to the issue's gaps:

| Gap | Fix |
|---|---|
| 1 — string/numeric members never matched | column types derived from CLR member type; translator emits the matching expression |
| 2 — DateTimeOffset can't be PERSISTED | deterministic `CONVERT(..., 126)` on both sides |
| 3 — composite columns can't be typed independently | each path resolves its own type; `SqlTypeByPath` for overrides |

Only **Default-casing** indexes are rewritten (Upper/Lower fold case and must not capture a plain predicate); non-indexed members are untouched.

### Deferred: gap 4 (`.Duplicate()`)

Left as a follow-up. A `.Duplicate()` is a different mechanism — a *real* persisted column populated on write (not a computed column) — and is orthogonal to making the computed-column path correct. Filing separately keeps this PR focused.

## Tests

New `computed_column_index_usability_tests`:
- **Unit** — the deterministic `CONVERT(..., 126)` for dates, `CAST` for strings, and `ResolveSqlType` precedence.
- **Gap 2** — a `DateTimeOffset` index now creates cleanly and the column is `is_persisted = 1`, type `datetimeoffset` (previously threw at schema-apply).
- **Gap 1** — the generated SQL for a string equality and a date range predicate targets the computed-column expression (deterministic; cost-based seek selection on tiny tables is not asserted). Non-indexed members keep their plain locator.
- **Gap 3** — a composite `(string, DateTimeOffset)` index types `cc_servicename` as `varchar` and `cc_bucketend` as `datetimeoffset`.
- **End-to-end** — the issue's `MetricsSample` scenario: `WHERE ServiceName = ? AND BucketEnd >= ?` returns the right rows and `DeleteWhere(x => x.BucketEnd < cutoff)` prunes correctly.

Full `Storage` + `Linq` + `Documents` suites stay green (279 tests); the existing 24 `document_index_tests` are unchanged (path-based column names preserved).

## Downstream
Unblocks CritterWatch's `MetricsSample` getting a usable index on Polecat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)