### PR TITLE
feat: PartitionOn(...).ByRange()/.ByExternallyManagedRange() + externally-managed range partitioning (#255)

### DIFF
--- a/src/Polecat.Tests/Storage/document_range_partitioning_tests.cs
+++ b/src/Polecat.Tests/Storage/document_range_partitioning_tests.cs
@@ -1,4 +1,5 @@
 using JasperFx;
+using Polecat.Linq;
 using Polecat.Tests.Harness;
 using Shouldly;
 
@@ -15,6 +16,14 @@ public class MetricsSample
 // Distinct type for the roll-forward test so its partition function (named from the table) does not
 // collide with the other tests' — SQL Server partition functions/schemes are database-scoped.
 public class RolledMetricsSample
+{
+    public Guid Id { get; set; }
+    public DateTimeOffset BucketEnd { get; set; }
+    public double Value { get; set; }
+}
+
+// Distinct type so its database-scoped partition function/scheme don't collide with the others'.
+public class ExternalMetricsSample
 {
     public Guid Id { get; set; }
     public DateTimeOffset BucketEnd { get; set; }
@@ -182,5 +191,74 @@ public class document_range_partitioning_tests : IntegrationContext
         });
 
         ex.Message.ShouldContain("conjoined");
+    }
+
+    // ---- #255: Marten-parity PartitionOn(...).ByRange(...) DSL ----------------------------------
+
+    [Fact]
+    public async Task partition_on_by_range_is_equivalent_to_partition_by_range()
+    {
+        await ResetAsync("pc_doc_metricssample");
+        await StoreOptions(opts =>
+        {
+            opts.DatabaseSchemaName = Schema;
+            // The Marten-parity fluent form over the same machinery as PartitionByRange.
+            opts.Schema.For<MetricsSample>().PartitionOn(x => x.BucketEnd).ByRange(Jan, Feb, Mar);
+        });
+
+        theSession.Store(new MetricsSample
+        {
+            Id = Guid.NewGuid(), BucketEnd = Jan.AddDays(5), Metric = "cpu", Value = 1
+        });
+        await theSession.SaveChangesAsync();
+
+        (await PartitionCountAsync("pc_doc_metricssample")).ShouldBe(4); // 3 boundaries -> 4 partitions
+    }
+
+    // ---- #255: externally-managed range partitioning (time-series retention) --------------------
+
+    [Fact]
+    public async Task externally_managed_range_is_provisioned_once_and_never_reconciled()
+    {
+        const string table = "pc_doc_externalmetricssample";
+        await ResetAsync(table);
+
+        // Initial boundaries [Jan, Feb] -> 3 partitions. Externally-managed means Polecat creates the
+        // partitioned table once and never reconciles it afterward.
+        await StoreOptions(opts =>
+        {
+            opts.DatabaseSchemaName = Schema;
+            opts.Schema.For<ExternalMetricsSample>()
+                .PartitionOn(x => x.BucketEnd).ByExternallyManagedRange(Jan, Feb);
+        });
+
+        theSession.Store(new ExternalMetricsSample { Id = Guid.NewGuid(), BucketEnd = Jan.AddDays(3), Value = 1 });
+        await theSession.SaveChangesAsync();
+
+        (await PartitionCountAsync(table)).ShouldBe(3);
+
+        // Simulate the app/DBA rolling March forward at runtime (the partition Polecat must not touch).
+        await SplitRangeAsync(table, "2026-03-01T00:00:00.0000000+00:00");
+        (await PartitionCountAsync(table)).ShouldBe(4);
+
+        // A bulk schema apply must NOT reconcile the externally-managed table back to its declared
+        // [Jan, Feb] boundaries — the app-managed March partition must survive.
+        await theDatabase.ApplyAllConfiguredChangesToDatabaseAsync();
+        (await PartitionCountAsync(table)).ShouldBe(4);
+
+        // And the data is intact + still queryable.
+        await using var query = theStore.QuerySession();
+        (await query.Query<ExternalMetricsSample>().CountAsync()).ShouldBe(1);
+    }
+
+    private async Task SplitRangeAsync(string table, string boundaryLiteral)
+    {
+        await using var conn = await OpenConnectionAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"""
+            ALTER PARTITION SCHEME [ps_{table}_bucket_end] NEXT USED [PRIMARY];
+            ALTER PARTITION FUNCTION [pf_{table}_bucket_end]() SPLIT RANGE (CONVERT(datetimeoffset, '{boundaryLiteral}'));
+            """;
+        await cmd.ExecuteNonQueryAsync();
     }
 }

