### PR TITLE
Covering computed-column indexes via INCLUDE columns

### DIFF
--- a/src/Polecat.Tests/Storage/covering_index_tests.cs
+++ b/src/Polecat.Tests/Storage/covering_index_tests.cs
@@ -1,0 +1,95 @@
+using Polecat.Linq;
+using Polecat.Storage;
+using Polecat.Tests.Harness;
+
+namespace Polecat.Tests.Storage;
+
+/// <summary>
+/// Covering computed-column indexes: Index(key, include: ...) carries the include members as non-key
+/// INCLUDE columns so a query can be satisfied from the index alone (no key lookup). Each include
+/// path gets its own persisted computed column. Works on any SQL Server (it's a standard nonclustered
+/// index over computed columns), so these run on both native-json and nvarchar storage.
+/// </summary>
+public class covering_index_tests : OneOffConfigurationsContext
+{
+    public class Doc
+    {
+        public Guid Id { get; set; }
+        public string ServiceName { get; set; } = string.Empty;
+        public DateTimeOffset BucketEnd { get; set; }
+        public int Count { get; set; }
+    }
+
+    private const string Table = "pc_doc_doc";
+    private const string IndexName = "ix_pc_doc_doc_servicename";
+    private string Schema => GetType().Name.ToLowerInvariant();
+
+    [Fact]
+    public void ddl_creates_include_columns_and_include_clause()
+    {
+        var mapping = new DocumentMapping(typeof(Doc), new StoreOptions { DatabaseSchemaName = "s" });
+        var index = new DocumentIndex(["$.serviceName"]) { IncludePaths = ["$.bucketEnd", "$.count"] };
+
+        var ddl = index.ToDdlStatements(mapping);
+        var joined = string.Join("\n", ddl);
+
+        // computed columns for the key and both include paths
+        joined.ShouldContain("[cc_servicename] AS");
+        joined.ShouldContain("[cc_bucketend] AS");
+        joined.ShouldContain("[cc_count] AS");
+        // INCLUDE clause over the include columns
+        ddl[^1].ShouldContain("([cc_servicename]) INCLUDE ([cc_bucketend], [cc_count])");
+    }
+
+    [Fact]
+    public async Task covering_index_marks_only_the_include_paths_as_included()
+    {
+        ConfigureStore(opts =>
+            opts.Schema.For<Doc>().Index(x => x.ServiceName, include: x => new { x.BucketEnd, x.Count }));
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Store(new Doc { Id = Guid.NewGuid(), ServiceName = "svc", BucketEnd = DateTimeOffset.UtcNow, Count = 3 });
+            await session.SaveChangesAsync();
+        }
+
+        await using var conn = await OpenConnectionAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"""
+            SELECT c.name, ic.is_included_column
+            FROM sys.indexes i
+            JOIN sys.index_columns ic ON i.object_id = ic.object_id AND i.index_id = ic.index_id
+            JOIN sys.columns c ON ic.object_id = c.object_id AND ic.column_id = c.column_id
+            WHERE i.name = '{IndexName}' AND i.object_id = OBJECT_ID('[{Schema}].[{Table}]');
+            """;
+
+        var included = new Dictionary<string, bool>();
+        await using (var reader = await cmd.ExecuteReaderAsync())
+        {
+            while (await reader.ReadAsync()) included[reader.GetString(0)] = reader.GetBoolean(1);
+        }
+
+        included["cc_servicename"].ShouldBeFalse(); // key column
+        included["cc_bucketend"].ShouldBeTrue();    // included
+        included["cc_count"].ShouldBeTrue();        // included
+    }
+
+    [Fact]
+    public async Task covering_index_still_returns_correct_rows()
+    {
+        ConfigureStore(opts =>
+            opts.Schema.For<Doc>().Index(x => x.ServiceName, include: x => x.Count));
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Store(new Doc { Id = Guid.NewGuid(), ServiceName = "svc-A", Count = 1 });
+            session.Store(new Doc { Id = Guid.NewGuid(), ServiceName = "svc-A", Count = 2 });
+            session.Store(new Doc { Id = Guid.NewGuid(), ServiceName = "svc-B", Count = 3 });
+            await session.SaveChangesAsync();
+        }
+
+        await using var session2 = theStore.QuerySession();
+        var rows = await session2.Query<Doc>().Where(x => x.ServiceName == "svc-A").ToListAsync();
+        rows.Count.ShouldBe(2);
+    }
+}

--- a/src/Polecat/Storage/DocumentIndex.cs
+++ b/src/Polecat/Storage/DocumentIndex.cs
@@ -56,6 +56,14 @@ public class DocumentIndex
     public Dictionary<string, string> SqlTypeByPath { get; } = new();
 
     /// <summary>
+    ///     JSON paths whose values are carried in the index as non-key INCLUDE columns (covering
+    ///     index). Each include path gets its own persisted computed column. Including the columns a
+    ///     query also selects lets SQL Server satisfy the query from the index alone, avoiding a key
+    ///     lookup back into the table. Include columns are always Default casing (payload, not keys).
+    /// </summary>
+    public string[] IncludePaths { get; set; } = [];
+
+    /// <summary>
     ///     Sort order for the index columns.
     /// </summary>
     public SortOrder SortOrder { get; set; } = SortOrder.Ascending;
