### PR TITLE
Native SQL Server 2025 JSON indexes (CREATE JSON INDEX)

### DIFF
--- a/src/Polecat.Tests/Storage/json_index_tests.cs
+++ b/src/Polecat.Tests/Storage/json_index_tests.cs
@@ -1,0 +1,163 @@
+using Polecat.Linq;
+using Polecat.Storage;
+using Polecat.TestUtils;
+using Polecat.Tests.Harness;
+
+namespace Polecat.Tests.Storage;
+
+/// <summary>
+/// Native SQL Server 2025 JSON indexes (CREATE JSON INDEX) over the json `data` column — one index
+/// covering multiple JSON paths, gated on UseNativeJsonType.
+/// </summary>
+public class json_index_tests : OneOffConfigurationsContext
+{
+    public class Doc
+    {
+        public Guid Id { get; set; }
+        public string ServiceName { get; set; } = string.Empty;
+        public DateTimeOffset BucketEnd { get; set; }
+        public List<string> Tags { get; set; } = new();
+    }
+
+    private const string Table = "pc_doc_doc";
+    private string Schema => GetType().Name.ToLowerInvariant();
+
+    // ---- unit: DDL generation (no DB) -----------------------------------------------------------
+
+    [Fact]
+    public void ddl_for_multiple_paths()
+    {
+        var mapping = new DocumentMapping(typeof(Doc), new StoreOptions { DatabaseSchemaName = "s" });
+        var ddl = new JsonIndex(["$.serviceName", "$.bucketEnd"]).ToDdlStatements(mapping);
+
+        ddl[0].ShouldContain(
+            "CREATE JSON INDEX [jidx_pc_doc_doc] ON [s].[pc_doc_doc] (data) FOR ('$.serviceName', '$.bucketEnd')");
+        ddl[0].ShouldContain("SET QUOTED_IDENTIFIER ON");
+    }
+
+    [Fact]
+    public void ddl_for_whole_document_omits_the_for_clause()
+    {
+        var mapping = new DocumentMapping(typeof(Doc), new StoreOptions { DatabaseSchemaName = "s" });
+        var ddl = new JsonIndex([]).ToDdlStatements(mapping);
+
+        ddl[0].ShouldContain("CREATE JSON INDEX [jidx_pc_doc_doc] ON [s].[pc_doc_doc] (data);");
+        ddl[0].ShouldNotContain("FOR (");
+    }
+
+    [Fact]
+    public void ddl_with_options()
+    {
+        var mapping = new DocumentMapping(typeof(Doc), new StoreOptions { DatabaseSchemaName = "s" });
+        var ddl = new JsonIndex(["$.tags"]) { OptimizeForArraySearch = true, FillFactor = 80 }
+            .ToDdlStatements(mapping);
+
+        ddl[0].ShouldContain("WITH (OPTIMIZE_FOR_ARRAY_SEARCH = ON, FILLFACTOR = 80)");
+    }
+
+    [Fact]
+    public void ddl_throws_without_native_json()
+    {
+        var mapping = new DocumentMapping(typeof(Doc),
+            new StoreOptions { DatabaseSchemaName = "s", UseNativeJsonType = false });
+
+        Should.Throw<InvalidOperationException>(() => new JsonIndex([]).ToDdlStatements(mapping))
+            .Message.ShouldContain("native json");
+    }
+
+    // ---- integration: actually create the index (native json only) ------------------------------
+
+    [RequiresNativeJsonFact(true)]
+    public async Task creates_a_json_index_covering_the_given_paths()
+    {
+        ConfigureStore(opts =>
+            opts.Schema.For<Doc>().JsonIndex(x => new { x.ServiceName, x.BucketEnd }));
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Store(new Doc { Id = Guid.NewGuid(), ServiceName = "svc", BucketEnd = DateTimeOffset.UtcNow });
+            await session.SaveChangesAsync();
+        }
+
+        (await JsonIndexCountAsync()).ShouldBe(1);
+    }
+
+    [RequiresNativeJsonFact(true)]
+    public async Task whole_document_json_index_is_created()
+    {
+        ConfigureStore(opts => opts.Schema.For<Doc>().JsonIndex());
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Store(new Doc { Id = Guid.NewGuid(), ServiceName = "svc" });
+            await session.SaveChangesAsync();
+        }
+
+        (await JsonIndexCountAsync()).ShouldBe(1);
+    }
+
+    [RequiresNativeJsonFact(true)]
+    public async Task optimize_for_array_search_is_applied()
+    {
+        ConfigureStore(opts =>
+            opts.Schema.For<Doc>().JsonIndex(x => x.Tags, idx => idx.OptimizeForArraySearch = true));
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Store(new Doc { Id = Guid.NewGuid(), Tags = new List<string> { "a", "b" } });
+            await session.SaveChangesAsync();
+        }
+
+        await using var conn = await OpenConnectionAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"""
+            SELECT ji.optimize_for_array_search
+            FROM sys.json_indexes ji
+            WHERE ji.object_id = OBJECT_ID('[{Schema}].[{Table}]');
+            """;
+        (await cmd.ExecuteScalarAsync()).ShouldBe(true);
+    }
+
+    [RequiresNativeJsonFact(true)]
+    public async Task queries_return_correct_rows_with_a_json_index_present()
+    {
+        ConfigureStore(opts => opts.Schema.For<Doc>().JsonIndex(x => x.ServiceName));
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Store(new Doc { Id = Guid.NewGuid(), ServiceName = "svc-A" });
+            session.Store(new Doc { Id = Guid.NewGuid(), ServiceName = "svc-A" });
+            session.Store(new Doc { Id = Guid.NewGuid(), ServiceName = "svc-B" });
+            await session.SaveChangesAsync();
+        }
+
+        await using var session2 = theStore.QuerySession();
+        var a = await session2.Query<Doc>().Where(x => x.ServiceName == "svc-A").ToListAsync();
+        a.Count.ShouldBe(2);
+    }
+
+    [RequiresNativeJsonFact(true)]
+    public async Task re_ensuring_is_idempotent()
+    {
+        ConfigureStore(opts => opts.Schema.For<Doc>().JsonIndex(x => x.ServiceName));
+
+        for (var i = 0; i < 2; i++)
+        {
+            await using var session = theStore.LightweightSession();
+            session.Store(new Doc { Id = Guid.NewGuid(), ServiceName = $"svc-{i}" });
+            await session.SaveChangesAsync();
+        }
+
+        (await JsonIndexCountAsync()).ShouldBe(1); // still exactly one, no duplicate-create error
+    }
+
+    private async Task<int> JsonIndexCountAsync()
+    {
+        await using var conn = await OpenConnectionAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"""
+            SELECT COUNT(*) FROM sys.json_indexes WHERE object_id = OBJECT_ID('[{Schema}].[{Table}]');
+            """;
+        return (int)(await cmd.ExecuteScalarAsync())!;
+    }
+}