--- a/src/Polecat/Internal/DocumentTableEnsurer.cs
+++ b/src/Polecat/Internal/DocumentTableEnsurer.cs
@@ -81,10 +81,16 @@ internal class DocumentTableEnsurer
             // preserved — never a drop/recreate), then restores the default. No-op once bigint.
             await WidenVersionColumnIfNeededAsync(conn, provider.Mapping.QualifiedTableName, token);
 
-            // Use Weasel SchemaMigration to create or update the document table
+            // Use Weasel SchemaMigration to create or update the document table.
+            // #255: an externally-managed partitioned table is provisioned ONCE (CreateOnly) and
+            // never reconciled afterward, so a later schema apply can't clobber the partitions the
+            // app/DBA manages at runtime (SPLIT new months, SWITCH/DROP old ones for retention).
             var table = new DocumentTable(provider.Mapping);
+            var autoCreate = provider.Mapping.Partitioning is { ExternallyManaged: true }
+                ? AutoCreate.CreateOnly
+                : AutoCreate.CreateOrUpdate;
             var migration = await SchemaMigration.DetermineAsync(conn, token, table);
-            await migrator.ApplyAllAsync(conn, migration, AutoCreate.CreateOrUpdate, ct: token);
+            await migrator.ApplyAllAsync(conn, migration, autoCreate, ct: token);
 
             // Create custom indexes (computed columns + index)
             // Computed columns are not modeled in Weasel, so they remain as supplementary DDL.

--- a/src/Polecat/Storage/DocumentFeatureSchema.cs
+++ b/src/Polecat/Storage/DocumentFeatureSchema.cs
@@ -31,6 +31,17 @@ internal class DocumentFeatureSchema : FeatureSchemaBase
 
         foreach (var provider in _options.Providers.AllProviders)
         {
+            // #255: externally-managed partitioned tables are intentionally excluded from the bulk
+            // reconciliation path. The whole-database migration applies a single (global) AutoCreate,
+            // so leaving them in would reconcile their partition boundaries back to the declared
+            // initial set and clobber the partitions the app/DBA manages at runtime (SPLIT/SWITCH/DROP
+            // for retention). They are provisioned once, on first use, by DocumentTableEnsurer with
+            // AutoCreate.CreateOnly and never reconciled by either path.
+            if (provider.Mapping.Partitioning is { ExternallyManaged: true })
+            {
+                continue;
+            }
+
             yield return new DocumentTable(provider.Mapping);
         }
     }

--- a/src/Polecat/Storage/DocumentMappingExpression.cs
+++ b/src/Polecat/Storage/DocumentMappingExpression.cs
@@ -142,6 +142,65 @@ public class DocumentMappingExpression<T>
         Partitioning = DocumentPartitioning.For(member, boundaries, idMemberName);
         return this;
     }
