### PR TITLE
Fix: auto-assign Guid ids for plain Guid Id properties (#218)

### DIFF
--- a/src/Polecat.Tests/Documents/plain_guid_id_assignment_tests.cs
+++ b/src/Polecat.Tests/Documents/plain_guid_id_assignment_tests.cs
@@ -1,0 +1,88 @@
+using JasperFx;
+using Polecat.Linq;
+using Polecat.Tests.Harness;
+using Shouldly;
+
+namespace Polecat.Tests.Documents;
+
+/// <summary>
+/// #218: a document with a plain <c>Guid Id</c> property should get a new Guid auto-assigned when
+/// the id is default (Guid.Empty), exactly like strongly typed Guid wrappers do. Previously only
+/// strong-typed Guid ids were assigned, so a plain Guid id persisted as 00000000-0000-0000-0000-…
+/// </summary>
+[Collection("integration")]
+public class plain_guid_id_assignment_tests : IntegrationContext
+{
+    public plain_guid_id_assignment_tests(DefaultStoreFixture fixture) : base(fixture)
+    {
+    }
+
+    public override async Task InitializeAsync()
+    {
+        await StoreOptions(opts => { opts.DatabaseSchemaName = "plain_guid_id"; });
+    }
+
+    public class User
+    {
+        public Guid Id { get; set; }
+        public string FirstName { get; set; } = string.Empty;
+        public string LastName { get; set; } = string.Empty;
+    }
+
+    public class IdentityAttributedUser
+    {
+        [Identity]
+        public Guid Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+    }
+
+    [Fact]
+    public async Task store_assigns_a_new_guid_when_id_is_empty()
+    {
+        var user = new User { FirstName = "Marco", LastName = "Minerva" };
+        user.Id.ShouldBe(Guid.Empty);
+
+        await using var session = theStore.LightweightSession();
+        session.Store(user);
+        await session.SaveChangesAsync();
+
+        // The in-memory instance is updated...
+        user.Id.ShouldNotBe(Guid.Empty);
+
+        // ...and the row actually persisted under that id (not Guid.Empty).
+        await using var query = theStore.QuerySession();
+        var loaded = await query.LoadAsync<User>(user.Id);
+        loaded.ShouldNotBeNull();
+        loaded.FirstName.ShouldBe("Marco");
+    }
+
+    [Fact]
+    public async Task store_preserves_an_explicitly_set_guid()
+    {
+        var id = Guid.NewGuid();
+        var user = new User { Id = id, FirstName = "Explicit" };
+
+        await using var session = theStore.LightweightSession();
+        session.Store(user);
+        await session.SaveChangesAsync();
+
+        user.Id.ShouldBe(id); // not overwritten
+
+        await using var query = theStore.QuerySession();
+        (await query.LoadAsync<User>(id)).ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task identity_attribute_on_guid_id_is_assigned()
+    {
+        var doc = new IdentityAttributedUser { Name = "Attr" };
+
+        await using var session = theStore.LightweightSession();
+        session.Store(doc);
+        await session.SaveChangesAsync();
+
+        doc.Id.ShouldNotBe(Guid.Empty);
+        await using var query = theStore.QuerySession();
+        (await query.LoadAsync<IdentityAttributedUser>(doc.Id)).ShouldNotBeNull();
+    }
+}

--- a/src/Polecat/Internal/DocumentProvider.cs
+++ b/src/Polecat/Internal/DocumentProvider.cs
@@ -158,8 +158,12 @@ internal class DocumentProvider
 
     private void AssignIdIfNeeded(object document)
     {
-        // Auto-assign Guid for strongly typed Guid wrappers when default
-        if (Mapping.IsStrongTypedId && Mapping.InnerIdType == typeof(Guid))
+        // #218: auto-assign a new Guid when the id is default. This applies to BOTH a plain
+        // `Guid Id` property and strongly typed Guid wrappers — GetId/SetId already resolve the
+        // inner Guid for either, so gating on InnerIdType (not IsStrongTypedId) is what was missing:
+        // previously a plain Guid id fell through to the numeric branch and was never assigned,
+        // so documents persisted with Guid.Empty.
+        if (Mapping.InnerIdType == typeof(Guid))
         {
             var currentId = Mapping.GetId(document);
             if ((Guid)currentId == Guid.Empty)


### PR DESCRIPTION
Closes #218.

## The bug

A document with a plain `Guid Id` property persisted with `Guid.Empty` — the id was never auto-assigned, even with `[Identity]` on the property:

```csharp
public class User
{
    public Guid Id { get; set; }   // stays 00000000-0000-0000-0000-000000000000
    public string FirstName { get; set; } = null!;
    public string LastName { get; set; } = null!;
}
```

## Root cause

`DocumentProvider.AssignIdIfNeeded` gated Guid assignment on `Mapping.IsStrongTypedId`:

```csharp
if (Mapping.IsStrongTypedId && Mapping.InnerIdType == typeof(Guid)) { ... }
```

So only strongly typed Guid *wrappers* (e.g. `record struct InvoiceId(Guid Value)`) were assigned. A plain `Guid Id` is not a strong-typed id, so it fell through to the numeric/sequence branch — which is a no-op for Guid — and was never assigned.

## Fix

`Mapping.GetId`/`SetId` already resolve the inner Guid for both plain and wrapped ids, so the gate just needs to key on the id type, not the strong-typed flag:

```csharp
if (Mapping.InnerIdType == typeof(Guid)) { ... }
```

This covers both plain `Guid Id` and strongly typed Guid wrappers. Explicitly set ids are still preserved.

## Tests

New `plain_guid_id_assignment_tests`:
- a plain `Guid Id` is assigned when empty and the row is actually persisted/loadable under that id;
- an explicitly set Guid is preserved (not overwritten);
- `[Identity]` on a plain Guid id is assigned.

Strong-typed Guid assignment is unchanged, and the StrongTypedId + Documents suites stay green (147 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)