### PR TITLE
feat: add opt-in user_name (LastModifiedBy) event metadata column (#237)

### DIFF
--- a/src/Polecat.Tests/Events/event_metadata_tests.cs
+++ b/src/Polecat.Tests/Events/event_metadata_tests.cs
@@ -181,6 +181,90 @@ public class event_metadata_tests : OneOffConfigurationsContext
         events[0].Headers.ShouldBeNull();
     }
 
+    // ===== UserName (LastModifiedBy) tests (#237) =====
+
+    [Fact]
+    public async Task session_last_modified_by_propagates_to_event_user_name()
+    {
+        await ConfigureAndApply(opts =>
+        {
+            opts.Events.EnableUserName = true;
+        });
+
+        var streamId = Guid.NewGuid();
+
+        await using var session = theStore.LightweightSession();
+        session.LastModifiedBy = "alice@example.com";
+        session.Events.StartStream(streamId,
+            new QuestStarted("User Quest"),
+            new MembersJoined(1, "Town", ["A"]));
+        await session.SaveChangesAsync();
+
+        await using var query = theStore.QuerySession();
+        var events = await query.Events.FetchStreamAsync(streamId);
+
+        events.Count.ShouldBe(2);
+        events[0].UserName.ShouldBe("alice@example.com");
+        events[1].UserName.ShouldBe("alice@example.com");
+    }
+
+    [Fact]
+    public async Task event_level_user_name_takes_precedence_over_session()
+    {
+        await ConfigureAndApply(opts =>
+        {
+            opts.Events.EnableUserName = true;
+        });
+
+        var streamId = Guid.NewGuid();
+
+        await using var session = theStore.LightweightSession();
+        session.LastModifiedBy = "session-user";
+
+        var action = session.Events.StartStream(streamId, new QuestStarted("Override"));
+        action.Events[0].UserName = "event-user";
+        await session.SaveChangesAsync();
+
+        await using var query = theStore.QuerySession();
+        var events = await query.Events.FetchStreamAsync(streamId);
+
+        events[0].UserName.ShouldBe("event-user");
+    }
+
+    [Fact]
+    public async Task null_user_name_when_not_set()
+    {
+        await ConfigureAndApply(opts =>
+        {
+            opts.Events.EnableUserName = true;
+        });
+
+        var streamId = Guid.NewGuid();
+
+        await using var session = theStore.LightweightSession();
+        session.Events.StartStream(streamId, new QuestStarted("No User"));
+        await session.SaveChangesAsync();
+
+        await using var query = theStore.QuerySession();
+        var events = await query.Events.FetchStreamAsync(streamId);
+
+        events[0].UserName.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task user_name_column_not_created_when_disabled()
+    {
+        await ConfigureAndApply(_ => { });
+
+        await using var conn = await OpenConnectionAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"SELECT COL_LENGTH('[{_schema()}].[pc_events]', 'user_name')";
+        var result = await cmd.ExecuteScalarAsync();
+        (result == null || result == DBNull.Value).ShouldBeTrue();
+    }
+
+    private string _schema() => GetType().Name.ToLowerInvariant();
+
     // ===== Sequence / version capture tests =====
 
     [Fact]
@@ -490,6 +574,7 @@ public class event_metadata_tests : OneOffConfigurationsContext
             opts.Events.EnableCorrelationId = true;
             opts.Events.EnableCausationId = true;
             opts.Events.EnableHeaders = true;
+            opts.Events.EnableUserName = true;
         });
 
         var streamId = Guid.NewGuid();
@@ -497,6 +582,7 @@ public class event_metadata_tests : OneOffConfigurationsContext
         await using var session = theStore.LightweightSession();
         session.CorrelationId = "full-meta-corr";
         session.CausationId = "full-meta-cause";
+        session.LastModifiedBy = "full-meta-user";
         var action = session.Events.StartStream(streamId, new QuestStarted("Full Metadata"));
         action.Events[0].SetHeader("env", "test");
         action.Events[0].SetHeader("version", "1.0");
