### PR TITLE
Params composite-index overload + metadata-column index helpers

### DIFF
--- a/src/Polecat.Tests/Storage/index_params_and_metadata_tests.cs
+++ b/src/Polecat.Tests/Storage/index_params_and_metadata_tests.cs
@@ -1,0 +1,103 @@
+using Polecat.Linq;
+using Polecat.Storage;
+using Polecat.Tests.Harness;
+
+namespace Polecat.Tests.Storage;
+
+/// <summary>
+/// Two ergonomic index-DSL parity items: a params overload for composite indexes
+/// (Index(x => x.A, x => x.B)) and helpers that index the real metadata columns
+/// (created_at / last_modified / tenant_id). Both are plain nonclustered indexes that work on any
+/// SQL Server version.
+/// </summary>
+public class index_params_and_metadata_tests : OneOffConfigurationsContext
+{
+    public class Doc
+    {
+        public Guid Id { get; set; }
+        public string A { get; set; } = string.Empty;
+        public int B { get; set; }
+    }
+
+    private const string Table = "pc_doc_doc";
+    private string Schema => GetType().Name.ToLowerInvariant();
+
+    // ---- unit: raw-column DDL -------------------------------------------------------------------
+
+    [Fact]
+    public void metadata_index_ddl_targets_the_real_column_with_no_computed_column()
+    {
+        var mapping = new DocumentMapping(typeof(Doc), new StoreOptions { DatabaseSchemaName = "s" });
+        var index = new DocumentIndex([]) { RawColumn = "created_at" };
+
+        var ddl = index.ToDdlStatements(mapping);
+        ddl.Length.ShouldBe(1); // no ALTER TABLE ADD computed column
+        ddl[0].ShouldContain("CREATE NONCLUSTERED INDEX [ix_pc_doc_doc_created_at] ON [s].[pc_doc_doc] ([created_at])");
+    }
+
+    // ---- integration: params composite ----------------------------------------------------------
+
+    [Fact]
+    public async Task params_overload_creates_a_composite_index()
+    {
+        ConfigureStore(opts => opts.Schema.For<Doc>().Index(x => x.A, x => x.B));
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Store(new Doc { Id = Guid.NewGuid(), A = "x", B = 1 });
+            await session.SaveChangesAsync();
+        }
+
+        // Both members are key columns of one index.
+        (await KeyColumnsAsync("ix_pc_doc_doc_a_b")).ShouldBe(new[] { "cc_a", "cc_b" });
+    }
+
+    // ---- integration: metadata-column helpers ---------------------------------------------------
+
+    [Fact]
+    public async Task index_created_at_indexes_the_metadata_column()
+    {
+        ConfigureStore(opts => opts.Schema.For<Doc>().IndexCreatedAt());
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Store(new Doc { Id = Guid.NewGuid(), A = "x" });
+            await session.SaveChangesAsync();
+        }
+
+        (await KeyColumnsAsync("ix_pc_doc_doc_created_at")).ShouldBe(new[] { "created_at" });
+    }
+
+    [Fact]
+    public async Task index_last_modified_indexes_the_metadata_column()
+    {
+        ConfigureStore(opts => opts.Schema.For<Doc>().IndexLastModified(idx => idx.SortOrder = SortOrder.Descending));
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Store(new Doc { Id = Guid.NewGuid(), A = "x" });
+            await session.SaveChangesAsync();
+        }
+
+        (await KeyColumnsAsync("ix_pc_doc_doc_last_modified")).ShouldBe(new[] { "last_modified" });
+    }
+
+    private async Task<string[]> KeyColumnsAsync(string indexName)
+    {
+        await using var conn = await OpenConnectionAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"""
+            SELECT c.name
+            FROM sys.indexes i
+            JOIN sys.index_columns ic ON i.object_id = ic.object_id AND i.index_id = ic.index_id
+            JOIN sys.columns c ON ic.object_id = c.object_id AND ic.column_id = c.column_id
+            WHERE i.name = '{indexName}' AND i.object_id = OBJECT_ID('[{Schema}].[{Table}]')
+              AND ic.is_included_column = 0
+            ORDER BY ic.key_ordinal;
+            """;
+        var cols = new List<string>();
+        await using var reader = await cmd.ExecuteReaderAsync();
+        while (await reader.ReadAsync()) cols.Add(reader.GetString(0));
+        return cols.ToArray();
+    }
+}

--- a/src/Polecat/Storage/DocumentIndex.cs
+++ b/src/Polecat/Storage/DocumentIndex.cs
@@ -64,6 +64,13 @@ public class DocumentIndex
     public string[] IncludePaths { get; set; } = [];
 
     /// <summary>
+    ///     When set, the index targets a real table column directly (e.g. the metadata columns
+    ///     created_at / last_modified / tenant_id) instead of a JSON path, so no computed column is
+    ///     generated. Used by the IndexCreatedAt / IndexLastModified / IndexTenantId helpers.
+    /// </summary>
+    internal string? RawColumn { get; set; }
+
+    /// <summary>
     ///     Sort order for the index columns.
     /// </summary>
     public SortOrder SortOrder { get; set; } = SortOrder.Ascending;
@@ -150,6 +157,29 @@ public class DocumentIndex
         var name = GetIndexName(table);
         var unique = IsUnique ? "UNIQUE " : "";
 
