### PR TITLE
fix: honor AutoCreate.None at runtime and stop dropping unmodeled doc-table objects (#267)

### DIFF
--- a/src/Polecat.Tests/Storage/auto_create_none_runtime_ddl_tests.cs
+++ b/src/Polecat.Tests/Storage/auto_create_none_runtime_ddl_tests.cs
@@ -1,0 +1,71 @@
+using JasperFx;
+using Microsoft.Data.SqlClient;
+using Polecat.Tests.Harness;
+
+namespace Polecat.Tests.Storage;
+
+/// <summary>
+/// #267: with AutoCreate.None the user owns the schema (e.g. EF migrations on a least-privilege
+/// Azure SQL connection with no ALTER). NO runtime schema DDL may run on any storage-ensure —
+/// not the async daemon's first storage access, and not the HiLo sequence's pc_hilo provisioning.
+/// Previously PolecatDatabase.EnsureStorageExistsAsync force-applied the WHOLE schema (and Weasel
+/// promotes None -> CreateOrUpdate), so the daemon emitted ALTER on any model drift and failed.
+/// </summary>
+public class auto_create_none_runtime_ddl_tests : OneOffConfigurationsContext
+{
+    public record ThingHappened(string Name);
+
+    public class NumberedDoc
+    {
+        public int Id { get; set; }
+        public string? Name { get; set; }
+    }
+
+    private string SchemaName => GetType().Name.ToLowerInvariant();
+
+    private async Task<bool> TableExistsAsync(string tableName)
+    {
+        await using var conn = new SqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = """
+            SELECT COUNT(*) FROM sys.tables t
+            JOIN sys.schemas s ON t.schema_id = s.schema_id
+            WHERE s.name = @schema AND t.name = @table;
+            """;
+        cmd.Parameters.AddWithValue("@schema", SchemaName);
+        cmd.Parameters.AddWithValue("@table", tableName);
+        var count = (int)(await cmd.ExecuteScalarAsync())!;
+        return count > 0;
+    }
+
+    [Fact]
+    public async Task building_the_daemon_under_auto_create_none_does_not_create_the_event_store()
+    {
+        ConfigureStore(opts => opts.AutoCreateSchemaObjects = AutoCreate.None);
+
+        // The daemon's first storage access must NOT force-apply schema under None.
+        var daemon = await theStore.BuildProjectionDaemonAsync();
+        if (daemon is IAsyncDisposable asyncDisposable) AsyncDisposables.Add(asyncDisposable);
+        else if (daemon is IDisposable disposable) Disposables.Add(disposable);
+
+        (await TableExistsAsync("pc_events")).ShouldBeFalse();
+        (await TableExistsAsync("pc_streams")).ShouldBeFalse();
+        (await TableExistsAsync("pc_event_progression")).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task hilo_sequence_under_auto_create_none_does_not_create_pc_hilo()
+    {
+        ConfigureStore(opts => opts.AutoCreateSchemaObjects = AutoCreate.None);
+
+        await using var session = theStore.LightweightSession();
+
+        // HiLo id assignment runs synchronously at Store() time. Under None the sequence must not
+        // provision pc_hilo, so the advance fails fast against the (user-owned, here absent) table.
+        Should.Throw<Exception>(() => session.Store(new NumberedDoc { Name = "x" }));
+
+        // Critically, the HiLo id-assignment path must not have created pc_hilo on the way.
+        (await TableExistsAsync("pc_hilo")).ShouldBeFalse();
+    }
+}

--- a/src/Polecat.Tests/Storage/document_table_ignores_unmodeled_objects_tests.cs
+++ b/src/Polecat.Tests/Storage/document_table_ignores_unmodeled_objects_tests.cs
@@ -1,0 +1,120 @@
+using Microsoft.Data.SqlClient;
+using Polecat.Storage;
+using Polecat.Tests.Harness;
+using Weasel.Core;
+using Weasel.SqlServer;
+
+namespace Polecat.Tests.Storage;
+
+/// <summary>
+/// #267 (secondary modeling bug): a pc_doc_ table may carry columns/indexes Polecat does not model —
+/// the persisted computed columns + secondary indexes Polecat itself manages via raw DDL, or objects a
+/// user adds (e.g. a unique index + persisted computed column via an EF migration). Weasel's default
+/// table diff would treat those as "extras" and DROP them, and the resulting permanently non-empty diff
+/// keeps every storage-ensure emitting DDL. DocumentTable.CreateDeltaAsync now strips unmodeled objects
+/// from the diff so Polecat is purely additive: it never drops them and the diff settles to None.
+/// </summary>
+public class document_table_ignores_unmodeled_objects_tests : OneOffConfigurationsContext
+{
+    public class Customer
+    {
+        public Guid Id { get; set; }
+        public string? Name { get; set; }
+    }
+
+    private string SchemaName => GetType().Name.ToLowerInvariant();
+    private const string TableName = "pc_doc_customer";
+
+    private async Task AddUserManagedObjectsAsync()
+    {
+        await using var conn = new SqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        // A persisted computed column + unique filtered index, as a user would add via a raw EF migration.
+        cmd.CommandText = $"""
+            ALTER TABLE [{SchemaName}].[{TableName}]
+                ADD external_code AS CAST(JSON_VALUE(data, '$.name') AS varchar(100)) PERSISTED;
+            """;
+        await cmd.ExecuteNonQueryAsync();
+
+        await using var indexCmd = conn.CreateCommand();
+        indexCmd.CommandText = $"""
+            CREATE UNIQUE INDEX ux_customer_external_code
+                ON [{SchemaName}].[{TableName}] (external_code);
+            """;
+        await indexCmd.ExecuteNonQueryAsync();
+    }
+
+    private async Task<(bool columnExists, bool indexExists)> ProbeUserObjectsAsync()
+    {
+        await using var conn = new SqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+
+        await using var colCmd = conn.CreateCommand();
+        // COL_LENGTH returns smallint (or NULL when the column is absent), so test for non-null
+        // rather than a specific CLR numeric type.
+        colCmd.CommandText = $"SELECT COL_LENGTH('{SchemaName}.{TableName}', 'external_code');";
+        var colResult = await colCmd.ExecuteScalarAsync();
+        var columnExists = colResult != null && colResult != DBNull.Value;
+
+        await using var idxCmd = conn.CreateCommand();
+        idxCmd.CommandText = """
+            SELECT COUNT(*) FROM sys.indexes i
+            JOIN sys.tables t ON i.object_id = t.object_id
+            JOIN sys.schemas s ON t.schema_id = s.schema_id
+            WHERE s.name = @schema AND t.name = @table AND i.name = 'ux_customer_external_code';
+            """;
+        idxCmd.Parameters.AddWithValue("@schema", SchemaName);
+        idxCmd.Parameters.AddWithValue("@table", TableName);
+        var indexExists = (int)(await idxCmd.ExecuteScalarAsync())! > 0;
+
+        return (columnExists, indexExists);
+    }
+
+    [Fact]
+    public async Task user_added_column_and_index_survive_a_full_migration()
+    {
+        ConfigureStore(_ => { }); // default AutoCreate.All (CreateOrUpdate semantics)
+
+        // Provision the document table.
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Store(new Customer { Id = Guid.NewGuid(), Name = "first" });
+            await session.SaveChangesAsync();
+        }
+
+        await AddUserManagedObjectsAsync();
+
+        // A full schema reconciliation must NOT drop the user-managed objects.
+        await theDatabase.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        var (columnExists, indexExists) = await ProbeUserObjectsAsync();
+        columnExists.ShouldBeTrue();
+        indexExists.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task diff_settles_to_none_with_unmodeled_objects_present()
+    {
+        ConfigureStore(_ => { });
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Store(new Customer { Id = Guid.NewGuid(), Name = "first" });
+            await session.SaveChangesAsync();
+        }
+
+        await AddUserManagedObjectsAsync();
+
+        // The diff (via DetermineAsync -> DocumentTable.CreateDeltaAsync) must report NO drift, so
+        // storage-ensure no longer force-applies DDL on every access.
+        var mapping = theStore.GetProvider(typeof(Customer)).Mapping;
+        var docTable = new DocumentTable(mapping);
+
+        await using var conn = new SqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        var migration = await SchemaMigration.DetermineAsync(conn, CancellationToken.None, docTable);
+
+        migration.Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+}

--- a/src/Polecat/Schema/Identity/Sequences/HiloSequence.cs
+++ b/src/Polecat/Schema/Identity/Sequences/HiloSequence.cs
@@ -19,15 +19,17 @@ internal class HiloSequence : HiloSequenceBase
     private readonly ConnectionFactory _connectionFactory;
     private readonly string _schemaName;
     private readonly ResiliencePipeline _resilience;
+    private readonly AutoCreate _autoCreate;
     private bool _tableEnsured;
 
     public HiloSequence(ConnectionFactory connectionFactory, string schemaName, string entityName,
-        HiloSettings settings, ResiliencePipeline resilience)
+        HiloSettings settings, ResiliencePipeline resilience, AutoCreate autoCreate)
         : base(entityName, settings)
     {
         _connectionFactory = connectionFactory;
         _schemaName = schemaName;
         _resilience = resilience;
+        _autoCreate = autoCreate;
     }
 
     public override async Task SetFloor(long floor)
@@ -105,6 +107,16 @@ internal class HiloSequence : HiloSequenceBase
     {
         if (_tableEnsured) return;
 
+        // #267: honor AutoCreate.None — the user manages the pc_hilo table themselves, so never
+        // emit DDL at runtime (mirrors DocumentTableEnsurer). A subsequent UPDATE/INSERT against a
+        // missing table surfaces as a clean "invalid object" error, the same opt-out contract as
+        // document and event-store tables.
+        if (_autoCreate == AutoCreate.None)
+        {
+            _tableEnsured = true;
+            return;
+        }
+
         var table = new HiloTable(_schemaName);
         var migrator = new SqlServerMigrator();
         var migration = await SchemaMigration.DetermineAsync(conn, ct, table);
@@ -115,6 +127,13 @@ internal class HiloSequence : HiloSequenceBase
     private void EnsureHiloTableSync(SqlConnection conn)
     {
         if (_tableEnsured) return;
+
+        // #267: honor AutoCreate.None (see EnsureHiloTableAsync).
+        if (_autoCreate == AutoCreate.None)
+        {
+            _tableEnsured = true;
+            return;
+        }
 
         var table = new HiloTable(_schemaName);
         var migrator = new SqlServerMigrator();

--- a/src/Polecat/Schema/Identity/Sequences/SequenceFactory.cs
+++ b/src/Polecat/Schema/Identity/Sequences/SequenceFactory.cs
@@ -26,7 +26,7 @@ internal class SequenceFactory
     {
         var name = GetSequenceName(documentType, settings);
         return _sequences.GetOrAdd(name,
-            sequenceName => new HiloSequence(_connectionFactory, _options.DatabaseSchemaName, sequenceName, settings, _options.ResiliencePipeline));
+            sequenceName => new HiloSequence(_connectionFactory, _options.DatabaseSchemaName, sequenceName, settings, _options.ResiliencePipeline, _options.AutoCreateSchemaObjects));
     }
 
     private static string GetSequenceName(Type documentType, HiloSettings settings)

--- a/src/Polecat/Storage/DocumentTable.cs
+++ b/src/Polecat/Storage/DocumentTable.cs
@@ -1,4 +1,6 @@
+using System.Data.Common;
 using Polecat.Metadata;
+using Weasel.Core;
 using Weasel.SqlServer;
 using Weasel.SqlServer.Tables;
 
@@ -100,5 +102,58 @@ internal class DocumentTable : Table
                 range.AddBoundary(boundary);
             }
         }
