### PR TITLE
fix: honor [JsonPropertyName] and [JsonStringEnumMemberName] in LINQ and patching (#270)

### DIFF
--- a/src/Polecat.Tests/Linq/json_naming_attribute_queries.cs
+++ b/src/Polecat.Tests/Linq/json_naming_attribute_queries.cs
@@ -1,0 +1,109 @@
+using System.Text.Json.Serialization;
+using Polecat.Linq;
+using Polecat.Tests.Harness;
+using Weasel.Core;
+
+namespace Polecat.Tests.Linq;
+
+/// <summary>
+/// #270: System.Text.Json member-name override attributes — [JsonPropertyName] on a property and
+/// [JsonStringEnumMemberName] on an enum member — are honored when documents are written, so the
+/// stored JSON uses "cityName" and "enabled"/"disabled". But the LINQ translator ignored them: it
+/// applied only the naming *policy*, emitting JSON_VALUE(data, '$.city') = 'active' instead of
+/// JSON_VALUE(data, '$.cityName') = 'enabled', so predicates over these members matched nothing.
+/// </summary>
+public class json_naming_attribute_queries : OneOffConfigurationsContext
+{
+    public enum ActiveStatus
+    {
+        [JsonStringEnumMemberName("enabled")]
+        Active,
+
+        [JsonStringEnumMemberName("disabled")]
+        Inactive
+    }
+
+    public class User
+    {
+        public Guid Id { get; set; }
+        public string FirstName { get; set; } = string.Empty;
+        public string LastName { get; set; } = string.Empty;
+
+        [JsonPropertyName("cityName")]
+        public string City { get; set; } = string.Empty;
+
+        public ActiveStatus Status { get; set; }
+    }
+
+    private async Task SeedAsync()
+    {
+        ConfigureStore(opts => opts.ConfigureSerialization(EnumStorage.AsString));
+
+        await using var session = theStore.LightweightSession();
+        session.Store(new User
+        {
+            Id = Guid.NewGuid(), FirstName = "Evan", LastName = "Kutch",
+            City = "Taggia", Status = ActiveStatus.Active
+        });
+        session.Store(new User
+        {
+            Id = Guid.NewGuid(), FirstName = "Jane", LastName = "Doe",
+            City = "Taggia", Status = ActiveStatus.Inactive
+        });
+        session.Store(new User
+        {
+            Id = Guid.NewGuid(), FirstName = "John", LastName = "Roe",
+            City = "Milan", Status = ActiveStatus.Active
+        });
+        await session.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task query_by_json_property_name_override()
+    {
+        await SeedAsync();
+
+        await using var query = theStore.QuerySession();
+
+        // City is stored under "cityName" — the predicate must target $.cityName, not $.city.
+        var results = await query.Query<User>()
+            .Where(u => u.City == "Taggia")
+            .ToListAsync();
+
+        results.Count.ShouldBe(2);
+        results.ShouldAllBe(u => u.City == "Taggia");
+    }
+
+    [Fact]
+    public async Task query_by_json_string_enum_member_name_override()
+    {
+        await SeedAsync();
+
+        await using var query = theStore.QuerySession();
+
+        // Active is stored as "enabled" — the predicate must compare against "enabled".
+        var active = await query.Query<User>()
+            .Where(u => u.Status == ActiveStatus.Active)
+            .ToListAsync();
+
+        active.Count.ShouldBe(2);
+        active.ShouldAllBe(u => u.Status == ActiveStatus.Active);
+    }
+
+    [Fact]
+    public async Task query_the_reporters_exact_predicate()
+    {
+        await SeedAsync();
+
+        await using var query = theStore.QuerySession();
+
+        // The exact repro from the issue: combined enum + [JsonPropertyName] predicate.
+        var users = await query.Query<User>()
+            .Where(u => u.Status == ActiveStatus.Active && u.City == "Taggia")
+            .OrderBy(u => u.FirstName).ThenBy(u => u.LastName)
+            .ToListAsync();
+
+        users.Count.ShouldBe(1);
+        users[0].FirstName.ShouldBe("Evan");
+    }
+}

--- a/src/Polecat.Tests/Patching/patching_json_naming_attributes.cs
+++ b/src/Polecat.Tests/Patching/patching_json_naming_attributes.cs
@@ -1,0 +1,79 @@
+using System.Text.Json.Serialization;
+using Polecat.Patching;
+using Polecat.Tests.Harness;
+using Shouldly;
+using Weasel.Core;
+
+namespace Polecat.Tests.Patching;
+
+/// <summary>
+///     #270: Patch().Set(...) must target the JSON key the document was actually written with. A
+///     [JsonPropertyName] override on the property (City → "cityName") and a
+///     [JsonStringEnumMemberName] override on an enum member (Active → "enabled") were ignored: the
+///     path resolver only applied the naming policy, so JSON_MODIFY wrote a *second* "city" key
+///     instead of updating "cityName".
+/// </summary>
+public class patching_json_naming_attributes : OneOffConfigurationsContext
+{
+    public enum ActiveStatus
+    {
+        [JsonStringEnumMemberName("enabled")]
+        Active,
+
+        [JsonStringEnumMemberName("disabled")]
+        Inactive
+    }
+
+    public class PatchUser
+    {
+        public Guid Id { get; set; }
+
+        [JsonPropertyName("cityName")]
+        public string City { get; set; } = string.Empty;
+
+        public ActiveStatus Status { get; set; }
+    }
+
+    private async Task<string> RawJsonAsync(Guid id)
+    {
+        var schema = theStore.Options.DatabaseSchemaName;
+        await using var conn = await OpenConnectionAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"SELECT CAST(data AS nvarchar(max)) FROM [{schema}].[pc_doc_patchuser] WHERE id = @id";
+        cmd.Parameters.AddWithValue("@id", id);
+        return (string)(await cmd.ExecuteScalarAsync())!;
+    }
+
+    [Fact]
+    public async Task set_honors_json_property_name_and_enum_member_name()
+    {
+        ConfigureStore(opts => opts.ConfigureSerialization(EnumStorage.AsString));
+
+        var user = new PatchUser { Id = Guid.NewGuid(), City = "Milan", Status = ActiveStatus.Inactive };
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Store(user);
+            await session.SaveChangesAsync();
+        }
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Patch<PatchUser>(user.Id).Set(x => x.City, "Taggia");
+            session.Patch<PatchUser>(user.Id).Set(x => x.Status, ActiveStatus.Active);
+            await session.SaveChangesAsync();
+        }
+
+        var json = await RawJsonAsync(user.Id);
+
+        // The patch must UPDATE the existing "cityName" key, not create a stray "city" key.
+        json.ShouldContain("\"cityName\":\"Taggia\"");
+        json.ShouldNotContain("\"city\":");
+        // Enum value serialized through the [JsonStringEnumMemberName] override.
+        json.ShouldContain("\"status\":\"enabled\"");
+
+        await using var query = theStore.QuerySession();
+        var reloaded = (await query.LoadAsync<PatchUser>(user.Id))!;
+        reloaded.City.ShouldBe("Taggia");
+        reloaded.Status.ShouldBe(ActiveStatus.Active);
+    }
+}

