### PR TITLE
feat: use sequential GUIDs for auto-assigned document ids (#235)

### DIFF
--- a/src/Polecat.Tests/Utilities/SequentialGuidTests.cs
+++ b/src/Polecat.Tests/Utilities/SequentialGuidTests.cs
@@ -1,0 +1,42 @@
+using System.Data.SqlTypes;
+using Polecat.Internal;
+using Shouldly;
+
+namespace Polecat.Tests.Utilities;
+
+/// <summary>
+/// #235: auto-assigned Guid ids should be generated sequentially so they sort in SQL Server's
+/// <c>uniqueidentifier</c> order, avoiding clustered-index fragmentation. SQL Server compares
+/// uniqueidentifier values by their last six bytes first, which <see cref="SqlGuid"/> models
+/// exactly, so consecutively generated values must be monotonically increasing under SqlGuid.
+/// </summary>
+public class SequentialGuidTests
+{
+    [Fact]
+    public void generates_distinct_values()
+    {
+        var set = new HashSet<Guid>();
+        for (var i = 0; i < 1000; i++)
+        {
+            set.Add(SequentialGuid.NewGuid()).ShouldBeTrue();
+        }
+    }
+
+    [Fact]
+    public void values_increase_in_sql_server_ordering()
+    {
+        var previous = new SqlGuid(SequentialGuid.NewGuid());
+        for (var i = 0; i < 500; i++)
+        {
+            var current = new SqlGuid(SequentialGuid.NewGuid());
+            current.CompareTo(previous).ShouldBeGreaterThan(0);
+            previous = current;
+        }
+    }
+
+    [Fact]
+    public void is_not_an_empty_guid()
+    {
+        SequentialGuid.NewGuid().ShouldNotBe(Guid.Empty);
+    }
+}

--- a/src/Polecat/AdvancedOperations.cs
+++ b/src/Polecat/AdvancedOperations.cs
@@ -100,7 +100,7 @@ public class AdvancedOperations
                 var currentId = mapping.GetId(doc);
                 if ((Guid)currentId == Guid.Empty)
                 {
-                    mapping.SetId(doc, Guid.NewGuid());
+                    mapping.SetId(doc, Internal.SequentialGuid.NewGuid());
                 }
             }
             // Assign HiLo ID if needed
@@ -211,7 +211,7 @@ public class AdvancedOperations
                 var currentId = mapping.GetId(doc);
                 if ((Guid)currentId == Guid.Empty)
                 {
-                    mapping.SetId(doc, Guid.NewGuid());
+                    mapping.SetId(doc, Internal.SequentialGuid.NewGuid());
                 }
             }
             else if (mapping.IsNumericId && provider.Sequence != null)

--- a/src/Polecat/Internal/DocumentProvider.cs
+++ b/src/Polecat/Internal/DocumentProvider.cs
@@ -168,7 +168,7 @@ internal class DocumentProvider
             var currentId = Mapping.GetId(document);
             if ((Guid)currentId == Guid.Empty)
             {
-                Mapping.SetId(document, Guid.NewGuid());
+                Mapping.SetId(document, SequentialGuid.NewGuid());
             }
 
             return;

--- a/src/Polecat/Internal/SequentialGuid.cs
+++ b/src/Polecat/Internal/SequentialGuid.cs
@@ -1,0 +1,45 @@
+using System.Threading;
+
+namespace Polecat.Internal;
+
+/// <summary>
+///     Generates sequential <see cref="Guid" /> values that sort sequentially in SQL Server's
+///     <c>uniqueidentifier</c> ordering, avoiding the index fragmentation caused by random
+///     <see cref="Guid.NewGuid" /> values used as clustered primary keys (#235).
+/// </summary>
+/// <remarks>
+///     SQL Server orders <c>uniqueidentifier</c> values by their last six bytes first, so a
+///     monotonically increasing counter is woven into exactly those bytes. The algorithm mirrors
+///     EF Core's <c>SequentialGuidValueGenerator</c>
+///     (https://github.com/dotnet/efcore/blob/main/src/EFCore/ValueGeneration/SequentialGuidValueGenerator.cs)
+///     so Polecat-assigned ids interleave cleanly with EF-assigned ones in the same table.
+/// </remarks>
+internal static class SequentialGuid
+{
+    private static long _counter = System.DateTime.UtcNow.Ticks;
+
+    /// <summary>
+    ///     Creates a new sequential <see cref="Guid" />.
+    /// </summary>
+    public static Guid NewGuid()
+    {
+        var guidBytes = Guid.NewGuid().ToByteArray();
+        var counterBytes = BitConverter.GetBytes(Interlocked.Increment(ref _counter));
+
+        if (!BitConverter.IsLittleEndian)
+        {
+            Array.Reverse(counterBytes);
+        }
+
+        guidBytes[08] = counterBytes[1];
+        guidBytes[09] = counterBytes[0];
+        guidBytes[10] = counterBytes[7];
+        guidBytes[11] = counterBytes[6];
+        guidBytes[12] = counterBytes[5];
+        guidBytes[13] = counterBytes[4];
+        guidBytes[14] = counterBytes[3];
+        guidBytes[15] = counterBytes[2];
+
+        return new Guid(guidBytes);
+    }
+}


### PR DESCRIPTION
Closes #235.

## Problem
Auto-assigned `Guid` document ids were generated with `Guid.NewGuid()`. Random GUIDs used as clustered `uniqueidentifier` primary keys cause heavy index fragmentation on SQL Server because inserts land at random points in the index.

## Fix
Add `Polecat.Internal.SequentialGuid.NewGuid()`, ported from EF Core's [`SequentialGuidValueGenerator`](https://github.com/dotnet/efcore/blob/main/src/EFCore/ValueGeneration/SequentialGuidValueGenerator.cs) (referenced in the issue). It weaves a monotonically increasing counter into exactly the six bytes SQL Server orders `uniqueidentifier` values by, so generated ids sort sequentially and inserts append to the tail of the index.

Note: UUIDv7 (`Guid.CreateVersion7()`) would *not* help here — it is byte-order sequential, but SQL Server sorts `uniqueidentifier` by the last six bytes, so v7 values still fragment. The EF Core algorithm targets SQL Server's ordering specifically.

Applied at every document-id auto-assignment site:
- `DocumentProvider.AssignIdIfNeeded` (plain `Guid Id` and strongly-typed Guid wrappers)
- `AdvancedOperations` bulk insert (x2)

## Tests
`SequentialGuidTests` asserts distinctness, non-empty, and — using `System.Data.SqlTypes.SqlGuid` (which models SQL Server's comparison semantics) — that consecutively generated values are strictly increasing in SQL Server ordering. Existing `plain_guid_id_assignment_tests` still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)