+    }
+
+    /// <summary>
+    ///     #267: Polecat's <see cref="DocumentTable" /> models only the columns it manages. The
+    ///     persisted computed columns and secondary indexes Polecat itself creates are applied as
+    ///     idempotent raw DDL by <see cref="Internal.DocumentTableEnsurer" /> (not modeled here), and a
+    ///     user may add their own (e.g. a persisted computed column + unique index via an EF migration).
+    ///     Weasel's default <see cref="TableDelta" /> would treat every such object as an "extra" and
+    ///     emit <c>DROP COLUMN</c> / <c>DROP INDEX</c> — destructive — while also leaving the table with
+    ///     a permanently non-empty diff that makes every storage-ensure re-run DDL.
+    ///     <para>
+    ///     This override strips those unmodeled objects from the fetched (actual) table before the diff
+    ///     is computed, so Polecat is purely additive: it creates what is missing from its own model and
+    ///     never drops or churns columns/indexes it does not own. Columns and indexes Polecat <em>does</em>
+    ///     model still reconcile normally (missing/different are detected as before).
+    ///     </para>
+    /// </summary>
+    public override async Task<ISchemaObjectDelta> CreateDeltaAsync(DbDataReader reader,
+        CancellationToken ct = default)
+    {
+        var delta = (TableDelta)await base.CreateDeltaAsync(reader, ct).ConfigureAwait(false);
+
+        // Null Actual => the table does not exist yet; nothing to strip (this is a Create).
+        var actual = delta.Actual;
+        if (actual == null)
+        {
+            return delta;
+        }
+
+        var modeledColumns = Columns.Select(x => x.Name).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        foreach (var extra in actual.Columns.Where(c => !modeledColumns.Contains(c.Name)).ToList())
+        {
+            actual.RemoveColumn(extra.Name);
+        }
+
+        // DocumentTable does not model secondary indexes in Weasel (they are raw-DDL managed), so any
+        // non-primary-key index on the live table is treated as user/Polecat-owned and left in place.
+        var modeledIndexes = Indexes.Select(x => x.Name).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        foreach (var extra in actual.Indexes.Where(i => !modeledIndexes.Contains(i.Name)).ToList())
+        {
+            actual.Indexes.Remove(extra);
+        }
+
+        // Foreign keys are likewise raw-DDL managed (DocumentTableEnsurer.EnsureForeignKeysAsync) and
+        // not modeled here, so an unmodeled FK — Polecat's own or a user's — must not be dropped either.
+        var modeledForeignKeys = ForeignKeys.Select(x => x.Name).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        foreach (var extra in actual.ForeignKeys.Where(f => !modeledForeignKeys.Contains(f.Name)).ToList())
+        {
+            actual.ForeignKeys.Remove(extra);
+        }
+
+        // Recompute the diff against the now-stripped actual table.
+        return new TableDelta(this, actual);
     }
 }