--- a/src/Polecat/Internal/DocumentProviderRegistry.cs
+++ b/src/Polecat/Internal/DocumentProviderRegistry.cs
@@ -107,6 +107,16 @@ internal class DocumentProviderRegistry
                 }
             }
 
+            // Apply JSON indexes
+            var jsonIndexesField = exprType.GetField("JsonIndexes", BindingFlags.NonPublic | BindingFlags.Instance);
+            if (jsonIndexesField?.GetValue(expr) is IEnumerable<Storage.JsonIndex> jsonIndexes)
+            {
+                foreach (var jsonIndex in jsonIndexes)
+                {
+                    mapping.JsonIndexes.Add(jsonIndex);
+                }
+            }
+
             // Apply foreign keys
             var fkField = exprType.GetField("ForeignKeys", BindingFlags.NonPublic | BindingFlags.Instance);
             if (fkField?.GetValue(expr) is IEnumerable<Storage.DocumentForeignKey> foreignKeys)

--- a/src/Polecat/Internal/DocumentTableEnsurer.cs
+++ b/src/Polecat/Internal/DocumentTableEnsurer.cs
@@ -92,6 +92,17 @@ internal class DocumentTableEnsurer
                 }
             }
 
+            // Native SQL Server 2025 JSON indexes (CREATE JSON INDEX) on the json data column.
+            foreach (var jsonIndex in provider.Mapping.JsonIndexes)
+            {
+                foreach (var statement in jsonIndex.ToDdlStatements(provider.Mapping))
+                {
+                    await using var jsonIndexCmd = conn.CreateCommand();
+                    jsonIndexCmd.CommandText = statement;
+                    await jsonIndexCmd.ExecuteNonQueryAsync(token);
+                }
+            }
+
             _ensured.TryAdd(docType, true);
         }
         finally

