### PR TITLE
feat: use JSON_VALUE(... RETURNING type) for persisted computed columns (#236)

### DIFF
--- a/src/Polecat.Tests/Storage/computed_column_index_usability_tests.cs
+++ b/src/Polecat.Tests/Storage/computed_column_index_usability_tests.cs
@@ -42,15 +42,35 @@ public class computed_column_index_usability_tests : OneOffConfigurationsContext
     [Fact]
     public void datetimeoffset_uses_deterministic_convert_so_it_can_be_persisted()
     {
-        DocumentIndex.ComputedColumnExpression("$.bucketEnd", "datetimeoffset", IndexCasing.Default)
+        // Date/time stays on CONVERT(..., 126) regardless of native json: a CAST of a string to a
+        // date/time type is non-deterministic and cannot be PERSISTED, and #236's RETURNING swap
+        // only applies to the non-date branch.
+        DocumentIndex.ComputedColumnExpression("$.bucketEnd", "datetimeoffset", IndexCasing.Default, useReturning: true)
+            .ShouldBe("CONVERT(datetimeoffset, JSON_VALUE(data, '$.bucketEnd'), 126)");
+        DocumentIndex.ComputedColumnExpression("$.bucketEnd", "datetimeoffset", IndexCasing.Default, useReturning: false)
             .ShouldBe("CONVERT(datetimeoffset, JSON_VALUE(data, '$.bucketEnd'), 126)");
     }
 
     [Fact]
-    public void string_uses_cast_to_the_bounded_type()
+    public void string_uses_returning_on_native_json_and_cast_otherwise()
     {
-        DocumentIndex.ComputedColumnExpression("$.serviceName", "varchar(250)", IndexCasing.Default)
+        // #236: on native json storage the persisted computed column uses JSON_VALUE(... RETURNING),
+        // matching the #217 query-side form, so the index stays seekable.
+        DocumentIndex.ComputedColumnExpression("$.serviceName", "varchar(250)", IndexCasing.Default, useReturning: true)
+            .ShouldBe("JSON_VALUE(data, '$.serviceName' RETURNING varchar(250))");
+
+        // On nvarchar(max) storage RETURNING is a syntax error, so fall back to CAST.
+        DocumentIndex.ComputedColumnExpression("$.serviceName", "varchar(250)", IndexCasing.Default, useReturning: false)
             .ShouldBe("CAST(JSON_VALUE(data, '$.serviceName') AS varchar(250))");
+    }
+
+    [Fact]
+    public void uniqueidentifier_keeps_cast_even_on_native_json()
+    {
+        // RETURNING has no uniqueidentifier type, so Guid-typed computed columns (e.g. FK columns)
+        // always fall back to CAST.
+        DocumentIndex.ComputedColumnExpression("$.userId", "uniqueidentifier", IndexCasing.Default, useReturning: true)
+            .ShouldBe("CAST(JSON_VALUE(data, '$.userId') AS uniqueidentifier)");
     }
 
     [Fact]
@@ -107,6 +127,43 @@ public class computed_column_index_usability_tests : OneOffConfigurationsContext
         reader.GetString(1).ShouldBe("datetimeoffset");
     }
 
+    [Fact]
+    public async Task int_index_column_uses_returning_definition_on_native_json()
+    {
+        // #236: the persisted computed column for a non-date member should use
+        // JSON_VALUE(... RETURNING type) on native json storage rather than CAST.
+        ConfigureStore(opts => opts.Schema.For<IndexedMetric>().Index(x => x.Count));
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Store(new IndexedMetric
+            {
+                Id = Guid.NewGuid(), ServiceName = "svc", BucketEnd = DateTimeOffset.UtcNow, Count = 7
+            });
+            await session.SaveChangesAsync();
+        }
+
+        await using var conn = await OpenConnectionAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"""
+            SELECT cc.is_persisted, cc.definition
+            FROM sys.computed_columns cc
+            WHERE cc.object_id = OBJECT_ID('[{_schema()}].[{Table}]') AND cc.name = 'cc_count';
+            """;
+        await using var reader = await cmd.ExecuteReaderAsync();
+        (await reader.ReadAsync()).ShouldBeTrue();
+        reader.GetBoolean(0).ShouldBeTrue(); // PERSISTED
+        var definition = reader.GetString(1);
+        if (ConnectionSource.SupportsNativeJson)
+        {
+            definition.ShouldContain("RETURNING");
+        }
+        else
+        {
+            definition.ShouldNotContain("RETURNING"); // CAST fallback on nvarchar(max) storage
+        }
+    }
+
     // ---- gap 1: the translator targets the computed column --------------------------------------
 
     [Fact]
@@ -119,8 +176,11 @@ public class computed_column_index_usability_tests : OneOffConfigurationsContext
         var query = session.Query<IndexedMetric>().Where(x => x.ServiceName == "svc-A");
 
         // Bare JSON_VALUE (the old behavior) could never match the varchar(250) computed column.