--- a/src/Polecat/Storage/MasterTableTenancy.cs
+++ b/src/Polecat/Storage/MasterTableTenancy.cs
@@ -288,6 +288,15 @@ public class MasterTableTenancy : ITenancy
     {
         if (_masterTableEnsured) return;
 
+        // #267: honor AutoCreate.None — when the user manages the schema, the pc_tenants control
+        // table is theirs to provision; never emit DDL at runtime on a least-privilege connection.
+        // A later read against a missing table surfaces as a clean "invalid object" error.
+        if (_options.AutoCreateSchemaObjects == AutoCreate.None)
+        {
+            _masterTableEnsured = true;
+            return;
+        }
+
         await _ensureLock.WaitAsync(token).ConfigureAwait(false);
         try
         {

--- a/src/Polecat/Storage/PolecatDatabase.cs
+++ b/src/Polecat/Storage/PolecatDatabase.cs
@@ -1,3 +1,4 @@
+using JasperFx;
 using JasperFx.Core.Reflection;
 using JasperFx.Descriptors;
 using JasperFx.Events;
@@ -387,6 +388,19 @@ public class PolecatDatabase : DatabaseBase<SqlConnection>, IEventDatabase, IPro
 
     public new async Task EnsureStorageExistsAsync(Type storageType, CancellationToken token)
     {
+        // #267: honor AutoCreate.None. When the user opts out of runtime schema management
+        // (e.g. the schema is owned by EF migrations on a least-privilege Azure SQL connection
+        // with no ALTER), no DDL may run on a storage-ensure. ApplyAllConfiguredChangesToDatabaseAsync
+        // would otherwise force-apply the WHOLE schema — and Weasel's DatabaseBase promotes
+        // None -> CreateOrUpdate, so any drift between the live schema and Polecat's model emits
+        // ALTER/sp_rename and fails. This is the daemon's first storage access (see
+        // DocumentStore.BuildProjectionDaemonAsync); on-the-fly session/query creation is already
+        // gated in DocumentTableEnsurer (#219).
+        if (AutoCreate == AutoCreate.None)
+        {
+            return;
+        }
+
         await ApplyAllConfiguredChangesToDatabaseAsync(ct: token);
     }
 


### PR DESCRIPTION
Fixes #267.

## Part 1 — `AutoCreate.None` is now honored in every runtime-DDL pathway

`PolecatDatabase.EnsureStorageExistsAsync` `new`-shadowed Weasel's base method and force-applied the **entire** schema on every storage-ensure, ignoring `AutoCreate` and the `storageType` arg. Weasel then promotes `None → CreateOrUpdate`, so on a least-privilege connection (Azure SQL Managed Identity, no `ALTER`) the daemon's first storage access emitted `ALTER`/`sp_rename` and failed.

- `PolecatDatabase.EnsureStorageExistsAsync` (the daemon path) now no-ops under `None`.
- `HiloSequence` (setting threaded through `SequenceFactory`) no longer provisions `pc_hilo` on first numeric-id `Store()` under `None`.
- `MasterTableTenancy.EnsureMasterTableAsync` no longer creates `pc_tenants` under `None`.

The on-first-use document/event-store paths were already gated (#219). The explicit opt-in resource model (`ApplyAllDatabaseChangesOnStartup` / `AddResourceSetupOnStartup`) is intentionally left to apply regardless of `AutoCreate`.

## Part 2 — `DocumentTable` modeling bug (secondary issue from the report)

`DocumentTable` models only the columns Polecat manages; its persisted computed columns, secondary indexes, and FKs are applied as idempotent **raw DDL** (not in the Weasel model). A user may also add their own (e.g. a unique index + persisted computed column via a raw EF migration). Weasel's `TableDelta` treated all of those as "extras" and emitted `DROP COLUMN`/`DROP INDEX`/`DROP CONSTRAINT` — destructive — while leaving a permanently non-empty diff that kept every storage-ensure re-applying DDL.

`DocumentTable.CreateDeltaAsync` now strips unmodeled columns, indexes, and foreign keys from the fetched table before diffing, so Polecat is purely **additive**: it never drops or churns objects it does not own, and the diff settles to `None`.

## Tests
- `auto_create_none_runtime_ddl_tests` — daemon build + HiLo under `None` create no schema.
- `document_table_ignores_unmodeled_objects_tests` — user-added column/index survive a full migration; diff reports no drift.
- Full suite: **1342 passed, 0 failed, 3 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)