### PR TITLE
feat: metadata-filtered document + event queries (4.7.0-alpha.2, #256)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>4.7.0-alpha.1</Version>
+        <Version>4.7.0-alpha.2</Version>
         <LangVersion>latest</LangVersion>
         <Authors>Jeremy D. Miller</Authors>
         <PackageIcon>logo.png</PackageIcon>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,8 +22,8 @@
              IEventDatabase.QueryDeadLetterEventsAsync (dead-letter row drill-in), DeadLetterEvent.TenantId,
              and the tenant-aware daemon surface. Polecat implements the dead-letter row query + per-tenant
              FetchDeadLetterCountsAsync below. -->
-        <PackageVersion Include="JasperFx" Version="2.17.0" />
-        <PackageVersion Include="JasperFx.Events" Version="2.17.0" />
+        <PackageVersion Include="JasperFx" Version="2.18.0" />
+        <PackageVersion Include="JasperFx.Events" Version="2.18.0" />
         <!-- Pin the sibling JasperFx packages for parity with Marten 9's matrix
              even though Polecat doesn't currently reference them directly —
              keeps the lockstep matrix coherent when transitive resolution
@@ -31,7 +31,7 @@
              RuntimeCompiler 5.x line is the active continuation of the 4.x
              lineage; do not pin against the parallel stale 2.0.x series. -->
         <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.17.0" />
+        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.18.0" />
         <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
@@ -57,7 +57,7 @@
         <PackageVersion Include="StronglyTypedId" Version="1.0.0-beta08" />
 
         <!-- Source generators (matched to JasperFx.Events above) -->
-        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.17.0" />
+        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.18.0" />
 
         <!-- Build automation -->
         <PackageVersion Include="Nuke.Common" Version="9.0.4" />

--- a/src/Polecat.Tests/Metadata/document_metadata_filter_tests.cs
+++ b/src/Polecat.Tests/Metadata/document_metadata_filter_tests.cs
@@ -1,0 +1,196 @@
+using System.Text.Json;
+using JasperFx;
+using JasperFx.Documents;
+using Microsoft.Data.SqlClient;
+using Polecat.TestUtils;
+using Shouldly;
+
+namespace Polecat.Tests.Metadata;
+
+/// <summary>
+/// #256: exact-match metadata filters on <see cref="IDocumentStoreDiagnostics.QueryDocumentsAsync"/>
+/// (parity with marten#4791). Each of CorrelationId / CausationId / LastModifiedBy is honored only
+/// when the option is set AND the document mapping enables that opt-in column (#241/#243) — a WHERE on
+/// a column that doesn't exist would throw, so a disabled column silently drops the filter.
+///
+/// Seeding: 8 docs covering every combination of correlation ∈ {c0,c1} × causation ∈ {u0,u1} ×
+/// last_modified_by ∈ {b0,b1}, indexed 0..7 by the (corr,caus,lmb) binary tuple.
+/// </summary>
+public class document_metadata_filter_tests
+{
+    public class DiagMetaDoc
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+    }
+
+    private static string NameForIndex(int i) => $"doc-{i}";
+
+    private static string? NameOf(string json)
+    {
+        using var doc = JsonDocument.Parse(json);
+        foreach (var p in doc.RootElement.EnumerateObject())
+        {
+            if (string.Equals(p.Name, "name", StringComparison.OrdinalIgnoreCase))
+            {
+                return p.Value.GetString();
+            }
+        }
+
+        return null;
+    }
+
+    private static async Task<DocumentStore> CreateStoreAsync(
+        string schema, bool enableCorr, bool enableCaus, bool enableLmb)
+    {
+        // Drop the doc table so each schema/metadata permutation starts clean across reruns.
+        await using (var conn = new SqlConnection(ConnectionSource.ConnectionString))
+        {
+            await conn.OpenAsync();
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = $"IF OBJECT_ID('[{schema}].[pc_doc_diagmetadoc]','U') IS NOT NULL DROP TABLE [{schema}].[pc_doc_diagmetadoc];";
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        return DocumentStore.For(opts =>
+        {
+            opts.ConnectionString = ConnectionSource.ConnectionString;
+            opts.DatabaseSchemaName = schema;
+            opts.AutoCreateSchemaObjects = AutoCreate.All;
+            opts.UseNativeJsonType = ConnectionSource.SupportsNativeJson;
+            opts.Schema.For<DiagMetaDoc>().Metadata(m =>
+            {
+                if (enableCorr) m.CorrelationId.Enabled = true;
+                if (enableCaus) m.CausationId.Enabled = true;
+                if (enableLmb) m.LastModifiedBy.Enabled = true;
+            });
+        });
+    }
+
+    private static async Task SeedMatrixAsync(DocumentStore store)
+    {
+        for (var i = 0; i < 8; i++)
+        {
+            await using var session = store.LightweightSession();
+            session.CorrelationId = (i & 0b100) == 0 ? "c0" : "c1";
+            session.CausationId = (i & 0b010) == 0 ? "u0" : "u1";
+            session.LastModifiedBy = (i & 0b001) == 0 ? "b0" : "b1";
+            session.Store(new DiagMetaDoc { Id = Guid.NewGuid(), Name = NameForIndex(i) });
+            await session.SaveChangesAsync();
+        }
+    }
+
+    private static Task<DocumentQueryResult> QueryAsync(DocumentStore store, DocumentQueryOptions options)
+        => ((IDocumentStoreDiagnostics)store).QueryDocumentsAsync(typeof(DiagMetaDoc).FullName!, options, default);
+
+    [Theory]
+    // (corr, caus, lmb, expectedDocIndices) — every combo of the three filters on/off (2^3 = 8)
+    [InlineData(null, null, null, new[] { 0, 1, 2, 3, 4, 5, 6, 7 })]
+    [InlineData("c0", null, null, new[] { 0, 1, 2, 3 })]
+    [InlineData(null, "u0", null, new[] { 0, 1, 4, 5 })]
+    [InlineData(null, null, "b0", new[] { 0, 2, 4, 6 })]
+    [InlineData("c0", "u0", null, new[] { 0, 1 })]
+    [InlineData("c0", null, "b0", new[] { 0, 2 })]
+    [InlineData(null, "u0", "b0", new[] { 0, 4 })]
+    [InlineData("c0", "u0", "b0", new[] { 0 })]
+    public async Task every_filter_combo_returns_the_expected_subset(
+        string? corr, string? caus, string? lmb, int[] expectedIndices)
+    {
+        await using var store = await CreateStoreAsync("doc256_combo", true, true, true);
+        await SeedMatrixAsync(store);
+
+        var result = await QueryAsync(store, new DocumentQueryOptions(1, 100)
+        {
+            CorrelationId = corr,
+            CausationId = caus,
+            LastModifiedBy = lmb
+        });
+
+        result.TotalCount.ShouldBe(expectedIndices.Length);
+        result.DocumentsJson.Select(NameOf).ShouldBe(expectedIndices.Select(NameForIndex), ignoreOrder: true);
+    }
+
+    [Fact]
+    public async Task filter_on_unmatched_value_returns_zero()
+    {
+        await using var store = await CreateStoreAsync("doc256_unmatched", true, true, true);
+        await SeedMatrixAsync(store);
+
+        var result = await QueryAsync(store, new DocumentQueryOptions(1, 100) { CorrelationId = "nope" });
+
+        result.TotalCount.ShouldBe(0);
+        result.DocumentsJson.Count.ShouldBe(0);
+    }
+
+    [Theory]
+    [InlineData(false, true, true, "correlation")]
+    [InlineData(true, false, true, "causation")]
+    [InlineData(true, true, false, "lastmodifiedby")]
+    public async Task filter_is_silently_ignored_when_its_column_is_disabled(
+        bool enableCorr, bool enableCaus, bool enableLmb, string which)
+    {
+        await using var store = await CreateStoreAsync($"doc256_off_{which}", enableCorr, enableCaus, enableLmb);
+        await SeedMatrixAsync(store);
+
+        // Set ONLY the disabled filter to a value that would otherwise narrow to 4 docs.
+        var options = which switch
+        {
+            "correlation" => new DocumentQueryOptions(1, 100) { CorrelationId = "c0" },
+            "causation" => new DocumentQueryOptions(1, 100) { CausationId = "u0" },
+            _ => new DocumentQueryOptions(1, 100) { LastModifiedBy = "b0" }
+        };
+
+        var result = await QueryAsync(store, options);
+
+        result.TotalCount.ShouldBe(8); // disabled column → filter dropped → all rows
+    }
+
+    [Fact]
+    public async Task disabled_filter_does_not_suppress_an_enabled_one()
+    {
+        // causation disabled, correlation + lmb enabled. Setting all three must still narrow via the
+        // enabled columns and silently ignore the disabled causation filter.
+        await using var store = await CreateStoreAsync("doc256_mixed", true, false, true);
+        await SeedMatrixAsync(store);
+
+        var result = await QueryAsync(store, new DocumentQueryOptions(1, 100)
+        {
+            CorrelationId = "c0",  // honored
+            CausationId = "u0",     // ignored (disabled)
+            LastModifiedBy = "b0"   // honored
+        });
+
+        result.TotalCount.ShouldBe(2);
+        result.DocumentsJson.Select(NameOf).ShouldBe(new[] { NameForIndex(0), NameForIndex(2) }, ignoreOrder: true);
+    }
+
+    [Fact]
+    public async Task id_and_metadata_filters_compose_with_and()
+    {
+        await using var store = await CreateStoreAsync("doc256_id_meta", true, true, true);
+        await SeedMatrixAsync(store);
+
+        // doc 0 has corr=c0, caus=u0, lmb=b0. Find its id.
+        var doc0Json = (await QueryAsync(store, new DocumentQueryOptions(1, 100)
+        {
+            CorrelationId = "c0", CausationId = "u0", LastModifiedBy = "b0"
+        })).DocumentsJson.Single();
+        using var d = JsonDocument.Parse(doc0Json);
+        var id = d.RootElement.EnumerateObject()
+            .First(p => string.Equals(p.Name, "id", StringComparison.OrdinalIgnoreCase)).Value.GetString();
+
+        // id + all matching metadata → that one row.
+        var hit = await QueryAsync(store, new DocumentQueryOptions(1, 100, IdEquals: id)
+        {
+            CorrelationId = "c0", CausationId = "u0", LastModifiedBy = "b0"
+        });
+        hit.TotalCount.ShouldBe(1);
+
+        // same id but a non-matching metadata value → AND yields empty.
+        var miss = await QueryAsync(store, new DocumentQueryOptions(1, 100, IdEquals: id)
+        {
+            CorrelationId = "c1"
+        });
+        miss.TotalCount.ShouldBe(0);
+    }
+}

--- a/src/Polecat.Tests/Metadata/event_metadata_filter_tests.cs
+++ b/src/Polecat.Tests/Metadata/event_metadata_filter_tests.cs
@@ -1,0 +1,194 @@
+using JasperFx;
+using JasperFx.Events;
+using Polecat.TestUtils;
+using Shouldly;
+
+namespace Polecat.Tests.Metadata;
+
+/// <summary>
+/// #256: exact-match metadata filters on the event read store's <see cref="IReadOnlyEventStore.QueryEventsAsync"/>
+/// (parity with the JasperFx EventQuery surface). CorrelationId / CausationId / UserName are honored only
+/// when the option is set AND the event store captures that column (EnableCorrelationId / EnableCausationId /
+/// EnableUserName, #237). UserName is sourced from the session's LastModifiedBy (#237/#239).
+///
+/// Seeding: 8 single-event streams covering every combination of correlation ∈ {c0,c1} ×
+/// causation ∈ {u0,u1} × user ∈ {b0,b1}, indexed 0..7 by the (corr,caus,user) binary tuple.
+/// </summary>
+public class event_metadata_filter_tests
+{
+    public record MetricRecorded(double Value);
+
+    private static async Task<DocumentStore> CreateStoreAsync(
+        string schema, bool enableCorr = true, bool enableCaus = true, bool enableUser = true)
+    {
+        await using (var conn = new Microsoft.Data.SqlClient.SqlConnection(ConnectionSource.ConnectionString))
+        {
+            await conn.OpenAsync();
+            await using var cmd = conn.CreateCommand();
+            // Drop the event tables so each schema starts clean across reruns.
+            cmd.CommandText = $"""
+                IF OBJECT_ID('[{schema}].[pc_events]','U') IS NOT NULL DROP TABLE [{schema}].[pc_events];
+                IF OBJECT_ID('[{schema}].[pc_streams]','U') IS NOT NULL DROP TABLE [{schema}].[pc_streams];
+                """;
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        return DocumentStore.For(opts =>
+        {
+            opts.ConnectionString = ConnectionSource.ConnectionString;
+            opts.DatabaseSchemaName = schema;
+            opts.AutoCreateSchemaObjects = AutoCreate.All;
+            opts.UseNativeJsonType = ConnectionSource.SupportsNativeJson;
+            opts.Events.EnableCorrelationId = enableCorr;
+            opts.Events.EnableCausationId = enableCaus;
+            opts.Events.EnableUserName = enableUser;
+        });
+    }
+
+    private static async Task SeedMatrixAsync(DocumentStore store)
+    {
+        for (var i = 0; i < 8; i++)
+        {
+            await using var session = store.LightweightSession();
+            session.CorrelationId = (i & 0b100) == 0 ? "c0" : "c1";
+            session.CausationId = (i & 0b010) == 0 ? "u0" : "u1";
+            session.LastModifiedBy = (i & 0b001) == 0 ? "b0" : "b1"; // → event.UserName
+            session.Events.StartStream(Guid.NewGuid(), new MetricRecorded(i));
+            await session.SaveChangesAsync();
+        }
+    }
+
+    private static Task<PagedEvents> QueryAsync(DocumentStore store, EventQuery query)
+        => ((IEventStore)store).OpenReadOnlyEventStore().QueryEventsAsync(query, default);
+
+    [Theory]
+    // (corr, caus, user, expectedCount)
+    [InlineData(null, null, null, 8)]
+    [InlineData("c0", null, null, 4)]
+    [InlineData(null, "u0", null, 4)]
+    [InlineData(null, null, "b0", 4)]
+    [InlineData("c0", "u0", null, 2)]
+    [InlineData("c0", null, "b0", 2)]
+    [InlineData(null, "u0", "b0", 2)]
+    [InlineData("c0", "u0", "b0", 1)]
+    public async Task every_filter_combo_returns_the_expected_subset(
+        string? corr, string? caus, string? user, int expectedCount)
+    {
+        await using var store = await CreateStoreAsync("evt256_combo");
+        await SeedMatrixAsync(store);
+
+        var result = await QueryAsync(store, new EventQuery
+        {
+            PageSize = 50,
+            CorrelationId = corr,
+            CausationId = caus,
+            UserName = user
+        });
+
+        result.TotalCount.ShouldBe(expectedCount);
+        result.Events.Count.ShouldBe(expectedCount);
+
+        // Every returned event must actually match each set filter.
+        foreach (var e in result.Events)
+        {
+            if (corr != null) e.CorrelationId.ShouldBe(corr);
+            if (caus != null) e.CausationId.ShouldBe(caus);
+            if (user != null) e.UserName.ShouldBe(user);
+        }
+    }
+
+    [Fact]
+    public async Task filter_on_unmatched_value_returns_zero()
+    {
+        await using var store = await CreateStoreAsync("evt256_unmatched");
+        await SeedMatrixAsync(store);
+
+        var result = await QueryAsync(store, new EventQuery { PageSize = 50, CorrelationId = "nope" });
+
+        result.TotalCount.ShouldBe(0);
+        result.Events.Count.ShouldBe(0);
+    }
+
+    [Theory]
+    [InlineData(false, true, true, "correlation")]
+    [InlineData(true, false, true, "causation")]
+    [InlineData(true, true, false, "username")]
+    public async Task filter_is_silently_ignored_when_its_column_is_disabled(
+        bool enableCorr, bool enableCaus, bool enableUser, string which)
+    {
+        await using var store = await CreateStoreAsync($"evt256_off_{which}", enableCorr, enableCaus, enableUser);
+        await SeedMatrixAsync(store);
+
+        var query = which switch
+        {
+            "correlation" => new EventQuery { PageSize = 50, CorrelationId = "c0" },
+            "causation" => new EventQuery { PageSize = 50, CausationId = "u0" },
+            _ => new EventQuery { PageSize = 50, UserName = "b0" }
+        };
+
+        var result = await QueryAsync(store, query);
+
+        result.TotalCount.ShouldBe(8); // disabled column → filter dropped → all events
+    }
+
+    [Fact]
+    public async Task disabled_filter_does_not_suppress_an_enabled_one()
+    {
+        // causation disabled, correlation + user enabled.
+        await using var store = await CreateStoreAsync("evt256_mixed", enableCorr: true, enableCaus: false, enableUser: true);
+        await SeedMatrixAsync(store);
+
+        var result = await QueryAsync(store, new EventQuery
+        {
+            PageSize = 50,
+            CorrelationId = "c0", // honored
+            CausationId = "u0",    // ignored (disabled)
+            UserName = "b0"        // honored
+        });
+
+        result.TotalCount.ShouldBe(2); // c0 ∩ b0
+    }
+
+    [Fact]
+    public async Task event_type_name_and_stream_id_filters_apply()
+    {
+        await using var store = await CreateStoreAsync("evt256_type_stream");
+        var streamA = Guid.NewGuid();
+        var streamB = Guid.NewGuid();
+        await using (var session = store.LightweightSession())
+        {
+            session.Events.StartStream(streamA, new MetricRecorded(1), new MetricRecorded(2));
+            session.Events.StartStream(streamB, new MetricRecorded(3));
+            await session.SaveChangesAsync();
+        }
+
+        // EventTypeName matches the only type → all 3 events.
+        var all = await QueryAsync(store, new EventQuery { PageSize = 50, EventTypeName = "metric_recorded" });
+        all.TotalCount.ShouldBe(3);
+
+        // Bogus EventTypeName → none.
+        var none = await QueryAsync(store, new EventQuery { PageSize = 50, EventTypeName = "no_such_type" });
+        none.TotalCount.ShouldBe(0);
+
+        // StreamId scopes to a single stream.
+        var streamScoped = await QueryAsync(store, new EventQuery { PageSize = 50, StreamId = streamA.ToString() });
+        streamScoped.TotalCount.ShouldBe(2);
+        streamScoped.Events.ShouldAllBe(e => e.StreamId == streamA);
+    }
+
+    [Fact]
+    public async Task paging_limits_and_reports_total()
+    {
+        await using var store = await CreateStoreAsync("evt256_paging");
+        await SeedMatrixAsync(store); // 8 events
+
+        var page1 = await QueryAsync(store, new EventQuery { PageNumber = 1, PageSize = 3 });
+        page1.TotalCount.ShouldBe(8); // full count regardless of page size
+        page1.Events.Count.ShouldBe(3);
+        page1.PageNumber.ShouldBe(1);
+        page1.PageSize.ShouldBe(3);
+
+        var page3 = await QueryAsync(store, new EventQuery { PageNumber = 3, PageSize = 3 });
+        page3.Events.Count.ShouldBe(2); // 8 = 3 + 3 + 2
+    }
+}

--- a/src/Polecat/DocumentStore.DocumentDiagnostics.cs
+++ b/src/Polecat/DocumentStore.DocumentDiagnostics.cs
@@ -53,10 +53,29 @@ public partial class DocumentStore : IDocumentStoreDiagnostics
         // single-database store, so a tenant id filters the conjoined tenant_id column.
         var filterByTenant = options.TenantId != null && mapping.TenancyStyle == TenancyStyle.Conjoined;
 
+        // #256: exact-match metadata filters, honored only when the option is set AND the document
+        // type actually persists that opt-in column (#241). A filter on a disabled column would
+        // reference a column that doesn't exist, so it is silently skipped — mirroring the event side.
+        var filterCorrelation = options.CorrelationId != null && mapping.Metadata.CorrelationId.Enabled;
+        var filterCausation = options.CausationId != null && mapping.Metadata.CausationId.Enabled;
+        var filterLastModifiedBy = options.LastModifiedBy != null && mapping.Metadata.LastModifiedBy.Enabled;
+
         var conditions = new List<string>();
         if (options.IdEquals != null) conditions.Add("cast(id as nvarchar(max)) = @id");
         if (filterByTenant) conditions.Add("tenant_id = @tenant");
+        if (filterCorrelation) conditions.Add("correlation_id = @correlation");
+        if (filterCausation) conditions.Add("causation_id = @causation");
+        if (filterLastModifiedBy) conditions.Add("last_modified_by = @last_modified_by");
         var where = conditions.Count > 0 ? " where " + string.Join(" and ", conditions) : "";
+
+        void BindParameters(SqlCommand command)
+        {
+            if (options.IdEquals != null) command.Parameters.AddWithValue("@id", options.IdEquals);
+            if (filterByTenant) command.Parameters.AddWithValue("@tenant", options.TenantId!);
+            if (filterCorrelation) command.Parameters.AddWithValue("@correlation", options.CorrelationId!);
+            if (filterCausation) command.Parameters.AddWithValue("@causation", options.CausationId!);
+            if (filterLastModifiedBy) command.Parameters.AddWithValue("@last_modified_by", options.LastModifiedBy!);
+        }
 
         await using var conn = new SqlConnection(Database.ConnectionString);
         await conn.OpenAsync(token).ConfigureAwait(false);
@@ -65,15 +84,7 @@ public partial class DocumentStore : IDocumentStoreDiagnostics
         await using (var countCmd = conn.CreateCommand())
         {
             countCmd.CommandText = $"select count_big(*) from {table}{where}";
-            if (options.IdEquals != null)
-            {
-                countCmd.Parameters.AddWithValue("@id", options.IdEquals);
-            }
-            if (filterByTenant)
-            {
-                countCmd.Parameters.AddWithValue("@tenant", options.TenantId!);
-            }
-
+            BindParameters(countCmd);
             total = Convert.ToInt64(await countCmd.ExecuteScalarAsync(token).ConfigureAwait(false));
         }
 
@@ -85,14 +96,7 @@ public partial class DocumentStore : IDocumentStoreDiagnostics
             cmd.CommandText =
                 $"select cast(data as nvarchar(max)) from {table}{where} " +
                 $"order by id offset {offset} rows fetch next {pageSize} rows only";
-            if (options.IdEquals != null)
-            {
-                cmd.Parameters.AddWithValue("@id", options.IdEquals);
-            }
-            if (filterByTenant)
-            {
-                cmd.Parameters.AddWithValue("@tenant", options.TenantId!);
-            }
+            BindParameters(cmd);
 
             await using var reader = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false);
             while (await reader.ReadAsync(token).ConfigureAwait(false))

--- a/src/Polecat/Events/Linq/EventLinqQueryProvider.cs
+++ b/src/Polecat/Events/Linq/EventLinqQueryProvider.cs
@@ -132,9 +132,15 @@ internal class EventLinqQueryProvider : IPolecatAsyncQueryProvider
         {
             if (_isAllEvents)
             {
-                // Full IEvent result set
-                parser.Statement.SelectColumns =
-                    "seq_id, id, stream_id, version, data, type, timestamp, tenant_id, dotnet_type, is_archived";
+                // Full IEvent result set. #256: append the opt-in metadata columns (when enabled) so
+                // hydrated events carry correlation/causation/user_name — EventListHandler reads them
+                // at the trailing ordinals in this same enable order.
+                var columns = "seq_id, id, stream_id, version, data, type, timestamp, tenant_id, dotnet_type, is_archived";
+                var eventOptions = _events.EventOptions;
+                if (eventOptions.EnableCorrelationId) columns += ", correlation_id";
+                if (eventOptions.EnableCausationId) columns += ", causation_id";
+                if (eventOptions.EnableUserName) columns += ", user_name";
+                parser.Statement.SelectColumns = columns;
             }
             else
             {

--- a/src/Polecat/Events/Linq/EventListHandler.cs
+++ b/src/Polecat/Events/Linq/EventListHandler.cs
@@ -68,6 +68,26 @@ internal class EventListHandler
                 @event.StreamKey = streamId.ToString();
             }
 
+            // #256: read the opt-in metadata columns appended to the full-event SELECT (when enabled),
+            // in the same enable order the query provider emitted them.
+            var options = _events.EventOptions;
+            var ordinal = 10;
+            if (options.EnableCorrelationId)
+            {
+                @event.CorrelationId = sqlReader.IsDBNull(ordinal) ? null : sqlReader.GetString(ordinal);
+                ordinal++;
+            }
+            if (options.EnableCausationId)
+            {
+                @event.CausationId = sqlReader.IsDBNull(ordinal) ? null : sqlReader.GetString(ordinal);
+                ordinal++;
+            }
+            if (options.EnableUserName)
+            {
+                @event.UserName = sqlReader.IsDBNull(ordinal) ? null : sqlReader.GetString(ordinal);
+                ordinal++;
+            }
+
             results.Add(@event);
         }
 

--- a/src/Polecat/Events/Linq/EventMemberFactory.cs
+++ b/src/Polecat/Events/Linq/EventMemberFactory.cs
@@ -22,6 +22,7 @@ internal class EventMemberFactory : IMemberResolver
         { "IsArchived", ("is_archived", typeof(bool)) },
         { "CorrelationId", ("correlation_id", typeof(string)) },
         { "CausationId", ("causation_id", typeof(string)) },
+        { "UserName", ("user_name", typeof(string)) },
         { "TenantId", ("tenant_id", typeof(string)) }
     };
 

