### PR TITLE
feat: add Schema.For<T>().Metadata(m => ...) DSL + metadata attributes (#243)

### DIFF
--- a/src/Polecat.Tests/Storage/metadata_dsl_tests.cs
+++ b/src/Polecat.Tests/Storage/metadata_dsl_tests.cs
@@ -1,0 +1,119 @@
+using Polecat.Attributes;
+using Polecat.Storage;
+using Polecat.TestUtils;
+using Shouldly;
+
+namespace Polecat.Tests.Storage;
+
+/// <summary>
+/// #243: the document metadata DSL — Schema.For&lt;T&gt;().Metadata(m => ...) with Enabled + MapTo,
+/// plus metadata attributes. This issue adds the configuration surface (the columns issue #241 and
+/// the read API #242 consume it); these tests assert the config is captured correctly.
+/// </summary>
+public class metadata_dsl_tests
+{
+    public class PlainDoc
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+    }
+
+    public class MappedDoc
+    {
+        public Guid Id { get; set; }
+        public DateTimeOffset CreatedDate { get; set; }
+        public string? ModifiedBy { get; set; }
+    }
+
+    public class AttributedDoc
+    {
+        public Guid Id { get; set; }
+
+        [LastModifiedByMetadata]
+        public string? ModifiedByUser { get; set; }
+
+        [CreatedAtMetadata]
+        public DateTimeOffset WhenCreated { get; set; }
+
+        [CorrelationIdMetadata]
+        public string? Correlation { get; set; }
+    }
+
+    [Fact]
+    public void dsl_enables_optin_columns()
+    {
+        var expr = new DocumentMappingExpression<PlainDoc>();
+        expr.Metadata(m =>
+        {
+            m.CorrelationId.Enabled = true;
+            m.CausationId.Enabled = true;
+            m.LastModifiedBy.Enabled = true;
+            m.Headers.Enabled = true;
+        });
+
+        expr.MetadataConfig.CorrelationId.Enabled.ShouldBeTrue();
+        expr.MetadataConfig.CausationId.Enabled.ShouldBeTrue();
+        expr.MetadataConfig.LastModifiedBy.Enabled.ShouldBeTrue();
+        expr.MetadataConfig.Headers.Enabled.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void dsl_mapto_resolves_member_and_enables_column()
+    {
+        var expr = new DocumentMappingExpression<MappedDoc>();
+        expr.Metadata(m =>
+        {
+            m.CreatedAt.MapTo(x => x.CreatedDate);
+            m.LastModifiedBy.MapTo(x => x.ModifiedBy);
+        });
+
+        expr.MetadataConfig.CreatedAt.Member!.Name.ShouldBe(nameof(MappedDoc.CreatedDate));
+        expr.MetadataConfig.LastModifiedBy.Member!.Name.ShouldBe(nameof(MappedDoc.ModifiedBy));
+        expr.MetadataConfig.LastModifiedBy.Enabled.ShouldBeTrue(); // MapTo implies Enabled
+    }
+
+    [Fact]
+    public void attributes_enable_and_map_columns()
+    {
+        var mapping = new DocumentMapping(typeof(AttributedDoc), new StoreOptions());
+
+        mapping.Metadata.LastModifiedBy.Enabled.ShouldBeTrue();
+        mapping.Metadata.LastModifiedBy.Member!.Name.ShouldBe(nameof(AttributedDoc.ModifiedByUser));
+
+        mapping.Metadata.CreatedAt.Member!.Name.ShouldBe(nameof(AttributedDoc.WhenCreated));
+
+        mapping.Metadata.CorrelationId.Enabled.ShouldBeTrue();
+        mapping.Metadata.CorrelationId.Member!.Name.ShouldBe(nameof(AttributedDoc.Correlation));
+    }
+
+    [Fact]
+    public void default_optin_columns_disabled()
+    {
+        var mapping = new DocumentMapping(typeof(PlainDoc), new StoreOptions());
+
+        mapping.Metadata.CorrelationId.Enabled.ShouldBeFalse();
+        mapping.Metadata.CausationId.Enabled.ShouldBeFalse();
+        mapping.Metadata.LastModifiedBy.Enabled.ShouldBeFalse();
+        mapping.Metadata.Headers.Enabled.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void dsl_config_merges_onto_mapping_through_the_store()
+    {
+        using var store = DocumentStore.For(opts =>
+        {
+            opts.ConnectionString = ConnectionSource.ConnectionString;
+            opts.Schema.For<MappedDoc>().Metadata(m =>
+            {
+                m.CorrelationId.Enabled = true;
+                m.LastModifiedBy.MapTo(x => x.ModifiedBy);
+            });
+        });
+
+        var mapping = store.GetProvider(typeof(MappedDoc)).Mapping;
+
+        mapping.Metadata.CorrelationId.Enabled.ShouldBeTrue();
+        mapping.Metadata.LastModifiedBy.Enabled.ShouldBeTrue();
+        mapping.Metadata.LastModifiedBy.Member!.Name.ShouldBe(nameof(MappedDoc.ModifiedBy));
+    }
+}

--- a/src/Polecat/Attributes/MetadataAttributes.cs
+++ b/src/Polecat/Attributes/MetadataAttributes.cs
@@ -1,0 +1,85 @@
+using System.Reflection;
+using Polecat.Storage;
+using Polecat.Storage.Metadata;
+
+namespace Polecat.Attributes;
+
+/// <summary>
+///     #243: base class for attributes that map a stored document-metadata value onto a document
+///     member (and enable the corresponding column). Mirrors Marten's metadata attributes
+///     (<c>[CorrelationIdMetadata]</c>, <c>[LastModifiedMetadata]</c>, …).
+/// </summary>
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
+public abstract class MetadataAttribute : Attribute
+{
+    /// <summary>
+    ///     Select the metadata column this member maps to, then assign the member and enable it.
+    /// </summary>
+    internal abstract void Apply(DocumentMetadataConfig config, MemberInfo member);
+
+    protected static void Map(MetadataColumn column, MemberInfo member)
+    {
+        column.Member = member;
+        column.Enabled = true;
+    }
+}
+
+/// <summary>Maps the stored correlation id onto this member (and enables the <c>correlation_id</c> column).</summary>
+public sealed class CorrelationIdMetadataAttribute : MetadataAttribute
+{
+    internal override void Apply(DocumentMetadataConfig config, MemberInfo member) => Map(config.CorrelationId, member);
+}
+
+/// <summary>Maps the stored causation id onto this member (and enables the <c>causation_id</c> column).</summary>
+public sealed class CausationIdMetadataAttribute : MetadataAttribute
+{
+    internal override void Apply(DocumentMetadataConfig config, MemberInfo member) => Map(config.CausationId, member);
+}
+
+/// <summary>Maps the stored user / last-modified-by onto this member (and enables the <c>last_modified_by</c> column).</summary>
+public sealed class LastModifiedByMetadataAttribute : MetadataAttribute
+{
+    internal override void Apply(DocumentMetadataConfig config, MemberInfo member) => Map(config.LastModifiedBy, member);
+}
+
+/// <summary>Maps the stored headers onto this member (and enables the <c>headers</c> column).</summary>
+public sealed class HeadersMetadataAttribute : MetadataAttribute
+{
+    internal override void Apply(DocumentMetadataConfig config, MemberInfo member) => Map(config.Headers, member);
+}
+
+/// <summary>Maps the <c>created_at</c> timestamp onto this member.</summary>
+public sealed class CreatedAtMetadataAttribute : MetadataAttribute
+{
+    internal override void Apply(DocumentMetadataConfig config, MemberInfo member) => Map(config.CreatedAt, member);
+}
+
+/// <summary>Maps the <c>last_modified</c> timestamp onto this member.</summary>
+public sealed class LastModifiedMetadataAttribute : MetadataAttribute
+{
+    internal override void Apply(DocumentMetadataConfig config, MemberInfo member) => Map(config.LastModified, member);
+}
+
+/// <summary>Maps the <c>version</c> onto this member.</summary>
+public sealed class VersionMetadataAttribute : MetadataAttribute
+{
+    internal override void Apply(DocumentMetadataConfig config, MemberInfo member) => Map(config.Version, member);
+}
+
+/// <summary>Maps the <c>tenant_id</c> onto this member.</summary>
+public sealed class TenantIdMetadataAttribute : MetadataAttribute
+{
+    internal override void Apply(DocumentMetadataConfig config, MemberInfo member) => Map(config.TenantId, member);
+}
+
+/// <summary>Maps the <c>is_deleted</c> soft-delete flag onto this member.</summary>
+public sealed class IsSoftDeletedMetadataAttribute : MetadataAttribute
+{
+    internal override void Apply(DocumentMetadataConfig config, MemberInfo member) => Map(config.IsSoftDeleted, member);
+}
+
+/// <summary>Maps the <c>dotnet_type</c> discriminator onto this member.</summary>
+public sealed class DotNetTypeMetadataAttribute : MetadataAttribute
+{
+    internal override void Apply(DocumentMetadataConfig config, MemberInfo member) => Map(config.DotNetType, member);
+}

--- a/src/Polecat/Internal/DocumentProviderRegistry.cs
+++ b/src/Polecat/Internal/DocumentProviderRegistry.cs
@@ -123,6 +123,13 @@ internal class DocumentProviderRegistry
             {
                 mapping.Partitioning = partitioning;
             }
+
+            // #243: apply the fluent .Metadata(...) DSL config over the attribute-derived config.
+            var metadataField = exprType.GetField("MetadataConfig", BindingFlags.NonPublic | BindingFlags.Instance);
+            if (metadataField?.GetValue(expr) is Storage.Metadata.DocumentMetadataConfig metadataConfig)
+            {
+                mapping.Metadata.MergeFrom(metadataConfig);
+            }
         }
     }
 