-        SqlFor(session, query)
-            .ShouldContain("CAST(JSON_VALUE(data, '$.serviceName') AS varchar(250))");
+        // The predicate must use the EXACT same expression as the persisted column — RETURNING on
+        // native json (#236), CAST on nvarchar(max) — so the index is seekable on either.
+        var expected = DocumentIndex.ComputedColumnExpression(
+            "$.serviceName", "varchar(250)", IndexCasing.Default, ConnectionSource.SupportsNativeJson);
+        SqlFor(session, query).ShouldContain(expected);
     }
 
     [Fact]

--- a/src/Polecat.Tests/Storage/document_index_tests.cs
+++ b/src/Polecat.Tests/Storage/document_index_tests.cs
@@ -705,8 +705,9 @@ public class document_index_tests : IntegrationContext
 
         var statements = index.ToDdlStatements(mapping);
 
-        // Should use LOWER() wrapping
-        statements[0].ShouldContain("LOWER(CAST(JSON_VALUE(data, '$.name')");
+        // Should use LOWER() wrapping. #236: native json storage (TestDocumentMapping's default
+        // StoreOptions) emits JSON_VALUE(... RETURNING type) rather than CAST.
+        statements[0].ShouldContain("LOWER(JSON_VALUE(data, '$.name' RETURNING ");
         // Column name should include _lower suffix
         statements[0].ShouldContain("cc_name_lower");
     }
@@ -719,8 +720,8 @@ public class document_index_tests : IntegrationContext
 
         var statements = index.ToDdlStatements(mapping);
 
-        // Should use UPPER() wrapping
-        statements[0].ShouldContain("UPPER(CAST(JSON_VALUE(data, '$.email')");
+        // Should use UPPER() wrapping. #236: native json storage emits RETURNING.
+        statements[0].ShouldContain("UPPER(JSON_VALUE(data, '$.email' RETURNING ");
         // Column name should include _upper suffix
         statements[0].ShouldContain("cc_email_upper");
     }
@@ -736,8 +737,8 @@ public class document_index_tests : IntegrationContext
         // Should NOT contain UPPER or LOWER
         statements[0].ShouldNotContain("UPPER");
         statements[0].ShouldNotContain("LOWER");
-        // Should contain plain CAST
-        statements[0].ShouldContain("CAST(JSON_VALUE(data, '$.name')");
+        // #236: plain (un-cased) computed column. Native json storage emits RETURNING.
+        statements[0].ShouldContain("JSON_VALUE(data, '$.name' RETURNING ");
     }
 
     [Fact]

--- a/src/Polecat.Tests/Storage/nested_member_index_tests.cs
+++ b/src/Polecat.Tests/Storage/nested_member_index_tests.cs
@@ -84,7 +84,10 @@ public class nested_member_index_tests : OneOffConfigurationsContext
 
         // The index computed column is over '$.address.city'; the predicate must target the same
         // path (and be rewritten to the computed-column expression so the index is seekable).
-        sql.ShouldContain("JSON_VALUE(data, '$.address.city')");
+        // Form-agnostic: the indexed locator is JSON_VALUE(... '$.address.city' RETURNING type) on
+        // native json (#236) or CAST(JSON_VALUE(... '$.address.city') AS type) on nvarchar(max), so
+        // assert the path occurrence without the trailing ')'.
+        sql.ShouldContain("JSON_VALUE(data, '$.address.city'");
         sql.ShouldNotContain("'$.city'"); // the old, wrong leaf-only path
     }
 

--- a/src/Polecat/Linq/Members/MemberFactory.cs
+++ b/src/Polecat/Linq/Members/MemberFactory.cs
@@ -96,7 +96,7 @@ internal class MemberFactory : IMemberResolver
         if (index == null) return false;
 
         var sqlType = index.ResolveSqlType(jsonPath, underlying);
-        locator = DocumentIndex.ComputedColumnExpression(jsonPath, sqlType, IndexCasing.Default);
+        locator = DocumentIndex.ComputedColumnExpression(jsonPath, sqlType, IndexCasing.Default, _useReturning);
         return true;
     }
 

--- a/src/Polecat/Storage/DocumentForeignKey.cs
+++ b/src/Polecat/Storage/DocumentForeignKey.cs
@@ -58,10 +58,14 @@ public class DocumentForeignKey
 
         var statements = new List<string>();
 
-        // Add persisted computed column for the FK property
+        // Add persisted computed column for the FK property. #236: routes through the shared
+        // ComputedColumnExpression so the FK column uses JSON_VALUE(... RETURNING type) on native
+        // json storage too (Guid ids still fall back to CAST — RETURNING has no uniqueidentifier).
+        var computedExpr = DocumentIndex.ComputedColumnExpression(
+            JsonPath, sqlType, IndexCasing.Default, DocumentIndex.UsesNativeJson(parentMapping));
         statements.Add($"""
             IF COL_LENGTH('{schema}.{table}', '{colName}') IS NULL
-                ALTER TABLE {qualifiedTable} ADD [{colName}] AS CAST(JSON_VALUE(data, '{JsonPath}') AS {sqlType}) PERSISTED;
+                ALTER TABLE {qualifiedTable} ADD [{colName}] AS {computedExpr} PERSISTED;
             """);
 
         // Build ON DELETE clause