+
+    /// <summary>
+    ///     #255: begin a fluent declaration of RANGE partitioning on a member, mirroring Marten's
+    ///     <c>PartitionOn(x =&gt; x.Member)</c>. Follow with <see cref="PartitioningExpression{T,TValue}.ByRange" />
+    ///     (Polecat manages + rolls the boundaries) or
+    ///     <see cref="PartitioningExpression{T,TValue}.ByExternallyManagedRange" /> (Polecat provisions the
+    ///     partitioned table once, then leaves the partitions to be managed externally — the
+    ///     time-series-retention pattern).
+    /// </summary>
+    public PartitioningExpression<T, TValue> PartitionOn<TValue>(Expression<Func<T, TValue>> member)
+    {
+        return new PartitioningExpression<T, TValue>(this, member);
+    }
+
+    /// <summary>Internal hook used by <see cref="PartitioningExpression{T,TValue}" /> to set the descriptor.</summary>
+    internal void SetPartitioning<TValue>(Expression<Func<T, TValue>> member, TValue[] boundaries,
+        bool externallyManaged)
+    {
+        var idMemberName = DocumentMapping.FindIdProperty(typeof(T))?.Name ?? "Id";
+        Partitioning = DocumentPartitioning.For(member, boundaries, idMemberName, externallyManaged);
+    }
+}
+
+/// <summary>
+///     #255: fluent continuation of <see cref="DocumentMappingExpression{T}.PartitionOn{TValue}" />,
+///     mirroring Marten's <c>PartitioningExpression</c>. Choose the range-partitioning strategy.
+/// </summary>
+public class PartitioningExpression<T, TValue>
+{
+    private readonly DocumentMappingExpression<T> _parent;
+    private readonly Expression<Func<T, TValue>> _member;
+
+    internal PartitioningExpression(DocumentMappingExpression<T> parent, Expression<Func<T, TValue>> member)
+    {
+        _parent = parent;
+        _member = member;
+    }
+
+    /// <summary>
+    ///     Polecat-managed RANGE partitioning: the boundaries are owned by Polecat and rolled forward
+    ///     in place via <c>SPLIT RANGE</c> when you add new ones. N boundaries → N+1 partitions.
+    /// </summary>
+    public DocumentMappingExpression<T> ByRange(params TValue[] boundaries)
+    {
+        _parent.SetPartitioning(_member, boundaries, externallyManaged: false);
+        return _parent;
+    }
+
+    /// <summary>
+    ///     #255: externally-managed RANGE partitioning. Polecat creates the partition function/scheme
+    ///     and table once (with the supplied <paramref name="initialBoundaries" />) and then never
+    ///     reconciles the partitioning, so the app/DBA can SPLIT new partitions and SWITCH/DROP old
+    ///     ones at runtime for time-series retention without a later schema apply clobbering them.
+    /// </summary>
+    public DocumentMappingExpression<T> ByExternallyManagedRange(params TValue[] initialBoundaries)
+    {
+        _parent.SetPartitioning(_member, initialBoundaries, externallyManaged: true);
+        return _parent;
+    }
 }
 
 /// <summary>

--- a/src/Polecat/Storage/DocumentPartitioning.cs
+++ b/src/Polecat/Storage/DocumentPartitioning.cs
@@ -16,13 +16,14 @@ internal sealed class DocumentPartitioning
     private readonly Func<object, object?>? _getter;
 
     private DocumentPartitioning(string columnName, string sqlDataType, bool partitionOnId,
-        IReadOnlyList<object> boundaries, Func<object, object?>? getter)
+        IReadOnlyList<object> boundaries, Func<object, object?>? getter, bool externallyManaged)
     {
         ColumnName = columnName;
         SqlDataType = sqlDataType;
         PartitionOnId = partitionOnId;
         Boundaries = boundaries;
         _getter = getter;
+        ExternallyManaged = externallyManaged;
     }
 
     /// <summary>The partition column name. <c>id</c> when <see cref="PartitionOnId" /> is true.</summary>
@@ -42,6 +43,16 @@ internal sealed class DocumentPartitioning
 
     /// <summary>True when a real duplicated column must be created and written on upsert.</summary>
     public bool RequiresDuplicatedColumn => !PartitionOnId;
+
+    /// <summary>
+    ///     #255: when true, Polecat creates the partition function/scheme + table once (with the
+    ///     initial <see cref="Boundaries" />) and thereafter does NOT reconcile the partitioning — the
+    ///     partition boundaries are managed externally (app/DBA SPLIT/MERGE/SWITCH for monthly
+    ///     time-series retention). The table migration runs with <c>AutoCreate.CreateOnly</c> so a
+    ///     later schema apply never clobbers externally-managed partitions. When false (the default),
+    ///     Polecat owns the boundaries and rolls them forward in place via SPLIT RANGE.
+    /// </summary>
+    public bool ExternallyManaged { get; }
 
     /// <summary>Extract the partition value from a document instance for the write path.</summary>
     public object GetValue(object document)
