### PR TITLE
fix: support DateTime/DateTimeOffset/DateOnly/TimeOnly in Patch().Set() (#263)

### DIFF
--- a/src/Polecat.Tests/Harness/TestDocumentTypes.cs
+++ b/src/Polecat.Tests/Harness/TestDocumentTypes.cs
@@ -45,6 +45,13 @@ public class Target
     public float Float { get; set; }
     public decimal Decimal { get; set; }
 
+    // Date/time properties for date patching tests (#263)
+    public DateTime DateTime { get; set; }
+    public DateTimeOffset DateTimeOffset { get; set; }
+    public DateOnly DateOnly { get; set; }
+    public TimeOnly TimeOnly { get; set; }
+    public DateTimeOffset? NullableDateTimeOffset { get; set; }
+
     // Recursive nested property for deep patching
     public Target? Inner { get; set; }
     public Target? Inner2 { get; set; }

--- a/src/Polecat.Tests/Patching/patching_datetime.cs
+++ b/src/Polecat.Tests/Patching/patching_datetime.cs
@@ -1,0 +1,115 @@
+using Polecat.Patching;
+using Polecat.Tests.Harness;
+using Shouldly;
+
+namespace Polecat.Tests.Patching;
+
+/// <summary>
+///     #263: Patch().Set(...) on DateTime/DateTimeOffset/DateOnly/TimeOnly properties bound the
+///     raw CLR value into JSON_MODIFY. DateTime/DateTimeOffset bound a SQL datetimeoffset, which
+///     JSON_MODIFY rejects ("Argument data type datetimeoffset is invalid for argument 3"), and
+///     DateOnly/TimeOnly fell through to the complex JSON_QUERY path and produced malformed JSON.
+///     All four must now serialize to their System.Text.Json string form and round-trip cleanly.
+/// </summary>
+[Collection("integration")]
+public class patching_datetime : IntegrationContext
+{
+    public patching_datetime(DefaultStoreFixture fixture) : base(fixture)
+    {
+    }
+
+    public override async Task InitializeAsync()
+    {
+        await StoreOptions(opts => { opts.DatabaseSchemaName = "patching_dates"; });
+    }
+
+    [Fact]
+    public async Task set_datetime_property()
+    {
+        var target = Target.Random();
+        theSession.Store(target);
+        await theSession.SaveChangesAsync();
+
+        var expected = new DateTime(2026, 6, 29, 12, 13, 26, DateTimeKind.Utc);
+        theSession.Patch<Target>(target.Id).Set(x => x.DateTime, expected);
+        await theSession.SaveChangesAsync();
+
+        await using var query = theStore.QuerySession();
+        (await query.LoadAsync<Target>(target.Id))!.DateTime.ShouldBe(expected);
+    }
+
+    [Fact]
+    public async Task set_datetimeoffset_property()
+    {
+        var target = Target.Random();
+        theSession.Store(target);
+        await theSession.SaveChangesAsync();
+
+        var expected = new DateTimeOffset(2026, 6, 29, 12, 13, 26, TimeSpan.FromHours(2));
+        theSession.Patch<Target>(target.Id).Set(x => x.DateTimeOffset, expected);
+        await theSession.SaveChangesAsync();
+
+        await using var query = theStore.QuerySession();
+        (await query.LoadAsync<Target>(target.Id))!.DateTimeOffset.ShouldBe(expected);
+    }
+
+    [Fact]
+    public async Task set_dateonly_property()
+    {
+        var target = Target.Random();
+        theSession.Store(target);
+        await theSession.SaveChangesAsync();
+
+        var expected = new DateOnly(2026, 6, 29);
+        theSession.Patch<Target>(target.Id).Set(x => x.DateOnly, expected);
+        await theSession.SaveChangesAsync();
+
+        await using var query = theStore.QuerySession();
+        (await query.LoadAsync<Target>(target.Id))!.DateOnly.ShouldBe(expected);
+    }
+
+    [Fact]
+    public async Task set_timeonly_property()
+    {
+        var target = Target.Random();
+        theSession.Store(target);
+        await theSession.SaveChangesAsync();
+
+        var expected = new TimeOnly(12, 13, 26);
+        theSession.Patch<Target>(target.Id).Set(x => x.TimeOnly, expected);
+        await theSession.SaveChangesAsync();
+
+        await using var query = theStore.QuerySession();
+        (await query.LoadAsync<Target>(target.Id))!.TimeOnly.ShouldBe(expected);
+    }
+
+    [Fact]
+    public async Task set_nullable_datetimeoffset_property()
+    {
+        var target = Target.Random();
+        theSession.Store(target);
+        await theSession.SaveChangesAsync();
+
+        var expected = new DateTimeOffset(2026, 6, 29, 12, 13, 26, TimeSpan.FromHours(2));
+        theSession.Patch<Target>(target.Id).Set(x => x.NullableDateTimeOffset, expected);
+        await theSession.SaveChangesAsync();
+
+        await using var query = theStore.QuerySession();
+        (await query.LoadAsync<Target>(target.Id))!.NullableDateTimeOffset.ShouldBe(expected);
+    }
+
+    [Fact]
+    public async Task set_datetimeoffset_by_where_clause()
+    {
+        var target = new Target { Id = Guid.NewGuid(), Color = "Blue" };
+        theSession.Store(target);
+        await theSession.SaveChangesAsync();
+
+        var expected = new DateTimeOffset(2026, 6, 29, 12, 13, 26, TimeSpan.FromHours(2));
+        theSession.Patch<Target>(x => x.Color == "Blue").Set(x => x.DateTimeOffset, expected);
+        await theSession.SaveChangesAsync();
+
+        await using var query = theStore.QuerySession();
+        (await query.LoadAsync<Target>(target.Id))!.DateTimeOffset.ShouldBe(expected);
+    }
+}

--- a/src/Polecat/Patching/PatchExpression.cs
+++ b/src/Polecat/Patching/PatchExpression.cs
@@ -327,11 +327,45 @@ internal class PatchExpression<T> : IPatchExpression<T>
         }
         else if (PatchOperation.IsScalarType(typeof(TValue)))
         {
-            _actions.Add(PatchOperation.SetScalar(path, value));
+            _actions.Add(BuildScalarSet(path, value));
         }
         else
         {
             _actions.Add(PatchOperation.SetComplex(path, _serializer.ToJson(value)));
+        }
+    }
+
+    /// <summary>
+    ///     Builds a scalar JSON_MODIFY assignment whose value matches exactly how the
+    ///     property is persisted in the document body. The value is serialized through the
+    ///     configured serializer first, so enum storage (AsString vs AsInteger) and
+    ///     System.Text.Json's date/time formatting are honored rather than binding the raw
+    ///     CLR value — which would emit the wrong representation (e.g. the integer behind a
+    ///     string enum) or a SQL type JSON_MODIFY rejects (e.g. datetimeoffset).
+    /// </summary>
+    private Action<ICommandBuilder> BuildScalarSet<TValue>(string path, TValue value)
+    {
+        var json = _serializer.ToJson(value!);
+        using var doc = JsonDocument.Parse(json);
+        switch (doc.RootElement.ValueKind)
+        {
+            case JsonValueKind.String:
+                // JSON_MODIFY escapes and stores an nvarchar argument as a JSON string —
+                // the right rendering for enum-as-string, DateTime/DateTimeOffset,
+                // DateOnly/TimeOnly, Guid, and string values.
+                return PatchOperation.SetScalar(path, doc.RootElement.GetString());
+
+            case JsonValueKind.True:
+            case JsonValueKind.False:
+                // A bit argument is rendered as JSON true/false by JSON_MODIFY.
+                return PatchOperation.SetScalar(path, doc.RootElement.GetBoolean());
+
+            case JsonValueKind.Null:
+                return PatchOperation.DeleteProperty(path);
+
+            default:
+                // Numeric: pass the original CLR value so JSON_MODIFY stores a JSON number.
+                return PatchOperation.SetScalar(path, value);
         }
     }
 }

