### PR TITLE
Use JSON_VALUE(... RETURNING type) on native json storage (#217)

### DIFF
--- a/src/Polecat.Tests/Linq/json_value_returning_tests.cs
+++ b/src/Polecat.Tests/Linq/json_value_returning_tests.cs
@@ -1,0 +1,118 @@
+using Polecat.Linq;
+using Polecat.Tests.Harness;
+using Weasel.Core;
+
+namespace Polecat.Tests.Linq;
+
+/// <summary>
+/// #217: on SQL Server 2025 native json storage, prefer JSON_VALUE(data, '$.x' RETURNING type)
+/// over CAST(JSON_VALUE(data, '$.x') AS type). RETURNING is only valid against the native json
+/// column type (UseNativeJsonType) and does not support uniqueidentifier, so Guid members and
+/// nvarchar(max) storage keep CAST.
+/// </summary>
+public class json_value_returning_tests : OneOffConfigurationsContext
+{
+    public enum Status
+    {
+        Active,
+        Inactive
+    }
+
+    public class Doc
+    {
+        public Guid Id { get; set; }
+        public int Count { get; set; }
+        public decimal Price { get; set; }
+        public DateTimeOffset BucketEnd { get; set; }
+        public Guid Ref { get; set; }
+        public Status Status { get; set; }
+        public string Name { get; set; } = string.Empty;
+    }
+
+    private static string SqlFor<T>(IQuerySession session, IQueryable<T> query)
+    {
+        var provider = (PolecatLinqQueryProvider)query.Provider;
+        return provider.BuildSql(query.Expression, session.TenantId);
+    }
+
+    [Fact]
+    public async Task native_json_uses_returning_for_numeric()
+    {
+        ConfigureStore(_ => { }); // UseNativeJsonType defaults to true (native json on SQL 2025)
+        await using var session = theStore.QuerySession();
+        var sql = SqlFor(session, session.Query<Doc>().Where(x => x.Count == 5));
+
+        sql.ShouldContain("JSON_VALUE(data, '$.count' RETURNING int)");
+        sql.ShouldNotContain("CAST(JSON_VALUE(data, '$.count')");
+    }
+
+    [Fact]
+    public async Task native_json_uses_returning_for_decimal_and_datetimeoffset()
+    {
+        ConfigureStore(_ => { });
+        var cutoff = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        await using var session = theStore.QuerySession();
+        var sql = SqlFor(session,
+            session.Query<Doc>().Where(x => x.Price > 10m && x.BucketEnd >= cutoff));
+
+        sql.ShouldContain("JSON_VALUE(data, '$.price' RETURNING decimal(18,6))");
+        sql.ShouldContain("JSON_VALUE(data, '$.bucketEnd' RETURNING datetimeoffset)");
+    }
+
+    [Fact]
+    public async Task guid_member_keeps_cast_because_returning_has_no_uniqueidentifier()
+    {
+        ConfigureStore(_ => { });
+        var someGuid = Guid.NewGuid();
+        await using var session = theStore.QuerySession();
+        var sql = SqlFor(session, session.Query<Doc>().Where(x => x.Ref == someGuid));
+
+        sql.ShouldContain("CAST(JSON_VALUE(data, '$.ref') AS uniqueidentifier)");
+        sql.ShouldNotContain("RETURNING uniqueidentifier");
+    }
+
+    [Fact]
+    public async Task enum_as_integer_uses_returning_int()
+    {
+        ConfigureStore(opts => opts.ConfigureSerialization(EnumStorage.AsInteger));
+        await using var session = theStore.QuerySession();
+        var sql = SqlFor(session, session.Query<Doc>().Where(x => x.Status == Status.Inactive));
+
+        sql.ShouldContain("JSON_VALUE(data, '$.status' RETURNING int)");
+    }
+
+    [Fact]
+    public async Task nvarchar_storage_falls_back_to_cast()
+    {
+        // Without the native json column type, RETURNING is a syntax error — must use CAST.
+        ConfigureStore(opts => opts.UseNativeJsonType = false);
+        await using var session = theStore.QuerySession();
+        var sql = SqlFor(session, session.Query<Doc>().Where(x => x.Count == 5));
+
+        sql.ShouldContain("CAST(JSON_VALUE(data, '$.count') AS int)");
+        // Note: the schema name itself contains "returning", so assert the clause, not the word.
+        sql.ShouldNotContain("' RETURNING ");
+    }
+
+    [Fact]
+    public async Task returning_query_returns_correct_rows_end_to_end()
+    {
+        ConfigureStore(_ => { });
+        var t0 = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Store(new Doc { Id = Guid.NewGuid(), Count = 1, Price = 5m, BucketEnd = t0, Status = Status.Active });
+            session.Store(new Doc { Id = Guid.NewGuid(), Count = 7, Price = 50m, BucketEnd = t0.AddHours(3), Status = Status.Inactive });
+            session.Store(new Doc { Id = Guid.NewGuid(), Count = 9, Price = 99m, BucketEnd = t0.AddHours(6), Status = Status.Inactive });
+            await session.SaveChangesAsync();
+        }
+
+        await using var session2 = theStore.QuerySession();
+
+        (await session2.Query<Doc>().Where(x => x.Count >= 7).ToListAsync()).Count.ShouldBe(2);
+        (await session2.Query<Doc>().Where(x => x.Price > 10m).ToListAsync()).Count.ShouldBe(2);
+        (await session2.Query<Doc>().Where(x => x.BucketEnd >= t0.AddHours(1)).ToListAsync()).Count.ShouldBe(2);
+        (await session2.Query<Doc>().Where(x => x.Status == Status.Inactive).ToListAsync()).Count.ShouldBe(2);
+    }
+}