--- a/src/Polecat/Storage/DocumentMapping.cs
+++ b/src/Polecat/Storage/DocumentMapping.cs
@@ -180,6 +180,11 @@ internal class DocumentMapping
     public List<DocumentIndex> Indexes { get; } = new();
 
     /// <summary>
+    ///     Native SQL Server 2025 JSON indexes (CREATE JSON INDEX) configured for this document type.
+    /// </summary>
+    public List<JsonIndex> JsonIndexes { get; } = new();
+
+    /// <summary>
     ///     Foreign key constraints configured for this document type.
     /// </summary>
     public List<DocumentForeignKey> ForeignKeys { get; } = new();

--- a/src/Polecat/Storage/DocumentMappingExpression.cs
+++ b/src/Polecat/Storage/DocumentMappingExpression.cs
@@ -14,6 +14,7 @@ public class DocumentMappingExpression<T>
     internal readonly Type DocumentType = typeof(T);
     internal readonly List<(Type SubClass, string? Alias)> SubClasses = new();
     internal readonly List<DocumentIndex> Indexes = new();
+    internal readonly List<JsonIndex> JsonIndexes = new();
     internal readonly List<DocumentForeignKey> ForeignKeys = new();
     internal DocumentPartitioning? Partitioning;
 
@@ -85,6 +86,33 @@ public class DocumentMappingExpression<T>
     public DocumentMappingExpression<T> AddIndex(DocumentIndex index)
     {
         Indexes.Add(index);
+        return this;
+    }
+
+    /// <summary>
+    ///     Add a native SQL Server 2025 JSON index (<c>CREATE JSON INDEX</c>) over one or more JSON
+    ///     paths in the document. A single JSON index covers all the given paths and accelerates
+    ///     JSON_VALUE (=) / JSON_PATH_EXISTS / JSON_CONTAINS predicates. Requires
+    ///     <c>UseNativeJsonType = true</c>. See <see cref="JsonIndex" /> for the constraints.
+    /// </summary>
+    public DocumentMappingExpression<T> JsonIndex(Expression<Func<T, object?>> expression,
+        Action<JsonIndex>? configure = null)
+    {
+        var paths = Storage.JsonIndex.ResolveJsonPaths(expression);
+        var index = new JsonIndex(paths);
+        configure?.Invoke(index);
+        JsonIndexes.Add(index);
+        return this;
+    }
+
+    /// <summary>
+    ///     Add a native JSON index over the entire JSON document (no <c>FOR</c> path filter).
+    /// </summary>
+    public DocumentMappingExpression<T> JsonIndex(Action<JsonIndex>? configure = null)
+    {
+        var index = new JsonIndex([]);
+        configure?.Invoke(index);
+        JsonIndexes.Add(index);
         return this;
     }
 

