### PR TITLE
release: Polecat 4.7.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>4.8.0-alpha.1</Version>
+        <Version>4.7.0</Version>
         <LangVersion>latest</LangVersion>
         <Authors>Jeremy D. Miller</Authors>
         <PackageIcon>logo.png</PackageIcon>


### PR DESCRIPTION
Finalizes the **4.7.0** stable release.

The earlier `4.8.0-alpha.1` bump on `main` was a mistake; this restores the package version to `4.7.0`.

Includes the two patch fixes just merged:
- #264 — honor `EnumStorage` in `Patch().Set()` (fixes #262)
- #265 — support `DateTime`/`DateTimeOffset`/`DateOnly`/`TimeOnly` in `Patch().Set()` (fixes #263)

🤖 Generated with [Claude Code](https://claude.com/claude-code)