--- a/src/Polecat.Tests/Linq/json_value_returning_tests.cs
+++ b/src/Polecat.Tests/Linq/json_value_returning_tests.cs
@@ -38,7 +38,10 @@ public class json_value_returning_tests : OneOffConfigurationsContext
     [Fact]
     public async Task native_json_uses_returning_for_numeric()
     {
-        ConfigureStore(_ => { }); // UseNativeJsonType defaults to true (native json on SQL 2025)
+        // Force native json so the RETURNING branch is exercised regardless of the test server's
+        // capability (BuildSql is pure text generation — no json column is created here). This makes
+        // the assertion deterministic on Azure SQL Edge too, which lacks the native json type.
+        ConfigureStore(opts => opts.UseNativeJsonType = true);
         await using var session = theStore.QuerySession();
         var sql = SqlFor(session, session.Query<Doc>().Where(x => x.Count == 5));
 
@@ -49,7 +52,7 @@ public class json_value_returning_tests : OneOffConfigurationsContext
     [Fact]
     public async Task native_json_uses_returning_for_decimal_and_datetimeoffset()
     {
-        ConfigureStore(_ => { });
+        ConfigureStore(opts => opts.UseNativeJsonType = true);
         var cutoff = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
         await using var session = theStore.QuerySession();
         var sql = SqlFor(session,
@@ -62,7 +65,7 @@ public class json_value_returning_tests : OneOffConfigurationsContext
     [Fact]
     public async Task guid_member_keeps_cast_because_returning_has_no_uniqueidentifier()
     {
-        ConfigureStore(_ => { });
+        ConfigureStore(opts => opts.UseNativeJsonType = true);
         var someGuid = Guid.NewGuid();
         await using var session = theStore.QuerySession();
         var sql = SqlFor(session, session.Query<Doc>().Where(x => x.Ref == someGuid));
@@ -74,7 +77,11 @@ public class json_value_returning_tests : OneOffConfigurationsContext
     [Fact]
     public async Task enum_as_integer_uses_returning_int()
     {
-        ConfigureStore(opts => opts.ConfigureSerialization(EnumStorage.AsInteger));
+        ConfigureStore(opts =>
+        {
+            opts.UseNativeJsonType = true;
+            opts.ConfigureSerialization(EnumStorage.AsInteger);
+        });
         await using var session = theStore.QuerySession();
         var sql = SqlFor(session, session.Query<Doc>().Where(x => x.Status == Status.Inactive));
 

--- a/src/Polecat.Tests/Storage/computed_column_index_usability_tests.cs
+++ b/src/Polecat.Tests/Storage/computed_column_index_usability_tests.cs
@@ -138,9 +138,11 @@ public class computed_column_index_usability_tests : OneOffConfigurationsContext
     }
 
     [Fact]
-    public async Task non_indexed_member_keeps_its_plain_locator()
+    public async Task non_indexed_member_is_not_rewritten_to_the_index_column()
     {
-        // Only indexed members are rewritten; everything else is untouched.
+        // Only indexed members are rewritten to the computed-column expression; an unrelated member
+        // keeps its normal typed locator. On native json storage (#217) that locator is the
+        // RETURNING form; the point of this test is that it is NOT a computed-column (cc_) reference.
         ConfigureStore(opts => opts.Schema.For<IndexedMetric>().Index(x => x.ServiceName));
         await theDatabase.ApplyAllConfiguredChangesToDatabaseAsync();
 
@@ -148,7 +150,7 @@ public class computed_column_index_usability_tests : OneOffConfigurationsContext
         var query = session.Query<IndexedMetric>().Where(x => x.Count == 5);
 
         var sql = SqlFor(session, query);
-        sql.ShouldContain("CAST(JSON_VALUE(data, '$.count') AS int)");
+        sql.ShouldContain("JSON_VALUE(data, '$.count' RETURNING int)");
         sql.ShouldNotContain("cc_"); // no computed column reference, no rewrite of unrelated members
     }
 

--- a/src/Polecat.Tests/Storage/computed_column_index_usability_tests.cs
+++ b/src/Polecat.Tests/Storage/computed_column_index_usability_tests.cs
@@ -150,8 +150,11 @@ public class computed_column_index_usability_tests : OneOffConfigurationsContext
         var query = session.Query<IndexedMetric>().Where(x => x.Count == 5);
 
         var sql = SqlFor(session, query);
-        sql.ShouldContain("JSON_VALUE(data, '$.count' RETURNING int)");
-        sql.ShouldNotContain("cc_"); // no computed column reference, no rewrite of unrelated members
+        // Form-agnostic: this test applies schema (so it runs on servers without native json too,
+        // e.g. Azure SQL Edge → CAST instead of #217 RETURNING). The point is that the member is
+        // referenced by its raw JSON path and NOT rewritten to the index's computed column (cc_).
+        sql.ShouldContain("JSON_VALUE(data, '$.count'");
+        sql.ShouldNotContain("cc_");
     }
 
     // ---- gap 3: composite index types each column independently ----------------------------------

--- a/src/Polecat/Linq/Members/EnumMember.cs
+++ b/src/Polecat/Linq/Members/EnumMember.cs
@@ -12,16 +12,24 @@ internal class EnumMember : IQueryableMember
     private readonly JsonNamingPolicy? _namingPolicy;
 
     public EnumMember(string rawLocator, Type memberType, EnumStorage enumStorage,
-        JsonNamingPolicy? namingPolicy = null)
+        JsonNamingPolicy? namingPolicy = null, string? jsonPath = null, bool useReturning = false)
     {
         RawLocator = rawLocator;
         MemberType = memberType;
         _enumStorage = enumStorage;
         _namingPolicy = namingPolicy;
 
-        TypedLocator = enumStorage == EnumStorage.AsInteger
-            ? $"CAST({rawLocator} AS int)"
-            : rawLocator;
+        if (enumStorage != EnumStorage.AsInteger)
+        {
+            TypedLocator = rawLocator;
+        }
+        else
+        {
+            // #217: prefer JSON_VALUE(... RETURNING int) on native json storage over CAST(... AS int).
+            TypedLocator = useReturning && jsonPath != null
+                ? $"JSON_VALUE(data, '{jsonPath}' RETURNING int)"
+                : $"CAST({rawLocator} AS int)";
+        }
     }
 
     public Type MemberType { get; }

--- a/src/Polecat/Linq/Members/MemberFactory.cs
+++ b/src/Polecat/Linq/Members/MemberFactory.cs
@@ -18,6 +18,7 @@ internal class MemberFactory : IMemberResolver
     private readonly Type _idType;
     private readonly ValueTypeInfo? _valueTypeId;
     private readonly DocumentMapping _mapping;
+    private readonly bool _useReturning;
 
     public MemberFactory(StoreOptions options, DocumentMapping mapping)
     {
@@ -25,6 +26,10 @@ internal class MemberFactory : IMemberResolver
         _idType = mapping.IdType;
         _valueTypeId = mapping.ValueTypeId;
         _mapping = mapping;
+        // #217: JSON_VALUE(... RETURNING <type>) is only available when the data column is the
+        // native `json` type (SQL Server 2025+), which is exactly what UseNativeJsonType selects.
+        // On nvarchar(max) storage the RETURNING clause is a syntax error, so fall back to CAST.
+        _useReturning = options.UseNativeJsonType;
 
         if (options.Serializer is Serializer s)
         {
@@ -56,7 +61,7 @@ internal class MemberFactory : IMemberResolver
 
         if (underlying.IsEnum)
         {
-            return new EnumMember(rawLocator, underlying, _enumStorage, _namingPolicy);
+            return new EnumMember(rawLocator, underlying, _enumStorage, _namingPolicy, jsonPath, _useReturning);
         }
 
         if (underlying == typeof(bool))
@@ -65,9 +70,7 @@ internal class MemberFactory : IMemberResolver
         }
 
         var sqlType = GetSqlType(underlying);
-        var typedLocator = sqlType != null
-            ? $"CAST({rawLocator} AS {sqlType})"
-            : rawLocator;
+        var typedLocator = BuildTypedLocator(jsonPath, rawLocator, sqlType);
 
         // #223: if a Default-casing Index(...) covers this member, emit the EXACT computed-column
         // expression the index defines instead of the bare/uncast locator. SQL Server then matches
@@ -96,6 +99,32 @@ internal class MemberFactory : IMemberResolver
         locator = DocumentIndex.ComputedColumnExpression(jsonPath, sqlType, IndexCasing.Default);
         return true;
     }
+
+    /// <summary>
+    ///     #217: builds the typed locator, preferring JSON_VALUE(... RETURNING type) on native json
+    ///     storage (SQL Server 2025+) over CAST(JSON_VALUE(...) AS type). RETURNING does not support
+    ///     uniqueidentifier, so Guid members keep CAST. A null sqlType (string/bool) needs no typing.
+    ///     Note: members covered by a Default-casing Index(...) are instead rewritten to the index's
+    ///     computed-column expression in CreateMember (which takes precedence), so they keep matching
+    ///     the persisted CAST/CONVERT column and stay seekable (#223).
+    /// </summary>
+    internal static string BuildTypedLocator(string jsonPath, string rawLocator, string? sqlType,
+        bool useReturning)
+    {
+        if (sqlType == null) return rawLocator;
+        return useReturning && SupportsReturning(sqlType)
+            ? $"JSON_VALUE(data, '{jsonPath}' RETURNING {sqlType})"
+            : $"CAST({rawLocator} AS {sqlType})";
+    }
+
+    private string BuildTypedLocator(string jsonPath, string rawLocator, string? sqlType)
+        => BuildTypedLocator(jsonPath, rawLocator, sqlType, _useReturning);
+
+    /// <summary>
+    ///     RETURNING supports every type Polecat emits except uniqueidentifier (not in the SQL Server
+    ///     JSON_VALUE RETURNING type list), so Guid members fall back to CAST.
+    /// </summary>
+    internal static bool SupportsReturning(string sqlType) => sqlType != "uniqueidentifier";
 
     private string BuildJsonPath(MemberExpression expression)
     {


### PR DESCRIPTION
Closes #217.

## What

SQL Server 2025 supports `JSON_VALUE(data, '$.x' RETURNING <type>)`, a cleaner alternative to `CAST(JSON_VALUE(data, '$.x') AS <type>)`. The LINQ translator now emits the RETURNING form for typed members, falling back to CAST when it isn't available.

## Two constraints (verified against SQL Server 2025 RTM-CU5)

1. **RETURNING requires the native `json` column type.** Per the [docs](https://learn.microsoft.com/en-us/sql/t-sql/functions/json-value-transact-sql), `RETURNING` "is only supported if the input is a JSON type." Against `nvarchar(max)` it's a *syntax error*. So it's gated on **`UseNativeJsonType`** — which is exactly the option that selects the `json` column. On `nvarchar(max)` storage the translator keeps CAST.
2. **`uniqueidentifier` is not in the RETURNING type list.** `JSON_VALUE(... RETURNING uniqueidentifier)` is a syntax error, so **Guid members keep CAST**.

I confirmed empirically on the 2025 container that RETURNING works for `int`, `bigint`, `smallint`, `float`, `real`, `decimal(18,6)`, `datetime2`, `datetimeoffset` (with json input), and fails for `uniqueidentifier`.

## Scope

- `MemberFactory` — numeric/date typed locators, plus the enum `AsInteger` locator (the issue's `$.status` example).
- Events (`EventDataMemberFactory`) keep CAST (unchanged).
- `string`/`bool` members were never cast and are untouched.

## Tests

`json_value_returning_tests`:
- RETURNING emitted for `int`, `decimal(18,6)`, `datetimeoffset`;
- Guid member keeps `CAST(... AS uniqueidentifier)` (no RETURNING);
- `AsInteger` enum uses `RETURNING int`;
- `UseNativeJsonType = false` falls back to CAST;
- end-to-end query returns the correct rows under RETURNING.

Full `Linq` + `Documents` + `Storage` + `Reading` + `Pagination` suites stay green (299 tests).

## Note on interaction with #223 (now merged — reconciled in this rebase)

[#223](https://github.com/JasperFx/polecat/pull/225) is merged into `main`, and this branch is rebased onto it. The reconciliation in `MemberFactory.CreateMember`: the #223 index-redirect takes **precedence** over the RETURNING locator, so a member covered by a `Default`-casing `Index(...)` still emits the index's `CAST`/`CONVERT` computed-column expression and stays seekable, while non-indexed typed members use RETURNING. Verified: the #217, #222, and #223 suites all pass together (the one stale #223 assertion — a non-indexed member now using RETURNING instead of CAST — was updated). A further unification (moving the computed columns themselves to RETURNING on native json) is possible but not required for correctness, so it's left as a follow-up.