--- a/src/Polecat/Storage/DocumentIndex.cs
+++ b/src/Polecat/Storage/DocumentIndex.cs
@@ -106,13 +106,28 @@ public class DocumentIndex
     ///     SQL Server match a predicate to the persisted computed column and seek the index.
     ///     Date/time types use a deterministic CONVERT(..., 126) so the column can be PERSISTED
     ///     (a CAST of a string to a date/time type is non-deterministic and rejected by PERSISTED).
+    ///     #236: on native <c>json</c> storage every other type prefers
+    ///     <c>JSON_VALUE(... RETURNING type)</c> over <c>CAST(JSON_VALUE(...) AS type)</c>, mirroring
+    ///     the #217 query-side change. Because the persisted computed column and the LINQ predicate
+    ///     both come from here, they stay textually identical and the index remains seekable.
     /// </summary>
-    internal static string ComputedColumnExpression(string jsonPath, string sqlType, IndexCasing casing)
+    internal static string ComputedColumnExpression(string jsonPath, string sqlType, IndexCasing casing,
+        bool useReturning)
     {
         var json = $"JSON_VALUE(data, '{jsonPath}')";
-        var expr = SqlTypeMap.IsDateTimeFamily(sqlType)
-            ? $"CONVERT({sqlType}, {json}, 126)"
-            : $"CAST({json} AS {sqlType})";
+        string expr;
+        if (SqlTypeMap.IsDateTimeFamily(sqlType))
+        {
+            expr = $"CONVERT({sqlType}, {json}, 126)";
+        }
+        else if (useReturning && Linq.Members.MemberFactory.SupportsReturning(sqlType))
+        {
+            expr = $"JSON_VALUE(data, '{jsonPath}' RETURNING {sqlType})";
+        }
+        else
+        {
+            expr = $"CAST({json} AS {sqlType})";
+        }
 
         return casing switch
         {
@@ -121,6 +136,12 @@ public class DocumentIndex
             _ => expr
         };
     }
+
+    /// <summary>
+    ///     Whether this document's <c>data</c> column is the native SQL Server 2025 <c>json</c> type,
+    ///     which is the precondition for the <c>JSON_VALUE(... RETURNING type)</c> form (#236).
+    /// </summary>
+    internal static bool UsesNativeJson(DocumentMapping mapping) => mapping.JsonColumnType == "json";
 
     /// <summary>
     ///     Gets the index name (explicit or derived).
@@ -149,7 +170,7 @@ public class DocumentIndex
         {
             var colName = ColumnNameForPath(path, Casing);
             var sqlType = ResolveSqlType(path, mapping.ResolveClrMemberType(path));
-            var castedExpr = ComputedColumnExpression(path, sqlType, Casing);
+            var castedExpr = ComputedColumnExpression(path, sqlType, Casing, UsesNativeJson(mapping));
 
             statements.Add($"""
                 IF COL_LENGTH('{schema}.{table}', '{colName}') IS NULL


### PR DESCRIPTION
Closes #236.

## Background
[#217](https://github.com/JasperFx/polecat/issues/217) switched the **query-side** `JSON_VALUE` to use `... RETURNING type` on native `json` storage instead of `CAST(JSON_VALUE(...) AS type)`. The **persisted computed columns** backing `Index(...)` and `ForeignKey(...)` were still emitted with `CAST`.

## Fix
The single `DocumentIndex.ComputedColumnExpression` already feeds *both* the index DDL and the LINQ translator (this is what keeps a predicate matching the persisted column so the index is seekable). It now emits `JSON_VALUE(data, '$.path' RETURNING type)` on native json storage. Because both sides flow through the same method, the persisted column and the predicate stay textually identical and the index remains seekable.

`DocumentForeignKey` now routes through the same helper too.

### Carve-outs (unchanged behavior)
- **Date/time** members keep the deterministic `CONVERT(..., 126)` form — a `CAST` of a string to a date/time type is non-deterministic and rejected by `PERSISTED`.
- **uniqueidentifier** keeps `CAST` — `RETURNING` has no `uniqueidentifier` type — so Guid FK columns are unaffected.
- **nvarchar(max)** storage keeps `CAST` — `RETURNING` is a syntax error there.

## Verification
Confirmed against the SQL Server 2025 container that `JSON_VALUE(data, '$.x' RETURNING int|datetimeoffset|varchar|bit|bigint|decimal|float|date) PERSISTED` is accepted and indexable, and that the stored `sys.computed_columns.definition` contains `RETURNING`.

## Tests
- New/updated unit assertions on `ComputedColumnExpression` (RETURNING on native json, CAST on nvarchar(max), Guid keeps CAST, date keeps CONVERT).
- New end-to-end test asserting the persisted `int` index column's definition contains `RETURNING` on native json.
- Existing computed-column index + FK tests updated to be native-json-aware (default vs. edge CI matrix) and pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)