--- a/src/Polecat/Patching/PatchOperation.cs
+++ b/src/Polecat/Patching/PatchOperation.cs
@@ -388,6 +388,7 @@ internal class PatchOperation : Polecat.Internal.IStorageOperation
         return underlying.IsPrimitive || underlying == typeof(string) || underlying == typeof(decimal) ||
                underlying == typeof(Guid) || underlying == typeof(DateTime) ||
                underlying == typeof(DateTimeOffset) ||
+               underlying == typeof(DateOnly) || underlying == typeof(TimeOnly) ||
                underlying.IsEnum;
     }
 }


### PR DESCRIPTION
Fixes #263.

## Problem

`Patch<T>(id).Set(x => x.SomeDate, value)` threw a `SqlException` for every date/time type:

- **DateTime / DateTimeOffset** bound a SQL `datetimeoffset`, which `JSON_MODIFY` rejects:
  `Argument data type datetimeoffset is invalid for argument 3 of json_modify function.`
- **DateOnly / TimeOnly** were not recognized as scalar types, so they fell through to the complex `JSON_QUERY(@p)` path with a serialized JSON string and failed:
  `JSON text is not properly formatted. Unexpected character '"' is found at position 0.`

## Fix

- Add `DateOnly`/`TimeOnly` to `PatchOperation.IsScalarType`.
- Route scalar `Set` values through the configured serializer (shares the mechanism added for #262) and bind the System.Text.Json string form as an `nvarchar` argument. `JSON_MODIFY` escapes and stores it as a proper JSON string, matching how the property is otherwise persisted.

## Tests

`patching_datetime` round-trips `DateTime`, `DateTimeOffset`, `DateOnly`, `TimeOnly`, a nullable `DateTimeOffset`, and a where-clause patch. Full patching suite (49 tests) green.

> Note: overlaps with #264 (issue #262) on the scalar-encoding change in `PatchExpression`; the two resolve cleanly since they introduce the identical helper. This PR additionally adds the `DateOnly`/`TimeOnly` scalar-type recognition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)