@@ -144,12 +152,25 @@ public class DocumentIndex
 
         var statements = new List<string>();
 
-        // Add persisted computed columns for each JSON path
+        // Add persisted computed columns for each key JSON path
         foreach (var path in JsonPaths)
         {
             var colName = ColumnNameForPath(path, Casing);
             var sqlType = ResolveSqlType(path, mapping.ResolveClrMemberType(path));
             var castedExpr = ComputedColumnExpression(path, sqlType, Casing);
+
+            statements.Add($"""
+                IF COL_LENGTH('{schema}.{table}', '{colName}') IS NULL
+                    ALTER TABLE {qualifiedTable} ADD [{colName}] AS {castedExpr} PERSISTED;
+                """);
+        }
+
+        // Add persisted computed columns for each INCLUDE (covering) path — always Default casing.
+        foreach (var path in IncludePaths)
+        {
+            var colName = ColumnNameForPath(path, IndexCasing.Default);
+            var sqlType = ResolveSqlType(path, mapping.ResolveClrMemberType(path));
+            var castedExpr = ComputedColumnExpression(path, sqlType, IndexCasing.Default);
 
             statements.Add($"""
                 IF COL_LENGTH('{schema}.{table}', '{colName}') IS NULL
@@ -172,12 +193,16 @@ public class DocumentIndex
         }
 
         var columnList = string.Join(", ", indexColumns);
+        var include = IncludePaths.Length > 0
+            ? " INCLUDE (" + string.Join(", ",
+                IncludePaths.Select(p => $"[{ColumnNameForPath(p, IndexCasing.Default)}]")) + ")"
+            : "";
         var where = !string.IsNullOrEmpty(Predicate) ? $" WHERE {Predicate}" : "";
 
         statements.Add($"""
             IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = '{name}'
                            AND object_id = OBJECT_ID('{qualifiedTable}'))
-                CREATE {unique}NONCLUSTERED INDEX [{name}] ON {qualifiedTable} ({columnList}){where};
+                CREATE {unique}NONCLUSTERED INDEX [{name}] ON {qualifiedTable} ({columnList}){include}{where};
             """);
 
         return statements.ToArray();

--- a/src/Polecat/Storage/DocumentMappingExpression.cs
+++ b/src/Polecat/Storage/DocumentMappingExpression.cs
@@ -55,26 +55,31 @@ public class DocumentMappingExpression<T>
 
     /// <summary>
     ///     Add a computed index on one or more document properties.
-    ///     Properties are extracted via JSON_VALUE from the data column.
+    ///     Properties are extracted via JSON_VALUE from the data column. Pass <paramref name="include" />
+    ///     (a member or anonymous type) to carry those members as non-key INCLUDE columns for a
+    ///     covering index that avoids key lookups.
     /// </summary>
     public DocumentMappingExpression<T> Index(Expression<Func<T, object?>> expression,
-        Action<DocumentIndex>? configure = null)
+        Action<DocumentIndex>? configure = null, Expression<Func<T, object?>>? include = null)
     {
         var paths = DocumentIndex.ResolveJsonPaths(expression);
         var index = new DocumentIndex(paths);
+        if (include != null) index.IncludePaths = DocumentIndex.ResolveJsonPaths(include);
         configure?.Invoke(index);
         Indexes.Add(index);
         return this;
     }
 
     /// <summary>
-    ///     Add a unique index on one or more document properties.
+    ///     Add a unique index on one or more document properties. Pass <paramref name="include" /> to
+    ///     carry extra members as non-key INCLUDE columns (covering index).
     /// </summary>
     public DocumentMappingExpression<T> UniqueIndex(Expression<Func<T, object?>> expression,
-        Action<DocumentIndex>? configure = null)
+        Action<DocumentIndex>? configure = null, Expression<Func<T, object?>>? include = null)
     {
         var paths = DocumentIndex.ResolveJsonPaths(expression);
         var index = new DocumentIndex(paths) { IsUnique = true };
+        if (include != null) index.IncludePaths = DocumentIndex.ResolveJsonPaths(include);
         configure?.Invoke(index);
         Indexes.Add(index);
         return this;


### PR DESCRIPTION
Index-DSL gap-fill sequence, #3d. **Stacked on #229 → #228** — base retargets as the chain merges.

## What

`Index(key, include: …)` (and `UniqueIndex`) carry extra members as non-key **INCLUDE** columns, so a query can be satisfied from the index alone — no key lookup back into the table. Microsoft explicitly recommends this for JSON computed-column indexes.

```csharp
.Index(x => x.ServiceName, include: x => new { x.BucketEnd, x.Count })
```

Each include path gets its own persisted computed column (always Default casing — payload, not keys), and the `CREATE INDEX` gains an `INCLUDE (...)` clause.

## Notes

- The `include` expression is a typed member or anonymous type, resolved exactly like the key expression (nested members supported via #228).
- It's a standard nonclustered index over computed columns, so it works on **both** native json and `nvarchar(max)` storage (unlike the JSON index in #229).
- Marten doesn't expose INCLUDE in its DSL, so this is Polecat going a step further.

## Tests

`covering_index_tests`: DDL (include computed columns + `INCLUDE` clause), the include columns marked `is_included_column = 1` while the key column is not, and queries returning correct rows. Green on **SQL Server 2025 and 2022**; existing `document_index_tests` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)