### PR TITLE
Add #216 regression test for AsString enum query

### DIFF
--- a/src/Polecat.Tests/Linq/enum_asstring_naming_policy_queries.cs
+++ b/src/Polecat.Tests/Linq/enum_asstring_naming_policy_queries.cs
@@ -142,4 +142,43 @@ public class enum_asstring_naming_policy_queries : OneOffConfigurationsContext
             .CountAsync(x => x.Granularity == Granularity.Hour);
         count.ShouldBe(1);
     }
+
+    // ---- #216: marcominerva's exact repro ------------------------------------------------------
+
+    public enum ActiveStatus
+    {
+        Active,
+        Inactive
+    }
+
+    public class User
+    {
+        public Guid Id { get; set; }
+        public string FirstName { get; set; } = string.Empty;
+        public string LastName { get; set; } = string.Empty;
+        public ActiveStatus Status { get; set; }
+    }
+
+    [Fact]
+    public async Task issue_216_query_by_asstring_enum_returns_matching_rows()
+    {
+        // EnumStorage.AsString with the default casing: Status is stored as "inactive". The
+        // predicate previously emitted JSON_VALUE(...) = '1' (the integer) and matched nothing.
+        ConfigureStore(opts => opts.ConfigureSerialization(EnumStorage.AsString));
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Store(new User { Id = Guid.NewGuid(), FirstName = "Marco", LastName = "Minerva", Status = ActiveStatus.Inactive });
+            session.Store(new User { Id = Guid.NewGuid(), FirstName = "Jane", LastName = "Doe", Status = ActiveStatus.Active });
+            await session.SaveChangesAsync();
+        }
+
+        await using var query = theStore.QuerySession();
+        var inactive = await query.Query<User>()
+            .Where(x => x.Status == ActiveStatus.Inactive)
+            .ToListAsync();
+
+        inactive.Count.ShouldBe(1);
+        inactive[0].FirstName.ShouldBe("Marco");
+    }
 }


### PR DESCRIPTION
Closes #216.

## Context

[#216](https://github.com/JasperFx/polecat/issues/216) ("Query error when using `EnumStorage.AsString`") shares its root cause with #222 — the LINQ predicate sent the enum's **underlying integer** (`'1'`) instead of the serialized string name, so it matched nothing. **The fix already merged** with #222 in [PR #224](https://github.com/JasperFx/polecat/pull/224) (the `EnumMember` change: resolve the member name via `Enum.GetName` and apply the serializer's `JsonNamingPolicy`).

The dedicated repro test was written alongside #224 but pushed a few minutes **after** #224 was merged (and squashed), so it never reached `main` — and #216 was left open. This re-lands it.

## What

marcominerva's exact repro as a permanent regression guard: an `ActiveStatus { Active, Inactive }` enum stored `AsString` (default casing → `"inactive"`), queried `Where(x => x.Status == ActiveStatus.Inactive)`, asserting the matching row is returned.

Test only — no production change (the fix is already in `main`). Passes against current `main`; full `enum_asstring_naming_policy_queries` class green (8 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)