--- a/src/Polecat/Linq/Members/EnumMember.cs
+++ b/src/Polecat/Linq/Members/EnumMember.cs
@@ -1,4 +1,6 @@
+using System.Reflection;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Weasel.Core;
 
 namespace Polecat.Linq.Members;
@@ -72,7 +74,22 @@ internal class EnumMember : IQueryableMember
             name = Enum.GetName(MemberType, value) ?? value.ToString();
         }
 
-        return _namingPolicy != null && name != null
+        if (name == null)
+        {
+            return null;
+        }
+
+        // #270: an explicit [JsonStringEnumMemberName] on the enum member wins verbatim over the
+        // naming policy — STJ's JsonStringEnumConverter serializes the attribute name as-is and does
+        // NOT apply the policy on top of it, so the predicate literal must not either.
+        var field = MemberType.GetField(name);
+        var attribute = field?.GetCustomAttribute<JsonStringEnumMemberNameAttribute>();
+        if (attribute != null)
+        {
+            return attribute.Name;
+        }
+
+        return _namingPolicy != null
             ? _namingPolicy.ConvertName(name)
             : name;
     }

--- a/src/Polecat/Linq/Members/MemberFactory.cs
+++ b/src/Polecat/Linq/Members/MemberFactory.cs
@@ -1,6 +1,7 @@
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using JasperFx.Core.Reflection;
 using Polecat.Serialization;
 using Polecat.Storage;
@@ -133,7 +134,7 @@ internal class MemberFactory : IMemberResolver
 
         while (current != null)
         {
-            segments.Insert(0, GetJsonPropertyName(current.Member.Name));
+            segments.Insert(0, GetJsonPropertyName(current.Member));
 
             if (current.Expression is ParameterExpression)
                 break;
@@ -144,9 +145,20 @@ internal class MemberFactory : IMemberResolver
         return "$." + string.Join(".", segments);
     }
 
-    private string GetJsonPropertyName(string clrPropertyName)
+    /// <summary>
+    ///     #270: resolves the JSON key for a member exactly as System.Text.Json serializes it — an
+    ///     explicit [JsonPropertyName] wins verbatim over the naming policy (STJ does NOT apply the
+    ///     policy on top of an explicit name), otherwise the configured naming policy is applied.
+    /// </summary>
+    private string GetJsonPropertyName(MemberInfo member)
     {
-        return _namingPolicy?.ConvertName(clrPropertyName) ?? clrPropertyName;
+        var attribute = member.GetCustomAttribute<JsonPropertyNameAttribute>();
+        if (attribute != null)
+        {
+            return attribute.Name;
+        }
+
+        return _namingPolicy?.ConvertName(member.Name) ?? member.Name;
     }
 
     private static Type GetMemberType(MemberInfo member)

--- a/src/Polecat/Patching/JsonPathHelper.cs
+++ b/src/Polecat/Patching/JsonPathHelper.cs
@@ -2,6 +2,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Polecat.Patching;
 