--- a/src/Polecat/Storage/JsonIndex.cs
+++ b/src/Polecat/Storage/JsonIndex.cs
@@ -1,0 +1,104 @@
+using System.Linq.Expressions;
+
+namespace Polecat.Storage;
+
+/// <summary>
+///     A native SQL Server 2025 JSON index (<c>CREATE JSON INDEX</c>) over a document's native
+///     <c>json</c> <c>data</c> column. Unlike a computed-column <see cref="DocumentIndex" />, a single
+///     JSON index can cover many JSON paths and accelerates <c>JSON_VALUE</c> (equality, including the
+///     <c>RETURNING</c> form), <c>JSON_PATH_EXISTS</c>, and <c>JSON_CONTAINS</c> predicates without any
+///     per-path computed columns.
+///
+///     Requirements (enforced / documented):
+///     - The <c>data</c> column must be the native <c>json</c> type — i.e. <c>UseNativeJsonType = true</c>
+///       (SQL Server 2025+). A computed-column <see cref="DocumentIndex" /> is the portable alternative.
+///     - The table needs a clustered primary key whose key is ≤128 bytes. Polecat's single-tenant
+///       <c>id</c> PK satisfies this; per-tenant tables (whose PK prepends a <c>varchar</c> tenant_id)
+///       can exceed the limit, in which case SQL Server rejects the index.
+///     - Only one JSON index can exist per <c>json</c> column, so a table has at most one JSON index.
+///     - Indexed paths can't overlap (e.g. <c>$.a</c> and <c>$.a.b</c>).
+///     - Does not support UNIQUE, filtered (WHERE), INCLUDE, ORDER BY/range seeks, or LIKE/IS NULL —
+///       use a computed-column <see cref="DocumentIndex" /> for those.
+/// </summary>
+public class JsonIndex
+{
+    public JsonIndex(string[] jsonPaths, string? indexName = null)
+    {
+        JsonPaths = jsonPaths;
+        IndexName = indexName;
+    }
+
+    /// <summary>
+    ///     The JSON paths to index (e.g. "$.serviceName", "$.address.city"). When empty, the entire
+    ///     JSON document is indexed (the <c>FOR</c> clause is omitted).
+    /// </summary>
+    public string[] JsonPaths { get; }
+
+    /// <summary>
+    ///     Optional explicit index name. Auto-derived from the table name when null.
+    /// </summary>
+    public string? IndexName { get; set; }
+
+    /// <summary>
+    ///     Maps to <c>WITH (OPTIMIZE_FOR_ARRAY_SEARCH = ON)</c> — tunes the index for searching inside
+    ///     JSON arrays (e.g. <c>JSON_CONTAINS</c> over an array property).
+    /// </summary>
+    public bool OptimizeForArraySearch { get; set; }
+
+    /// <summary>
+    ///     Optional <c>WITH (FILLFACTOR = n)</c>, 1–100.
+    /// </summary>
+    public int? FillFactor { get; set; }
+
+    /// <summary>
+    ///     Derives the index name. One JSON index per table, so the table name alone is unique.
+    /// </summary>
+    internal string GetIndexName(string tableName) => IndexName ?? $"jidx_{tableName}";
+
+    /// <summary>
+    ///     Generates the <c>CREATE JSON INDEX</c> DDL. Throws when the store isn't using the native
+    ///     json column type, since the statement is invalid against <c>nvarchar(max)</c> storage.
+    /// </summary>
+    internal string[] ToDdlStatements(DocumentMapping mapping)
+    {
+        if (mapping.JsonColumnType != "json")
+        {
+            throw new InvalidOperationException(
+                $"A JSON index on '{mapping.DocumentType.Name}' requires the native json column type. " +
+                "Set UseNativeJsonType = true (SQL Server 2025+), or use a computed-column Index(...) instead.");
+        }
+
+        var schema = mapping.DatabaseSchemaName;
+        var table = mapping.TableName;
+        var qualifiedTable = $"[{schema}].[{table}]";
+        var name = GetIndexName(table);
+
+        var forClause = JsonPaths.Length > 0
+            ? " FOR (" + string.Join(", ", JsonPaths.Select(p => $"'{p}'")) + ")"
+            : "";
+
+        var withOptions = new List<string>();
+        if (OptimizeForArraySearch) withOptions.Add("OPTIMIZE_FOR_ARRAY_SEARCH = ON");
+        if (FillFactor.HasValue) withOptions.Add($"FILLFACTOR = {FillFactor.Value}");
+        var withClause = withOptions.Count > 0 ? " WITH (" + string.Join(", ", withOptions) + ")" : "";
+
+        // CREATE JSON INDEX requires SET QUOTED_IDENTIFIER ON; set it explicitly so the statement is
+        // robust regardless of the caller's session options. Only one JSON index per json column is
+        // allowed, so existence is keyed on the table, not the index name.
+        return
+        [
+            $"""
+             SET QUOTED_IDENTIFIER ON;
+             IF NOT EXISTS (SELECT 1 FROM sys.json_indexes WHERE object_id = OBJECT_ID('{qualifiedTable}'))
+                 CREATE JSON INDEX [{name}] ON {qualifiedTable} (data){forClause}{withClause};
+             """
+        ];
+    }
+
+    /// <summary>
+    ///     Resolves a lambda to the JSON paths to index — a single (possibly nested) member or an
+    ///     anonymous type combining several. Reuses <see cref="DocumentIndex.ResolveJsonPaths{T}" />.
+    /// </summary>
+    internal static string[] ResolveJsonPaths<T>(Expression<Func<T, object?>> expression)
+        => DocumentIndex.ResolveJsonPaths(expression);
+}


