### PR TITLE
feat: add opt-in polecat.event.append OpenTelemetry counter (#238)

### DIFF
--- a/src/Polecat.Tests/Events/event_append_counter_tests.cs
+++ b/src/Polecat.Tests/Events/event_append_counter_tests.cs
@@ -1,0 +1,108 @@
+using System.Diagnostics.Metrics;
+using JasperFx;
+using Polecat.Tests.Harness;
+using Polecat.TestUtils;
+using Weasel.SqlServer;
+
+namespace Polecat.Tests.Events;
+
+/// <summary>
+///     #238: when <c>OpenTelemetry.TrackEventCounters()</c> is enabled, Polecat emits a
+///     <c>polecat.event.append</c> counter (unit <c>events</c>, tags <c>event_type</c> +
+///     <c>tenant_id</c>) incremented once per appended event on commit. Off by default.
+/// </summary>
+public class event_append_counter_tests : IAsyncLifetime
+{
+    public Task InitializeAsync() => Task.CompletedTask;
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    private static DocumentStore CreateStore(string schema, bool trackCounters)
+    {
+        return DocumentStore.For(opts =>
+        {
+            opts.ConnectionString = ConnectionSource.ConnectionString;
+            opts.DatabaseSchemaName = schema;
+            opts.AutoCreateSchemaObjects = AutoCreate.All;
+            opts.UseNativeJsonType = ConnectionSource.SupportsNativeJson;
+            if (trackCounters)
+            {
+                opts.OpenTelemetry.TrackEventCounters();
+            }
+        });
+    }
+
+    private static (MeterListener listener, List<(long Value, Dictionary<string, object?> Tags)> measurements) Listen()
+    {
+        var measurements = new List<(long, Dictionary<string, object?>)>();
+        var listener = new MeterListener
+        {
+            InstrumentPublished = (instrument, l) =>
+            {
+                if (instrument.Meter.Name == "Polecat" && instrument.Name == "polecat.event.append")
+                {
+                    l.EnableMeasurementEvents(instrument);
+                }
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((_, measurement, tags, _) =>
+        {
+            var dict = new Dictionary<string, object?>();
+            foreach (var tag in tags) dict[tag.Key] = tag.Value;
+            lock (measurements) measurements.Add((measurement, dict));
+        });
+        listener.Start();
+        return (listener, measurements);
+    }
+
+    [Fact]
+    public async Task disabled_by_default_emits_no_measurements()
+    {
+        await using var store = CreateStore("otel_counter_off", trackCounters: false);
+        store.Options.OpenTelemetry.EventCountersEnabled.ShouldBeFalse();
+
+        var (listener, measurements) = Listen();
+        using (listener)
+        {
+            await using var session = store.LightweightSession();
+            session.Events.StartStream(Guid.NewGuid(), new QuestStarted("No counter"));
+            await session.SaveChangesAsync();
+        }
+
+        measurements.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task counts_each_appended_event_with_type_and_tenant_tags()
+    {
+        await using var store = CreateStore("otel_counter_on", trackCounters: true);
+        store.Options.OpenTelemetry.EventCountersEnabled.ShouldBeTrue();
+
+        var (listener, measurements) = Listen();
+        using (listener)
+        {
+            await using var session = store.LightweightSession();
+            // 1 QuestStarted + 2 MembersJoined = 3 events
+            session.Events.StartStream(Guid.NewGuid(),
+                new QuestStarted("Counter Quest"),
+                new MembersJoined(1, "Town", ["A"]),
+                new MembersJoined(2, "City", ["B"]));
+            await session.SaveChangesAsync();
+
+            listener.RecordObservableInstruments();
+        }
+
+        // 3 increments of 1 each
+        measurements.Count.ShouldBe(3);
+        measurements.Sum(m => m.Value).ShouldBe(3);
+
+        // every measurement carries the default tenant + a known event type
+        measurements.ShouldAllBe(m => (string)m.Tags["tenant_id"]! == StorageConstants.DefaultTenantId);
+
+        var byType = measurements
+            .GroupBy(m => (string)m.Tags["event_type"]!)
+            .ToDictionary(g => g.Key, g => g.Sum(x => x.Value));
+
+        byType["quest_started"].ShouldBe(1);
+        byType["members_joined"].ShouldBe(2);
+    }
+}

--- a/src/Polecat/DocumentStore.EventStore.cs
+++ b/src/Polecat/DocumentStore.EventStore.cs
@@ -189,6 +189,7 @@ public partial class DocumentStore : IEventStore<IDocumentSession, IQuerySession
         // OpenTelemetry child
         var otel = new OptionsDescription { Subject = "Polecat.OpenTelemetryOptions" };
         otel.AddValue(nameof(Options.OpenTelemetry.TrackConnections), Options.OpenTelemetry.TrackConnections);
+        otel.AddValue(nameof(Options.OpenTelemetry.EventCountersEnabled), Options.OpenTelemetry.EventCountersEnabled);
         usage.Children["OpenTelemetry"] = otel;
 
         // Schema child — event-store table locations resolved through the lifted

--- a/src/Polecat/Internal/DocumentSessionBase.cs
+++ b/src/Polecat/Internal/DocumentSessionBase.cs
@@ -528,6 +528,9 @@ internal abstract class DocumentSessionBase : QuerySession, IDocumentSession
             // events before the work tracker is reset, then notify best-effort.
             NotifyAppendObserver();
 
+            // #238: emit the opt-in polecat.event.append OpenTelemetry counter, also before reset.
+            RecordEventAppendMetrics();
+
             _workTracker.Reset();
 
             Logger.RecordSavedChanges(this);
@@ -575,6 +578,28 @@ internal abstract class DocumentSessionBase : QuerySession, IDocumentSession
         catch (Exception ex)
         {
             Logger.LogFailure("IEventStoreInstrumentation.AppendObserver threw", ex);
+        }
+    }
+
+    /// <summary>
+    ///     #238: increment the opt-in <c>polecat.event.append</c> counter once per event committed in
+    ///     this unit of work, tagged with the event type and tenant. Mirrors Marten's event-append
+    ///     counter. Must be called after commit but before the work tracker is reset. No-op unless
+    ///     <see cref="Polecat.Internal.OpenTelemetry.OpenTelemetryOptions.EventCountersEnabled" /> is on.
+    /// </summary>
+    private void RecordEventAppendMetrics()
+    {
+        if (!Options.OpenTelemetry.EventCountersEnabled) return;
+
+        var counter = Options.OpenTelemetry.EventAppendCounter;
+        foreach (var stream in _workTracker.Streams)
+        {
+            foreach (var @event in stream.Events)
+            {
+                counter.Add(1,
+                    new KeyValuePair<string, object?>("event_type", @event.EventTypeName),
+                    new KeyValuePair<string, object?>("tenant_id", @event.TenantId ?? TenantId));
+            }
         }
     }
 

--- a/src/Polecat/Internal/OpenTelemetry/OpenTelemetryOptions.cs
+++ b/src/Polecat/Internal/OpenTelemetry/OpenTelemetryOptions.cs
@@ -1,19 +1,48 @@
+using System.Diagnostics.Metrics;
+
 namespace Polecat.Internal.OpenTelemetry;
 
 /// <summary>
 ///     OpenTelemetry configuration for Polecat. A thin subclass of the lifted
 ///     <see cref="JasperFx.OpenTelemetry.OpenTelemetryOptions"/> (jasperfx#332)
-///     that supplies the "Polecat" meter name via the base ctor. Polecat had
-///     nothing beyond the base (TrackConnections + Meter), so this subclass exists
-///     only to preserve the <c>Polecat.Internal.OpenTelemetry.OpenTelemetryOptions</c>
-///     public name and its parameterless construction
-///     (<c>StoreOptions.OpenTelemetry = new()</c>). TrackConnections + Meter come
-///     from the base; TrackLevel is type-forwarded to JasperFx.OpenTelemetry.TrackLevel
+///     that supplies the "Polecat" meter name via the base ctor. TrackConnections + Meter
+///     come from the base; TrackLevel is type-forwarded to JasperFx.OpenTelemetry.TrackLevel
 ///     via a global using alias.
 /// </summary>
 public sealed class OpenTelemetryOptions : JasperFx.OpenTelemetry.OpenTelemetryOptions
 {
+    private Counter<long>? _eventAppendCounter;
+
     public OpenTelemetryOptions() : base("Polecat")
     {
     }
+
+    /// <summary>
+    ///     #238: when true, Polecat emits the <c>polecat.event.append</c> counter (unit
+    ///     <c>events</c>, tags <c>event_type</c> + <c>tenant_id</c>), incremented once per appended
+    ///     event on a successful commit. Off by default. Mirrors Marten's opt-in event-append
+    ///     counter so OpenTelemetry dashboards line up across the two engines. Toggle via
+    ///     <see cref="TrackEventCounters" />.
+    /// </summary>
+    public bool EventCountersEnabled { get; private set; }
+
+    /// <summary>
+    ///     Opt into the <c>polecat.event.append</c> counter. Mirrors Marten's
+    ///     <c>OpenTelemetryOptions.TrackEventCounters()</c>.
+    /// </summary>
+    public void TrackEventCounters()
+    {
+        EventCountersEnabled = true;
+    }
+
+    /// <summary>
+    ///     The lazily-created append counter, published on the Polecat
+    ///     <see cref="JasperFx.OpenTelemetry.OpenTelemetryOptions.Meter" />. Created the first time
+    ///     it is touched (i.e. when <see cref="EventCountersEnabled" /> is on and events commit).
+    /// </summary>
+    internal Counter<long> EventAppendCounter =>
+        _eventAppendCounter ??= Meter.CreateCounter<long>(
+            "polecat.event.append",
+            "events",
+            "Number of events appended to the event store");
 }


### PR DESCRIPTION
Closes #238.

## Problem
Polecat registers a `Meter("Polecat")` but creates **no first-party metric instruments** of its own. Marten emits an opt-in event-append counter, so OpenTelemetry dashboards / CritterWatch's per-store throughput surface can't look the same across the two engines.

## Fix
Add an opt-in `polecat.event.append` counter (unit `events`, tags `event_type` + `tenant_id`), incremented once per appended event on a **successful commit** — right next to the existing `AppendObserver` hook in `SaveChangesAsync`, after `CommitAsync` and before the work tracker resets.

- `OpenTelemetry.TrackEventCounters()` opts in, mirroring Marten's method of the same name. Off by default (`EventCountersEnabled == false`).
- The counter is created lazily on the existing Polecat `Meter`, so nothing is published unless events are actually committed with the toggle on.
- Advertised on the event-store usage descriptor (`OpenTelemetry` child → `EventCountersEnabled`) so monitoring tooling can light up the surface automatically.

## Tests
`event_append_counter_tests` uses a `MeterListener`:
- disabled by default → no measurements emitted;
- enabled → 3 events produce 3 increments, each tagged with the default tenant and the correct `event_type` (`quest_started` ×1, `members_joined` ×2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)