### PR TITLE
perf: compile DocumentMapping id accessors with FEC instead of reflection (#273)

### DIFF
--- a/src/Polecat/Storage/DocumentMapping.cs
+++ b/src/Polecat/Storage/DocumentMapping.cs
@@ -1,5 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Linq.Expressions;
 using System.Reflection;
+using FastExpressionCompiler;
 using JasperFx;
 using JasperFx.Core.Reflection;
 using Polecat.Attributes;
@@ -16,6 +18,8 @@ namespace Polecat.Storage;
     Justification = "Class-level: AddSubClassHierarchy uses Assembly.GetTypes() to discover subclasses; document hierarchies are part of the registered surface and AOT consumers must preserve subclass types via their JsonSerializerContext / per-type registration.")]
 [UnconditionalSuppressMessage("Trimming", "IL2070:DynamicallyAccessedMembers",
     Justification = "Class-level: reflects PublicProperties on the document Type (FindIdProperty, DiscoverIndexAttributes). The document type is preserved at the registration boundary (Schema.For<T>()), where T flows in from caller code that trimming sees.")]
+[UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+    Justification = "Class-level: the id accessor delegates (BuildPropertyAccessors / BuildWrapper / BuildUnwrapper) compile expression trees with FastExpressionCompiler once per document type at registration — the same FEC accessor strategy Marten's closed-shape storage uses. AOT consumers supply a source-generator-backed serializer per the AOT publishing guide; the reflective serialize path is already the gating RUC/RDC surface.")]
 internal class DocumentMapping
 {
     private static readonly HashSet<Type> SupportedIdTypes =
@@ -23,6 +27,15 @@ internal class DocumentMapping
 
     private readonly PropertyInfo _idProperty;
     private readonly Type _documentType;
+
+    // #273 Phase 2: FEC-compiled id accessors built once per document type at construction, replacing
+    // per-call PropertyInfo.GetValue/SetValue on the Store/Load/assign hot paths. _idGetter/_idSetter
+    // read/write the raw (possibly wrapper) id member; the wrap/unwrap delegates are non-null only for
+    // strongly-typed-id documents.
+    private readonly Func<object, object?> _idGetter;
+    private readonly Action<object, object> _idSetter;
+    private readonly Func<object, object>? _idUnwrapper;
+    private readonly Func<object, object>? _idWrapper;
 
     public DocumentMapping(Type documentType, StoreOptions options)
     {
@@ -51,6 +64,14 @@ internal class DocumentMapping
         }
 
         IsNumericId = InnerIdType == typeof(int) || InnerIdType == typeof(long);
+
+        // Compile the id accessor delegates once, now that _idProperty and ValueTypeId are settled.
+        (_idGetter, _idSetter) = BuildPropertyAccessors(_idProperty);
+        if (ValueTypeId != null)
+        {
+            _idUnwrapper = BuildUnwrapper(ValueTypeId);
+            _idWrapper = BuildWrapper(ValueTypeId);
+        }
 
         // Read HiloSequenceAttribute if present on numeric ID types
         if (IsNumericId)
@@ -302,16 +323,11 @@ internal class DocumentMapping
     /// </summary>
     public object GetId(object document)
     {
-        var raw = _idProperty.GetValue(document)
+        var raw = _idGetter(document)
             ?? throw new InvalidOperationException(
                 $"Document of type '{_documentType.Name}' has a null Id.");
 
-        if (ValueTypeId != null)
-        {
-            return ValueTypeId.ValueProperty.GetValue(raw)!;
-        }
-
-        return raw;
+        return _idUnwrapper != null ? _idUnwrapper(raw) : raw;
     }
 
     /// <summary>
@@ -320,7 +336,7 @@ internal class DocumentMapping
     /// </summary>
     public object GetRawId(object document)
     {
-        return _idProperty.GetValue(document)
+        return _idGetter(document)
             ?? throw new InvalidOperationException(
                 $"Document of type '{_documentType.Name}' has a null Id.");
     }
@@ -330,34 +346,74 @@ internal class DocumentMapping
     /// </summary>
     public void SetId(object document, object id)
     {
-        if (ValueTypeId != null)
+        if (_idWrapper != null)
         {
-            // If id is already the wrapper type (e.g., PaymentId), use it directly
-            var idActualType = id.GetType();
+            // If id is already the wrapper type (e.g., PaymentId), set it directly
             var wrapperType = Nullable.GetUnderlyingType(IdType) ?? IdType;
-            if (idActualType == wrapperType)
+            if (id.GetType() == wrapperType)
             {
-                _idProperty.SetValue(document, id);
+                _idSetter(document, id);
                 return;
             }
 
-            // Wrap: Guid → OrderId
-            object wrapped;
-            if (ValueTypeId.Ctor != null)
-            {
-                wrapped = ValueTypeId.Ctor.Invoke([id]);
-            }
-            else
-            {
-                wrapped = ValueTypeId.Builder!.Invoke(null, [id])!;
-            }
-
-            _idProperty.SetValue(document, wrapped);
+            // Wrap the inner value (e.g., Guid → OrderId) then set
+            _idSetter(document, _idWrapper(id));
         }
         else
         {
-            _idProperty.SetValue(document, id);
+            _idSetter(document, id);
         }
+    }
+
+    /// <summary>
+    ///     Compiles boxed get/set delegates for a document's id property, replacing per-call reflection.
+    /// </summary>
+    private static (Func<object, object?> getter, Action<object, object> setter) BuildPropertyAccessors(
+        PropertyInfo property)
+    {
+        var targetType = property.DeclaringType!;
+
+        var getDocument = Expression.Parameter(typeof(object), "document");
+        var getBody = Expression.Convert(
+            Expression.Property(Expression.Convert(getDocument, targetType), property),
+            typeof(object));
+        var getter = Expression.Lambda<Func<object, object?>>(getBody, getDocument).CompileFast();
+
+        var setDocument = Expression.Parameter(typeof(object), "document");
+        var setValue = Expression.Parameter(typeof(object), "value");
+        var setBody = Expression.Assign(
+            Expression.Property(Expression.Convert(setDocument, targetType), property),
+            Expression.Convert(setValue, property.PropertyType));
+        var setter = Expression.Lambda<Action<object, object>>(setBody, setDocument, setValue).CompileFast();
+
+        return (getter, setter);
+    }
+
+    /// <summary>
+    ///     Compiles a delegate that reads the inner value out of a strong-typed-id wrapper instance.
+    /// </summary>
+    private static Func<object, object> BuildUnwrapper(ValueTypeInfo valueType)
+    {
+        var wrapper = Expression.Parameter(typeof(object), "wrapper");
+        var body = Expression.Convert(
+            Expression.Property(Expression.Convert(wrapper, valueType.OuterType), valueType.ValueProperty),
+            typeof(object));
+        return Expression.Lambda<Func<object, object>>(body, wrapper).CompileFast();
+    }
+
+    /// <summary>
+    ///     Compiles a delegate that wraps an inner value into its strong-typed-id wrapper, via the
+    ///     wrapper's constructor or its static builder method (whichever <see cref="ValueTypeInfo"/> found).
+    /// </summary>
+    private static Func<object, object> BuildWrapper(ValueTypeInfo valueType)
+    {
+        var inner = Expression.Parameter(typeof(object), "inner");
+        var innerValue = Expression.Convert(inner, valueType.SimpleType);
+        Expression construct = valueType.Ctor != null
+            ? Expression.New(valueType.Ctor, innerValue)
+            : Expression.Call(valueType.Builder!, innerValue);
+        return Expression.Lambda<Func<object, object>>(Expression.Convert(construct, typeof(object)), inner)
+            .CompileFast();
     }
 
     public static PropertyInfo? FindIdProperty(Type type)

--- a/src/Polecat/Storage/DocumentMapping.cs
+++ b/src/Polecat/Storage/DocumentMapping.cs
@@ -1,7 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
-using System.Linq.Expressions;
 using System.Reflection;
-using FastExpressionCompiler;
 using JasperFx;
 using JasperFx.Core.Reflection;
 using Polecat.Attributes;
@@ -19,7 +17,7 @@ namespace Polecat.Storage;
 [UnconditionalSuppressMessage("Trimming", "IL2070:DynamicallyAccessedMembers",
     Justification = "Class-level: reflects PublicProperties on the document Type (FindIdProperty, DiscoverIndexAttributes). The document type is preserved at the registration boundary (Schema.For<T>()), where T flows in from caller code that trimming sees.")]
 [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
-    Justification = "Class-level: the id accessor delegates (BuildPropertyAccessors / BuildWrapper / BuildUnwrapper) compile expression trees with FastExpressionCompiler once per document type at registration — the same FEC accessor strategy Marten's closed-shape storage uses. AOT consumers supply a source-generator-backed serializer per the AOT publishing guide; the reflective serialize path is already the gating RUC/RDC surface.")]
+    Justification = "Class-level: the id accessors close JasperFx's LambdaBuilder / ValueTypeInfo generic converters over the runtime document + id types via MakeGenericMethod once per document type at registration — the same FEC accessor helpers and runtime generic-closing Marten's closed-shape storage / ProviderGraph use. AOT consumers supply a source-generator-backed serializer per the AOT publishing guide; the reflective serialize path is already the gating RUC/RDC surface.")]
 internal class DocumentMapping
 {
     private static readonly HashSet<Type> SupportedIdTypes =
@@ -66,11 +64,10 @@ internal class DocumentMapping
         IsNumericId = InnerIdType == typeof(int) || InnerIdType == typeof(long);
 
         // Compile the id accessor delegates once, now that _idProperty and ValueTypeId are settled.
-        (_idGetter, _idSetter) = BuildPropertyAccessors(_idProperty);
+        (_idGetter, _idSetter) = BuildRawIdAccessors(_idProperty);
         if (ValueTypeId != null)
         {
-            _idUnwrapper = BuildUnwrapper(ValueTypeId);
-            _idWrapper = BuildWrapper(ValueTypeId);
+            (_idUnwrapper, _idWrapper) = BuildStrongTypedIdConverters(ValueTypeId);
         }
 
         // Read HiloSequenceAttribute if present on numeric ID types
@@ -365,55 +362,60 @@ internal class DocumentMapping
         }
     }
 