--- a/src/Polecat/Events/QueryEventStore.cs
+++ b/src/Polecat/Events/QueryEventStore.cs
@@ -14,7 +14,10 @@ namespace Polecat.Events;
 ///     Read-only event store implementation. Fetches events and stream state from the database.
 ///     All SQL execution routes through session's Polly-wrapped centralized methods.
 /// </summary>
-internal class QueryEventStore : IQueryEventStore
+// #256: also implements JasperFx.Events.IReadOnlyEventStore (FetchStream/FetchStreamState/QueryEvents)
+// so DocumentStore.OpenReadOnlyEventStore() can return this as IReadOnlyEventStore. All of its members
+// are already present on the read store.
+internal class QueryEventStore : IQueryEventStore, IReadOnlyEventStore
 {
     private readonly QuerySession _session;
     private readonly StoreOptions _options;
@@ -42,6 +45,70 @@ internal class QueryEventStore : IQueryEventStore
     {
         var provider = new EventLinqQueryProvider(_session, _events);
         return new PolecatLinqQueryable<IEvent>(provider);
+    }
+
+    /// <summary>
+    ///     #256: query events across all streams with exact-match metadata filters and pagination
+    ///     (the JasperFx <see cref="EventQuery" /> surface). The correlation/causation/user-name
+    ///     filters are honored only when the option is set AND the event store actually captures that
+    ///     metadata column (the <c>Enable*</c> flag), since a disabled column isn't populated. v1 is
+    ///     exact-match, AND-combined; headers and timestamp ranges are deferred.
+    /// </summary>
+    public async Task<PagedEvents> QueryEventsAsync(EventQuery query, CancellationToken token = default)
+    {
+        IQueryable<IEvent> queryable = QueryAllRawEvents();
+
+        if (query.EventTypeName != null)
+        {
+            queryable = queryable.Where(e => e.EventTypeName == query.EventTypeName);
+        }
+
+        if (query.StreamId != null)
+        {
+            if (_events.StreamIdentity == StreamIdentity.AsGuid && Guid.TryParse(query.StreamId, out var streamGuid))
+            {
+                queryable = queryable.Where(e => e.StreamId == streamGuid);
+            }
+            else
+            {
+                queryable = queryable.Where(e => e.StreamKey == query.StreamId);
+            }
+        }
+
+        var options = _events.EventOptions;
+        if (query.CorrelationId != null && options.EnableCorrelationId)
+        {
+            queryable = queryable.Where(e => e.CorrelationId == query.CorrelationId);
+        }
+
+        if (query.CausationId != null && options.EnableCausationId)
+        {
+            queryable = queryable.Where(e => e.CausationId == query.CausationId);
+        }
+
+        if (query.UserName != null && options.EnableUserName)
+        {
+            queryable = queryable.Where(e => e.UserName == query.UserName);
+        }
+
+        var pageNumber = query.PageNumber <= 0 ? 1 : query.PageNumber;
+        var pageSize = query.PageSize <= 0 ? 25 : query.PageSize;
+        var offset = (pageNumber - 1) * pageSize;
+
+        var total = await queryable.CountAsync(token);
+        var events = await queryable
+            .OrderBy(e => e.Sequence)
+            .Skip(offset)
+            .Take(pageSize)
+            .ToListAsync(token);
+
+        return new PagedEvents
+        {
+            Events = events,
+            TotalCount = total,
+            PageNumber = pageNumber,
+            PageSize = pageSize
+        };
     }
 
     public async Task<IReadOnlyList<IEvent>> FetchStreamAsync(Guid streamId, long version = 0,


### PR DESCRIPTION
Implements the JasperFx 2.18 metadata-filter contract (#256) for the CritterWatch metadata-filtered query feature.

## Changes
- `IDocumentStoreDiagnostics.QueryDocumentsAsync` honours `DocumentQueryOptions.{CorrelationId,CausationId,LastModifiedBy}` — exact-match WHERE on the `correlation_id` / `causation_id` / `last_modified_by` columns, applied only when set **and** the mapping enables that column.
- `QueryEventsAsync` honours `EventQuery.{CorrelationId,CausationId,UserName}` on the event table's metadata columns.
- References published **JasperFx 2.18.0**; bump to **4.7.0-alpha.2**.

Cross-engine `user_name` searching (parity with Marten). Tracked: JasperFx/CritterWatch#629.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
