### PR TITLE
Support nested members in Index(...) expressions

### DIFF
--- a/src/Polecat.Tests/Storage/nested_member_index_tests.cs
+++ b/src/Polecat.Tests/Storage/nested_member_index_tests.cs
@@ -1,0 +1,112 @@
+using Polecat.Linq;
+using Polecat.Storage;
+using Polecat.Tests.Harness;
+
+namespace Polecat.Tests.Storage;
+
+/// <summary>
+/// Nested-member support for Index(...) expressions. Previously x => x.Address.City silently
+/// resolved to "$.city" (only the leaf member name), which never matched the query translator's
+/// "$.address.city" path — so the index was unusable AND pointed at the wrong JSON path. Index
+/// path resolution now walks the full member chain, identical to MemberFactory.BuildJsonPath.
+/// </summary>
+public class nested_member_index_tests : OneOffConfigurationsContext
+{
+    public class Address
+    {
+        public string City { get; set; } = string.Empty;
+        public string PostalCode { get; set; } = string.Empty;
+    }
+
+    public class Customer
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public Address Address { get; set; } = new();
+    }
+
+    private const string Table = "pc_doc_customer";
+    private string Schema => GetType().Name.ToLowerInvariant();
+
+    private static string SqlFor<T>(IQuerySession session, IQueryable<T> query)
+    {
+        var provider = (PolecatLinqQueryProvider)query.Provider;
+        return provider.BuildSql(query.Expression, session.TenantId);
+    }
+
+    // ---- unit: path resolution ------------------------------------------------------------------
+
+    [Fact]
+    public void resolve_json_paths_walks_a_nested_member()
+    {
+        DocumentIndex.ResolveJsonPaths<Customer>(x => x.Address.City)
+            .ShouldBe(["$.address.city"]);
+    }
+
+    [Fact]
+    public void resolve_json_paths_handles_composite_with_nested_members()
+    {
+        DocumentIndex.ResolveJsonPaths<Customer>(x => new { x.Name, x.Address.City })
+            .ShouldBe(["$.name", "$.address.city"]);
+    }
+
+    // ---- integration: computed column + index path alignment ------------------------------------
+
+    [Fact]
+    public async Task nested_member_index_creates_the_expected_computed_column()
+    {
+        ConfigureStore(opts => opts.Schema.For<Customer>().Index(x => x.Address.City));
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Store(new Customer { Id = Guid.NewGuid(), Name = "A", Address = new Address { City = "Austin" } });
+            await session.SaveChangesAsync();
+        }
+
+        await using var conn = await OpenConnectionAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"""
+            SELECT COUNT(*) FROM sys.computed_columns
+            WHERE object_id = OBJECT_ID('[{Schema}].[{Table}]') AND name = 'cc_address_city';
+            """;
+        ((int)(await cmd.ExecuteScalarAsync())!).ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task nested_member_query_targets_the_index_path_not_the_leaf()
+    {
+        ConfigureStore(opts => opts.Schema.For<Customer>().Index(x => x.Address.City));
+        await theDatabase.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        await using var session = theStore.QuerySession();
+        var query = session.Query<Customer>().Where(x => x.Address.City == "Austin");
+        var sql = SqlFor(session, query);
+
+        // The index computed column is over '$.address.city'; the predicate must target the same
+        // path (and be rewritten to the computed-column expression so the index is seekable).
+        sql.ShouldContain("JSON_VALUE(data, '$.address.city')");
+        sql.ShouldNotContain("'$.city'"); // the old, wrong leaf-only path
+    }
+
+    [Fact]
+    public async Task end_to_end_nested_member_query_returns_correct_rows()
+    {
+        ConfigureStore(opts => opts.Schema.For<Customer>().Index(x => x.Address.City));
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Store(new Customer { Id = Guid.NewGuid(), Name = "A", Address = new Address { City = "Austin" } });
+            session.Store(new Customer { Id = Guid.NewGuid(), Name = "B", Address = new Address { City = "Austin" } });
+            session.Store(new Customer { Id = Guid.NewGuid(), Name = "C", Address = new Address { City = "Dallas" } });
+            await session.SaveChangesAsync();
+        }
+
+        await using var session2 = theStore.QuerySession();
+        var austin = await session2.Query<Customer>()
+            .Where(x => x.Address.City == "Austin")
+            .ToListAsync();
+
+        austin.Count.ShouldBe(2);
+        austin.ShouldAllBe(c => c.Address.City == "Austin");
+    }
+}

--- a/src/Polecat/Storage/DocumentIndex.cs
+++ b/src/Polecat/Storage/DocumentIndex.cs
@@ -198,7 +198,8 @@ public class DocumentIndex
     }
 
     /// <summary>
-    ///     Resolves a member expression to a JSON path (e.g., x => x.UserName → "$.userName").
+    ///     Resolves a single, non-nested member to a JSON path (e.g., UserName → "$.userName").
+    ///     Used for attribute-based indexes, where the member is always a direct property.
     /// </summary>
     internal static string MemberToJsonPath(MemberInfo member)
     {
@@ -207,7 +208,35 @@ public class DocumentIndex
     }
 
     /// <summary>