+        // A real-column index (metadata columns) needs no computed columns — index the column directly.
+        if (RawColumn != null)
+        {
+            var rawCols = new List<string>();
+            if (TenancyScope == TenancyScope.PerTenant)
+            {
+                rawCols.Add(JasperFx.StorageConstants.TenantIdColumn);
+            }
+
+            var rawSortDir = SortOrder == SortOrder.Descending ? " DESC" : "";
+            rawCols.Add($"[{RawColumn}]{rawSortDir}");
+            var rawWhere = !string.IsNullOrEmpty(Predicate) ? $" WHERE {Predicate}" : "";
+
+            return
+            [
+                $"""
+                 IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = '{name}'
+                                AND object_id = OBJECT_ID('{qualifiedTable}'))
+                     CREATE {unique}NONCLUSTERED INDEX [{name}] ON {qualifiedTable} ({string.Join(", ", rawCols)}){rawWhere};
+                 """
+            ];
+        }
+
         var statements = new List<string>();
 
         // Add persisted computed columns for each key JSON path
@@ -211,6 +241,11 @@ public class DocumentIndex
     private string DeriveIndexName(string tableName)
     {
         var prefix = IsUnique ? "ux" : "ix";
+        if (RawColumn != null)
+        {
+            return $"{prefix}_{tableName}_{RawColumn.ToLowerInvariant()}";
+        }
+
         var pathSuffix = string.Join("_", JsonPaths.Select(p =>
             p.Replace("$.", "").Replace(".", "_").ToLowerInvariant()));
         var casingSuffix = Casing switch

--- a/src/Polecat/Storage/DocumentMappingExpression.cs
+++ b/src/Polecat/Storage/DocumentMappingExpression.cs
@@ -86,10 +86,58 @@ public class DocumentMappingExpression<T>
     }
 
     /// <summary>
+    ///     Add a composite computed index over several members, each given as its own lambda
+    ///     (e.g. <c>Index(x => x.A, x => x.B)</c>) — the multi-lambda alternative to the anonymous
+    ///     type form <c>Index(x => new { x.A, x.B })</c>.
+    /// </summary>
+    public DocumentMappingExpression<T> Index(params Expression<Func<T, object?>>[] expressions)
+    {
+        var paths = expressions.SelectMany(DocumentIndex.ResolveJsonPaths).ToArray();
+        Indexes.Add(new DocumentIndex(paths));
+        return this;
+    }
+
+    /// <summary>
+    ///     Add a composite unique computed index over several members, each given as its own lambda.
+    /// </summary>
+    public DocumentMappingExpression<T> UniqueIndex(params Expression<Func<T, object?>>[] expressions)
+    {
+        var paths = expressions.SelectMany(DocumentIndex.ResolveJsonPaths).ToArray();
+        Indexes.Add(new DocumentIndex(paths) { IsUnique = true });
+        return this;
+    }
+
+    /// <summary>
     ///     Add a custom index with explicit configuration.
     /// </summary>
     public DocumentMappingExpression<T> AddIndex(DocumentIndex index)
     {
+        Indexes.Add(index);
+        return this;
+    }
+
+    /// <summary>
+    ///     Index the <c>created_at</c> metadata column.
+    /// </summary>
+    public DocumentMappingExpression<T> IndexCreatedAt(Action<DocumentIndex>? configure = null)
+        => AddMetadataIndex("created_at", configure);
+
+    /// <summary>
+    ///     Index the <c>last_modified</c> metadata column.
+    /// </summary>
+    public DocumentMappingExpression<T> IndexLastModified(Action<DocumentIndex>? configure = null)
+        => AddMetadataIndex("last_modified", configure);
+
+    /// <summary>
+    ///     Index the <c>tenant_id</c> metadata column (multi-tenant stores).
+    /// </summary>
+    public DocumentMappingExpression<T> IndexTenantId(Action<DocumentIndex>? configure = null)
+        => AddMetadataIndex(JasperFx.StorageConstants.TenantIdColumn, configure);
+
+    private DocumentMappingExpression<T> AddMetadataIndex(string column, Action<DocumentIndex>? configure)
+    {
+        var index = new DocumentIndex([]) { RawColumn = column };
+        configure?.Invoke(index);
         Indexes.Add(index);
         return this;
     }


### PR DESCRIPTION
Index-DSL gap-fill sequence, #3e (final). **Stacked on #230 → #229 → #228** — base retargets as the chain merges.

## What

Two ergonomic Marten-parity items:

**Params composite overload**
```csharp
.Index(x => x.A, x => x.B)         // multi-lambda alternative to Index(x => new { x.A, x.B })
.UniqueIndex(x => x.A, x => x.B)
```
The single-arg call (`Index(x => x.A)`) still binds to the existing `configure`/`include` overload — C# prefers the normal form over the params expanded form — so there's no ambiguity (verified by build).

**Metadata-column index helpers**
```csharp
.IndexCreatedAt()
.IndexLastModified(idx => idx.SortOrder = SortOrder.Descending)
.IndexTenantId()
```
These index the real `created_at` / `last_modified` / `tenant_id` columns directly. `DocumentIndex` gains an internal `RawColumn` mode that indexes a table column with **no** computed column.

## Notes

Both produce standard nonclustered indexes, so they work on any SQL Server version.

## Tests

`index_params_and_metadata_tests`: raw-column DDL, the params composite over two members (both key columns of one index), and the `created_at` / `last_modified` metadata indexes. Green on **SQL Server 2025 and 2022**; full Storage suite green (80).

🤖 Generated with [Claude Code](https://claude.com/claude-code)