@@ -508,6 +594,7 @@ public class event_metadata_tests : OneOffConfigurationsContext
         events.Count.ShouldBe(1);
         events[0].CorrelationId.ShouldBe("full-meta-corr");
         events[0].CausationId.ShouldBe("full-meta-cause");
+        events[0].UserName.ShouldBe("full-meta-user");
         events[0].Headers.ShouldNotBeNull();
         events[0].GetHeader("env")!.ToString().ShouldBe("test");
         events[0].GetHeader("version")!.ToString().ShouldBe("1.0");

--- a/src/Polecat/DocumentStore.EventStore.cs
+++ b/src/Polecat/DocumentStore.EventStore.cs
@@ -169,6 +169,7 @@ public partial class DocumentStore : IEventStore<IDocumentSession, IQuerySession
         usage.AddValue(nameof(Options.Events.EnableCorrelationId), Options.Events.EnableCorrelationId);
         usage.AddValue(nameof(Options.Events.EnableCausationId), Options.Events.EnableCausationId);
         usage.AddValue(nameof(Options.Events.EnableHeaders), Options.Events.EnableHeaders);
+        usage.AddValue(nameof(Options.Events.EnableUserName), Options.Events.EnableUserName);
         if (Options.Events.DatabaseSchemaName != null)
         {
             usage.AddValue(nameof(Options.Events.DatabaseSchemaName), Options.Events.DatabaseSchemaName);

--- a/src/Polecat/Events/Internal/PcEventsRowReader.cs
+++ b/src/Polecat/Events/Internal/PcEventsRowReader.cs
@@ -78,6 +78,7 @@ internal static class PcEventsRowReader
         if (options.EnableCorrelationId) sb.Append(", correlation_id");
         if (options.EnableCausationId) sb.Append(", causation_id");
         if (options.EnableHeaders) sb.Append(", headers");
+        if (options.EnableUserName) sb.Append(", user_name");
         return sb.ToString();
     }
 
@@ -183,6 +184,12 @@ internal static class PcEventsRowReader
             var headersJson = reader.GetString(slots.HeadersIdx);
             @event.Headers = ctx.Serializer.FromJson<Dictionary<string, object>>(headersJson);
         }
+        if (slots.UserNameIdx >= 0)
+        {
+            @event.UserName = reader.IsDBNull(slots.UserNameIdx)
+                ? null
+                : reader.GetString(slots.UserNameIdx);
+        }
 
         return @event;
     }
@@ -258,7 +265,8 @@ internal static class PcEventsRowReader
 ///     in the batch. <c>-1</c> means the column is not projected; the
 ///     reader skips it without checking the underlying flag.
 /// </summary>
-internal readonly record struct MetadataSlots(int CorrelationIdx, int CausationIdx, int HeadersIdx)
+internal readonly record struct MetadataSlots(int CorrelationIdx, int CausationIdx, int HeadersIdx,
+    int UserNameIdx)
 {
     /// <summary>
     ///     Sentinel indicating the column is not in the projected SELECT.
@@ -270,8 +278,9 @@ internal readonly record struct MetadataSlots(int CorrelationIdx, int CausationI
         var ordinal = 10;
         var correlation = options.EnableCorrelationId ? ordinal++ : Disabled;
         var causation = options.EnableCausationId ? ordinal++ : Disabled;
-        var headers = options.EnableHeaders ? ordinal : Disabled;
-        return new MetadataSlots(correlation, causation, headers);
+        var headers = options.EnableHeaders ? ordinal++ : Disabled;
+        var userName = options.EnableUserName ? ordinal : Disabled;
+        return new MetadataSlots(correlation, causation, headers, userName);
     }
 }
 

--- a/src/Polecat/Events/Schema/EventsTable.cs
+++ b/src/Polecat/Events/Schema/EventsTable.cs
@@ -88,6 +88,12 @@ internal class EventsTable : Table
             AddColumn("headers", events.JsonColumnType).AllowNulls();
         }
 