-    ///     Resolves a lambda expression to JSON paths for indexing.
+    ///     Resolves a (possibly nested) member access expression to a JSON path by walking the
+    ///     member chain, e.g. x => x.Address.City → "$.address.city". This mirrors the LINQ
+    ///     translator's MemberFactory.BuildJsonPath so an index path and the query predicate path
+    ///     are identical (otherwise the computed-column index can never match). Each segment is
+    ///     camelCased, matching the default serializer casing the rest of the index DSL assumes.
+    /// </summary>
+    internal static string MemberExpressionToJsonPath(MemberExpression expression)
+    {
+        var segments = new List<string>();
+        var current = expression;
+
+        while (current != null)
+        {
+            var name = current.Member.Name;
+            segments.Insert(0, char.ToLowerInvariant(name[0]) + name[1..]);
+
+            if (current.Expression is ParameterExpression)
+                break;
+
+            current = current.Expression as MemberExpression;
+        }
+
+        return "$." + string.Join(".", segments);
+    }
+
+    /// <summary>
+    ///     Resolves a lambda expression to JSON paths for indexing. Supports a single (possibly
+    ///     nested) member — x => x.Prop or x => x.Address.City — and an anonymous type combining
+    ///     several — x => new { x.Prop1, x.Address.City }.
     /// </summary>
     internal static string[] ResolveJsonPaths<T>(Expression<Func<T, object?>> expression)
     {
@@ -219,24 +248,40 @@ public class DocumentIndex
             body = unary.Operand;
         }
 
-        // Single member: x => x.Property
+        // Single (possibly nested) member: x => x.Property / x => x.Address.City
         if (body is MemberExpression memberExpr)
         {
-            return [MemberToJsonPath(memberExpr.Member)];
+            return [MemberExpressionToJsonPath(memberExpr)];
         }
 
-        // Anonymous type: x => new { x.Prop1, x.Prop2 }
+        // Anonymous type: x => new { x.Prop1, x.Address.City }
         if (body is NewExpression newExpr)
         {
             return newExpr.Arguments
-                .OfType<MemberExpression>()
-                .Select(m => MemberToJsonPath(m.Member))
+                .Select(UnwrapToMemberExpression)
+                .Where(m => m != null)
+                .Select(m => MemberExpressionToJsonPath(m!))
                 .ToArray();
         }
 
         throw new ArgumentException(
             $"Expression '{expression}' is not a supported index expression. " +
-            "Use a single property (x => x.Prop) or anonymous type (x => new {{ x.Prop1, x.Prop2 }}).");
+            "Use a single property (x => x.Prop), a nested property (x => x.Address.City), " +
+            "or an anonymous type (x => new {{ x.Prop1, x.Prop2 }}).");
+    }
+
+    /// <summary>
+    ///     Strips a Convert wrapper (value-type members boxed to object in some anonymous-type
+    ///     arguments) and returns the underlying MemberExpression, or null if it isn't one.
+    /// </summary>
+    private static MemberExpression? UnwrapToMemberExpression(Expression expression)
+    {
+        if (expression is UnaryExpression { NodeType: ExpressionType.Convert } unary)
+        {
+            expression = unary.Operand;
+        }
+
+        return expression as MemberExpression;
     }
 }
 


### PR DESCRIPTION
Part of the index-DSL gap-fill sequence (nested members, #3b).

## The bug

`Index(x => x.Address.City)` resolved to `"$.city"` — only the leaf member name — because `MemberToJsonPath` used `member.Name`. The LINQ translator, meanwhile, walks the chain (`MemberFactory.BuildJsonPath` → `"$.address.city"`). So a nested-member index:
- pointed at the **wrong JSON path** (`$.city`), and
- could **never match** a `Where(x => x.Address.City == …)` predicate (different path),

silently, with no error.

## Fix

`DocumentIndex.ResolveJsonPaths` now walks the full member chain via a new `MemberExpressionToJsonPath` that mirrors `BuildJsonPath` exactly, so the index path and the predicate path are guaranteed identical. Supported shapes:

```csharp
.Index(x => x.Address.City)                  // → "$.address.city"
.Index(x => new { x.Name, x.Address.City })  // → "$.name", "$.address.city"
```

Convert-wrapped anonymous-type arguments (value types boxed to `object`) are unwrapped. Attribute-based indexes still use `MemberToJsonPath` (always a direct property).

`DocumentMapping.ResolveClrMemberType` and `ColumnNameForPath` already handle dotted paths (`cc_address_city`), so the computed column types and names come out correct.

## Tests

`nested_member_index_tests`:
- path resolution for a single nested member and a composite mixing flat + nested;
- the computed column is created as `cc_address_city`;
- the query predicate targets `"$.address.city"` (asserts the old `"$.city"` is gone);
- an end-to-end nested-member query returns the right rows.

Storage suite green on **SQL Server 2025 and 2022**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)