--- a/src/Polecat/Storage/DocumentMapping.cs
+++ b/src/Polecat/Storage/DocumentMapping.cs
@@ -5,6 +5,7 @@ using JasperFx.Core.Reflection;
 using Polecat.Attributes;
 using Polecat.Metadata;
 using Polecat.Schema.Identity.Sequences;
+using Polecat.Storage.Metadata;
 
 namespace Polecat.Storage;
 
@@ -73,6 +74,9 @@ internal class DocumentMapping
 
         // Discover and register attribute-based indexes
         DiscoverIndexAttributes(documentType);
+
+        // #243: discover attribute-based document metadata mappings ([CorrelationIdMetadata], etc.)
+        DiscoverMetadataAttributes(documentType);
 
         // Detect soft delete: [SoftDeleted] attribute, ISoftDeleted interface, or policy
         if (documentType.GetCustomAttribute<SoftDeletedAttribute>() != null
@@ -178,6 +182,12 @@ internal class DocumentMapping
     ///     Custom indexes configured for this document type.
     /// </summary>
     public List<DocumentIndex> Indexes { get; } = new();
+
+    /// <summary>
+    ///     #243: document metadata configuration (opt-in columns + member mappings), populated from
+    ///     metadata attributes and the <c>Schema.For&lt;T&gt;().Metadata(...)</c> DSL.
+    /// </summary>
+    public DocumentMetadataConfig Metadata { get; } = new();
 
     /// <summary>
     ///     Foreign key constraints configured for this document type.
@@ -352,6 +362,25 @@ internal class DocumentMapping
     {
         var underlying = Nullable.GetUnderlyingType(candidate) ?? candidate;
         return SupportedIdTypes.Contains(underlying) || TryResolveValueTypeId(underlying) != null;
+    }
+
+    /// <summary>
+    ///     #243: scans the document type for metadata attributes ([CorrelationIdMetadata], etc.) and
+    ///     enables + maps the corresponding metadata columns.
+    /// </summary>
+    private void DiscoverMetadataAttributes(Type documentType)
+    {
+        var members = documentType.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Cast<MemberInfo>()
+            .Concat(documentType.GetFields(BindingFlags.Public | BindingFlags.Instance));
+
+        foreach (var member in members)
+        {
+            foreach (var attr in member.GetCustomAttributes<MetadataAttribute>())
+            {
+                attr.Apply(Metadata, member);
+            }
+        }
     }
 
     /// <summary>

--- a/src/Polecat/Storage/DocumentMappingExpression.cs
+++ b/src/Polecat/Storage/DocumentMappingExpression.cs
@@ -16,6 +16,18 @@ public class DocumentMappingExpression<T>
     internal readonly List<DocumentIndex> Indexes = new();
     internal readonly List<DocumentForeignKey> ForeignKeys = new();
     internal DocumentPartitioning? Partitioning;
+    internal readonly Metadata.DocumentMetadataConfig MetadataConfig = new();
+
+    /// <summary>
+    ///     #243: configure document metadata columns — enable opt-in columns
+    ///     (correlation/causation/last-modified-by/headers) and/or map any stored metadata value
+    ///     onto a document member. Mirrors Marten's <c>Schema.For&lt;T&gt;().Metadata(m =&gt; ...)</c>.
+    /// </summary>
+    public DocumentMappingExpression<T> Metadata(Action<Metadata.MetadataConfig<T>> configure)
+    {
+        configure(new Metadata.MetadataConfig<T>(MetadataConfig));
+        return this;
+    }
 
     /// <summary>
     ///     Register a subclass of T for document hierarchy (single-table inheritance).

--- a/src/Polecat/Storage/Metadata/DocumentMetadataConfig.cs
+++ b/src/Polecat/Storage/Metadata/DocumentMetadataConfig.cs
@@ -1,0 +1,85 @@
+namespace Polecat.Storage.Metadata;
+
+/// <summary>
+///     #243: per-document metadata configuration. Mirrors Marten's <c>DocumentMetadataCollection</c>
+///     — the set of metadata columns a document type can opt into and optionally map onto its own
+///     members. Lives on <see cref="DocumentMapping" />; populated from metadata attributes and the
+///     fluent <c>Schema.For&lt;T&gt;().Metadata(...)</c> DSL.
+/// </summary>
+public class DocumentMetadataConfig
+{
+    /// <summary>Stored correlation id (opt-in column, #241).</summary>
+    public MetadataColumn CorrelationId { get; } = new("correlation_id");
+
+    /// <summary>Stored causation id (opt-in column, #241).</summary>
+    public MetadataColumn CausationId { get; } = new("causation_id");
+
+    /// <summary>Stored user / last-modified-by (opt-in column, #241).</summary>
+    public MetadataColumn LastModifiedBy { get; } = new("last_modified_by");
+
+    /// <summary>Stored custom headers (opt-in column, #241).</summary>
+    public MetadataColumn Headers { get; } = new("headers");
+
+    /// <summary>The always-present <c>created_at</c> column; <see cref="MetadataColumn.Member" /> maps it onto a document member.</summary>
+    public MetadataColumn CreatedAt { get; } = new("created_at") { Enabled = true };
+
+    /// <summary>The always-present <c>last_modified</c> column; <see cref="MetadataColumn.Member" /> maps it onto a document member.</summary>
+    public MetadataColumn LastModified { get; } = new("last_modified") { Enabled = true };
+
+    /// <summary>The always-present <c>version</c> column; <see cref="MetadataColumn.Member" /> maps it onto a document member.</summary>
+    public MetadataColumn Version { get; } = new("version") { Enabled = true };
+
+    /// <summary>The always-present <c>tenant_id</c> column; <see cref="MetadataColumn.Member" /> maps it onto a document member.</summary>
+    public MetadataColumn TenantId { get; } = new("tenant_id") { Enabled = true };
+
+    /// <summary>The <c>is_deleted</c> soft-delete flag; <see cref="MetadataColumn.Member" /> maps it onto a document member.</summary>
+    public MetadataColumn IsSoftDeleted { get; } = new("is_deleted");
+
+    /// <summary>The always-present <c>dotnet_type</c> column; <see cref="MetadataColumn.Member" /> maps it onto a document member.</summary>
+    public MetadataColumn DotNetType { get; } = new("dotnet_type") { Enabled = true };
+
+    /// <summary>
+    ///     Every metadata column in a stable order.
+    /// </summary>
+    public IEnumerable<MetadataColumn> AllColumns()
+    {
+        yield return CorrelationId;
+        yield return CausationId;
+        yield return LastModifiedBy;
+        yield return Headers;
+        yield return CreatedAt;
+        yield return LastModified;
+        yield return Version;
+        yield return TenantId;
+        yield return IsSoftDeleted;
+        yield return DotNetType;
+    }
+
+    /// <summary>
+    ///     The opt-in columns Polecat actually adds to document tables (#241). The remaining columns
+    ///     are either always present (<c>created_at</c>/<c>last_modified</c>/<c>version</c>/
+    ///     <c>tenant_id</c>/<c>dotnet_type</c>) or governed by their own feature (<c>is_deleted</c>).
+    /// </summary>
+    public IEnumerable<MetadataColumn> OptInColumns()
+    {
+        yield return CorrelationId;
+        yield return CausationId;
+        yield return LastModifiedBy;
+        yield return Headers;
+    }
+
+    /// <summary>
+    ///     Merge another config into this one (the DSL config layered over attribute-derived config):
+    ///     enables any column the other enabled and copies any member mapping it set.
+    /// </summary>
+    internal void MergeFrom(DocumentMetadataConfig other)
+    {
+        using var mine = AllColumns().GetEnumerator();
+        using var theirs = other.AllColumns().GetEnumerator();
+        while (mine.MoveNext() && theirs.MoveNext())
+        {
+            if (theirs.Current.Enabled) mine.Current.Enabled = true;
+            if (theirs.Current.Member != null) mine.Current.Member = theirs.Current.Member;
+        }
+    }
+}

--- a/src/Polecat/Storage/Metadata/MetadataColumn.cs
+++ b/src/Polecat/Storage/Metadata/MetadataColumn.cs
@@ -1,0 +1,32 @@
+using System.Reflection;
+
+namespace Polecat.Storage.Metadata;
+
+/// <summary>
+///     #243: configuration for a single document metadata column. Mirrors Marten's
+///     <c>MetadataColumn</c>. Carries whether the column is enabled (persisted) and an optional
+///     document member the stored value is projected onto when a document is loaded.
+/// </summary>
+public class MetadataColumn
+{
+    public MetadataColumn(string name)
+    {
+        Name = name;
+    }
+
+    /// <summary>
+    ///     The SQL column name (e.g. <c>correlation_id</c>).
+    /// </summary>
+    public string Name { get; }
+
+    /// <summary>
+    ///     Whether this metadata column is persisted for the document type.
+    /// </summary>
+    public bool Enabled { get; set; }
+
+    /// <summary>
+    ///     Optional document member the stored value is mapped to/from. When set, loading a document
+    ///     projects the column value onto this member.
+    /// </summary>
+    public MemberInfo? Member { get; set; }
+}

--- a/src/Polecat/Storage/Metadata/MetadataConfig.cs
+++ b/src/Polecat/Storage/Metadata/MetadataConfig.cs
@@ -1,0 +1,90 @@
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Polecat.Storage.Metadata;
+
+/// <summary>
+///     #243: fluent accessor for one metadata column inside the
+///     <c>Schema.For&lt;T&gt;().Metadata(m => ...)</c> DSL. Mirrors Marten's per-column metadata
+///     surface: toggle <see cref="Enabled" /> and/or <see cref="MapTo" /> a document member.
+/// </summary>
+public class MetadataColumnExpression<T>
+{
+    private readonly MetadataColumn _column;
+
+    internal MetadataColumnExpression(MetadataColumn column)
+    {
+        _column = column;
+    }
+
+    /// <summary>
+    ///     Whether this metadata column is persisted for <typeparamref name="T" />.
+    /// </summary>
+    public bool Enabled
+    {
+        get => _column.Enabled;
+        set => _column.Enabled = value;
+    }
+
+    /// <summary>
+    ///     Map the stored metadata value onto a member of the document, and enable the column.
+    ///     Mirrors Marten's <c>MapTo(x => x.Member)</c>.
+    /// </summary>
+    public MetadataColumnExpression<T> MapTo(Expression<Func<T, object?>> member)
+    {
+        _column.Member = MetadataMemberResolver.Resolve(member);
+        _column.Enabled = true;
+        return this;
+    }
+}
+
+/// <summary>
+///     #243: the object passed to <c>Schema.For&lt;T&gt;().Metadata(m => ...)</c>. Exposes each
+///     metadata column as a <see cref="MetadataColumnExpression{T}" /> over a shared
+///     <see cref="DocumentMetadataConfig" />. Mirrors Marten's <c>MetadataConfig</c>.
+/// </summary>
+public class MetadataConfig<T>
+{
+    private readonly DocumentMetadataConfig _config;
+
+    internal MetadataConfig(DocumentMetadataConfig config)
+    {
+        _config = config;
+    }
+
+    public MetadataColumnExpression<T> CorrelationId => new(_config.CorrelationId);
+    public MetadataColumnExpression<T> CausationId => new(_config.CausationId);
+    public MetadataColumnExpression<T> LastModifiedBy => new(_config.LastModifiedBy);
+    public MetadataColumnExpression<T> Headers => new(_config.Headers);
+    public MetadataColumnExpression<T> CreatedAt => new(_config.CreatedAt);
+    public MetadataColumnExpression<T> LastModified => new(_config.LastModified);
+    public MetadataColumnExpression<T> Version => new(_config.Version);
+    public MetadataColumnExpression<T> TenantId => new(_config.TenantId);
+    public MetadataColumnExpression<T> IsSoftDeleted => new(_config.IsSoftDeleted);
+    public MetadataColumnExpression<T> DotNetType => new(_config.DotNetType);
+}
+
+/// <summary>
+///     Resolves a <c>x =&gt; x.Member</c> lambda (optionally wrapped in a Convert for value types)
+///     to the underlying <see cref="MemberInfo" />.
+/// </summary>
+internal static class MetadataMemberResolver
+{
+    public static MemberInfo Resolve<T>(Expression<Func<T, object?>> expression)
+    {
+        var body = expression.Body;
+        if (body is UnaryExpression { NodeType: ExpressionType.Convert } unary)
+        {
+            body = unary.Operand;
+        }
+
+        if (body is MemberExpression member)
+        {
+            return member.Member;
+        }
+
+        throw new ArgumentException(
+            $"Expression '{expression}' is not a supported metadata member mapping. " +
+            "Use a single property (x => x.Member).");
+    }
+}


### PR DESCRIPTION
Closes #243.

## Summary
Introduces the document-metadata **configuration surface**, mirroring Marten's `DocumentMetadataCollection` + `.Metadata(m => ...)` DSL + metadata attributes. This is the enable-surface the other two document-metadata issues consume — the columns (#241) and the read API (#242).

## What's here
- `MetadataColumn` + `DocumentMetadataConfig` — per-document config (each column has `Enabled` + an optional `MapTo` member), exposed on `DocumentMapping.Metadata`.
- `MetadataConfig<T>` + `MetadataColumnExpression<T>` — the fluent DSL: `m.LastModifiedBy.Enabled = true; m.CreatedAt.MapTo(x => x.CreatedDate);`. Surfaced via `DocumentMappingExpression<T>.Metadata(Action<MetadataConfig<T>>)`.
- Metadata attributes: `[CorrelationIdMetadata]`, `[CausationIdMetadata]`, `[LastModifiedByMetadata]`, `[HeadersMetadata]`, `[CreatedAtMetadata]`, `[LastModifiedMetadata]`, `[VersionMetadata]`, `[TenantIdMetadata]`, `[IsSoftDeletedMetadata]`, `[DotNetTypeMetadata]` — scanned in the `DocumentMapping` constructor.
- DSL config is merged **over** attribute-derived config in `DocumentProviderRegistry` (same reflection-apply path as indexes/foreign-keys/partitioning).

## Scope
This PR only **captures** configuration — no column persistence or load-path mapping yet. Persisting the opt-in `correlation_id`/`causation_id`/`last_modified_by`/`headers` columns lands in #241, and `MetadataForAsync` in #242, both consuming this config. The DSL/attributes are inert until then, so this is a safe, additive base.

## Tests
`metadata_dsl_tests` (unit): DSL enables opt-in columns; `MapTo` resolves the member and enables the column; attributes enable + map; opt-in columns default to disabled; and the DSL config merges onto the mapping end-to-end through a store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)