@@ -14,13 +15,6 @@ namespace Polecat.Patching;
 internal static class JsonPathHelper
 {
     public static string ToPath(Expression expression, JsonNamingPolicy? namingPolicy)
-    {
-        var members = ExtractMembers(expression);
-        var segments = members.Select(m => FormatName(m, namingPolicy));
-        return string.Join(".", segments);
-    }
-
-    private static List<string> ExtractMembers(Expression expression)
     {
         // Unwrap lambda
         if (expression is LambdaExpression lambda)
@@ -35,28 +29,31 @@ internal static class JsonPathHelper
         }
 
         var segments = new List<string>();
-        CollectSegments(expression, segments);
-        return segments;
+        CollectSegments(expression, segments, namingPolicy);
+        return string.Join(".", segments);
     }
 
-    private static void CollectSegments(Expression expression, List<string> segments)
+    private static void CollectSegments(Expression expression, List<string> segments,
+        JsonNamingPolicy? namingPolicy)
     {
         switch (expression)
         {
             case MemberExpression member:
                 if (member.Expression is not ParameterExpression)
                 {
-                    CollectSegments(member.Expression!, segments);
+                    CollectSegments(member.Expression!, segments, namingPolicy);
                 }
 
-                segments.Add(member.Member.Name);
+                segments.Add(FormatMember(member.Member, namingPolicy));
                 break;
 
             case MethodCallExpression methodCall when IsDictionaryIndexer(methodCall):
                 // Dictionary indexer: x.Dict["key"] or x.Dict[variable]
-                CollectSegments(methodCall.Object!, segments);
+                CollectSegments(methodCall.Object!, segments, namingPolicy);
                 var key = EvaluateExpression(methodCall.Arguments[0]);
-                segments.Add(key?.ToString() ?? throw new InvalidOperationException("Dictionary key cannot be null."));
+                segments.Add(FormatName(
+                    key?.ToString() ?? throw new InvalidOperationException("Dictionary key cannot be null."),
+                    namingPolicy));
                 break;
 
             case ParameterExpression:
@@ -108,6 +105,22 @@ internal static class JsonPathHelper
         var lambda = Expression.Lambda(expression);
         var compiled = lambda.Compile();
         return compiled.DynamicInvoke();
+    }
+
+    /// <summary>
+    ///     #270: resolves the JSON key for a member exactly as System.Text.Json serializes it — an
+    ///     explicit [JsonPropertyName] wins verbatim over the naming policy, otherwise the configured
+    ///     naming policy is applied — so a patch targets the same key the document was written with.
+    /// </summary>
+    private static string FormatMember(MemberInfo member, JsonNamingPolicy? namingPolicy)
+    {
+        var attribute = member.GetCustomAttribute<JsonPropertyNameAttribute>();
+        if (attribute != null)
+        {
+            return attribute.Name;
+        }
+
+        return FormatName(member.Name, namingPolicy);
     }
 
     private static string FormatName(string clrName, JsonNamingPolicy? namingPolicy)


### PR DESCRIPTION
Fixes #270.

## Problem

System.Text.Json member-name override attributes were honored when **writing** documents but ignored when **querying** or **patching**:

- `[JsonPropertyName("cityName")]` — the document stores `"cityName"`, but the LINQ translator emitted `JSON_VALUE(data, '$.city')`, so predicates/ordering over that member matched nothing.
- `[JsonStringEnumMemberName("enabled")]` — with `EnumStorage.AsString` the value stores as `"enabled"`, but the predicate literal was `"active"`, again matching nothing.

The reporter's exact query returned zero rows:

```sql
WHERE (JSON_VALUE(data, '$.status') = 'active' AND JSON_VALUE(data, '$.city') = 'Taggia')
-- should be: $.status = 'enabled' AND $.cityName = 'Taggia'
```

## Fix

Mirrors Marten's `ToJsonKey` precedence — an explicit `[JsonPropertyName]` wins **verbatim** over the naming policy (STJ does not apply the policy on top of an explicit name).

- **`MemberFactory.GetJsonPropertyName`** — reads `[JsonPropertyName]` before applying the naming policy (covers `Where`, `OrderBy`, `Select`, nested members).
- **`EnumMember.ConvertValue`** — reads `[JsonStringEnumMemberName]` before the naming policy. Polecat's serializer wires `JsonStringEnumConverter(namingPolicy)`, which honors this attribute on write, so the query side must match. (Note: this goes a step beyond Marten's Postgres implementation, which does not honor custom enum names.)
- **`JsonPathHelper`** (patch path resolver) — reads `[JsonPropertyName]` for member segments so `Patch().Set(...)` updates the correct key instead of writing a stray one. Dictionary-key segments keep their existing behavior. Patch **values** already route through the serializer, so `[JsonStringEnumMemberName]` was already honored on the value side.

## Tests

- `Linq/json_naming_attribute_queries.cs` — the reporter's `User`/`ActiveStatus` repro across `[JsonPropertyName]`, the enum override, and the exact combined predicate.
- `Patching/patching_json_naming_attributes.cs` — asserts raw stored JSON: the patch updates `"cityName"` (no stray `"city"`) and writes `"status":"enabled"`.

All Linq + Patching tests pass (211/211 on net10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)