@@ -65,7 +76,8 @@ internal sealed class DocumentPartitioning
     public static DocumentPartitioning For<T, TValue>(
         Expression<Func<T, TValue>> member,
         IReadOnlyList<TValue> boundaries,
-        string idMemberName)
+        string idMemberName,
+        bool externallyManaged = false)
     {
         var memberInfo = ResolveMember(member);
         var sqlType = ToSqlServerType(typeof(TValue));
@@ -73,14 +85,16 @@ internal sealed class DocumentPartitioning
 
         if (string.Equals(memberInfo.Name, idMemberName, StringComparison.Ordinal))
         {
-            return new DocumentPartitioning("id", sqlType, partitionOnId: true, boxed, getter: null);
+            return new DocumentPartitioning("id", sqlType, partitionOnId: true, boxed, getter: null,
+                externallyManaged);
         }
 
         var column = ToSnakeCase(memberInfo.Name);
         var compiled = member.Compile();
         Func<object, object?> getter = doc => compiled((T)doc);
 
-        return new DocumentPartitioning(column, sqlType, partitionOnId: false, boxed, getter);
+        return new DocumentPartitioning(column, sqlType, partitionOnId: false, boxed, getter,
+            externallyManaged);
     }
 
     private static MemberInfo ResolveMember<T, TValue>(Expression<Func<T, TValue>> member)


### PR DESCRIPTION
Closes #255. Parity with [marten#4779](https://github.com/JasperFx/marten/issues/4779).

## Context
Polecat **already** had declarative non-tenant range partitioning of a document table by an arbitrary date/int column — `Schema.For<T>().PartitionByRange(x => x.BucketEnd, jan, feb, mar)` — including a duplicated PK column written on upsert and rolling `SPLIT RANGE` reconciliation (tested in `document_range_partitioning_tests`). This PR closes the two gaps versus marten#4779.

## 1. Marten-parity DSL surface
`Schema.For<T>().PartitionOn(x => x.BucketEnd).ByRange(jan, feb, mar)` — a fluent `PartitioningExpression<T,TValue>` over the existing machinery (equivalent to `PartitionByRange`, which stays). The partition column is auto-duplicated into the PK, so a separate Marten-style `.Duplicate(...)` isn't required.

## 2. Externally-managed range partitioning (the time-series-retention enabler)
`Schema.For<T>().PartitionOn(x => x.BucketEnd).ByExternallyManagedRange(jan, feb)`:
- The on-the-fly `DocumentTableEnsurer` provisions the partition function/scheme + table **once** with `AutoCreate.CreateOnly`, then **never reconciles** it — so the app/DBA can `SPLIT` new months and `SWITCH`/`DROP` old ones at runtime for retention without a later schema apply clobbering them.
- Externally-managed tables are **excluded from the bulk `DocumentFeatureSchema`** (whole-database reconciliation), because that path applies a single global `AutoCreate` and would otherwise reconcile their boundaries back to the declared initial set. They're provisioned lazily by the ensurer instead.

This unblocks the Polecat/SQL-Server metrics-retention partition-drop pattern ([CritterWatch#573](https://github.com/JasperFx/CritterWatch/issues/573)); the actual drop-partition prune helper remains the separate downstream piece.

## Feasibility note (as requested)
Weasel.SqlServer 9.3.0 has **no native externally-managed non-tenant range partitioning** (`RangePartitioning` always owns its boundaries; reconciliation is driven by `TableDelta.PartitioningDifference`). So externally-managed is implemented entirely at the Polecat level via the `CreateOnly` + bulk-exclusion approach above — no Weasel change required, nothing blocked.

## Tests
- `partition_on_by_range_is_equivalent_to_partition_by_range` — the new DSL creates the expected partitions.
- `externally_managed_range_is_provisioned_once_and_never_reconciled` — created with the initial boundaries (3 partitions); a runtime `SPLIT` adds a 4th; a bulk `ApplyAllConfiguredChangesToDatabaseAsync` leaves it at 4 (not reconciled away) and the data stays queryable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)