### PR TITLE
feat: metadata capabilities + IEventStore bridge (#3219) + tenant-scoped document diagnostics (4.7.0-alpha.1)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>4.6.0</Version>
+        <Version>4.7.0-alpha.1</Version>
         <LangVersion>latest</LangVersion>
         <Authors>Jeremy D. Miller</Authors>
         <PackageIcon>logo.png</PackageIcon>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,8 +22,8 @@
              IEventDatabase.QueryDeadLetterEventsAsync (dead-letter row drill-in), DeadLetterEvent.TenantId,
              and the tenant-aware daemon surface. Polecat implements the dead-letter row query + per-tenant
              FetchDeadLetterCountsAsync below. -->
-        <PackageVersion Include="JasperFx" Version="2.16.0" />
-        <PackageVersion Include="JasperFx.Events" Version="2.16.0" />
+        <PackageVersion Include="JasperFx" Version="2.17.0" />
+        <PackageVersion Include="JasperFx.Events" Version="2.17.0" />
         <!-- Pin the sibling JasperFx packages for parity with Marten 9's matrix
              even though Polecat doesn't currently reference them directly —
              keeps the lockstep matrix coherent when transitive resolution
@@ -31,7 +31,7 @@
              RuntimeCompiler 5.x line is the active continuation of the 4.x
              lineage; do not pin against the parallel stale 2.0.x series. -->
         <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.16.0" />
+        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.17.0" />
         <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
@@ -57,7 +57,7 @@
         <PackageVersion Include="StronglyTypedId" Version="1.0.0-beta08" />
 
         <!-- Source generators (matched to JasperFx.Events above) -->
-        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.16.0" />
+        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.17.0" />
 
         <!-- Build automation -->
         <PackageVersion Include="Nuke.Common" Version="9.0.4" />

--- a/src/Polecat/DocumentStore.DocumentDiagnostics.cs
+++ b/src/Polecat/DocumentStore.DocumentDiagnostics.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using JasperFx.Core.Reflection;
 using JasperFx.Documents;
+using JasperFx.MultiTenancy;
 using Microsoft.Data.SqlClient;
 
 namespace Polecat;
@@ -43,11 +44,19 @@ public partial class DocumentStore : IDocumentStoreDiagnostics
         }
 
         var table = mapping.QualifiedTableName;
-        var where = options.IdEquals != null ? " where cast(id as nvarchar(max)) = @id" : "";
 
         var pageNumber = Math.Max(1, options.PageNumber);
         var pageSize = Math.Max(1, options.PageSize);
         var offset = (pageNumber - 1) * pageSize;
+
+        // Tenant scoping (#475 / EVENT_STORE_EXPLORER_PLAN §3.1): Polecat is a
+        // single-database store, so a tenant id filters the conjoined tenant_id column.
+        var filterByTenant = options.TenantId != null && mapping.TenancyStyle == TenancyStyle.Conjoined;
+
+        var conditions = new List<string>();
+        if (options.IdEquals != null) conditions.Add("cast(id as nvarchar(max)) = @id");
+        if (filterByTenant) conditions.Add("tenant_id = @tenant");
+        var where = conditions.Count > 0 ? " where " + string.Join(" and ", conditions) : "";
 
         await using var conn = new SqlConnection(Database.ConnectionString);
         await conn.OpenAsync(token).ConfigureAwait(false);
@@ -59,6 +68,10 @@ public partial class DocumentStore : IDocumentStoreDiagnostics
             if (options.IdEquals != null)
             {
                 countCmd.Parameters.AddWithValue("@id", options.IdEquals);
+            }
+            if (filterByTenant)
+            {
+                countCmd.Parameters.AddWithValue("@tenant", options.TenantId!);
             }
 
             total = Convert.ToInt64(await countCmd.ExecuteScalarAsync(token).ConfigureAwait(false));
@@ -75,6 +88,10 @@ public partial class DocumentStore : IDocumentStoreDiagnostics
             if (options.IdEquals != null)
             {
                 cmd.Parameters.AddWithValue("@id", options.IdEquals);
+            }
+            if (filterByTenant)
+            {
+                cmd.Parameters.AddWithValue("@tenant", options.TenantId!);
             }
 
             await using var reader = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false);

--- a/src/Polecat/DocumentStore.DocumentStoreUsage.cs
+++ b/src/Polecat/DocumentStore.DocumentStoreUsage.cs
@@ -116,6 +116,21 @@ public partial class DocumentStore : IDocumentStoreUsageSource
             Options.HiloSequenceDefaults.MaxAdvanceToNextHiAttempts);
         usage.AddValue(nameof(Options.UseNativeJsonType), Options.UseNativeJsonType);
 
