### PR TITLE
feat: expose session-level Headers + SetHeader/GetHeader (#240)

### DIFF
--- a/src/Polecat.Tests/Events/event_metadata_tests.cs
+++ b/src/Polecat.Tests/Events/event_metadata_tests.cs
@@ -181,6 +181,73 @@ public class event_metadata_tests : OneOffConfigurationsContext
         events[0].Headers.ShouldBeNull();
     }
 
+    // ===== Session-level headers (#240) =====
+
+    [Fact]
+    public async Task session_headers_merge_onto_every_event()
+    {
+        await ConfigureAndApply(opts =>
+        {
+            opts.Events.EnableHeaders = true;
+        });
+
+        var streamId = Guid.NewGuid();
+
+        await using var session = theStore.LightweightSession();
+        session.SetHeader("request-id", "req-42");
+        session.SetHeader("user-agent", "tests");
+        session.Events.StartStream(streamId,
+            new QuestStarted("Session Headers"),
+            new MembersJoined(1, "Town", ["A"]));
+        await session.SaveChangesAsync();
+
+        await using var query = theStore.QuerySession();
+        var events = await query.Events.FetchStreamAsync(streamId);
+
+        events.Count.ShouldBe(2);
+        foreach (var @event in events)
+        {
+            @event.Headers.ShouldNotBeNull();
+            @event.GetHeader("request-id")!.ToString().ShouldBe("req-42");
+            @event.GetHeader("user-agent")!.ToString().ShouldBe("tests");
+        }
+    }
+
+    [Fact]
+    public async Task event_level_header_wins_over_session_header()
+    {
+        await ConfigureAndApply(opts =>
+        {
+            opts.Events.EnableHeaders = true;
+        });
+
+        var streamId = Guid.NewGuid();
+
+        await using var session = theStore.LightweightSession();
+        session.SetHeader("scope", "session");
+
+        var action = session.Events.StartStream(streamId, new QuestStarted("Override"));
+        action.Events[0].SetHeader("scope", "event"); // event-level value must win
+        await session.SaveChangesAsync();
+
+        await using var query = theStore.QuerySession();
+        var events = await query.Events.FetchStreamAsync(streamId);
+
+        events[0].GetHeader("scope")!.ToString().ShouldBe("event");
+    }
+
+    [Fact]
+    public async Task session_headers_are_null_until_set_and_round_trip_via_get()
+    {
+        await using var session = theStore.LightweightSession();
+        session.Headers.ShouldBeNull();
+        session.GetHeader("missing").ShouldBeNull();
+
+        session.SetHeader("k", "v");
+        session.Headers.ShouldNotBeNull();
+        session.GetHeader("k")!.ToString().ShouldBe("v");
+    }
+
     // ===== Sequence / version capture tests =====
 
     [Fact]

--- a/src/Polecat/IQuerySession.cs
+++ b/src/Polecat/IQuerySession.cs
@@ -37,6 +37,25 @@ public interface IQuerySession : IAsyncDisposable
     string? LastModifiedBy { get; set; }
 
     /// <summary>
+    ///     #240: session-level custom headers. Set once per unit of work via
+    ///     <see cref="SetHeader" /> and merged onto every event appended in the session (when
+    ///     <c>Events.EnableHeaders</c> is on), so a whole unit of work can be tagged in one place.
+    ///     Mirrors Marten's session <c>Headers</c>. <see langword="null" /> until the first
+    ///     <see cref="SetHeader" />.
+    /// </summary>
+    Dictionary<string, object>? Headers { get; }
+
+    /// <summary>
+    ///     Set a session-level header value. Mirrors Marten's <c>SetHeader</c>.
+    /// </summary>
+    void SetHeader(string key, object value);
+
+    /// <summary>
+    ///     Read a session-level header value, or <see langword="null" /> if not set.
+    /// </summary>
+    object? GetHeader(string key);
+
+    /// <summary>
     ///     The number of database requests executed by this session.
     /// </summary>
     int RequestCount { get; }

--- a/src/Polecat/Internal/DocumentSessionBase.cs
+++ b/src/Polecat/Internal/DocumentSessionBase.cs
@@ -777,6 +777,17 @@ internal abstract class DocumentSessionBase : QuerySession, IDocumentSession
         if (CausationId != null && @event.CausationId == null)
             @event.CausationId = CausationId;
 
+        // #240: merge session-level headers into the event. Event-level keys win, so TryAdd only
+        // fills keys the event didn't already set.
+        if (Headers is { Count: > 0 })
+        {
+            @event.Headers ??= new Dictionary<string, object>();
+            foreach (var header in Headers)
+            {
+                @event.Headers.TryAdd(header.Key, header.Value);
+            }
+        }
+
         var eventOptions = _eventGraph.EventOptions;
 
         // Build column and value lists dynamically based on enabled metadata

--- a/src/Polecat/Internal/NestedTenantSession.cs
+++ b/src/Polecat/Internal/NestedTenantSession.cs
@@ -39,6 +39,9 @@ internal class NestedTenantSession : ITenantOperations
     public string? CorrelationId { get => _parent.CorrelationId; set => _parent.CorrelationId = value; }
     public string? CausationId { get => _parent.CausationId; set => _parent.CausationId = value; }
     public string? LastModifiedBy { get => _parent.LastModifiedBy; set => _parent.LastModifiedBy = value; }
+    public Dictionary<string, object>? Headers => _parent.Headers;
+    public void SetHeader(string key, object value) => _parent.SetHeader(key, value);
+    public object? GetHeader(string key) => _parent.GetHeader(key);
     public int RequestCount => _parent.RequestCount;
     public IPolecatSessionLogger Logger { get => _parent.Logger; set => _parent.Logger = value; }
     public IAdvancedSql AdvancedSql => _parent.AdvancedSql;

--- a/src/Polecat/Internal/QuerySession.cs
+++ b/src/Polecat/Internal/QuerySession.cs
@@ -100,6 +100,26 @@ internal partial class QuerySession : IQuerySession
     public string? CorrelationId { get; set; }
     public string? CausationId { get; set; }
     public string? LastModifiedBy { get; set; }
+
+    // #240: session-level header bag, lazily created on first SetHeader.
+    public Dictionary<string, object>? Headers { get; private set; }
+
+    public void SetHeader(string key, object value)
+    {
+        Headers ??= new Dictionary<string, object>();
+        Headers[key] = value;
+    }
+
+    public object? GetHeader(string key)
+    {
+        if (Headers != null && Headers.TryGetValue(key, out var value))
+        {
+            return value;
+        }
+
+        return null;
+    }
+
     public int RequestCount { get; internal set; }
     public IPolecatSessionLogger Logger { get; set; }
 


### PR DESCRIPTION
Closes #240.

## Summary
Marten exposes session-level `Headers` + `SetHeader(key, value)`, letting an application tag a whole unit of work once and have it flow onto every event. Polecat had **no session-level header surface** — headers could only be set per-event on `@event.Headers`.

## Changes
- `IQuerySession.Headers` (get) + `SetHeader(string, object)` + `GetHeader(string)`, implemented on `QuerySession` with a lazily-created bag and delegated through `NestedTenantSession`.
- At append time, session headers are merged into each event's `Headers` using `TryAdd`, so **event-level keys win** — exactly like the existing correlation/causation stamping.

Persistence of the merged headers rides the existing `EnableHeaders` event column. Document-headers persistence is tracked separately in #241.

## Tests
Added to `event_metadata_tests`:
- session headers merge onto every appended event;
- an event-level header wins over a session header of the same key;
- `Headers` is null until the first `SetHeader`, and `GetHeader` round-trips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)