+    // JasperFx's LambdaBuilder / ValueTypeInfo generate the FEC accessor delegates (the same helpers
+    // Marten's closed-shape storage uses), but they are typed-generic — LambdaBuilder.GetProperty
+    // requires TTarget to be the property's declaring type. DocumentMapping is non-generic, so each
+    // builder closes a small generic bridge over the runtime types via MakeGenericMethod (the same
+    // runtime generic-closing Marten's ProviderGraph performs) and adapts the typed delegate to object.
+
     /// <summary>
-    ///     Compiles boxed get/set delegates for a document's id property, replacing per-call reflection.
+    ///     Builds boxed get/set delegates for a document's id property via JasperFx's LambdaBuilder,
+    ///     replacing per-call reflection.
     /// </summary>
-    private static (Func<object, object?> getter, Action<object, object> setter) BuildPropertyAccessors(
+    [RequiresUnreferencedCode("Closes LambdaBuilder over the document + id types via MakeGenericMethod.")]
+    private static (Func<object, object?> getter, Action<object, object> setter) BuildRawIdAccessors(
         PropertyInfo property)
     {
-        var targetType = property.DeclaringType!;
+        var closed = typeof(DocumentMapping)
+            .GetMethod(nameof(RawIdAccessors), BindingFlags.NonPublic | BindingFlags.Static)!
+            .MakeGenericMethod(property.DeclaringType!, property.PropertyType);
+        return ((Func<object, object?>, Action<object, object>))closed.Invoke(null, [property])!;
+    }
 
-        var getDocument = Expression.Parameter(typeof(object), "document");
-        var getBody = Expression.Convert(
-            Expression.Property(Expression.Convert(getDocument, targetType), property),
-            typeof(object));
-        var getter = Expression.Lambda<Func<object, object?>>(getBody, getDocument).CompileFast();
-
-        var setDocument = Expression.Parameter(typeof(object), "document");
-        var setValue = Expression.Parameter(typeof(object), "value");
-        var setBody = Expression.Assign(
-            Expression.Property(Expression.Convert(setDocument, targetType), property),
-            Expression.Convert(setValue, property.PropertyType));
-        var setter = Expression.Lambda<Action<object, object>>(setBody, setDocument, setValue).CompileFast();
-
-        return (getter, setter);
+    [RequiresUnreferencedCode("Delegates to LambdaBuilder.GetProperty / SetProperty.")]
+    private static (Func<object, object?>, Action<object, object>) RawIdAccessors<TDoc, TId>(PropertyInfo property)
+        where TDoc : notnull
+    {
+        var getter = LambdaBuilder.GetProperty<TDoc, TId>(property);
+        var setter = LambdaBuilder.SetProperty<TDoc, TId>(property)!;
+        return (
+            document => getter((TDoc)document),
+            (document, value) => setter((TDoc)document, (TId)value));
     }
 
     /// <summary>
-    ///     Compiles a delegate that reads the inner value out of a strong-typed-id wrapper instance.
+    ///     Builds boxed unwrap (wrapper → inner) and wrap (inner → wrapper) delegates for a
+    ///     strongly-typed id via JasperFx's <see cref="ValueTypeInfo"/> converters.
     /// </summary>
-    private static Func<object, object> BuildUnwrapper(ValueTypeInfo valueType)
+    [RequiresUnreferencedCode("Closes ValueTypeInfo converters over the wrapper + inner types via MakeGenericMethod.")]
+    private static (Func<object, object> unwrapper, Func<object, object> wrapper) BuildStrongTypedIdConverters(
+        ValueTypeInfo valueType)
     {
-        var wrapper = Expression.Parameter(typeof(object), "wrapper");
-        var body = Expression.Convert(
-            Expression.Property(Expression.Convert(wrapper, valueType.OuterType), valueType.ValueProperty),
-            typeof(object));
-        return Expression.Lambda<Func<object, object>>(body, wrapper).CompileFast();
+        var closed = typeof(DocumentMapping)
+            .GetMethod(nameof(StrongTypedIdConverters), BindingFlags.NonPublic | BindingFlags.Static)!
+            .MakeGenericMethod(valueType.OuterType, valueType.SimpleType);
+        return ((Func<object, object>, Func<object, object>))closed.Invoke(null, [valueType])!;
     }
 
-    /// <summary>
-    ///     Compiles a delegate that wraps an inner value into its strong-typed-id wrapper, via the
-    ///     wrapper's constructor or its static builder method (whichever <see cref="ValueTypeInfo"/> found).
-    /// </summary>
-    private static Func<object, object> BuildWrapper(ValueTypeInfo valueType)
+    [RequiresUnreferencedCode("Delegates to ValueTypeInfo.UnWrapper / CreateWrapper.")]
+    private static (Func<object, object>, Func<object, object>) StrongTypedIdConverters<TOuter, TInner>(
+        ValueTypeInfo valueType)
     {
-        var inner = Expression.Parameter(typeof(object), "inner");
-        var innerValue = Expression.Convert(inner, valueType.SimpleType);
-        Expression construct = valueType.Ctor != null
-            ? Expression.New(valueType.Ctor, innerValue)
-            : Expression.Call(valueType.Builder!, innerValue);
-        return Expression.Lambda<Func<object, object>>(Expression.Convert(construct, typeof(object)), inner)
-            .CompileFast();
+        var unwrapper = valueType.UnWrapper<TOuter, TInner>();   // Func<TOuter, TInner>
+        var wrapper = valueType.CreateWrapper<TOuter, TInner>(); // Func<TInner, TOuter>
+        return (
+            outer => unwrapper((TOuter)outer)!,
+            inner => wrapper((TInner)inner)!);
     }
 
     public static PropertyInfo? FindIdProperty(Type type)


### PR DESCRIPTION
Phase 2 of #273 (FEC pre-positioning).

Replaces `DocumentMapping.GetId`/`GetRawId`/`SetId`'s per-call `PropertyInfo.GetValue`/`SetValue` — and the strong-typed-id `Ctor.Invoke`/`Builder.Invoke` reflection — with **FastExpressionCompiler-compiled delegates built once per document type** at construction:

- `_idGetter` / `_idSetter` — boxed get/set for the id property
- `_idUnwrapper` / `_idWrapper` — inner↔wrapper conversion for strongly-typed ids (built only when `ValueTypeId != null`)

This is the same FEC accessor strategy Marten's closed-shape storage uses (`LambdaBuilder`/`ValueTypeInfo` FEC), so it pre-positions Polecat for the closed-shape convergence (Phase 3/4). All 35 call sites — `Store`/`Insert`/`Update`/`Upsert`, `AssignIdIfNeeded`, bulk insert, identity map — route through these three methods and benefit transitively.

### Behavior & scope
- Exact behavior preserved: same null-id guard, same "id is already the wrapper type" fast path in `SetId`.
- Version-sync (`SyncVersionProperties`/`SyncTenantId`/`SyncCreatedAt`) already used interface pattern-matching, not reflection — unchanged.

### AOT
The codegen is contained to construction and covered by a class-level `IL3050` suppression on `DocumentMapping`. **No `[RequiresDynamicCode]` is added to any public member**, so Polecat's AOT surface is unchanged. The `Polecat.AotSmoke` project (warnings-as-errors) builds clean.

### Verification (net10)
- Strong-typed IDs (Guid/string/long/int wrappers + builder-pattern) + HiLo + CRUD + bulk insert + identity map: **246/246**
- Projections + events + LINQ: **548/548**
- Library + AOT smoke build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)