+        // jasperfx#475 — advertise which document metadata Polecat captures so
+        // store-aware consumers (CritterWatch) gate document-query facets by what is
+        // actually persisted. Version / last-modified / tenant / soft-delete are
+        // universal facets in Polecat and keep the descriptor's default of true; the
+        // opt-in columns (correlation/causation/last-modified-by) are only queryable
+        // where some document mapping has enabled them.
+        var mappings = Options.Providers.AllProviders.Select(p => p.Mapping).ToList();
+        usage.DocumentMetadata = new DocumentMetadataCapabilities
+        {
+            StoreType = "Polecat",
+            CorrelationId = mappings.Any(m => m.Metadata.CorrelationId.Enabled),
+            CausationId = mappings.Any(m => m.Metadata.CausationId.Enabled),
+            LastModifiedBy = mappings.Any(m => m.Metadata.LastModifiedBy.Enabled)
+        };
+
         return Task.FromResult<DocumentStoreUsage?>(usage);
     }
 

--- a/src/Polecat/DocumentStore.EventStore.cs
+++ b/src/Polecat/DocumentStore.EventStore.cs
@@ -279,6 +279,20 @@ public partial class DocumentStore : IEventStore<IDocumentSession, IQuerySession
             usage.MaxEventSequence = null;
         }
 
+        // jasperfx#475 — advertise which event/stream metadata Polecat captures so
+        // store-aware consumers (CritterWatch) gate query facets by what is actually
+        // persisted. The event flags are opt-in columns mapping straight off the
+        // event options (UserName landed in polecat#237); stream facets are universal
+        // in Polecat and keep the EventMetadataCapabilities defaults of true.
+        usage.EventMetadata = new EventMetadataCapabilities
+        {
+            StoreType = "Polecat",
+            CorrelationId = Options.Events.EnableCorrelationId,
+            CausationId = Options.Events.EnableCausationId,
+            Headers = Options.Events.EnableHeaders,
+            UserName = Options.Events.EnableUserName
+        };
+
         Options.Projections.Describe(usage, this);
         return usage;
     }

--- a/src/Polecat/PolecatServiceCollectionExtensions.cs
+++ b/src/Polecat/PolecatServiceCollectionExtensions.cs
@@ -98,6 +98,15 @@ public static class PolecatServiceCollectionExtensions
         // bridge for IEventStore.
         services.AddSingleton<JasperFx.Events.IDocumentStoreUsageSource>(sp =>
             sp.GetRequiredService<IDocumentStore>());
+
+        // wolverine#3219 — and the event-store side of the same bridge. Wolverine's
+        // ServiceCapabilities.readEventStores discovers stores via
+        // GetServices<JasperFx.Events.IEventStore>(); without this the Polecat store
+        // (which implements IEventStore) is invisible to CritterWatch's event-store
+        // surfaces, so its event metadata / projections never reach the dashboard.
+        // Marten registers IEventStore in its core DI; this brings Polecat to parity.
+        services.AddSingleton<JasperFx.Events.IEventStore>(sp =>
+            (JasperFx.Events.IEventStore)sp.GetRequiredService<IDocumentStore>());
         services.AddSingleton<JasperFx.Documents.IDocumentStoreDiagnostics>(sp =>
             (JasperFx.Documents.IDocumentStoreDiagnostics)sp.GetRequiredService<IDocumentStore>());
 


### PR DESCRIPTION
Implements the JasperFx 2.17.0 monitoring-descriptor surfaces for store-aware consoles (CritterWatch). Part of the Event Store / Document Store Explorer work.

## Changes
- Populate `EventStoreUsage.EventMetadata` (correlation/causation/headers/user-name from the event options) and `DocumentStoreUsage.DocumentMetadata` in the store usage descriptors (jasperfx#475).
- **#3219** — register the Polecat store as `JasperFx.Events.IEventStore` (mirrors the existing `IDocumentStoreUsageSource` bridge that the comment already promised). Wolverine's `ServiceCapabilities.readEventStores` discovers stores via `GetServices<IEventStore>()`; without this a Polecat-backed service was invisible to every event-store monitoring surface. Brings Polecat to parity with Marten's core DI.
- Tenant-scope `IDocumentStoreDiagnostics.QueryDocumentsAsync` — Polecat is single-database, so a tenant id filters the conjoined `tenant_id` column.
- Bump to **4.7.0-alpha.1**; `JasperFx.*` pins → **2.17.0** (`JasperFx.RuntimeCompiler` stays 5.0.0).

## Depends on
**JasperFx 2.17.0** (JasperFx/jasperfx#477). Publish that first; CI here stays red until 2.17.0 is on NuGet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
