### PR TITLE
feat: auto-seed CorrelationId/CausationId from Activity.Current on session open (#239)

### DIFF
--- a/src/Polecat.Tests/Events/activity_correlation_tests.cs
+++ b/src/Polecat.Tests/Events/activity_correlation_tests.cs
@@ -1,0 +1,116 @@
+using System.Diagnostics;
+using Polecat.Tests.Harness;
+
+namespace Polecat.Tests.Events;
+
+/// <summary>
+/// #239: a session auto-seeds CorrelationId from Activity.Current.RootId and CausationId from
+/// Activity.Current.ParentId on open, so distributed-tracing context flows onto events with zero
+/// app code (mirrors Marten). An explicit caller value still wins.
+/// </summary>
+public class activity_correlation_tests : OneOffConfigurationsContext
+{
+    private async Task ConfigureAndApply(Action<StoreOptions> configure)
+    {
+        ConfigureStore(configure);
+        await theDatabase.ApplyAllConfiguredChangesToDatabaseAsync();
+    }
+
+    private static (Activity parent, Activity child) StartActivityScope()
+    {
+        Activity.DefaultIdFormat = ActivityIdFormat.W3C;
+        var parent = new Activity("parent").Start();
+        var child = new Activity("child").Start(); // child of parent → has a non-null ParentId
+        return (parent, child);
+    }
+
+    [Fact]
+    public async Task session_seeds_correlation_and_causation_from_activity()
+    {
+        await ConfigureAndApply(_ => { });
+
+        var (parent, child) = StartActivityScope();
+        try
+        {
+            await using var session = theStore.LightweightSession();
+            session.CorrelationId.ShouldBe(child.RootId);
+            session.CausationId.ShouldBe(child.ParentId);
+        }
+        finally
+        {
+            child.Stop();
+            parent.Stop();
+        }
+    }
+
+    [Fact]
+    public async Task events_appended_in_activity_scope_carry_root_and_parent_ids()
+    {
+        await ConfigureAndApply(opts =>
+        {
+            opts.Events.EnableCorrelationId = true;
+            opts.Events.EnableCausationId = true;
+        });
+
+        var (parent, child) = StartActivityScope();
+        var streamId = Guid.NewGuid();
+        try
+        {
+            await using var session = theStore.LightweightSession();
+            session.Events.StartStream(streamId, new QuestStarted("Traced Quest"));
+            await session.SaveChangesAsync();
+        }
+        finally
+        {
+            child.Stop();
+            parent.Stop();
+        }
+
+        await using var query = theStore.QuerySession();
+        var events = await query.Events.FetchStreamAsync(streamId);
+
+        events.Count.ShouldBe(1);
+        events[0].CorrelationId.ShouldBe(child.RootId);
+        events[0].CausationId.ShouldBe(child.ParentId);
+    }
+
+    [Fact]
+    public async Task explicit_caller_value_wins_over_activity()
+    {
+        await ConfigureAndApply(_ => { });
+
+        var (parent, child) = StartActivityScope();
+        try
+        {
+            await using var session = theStore.LightweightSession();
+            session.CorrelationId = "explicit-corr";
+            session.CorrelationId.ShouldBe("explicit-corr");
+            session.CorrelationId.ShouldNotBe(child.RootId);
+        }
+        finally
+        {
+            child.Stop();
+            parent.Stop();
+        }
+    }
+
+    [Fact]
+    public async Task no_activity_leaves_correlation_null()
+    {
+        await ConfigureAndApply(_ => { });
+
+        // Ensure no ambient activity for this test.
+        var saved = Activity.Current;
+        Activity.Current = null;
+        try
+        {
+            await using var session = theStore.LightweightSession();
+            session.CorrelationId.ShouldBeNull();
+            session.CausationId.ShouldBeNull();
+        }
+        finally
+        {
+            Activity.Current = saved;
+        }
+    }
+}

--- a/src/Polecat/Internal/QuerySession.cs
+++ b/src/Polecat/Internal/QuerySession.cs
@@ -1,4 +1,5 @@
 using System.Data.Common;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using JasperFx;
 using Microsoft.Data.SqlClient;
@@ -91,6 +92,13 @@ internal partial class QuerySession : IQuerySession
         _tableEnsurer = tableEnsurer;
         _eventGraph = eventGraph;
         Logger = options.Logger.StartSession(this);
+
+        // #239: seed correlation/causation from the ambient Activity so distributed-tracing context
+        // flows onto events (and metadata columns) with zero app code, mirroring Marten's
+        // DocumentStore session wiring. A caller can still override either after construction; the
+        // ??= leaves any pre-seeded value untouched.
+        CorrelationId ??= Activity.Current?.RootId;
+        CausationId ??= Activity.Current?.ParentId;
     }
 
     internal StoreOptions Options { get; }


### PR DESCRIPTION
Closes #239.

## Summary
Marten auto-populates `session.CorrelationId` / `CausationId` from `Activity.Current` when a session opens, so distributed-tracing context flows onto events (and the opt-in `correlation_id` / `causation_id` columns) with zero app code. Polecat left them `null`, so those columns were empty in practice for most callers.

## Fix
Seed them in the `QuerySession` constructor (the single path both lightweight and identity-map sessions route through):

```csharp
CorrelationId ??= Activity.Current?.RootId;
CausationId  ??= Activity.Current?.ParentId;
```

The `??=` respects an explicit caller-set value.

## Tests
`activity_correlation_tests`:
- a session opened inside an `Activity` scope seeds `CorrelationId == Activity.RootId` and `CausationId == Activity.ParentId`;
- an event appended in that scope carries those ids end-to-end (with the columns enabled);
- an explicit caller value wins over the activity;
- no ambient activity leaves them `null`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)