+        // #237: opt-in user / last-modified-by column, mirroring Marten's user_name.
+        if (events.EventOptions.EnableUserName)
+        {
+            AddColumn("user_name", "varchar(250)").AllowNulls();
+        }
+
         // Archive flag
         var archiveColumn = AddColumn("is_archived", "bit").NotNull().DefaultValue(0);
 

--- a/src/Polecat/Internal/DocumentSessionBase.cs
+++ b/src/Polecat/Internal/DocumentSessionBase.cs
@@ -776,6 +776,8 @@ internal abstract class DocumentSessionBase : QuerySession, IDocumentSession
             @event.CorrelationId = CorrelationId;
         if (CausationId != null && @event.CausationId == null)
             @event.CausationId = CausationId;
+        if (LastModifiedBy != null && @event.UserName == null)
+            @event.UserName = LastModifiedBy;
 
         var eventOptions = _eventGraph.EventOptions;
 
@@ -814,6 +816,12 @@ internal abstract class DocumentSessionBase : QuerySession, IDocumentSession
         {
             columns += ", headers";
             values += ", @headers";
+        }
+
+        if (eventOptions.EnableUserName)
+        {
+            columns += ", user_name";
+            values += ", @user_name";
         }
 
         await using var cmd = new SqlCommand();
@@ -910,6 +918,12 @@ internal abstract class DocumentSessionBase : QuerySession, IDocumentSession
                 : null;
             cmd.Parameters.AddWithValue("@headers",
                 (object?)headersJson ?? DBNull.Value);
+        }
+
+        if (eventOptions.EnableUserName)
+        {
+            cmd.Parameters.AddWithValue("@user_name",
+                (object?)@event.UserName ?? DBNull.Value);
         }
 
         var seqId = (long)(await ExecuteScalarAsync(cmd, token))!;

--- a/src/Polecat/StoreOptions.cs
+++ b/src/Polecat/StoreOptions.cs
@@ -382,6 +382,14 @@ public class EventStoreOptions : IEventStoreInstrumentation
     public bool EnableHeaders { get; set; }
 
     /// <summary>
+    ///     #237: enable tracking of the user / last-modified-by metadata on events, persisted to the
+    ///     opt-in <c>user_name</c> column (maps <see cref="JasperFx.Events.IEvent.UserName" />).
+    ///     Mirrors Marten's opt-in <c>user_name</c> event-metadata column. Populated from the
+    ///     session's <c>LastModifiedBy</c> when the event doesn't already carry one.
+    /// </summary>
+    public bool EnableUserName { get; set; }
+
+    /// <summary>
     ///     Run inline projections' RaiseSideEffects (and other projection side effects) when an inline
     ///     projection is applied during SaveChangesAsync. Off by default; mirrors Marten's
     ///     <c>StoreOptions.Events.EnableSideEffectsOnInlineProjections</c>. CritterWatch relies on this so


### PR DESCRIPTION
Closes #237.

## Summary
Polecat had opt-in `CorrelationId` / `CausationId` / `Headers` event metadata but no `UserName` / `LastModifiedBy` equivalent — the only event-metadata element where it was not at parity with Marten. This adds `EnableUserName`, mirroring the existing three flags end-to-end so CritterWatch's cross-engine event-query UI can offer "filter by user" as a universal facet.

## Changes
- `EventStoreOptions.EnableUserName` flag (off by default).
- Opt-in `user_name varchar(250)` column on `pc_events` (`EventsTable`).
- Append path writes `user_name`; `session.LastModifiedBy` is stamped onto each event's `UserName` when the event doesn't already carry one (event-level value wins, exactly like correlation/causation).
- `PcEventsRowReader` projects and reads `user_name` back onto `IEvent.UserName` (new `MetadataSlots.UserNameIdx`).
- Advertised on the event-store usage descriptor next to the existing three flags.

## Tests
Added to `event_metadata_tests`:
- session `LastModifiedBy` propagates to every event's `UserName`;
- event-level `UserName` takes precedence over the session;
- `null` when unset;
- the `user_name` column is **not** created when disabled (default);
- extended the combined "all metadata" test to include `user_name`.

All 321 Events tests pass locally on net10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)