### PR TITLE
fix: honor EnumStorage in Patch().Set() (#262)

### DIFF
--- a/src/Polecat.Tests/Harness/TestDocumentTypes.cs
+++ b/src/Polecat.Tests/Harness/TestDocumentTypes.cs
@@ -39,6 +39,9 @@ public class Target
     public string? AnotherString { get; set; }
     public string? StringField { get; set; }
 
+    // Enum property for enum-storage patching tests (#262)
+    public ActiveStatus Status { get; set; }
+
     // Numeric properties for increment tests
     public long Long { get; set; }
     public double Double { get; set; }
@@ -96,6 +99,12 @@ public class Target
 
         return target;
     }
+}
+
+public enum ActiveStatus
+{
+    Active,
+    Inactive
 }
 
 public record TargetNested(Target[] Targets);

--- a/src/Polecat.Tests/Patching/patching_enum_storage.cs
+++ b/src/Polecat.Tests/Patching/patching_enum_storage.cs
@@ -1,0 +1,77 @@
+using Polecat.Patching;
+using Polecat.Tests.Harness;
+using Shouldly;
+using Weasel.Core;
+
+namespace Polecat.Tests.Patching;
+
+/// <summary>
+///     #262: Patch().Set(...) on an enum property ignored the configured EnumStorage and bound
+///     the raw integer value into JSON_MODIFY, so a store configured with EnumStorage.AsString
+///     ended up with an integer in the document body instead of the string representation.
+///     STJ's string-enum converter happily reads integers back, so these tests assert the raw
+///     stored JSON rather than only the round-tripped value.
+/// </summary>
+public class patching_enum_storage : OneOffConfigurationsContext
+{
+    private async Task<string> RawJsonAsync(Guid id)
+    {
+        var schema = theStore.Options.DatabaseSchemaName;
+        await using var conn = await OpenConnectionAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"SELECT CAST(data AS nvarchar(max)) FROM [{schema}].[pc_doc_target] WHERE id = @id";
+        cmd.Parameters.AddWithValue("@id", id);
+        return (string)(await cmd.ExecuteScalarAsync())!;
+    }
+
+    [Fact]
+    public async Task set_enum_with_as_string_storage_writes_string_representation()
+    {
+        ConfigureStore(opts => opts.ConfigureSerialization(EnumStorage.AsString));
+
+        var target = new Target { Id = Guid.NewGuid(), Status = ActiveStatus.Inactive };
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Store(target);
+            await session.SaveChangesAsync();
+        }
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Patch<Target>(target.Id).Set(x => x.Status, ActiveStatus.Active);
+            await session.SaveChangesAsync();
+        }
+
+        // The bug emitted "status":0; with AsString + CamelCase naming it must be the string name.
+        var json = await RawJsonAsync(target.Id);
+        json.ShouldContain("\"status\":\"active\"");
+
+        await using var query = theStore.QuerySession();
+        (await query.LoadAsync<Target>(target.Id))!.Status.ShouldBe(ActiveStatus.Active);
+    }
+
+    [Fact]
+    public async Task set_enum_with_as_integer_storage_writes_numeric_representation()
+    {
+        ConfigureStore(opts => opts.ConfigureSerialization(EnumStorage.AsInteger));
+
+        var target = new Target { Id = Guid.NewGuid(), Status = ActiveStatus.Active };
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Store(target);
+            await session.SaveChangesAsync();
+        }
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Patch<Target>(target.Id).Set(x => x.Status, ActiveStatus.Inactive);
+            await session.SaveChangesAsync();
+        }
+
+        var json = await RawJsonAsync(target.Id);
+        json.ShouldContain("\"status\":1");
+
+        await using var query = theStore.QuerySession();
+        (await query.LoadAsync<Target>(target.Id))!.Status.ShouldBe(ActiveStatus.Inactive);
+    }
+}

--- a/src/Polecat/Patching/PatchExpression.cs
+++ b/src/Polecat/Patching/PatchExpression.cs
@@ -327,11 +327,45 @@ internal class PatchExpression<T> : IPatchExpression<T>
         }
         else if (PatchOperation.IsScalarType(typeof(TValue)))
         {
-            _actions.Add(PatchOperation.SetScalar(path, value));
+            _actions.Add(BuildScalarSet(path, value));
         }
         else
         {
             _actions.Add(PatchOperation.SetComplex(path, _serializer.ToJson(value)));
+        }
+    }
+
+    /// <summary>
+    ///     Builds a scalar JSON_MODIFY assignment whose value matches exactly how the
+    ///     property is persisted in the document body. The value is serialized through the
+    ///     configured serializer first, so enum storage (AsString vs AsInteger) and
+    ///     System.Text.Json's date/time formatting are honored rather than binding the raw
+    ///     CLR value — which would emit the wrong representation (e.g. the integer behind a
+    ///     string enum) or a SQL type JSON_MODIFY rejects (e.g. datetimeoffset).
+    /// </summary>
+    private Action<ICommandBuilder> BuildScalarSet<TValue>(string path, TValue value)
+    {
+        var json = _serializer.ToJson(value!);
+        using var doc = JsonDocument.Parse(json);
+        switch (doc.RootElement.ValueKind)
+        {
+            case JsonValueKind.String:
+                // JSON_MODIFY escapes and stores an nvarchar argument as a JSON string —
+                // the right rendering for enum-as-string, DateTime/DateTimeOffset,
+                // DateOnly/TimeOnly, Guid, and string values.
+                return PatchOperation.SetScalar(path, doc.RootElement.GetString());
+
+            case JsonValueKind.True:
+            case JsonValueKind.False:
+                // A bit argument is rendered as JSON true/false by JSON_MODIFY.
+                return PatchOperation.SetScalar(path, doc.RootElement.GetBoolean());
+
+            case JsonValueKind.Null:
+                return PatchOperation.DeleteProperty(path);
+
+            default:
+                // Numeric: pass the original CLR value so JSON_MODIFY stores a JSON number.
+                return PatchOperation.SetScalar(path, value);
         }
     }
 }


### PR DESCRIPTION
Fixes #262.

## Problem

With `ConfigureSerialization(enumStorage: EnumStorage.AsString)`, storing a document serializes an enum property as its string name, but `Patch<T>(id).Set(x => x.Status, ...)` emitted the **integer** value:

```sql
... SET data = JSON_MODIFY(data, '$.status', @p0) ...  -- @p0 int = 0
```

The patch path bound the raw CLR value directly into `JSON_MODIFY`, ignoring the configured `EnumStorage`.

## Fix

`PatchExpression.AddSetAction` now routes scalar values through the configured serializer and inspects the resulting JSON token:

- **string** token (enum-as-string, dates, Guid, string) → bound as `nvarchar`; `JSON_MODIFY` renders it as a JSON string
- **bool** token → bound as `bit`; `JSON_MODIFY` renders `true`/`false`
- **number** token → keeps the original CLR value so `JSON_MODIFY` stores a JSON number

The patched value now matches exactly how the property is otherwise persisted.

## Tests

`patching_enum_storage` asserts the **raw stored JSON** (STJ's string-enum converter reads integers back, so a round-trip check alone wouldn't catch the bug):
- `AsString` → `"status":"active"`
- `AsInteger` → `"status":1`

Full patching suite (45 tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)