### PR DESCRIPTION
Index-DSL gap-fill sequence, #3a (the SQL 2025 headline). **Stacked on #228** (nested-member index paths) — base will retarget to `main` once #228 merges.

## What

A `.JsonIndex(...)` DSL that emits a native SQL Server 2025 **`CREATE JSON INDEX`** over the json `data` column. Unlike a computed-column `Index(...)`, **one** JSON index covers **many** JSON paths and accelerates `JSON_VALUE` (=, including the [#217](https://github.com/JasperFx/polecat/pull/227) `RETURNING` form), `JSON_PATH_EXISTS`, and `JSON_CONTAINS` — with no per-path computed columns.

```csharp
.JsonIndex(x => new { x.ServiceName, x.BucketEnd })   // FOR ('$.serviceName', '$.bucketEnd')
.JsonIndex()                                          // whole-document index
.JsonIndex(x => x.Tags, idx => idx.OptimizeForArraySearch = true)
```

This is the purpose-built answer to "index multiple fields inside the JSON body," and it composes with #217: `WHERE JSON_VALUE(data, '$.x' RETURNING int) = 5` is exactly what the JSON index optimizes.

## Design

- **Gated on `UseNativeJsonType = true`.** `CREATE JSON INDEX` is invalid against `nvarchar(max)`, so `JsonIndex.ToDdlStatements` throws a clear `InvalidOperationException` otherwise (fail-fast, not a silent no-op).
- DDL sets `QUOTED_IDENTIFIER ON` (required by `CREATE JSON INDEX`) and is idempotent — one JSON index per json column, existence keyed on the table.
- JSON indexes flow through the same expression → `DocumentProviderRegistry` → `DocumentMapping` → `DocumentTableEnsurer` path as computed-column indexes.

## Constraints (documented on `JsonIndex`)

Native json only · clustered PK key ≤128 bytes (fine for single-tenant `id` PKs; **per-tenant tables whose PK prepends a `varchar` tenant_id can exceed it** → SQL rejects the index) · one per table · no overlapping paths · **no UNIQUE / filtered / INCLUDE / range / LIKE / IS NULL** — use a computed-column `Index(...)` for those. **Preview, on-prem SQL Server 2025 only.**

So this is **additive** to computed-column indexes, not a replacement.

## Verification

Empirically confirmed against SQL Server 2025 RTM-CU5: multi-path `FOR`, `OPTIMIZE_FOR_ARRAY_SEARCH`, overlap rejection, and the `QUOTED_IDENTIFIER` requirement.

Tests: DDL generation (multi-path, whole-document, options, native-json guard) + native-json-gated integration (created in `sys.json_indexes`, array-search reflected, idempotent re-ensure, queries return correct rows). 9/9 on 2025; the 5 integration tests **skip** on 2022 via `[RequiresNativeJsonFact]` (4 unit still run). Storage/Documents/Schema suites green (172).

🤖 Generated with [Claude Code](https://claude.com/claude-code)