### PR TITLE
feat: adopt shared Weasel.Core.Identity generation strategies (#273)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -50,8 +50,8 @@
         <PackageVersion Include="Shouldly" Version="4.3.0" />
         <PackageVersion Include="xunit" Version="2.9.3" />
         <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.4" />
-        <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.3.0" />
-        <PackageVersion Include="Weasel.SqlServer" Version="9.3.0" />
+        <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.4.0" />
+        <PackageVersion Include="Weasel.SqlServer" Version="9.4.0" />
 
         <!-- Strongly typed IDs -->
         <PackageVersion Include="StronglyTypedId" Version="1.0.0-beta08" />

--- a/src/Polecat/AdvancedOperations.cs
+++ b/src/Polecat/AdvancedOperations.cs
@@ -94,27 +94,11 @@ public class AdvancedOperations
         var rows = new List<(object Id, string Json, string DotNetType)>(documents.Count);
         foreach (var doc in documents)
         {
-            // Auto-assign Guid for strongly typed Guid wrappers when default
-            if (mapping.IsStrongTypedId && mapping.InnerIdType == typeof(Guid))
+            // #273: route id generation through the shared Weasel.Core.Identity strategy, same as
+            // single-doc Store, so bulk insert and single-doc stay consistent (Guid → UUIDv7, etc.).
+            if (provider.SequenceSource is not null)
             {
-                var currentId = mapping.GetId(doc);
-                if ((Guid)currentId == Guid.Empty)
-                {
-                    mapping.SetId(doc, Internal.SequentialGuid.NewGuid());
-                }
-            }
-            // Assign HiLo ID if needed
-            else if (mapping.IsNumericId && provider.Sequence != null)
-            {
-                var currentId = mapping.GetId(doc);
-                if (mapping.InnerIdType == typeof(int) && (int)currentId <= 0)
-                {
-                    mapping.SetId(doc, provider.Sequence.NextInt());
-                }
-                else if (mapping.InnerIdType == typeof(long) && (long)currentId <= 0)
-                {
-                    mapping.SetId(doc, provider.Sequence.NextLong());
-                }
+                mapping.AssignIdIfMissing(doc, provider.SequenceSource);
             }
 
             // Sync metadata
@@ -206,25 +190,10 @@ public class AdvancedOperations
         var rows = new List<(object Id, string Json, string DotNetType, long ExpectedVersion)>(documents.Count);
         foreach (var (doc, expectedVersion) in documents)
         {
-            if (mapping.IsStrongTypedId && mapping.InnerIdType == typeof(Guid))
+            // #273: route id generation through the shared Weasel.Core.Identity strategy (see above).
+            if (provider.SequenceSource is not null)
             {
-                var currentId = mapping.GetId(doc);
-                if ((Guid)currentId == Guid.Empty)
-                {
-                    mapping.SetId(doc, Internal.SequentialGuid.NewGuid());
-                }
-            }
-            else if (mapping.IsNumericId && provider.Sequence != null)
-            {
-                var currentId = mapping.GetId(doc);
-                if (mapping.InnerIdType == typeof(int) && (int)currentId <= 0)
-                {
-                    mapping.SetId(doc, provider.Sequence.NextInt());
-                }
-                else if (mapping.InnerIdType == typeof(long) && (long)currentId <= 0)
-                {
-                    mapping.SetId(doc, provider.Sequence.NextLong());
-                }
+                mapping.AssignIdIfMissing(doc, provider.SequenceSource);
             }
 
             if (doc is ITenanted tenanted)

--- a/src/Polecat/Internal/DocumentProvider.cs
+++ b/src/Polecat/Internal/DocumentProvider.cs
@@ -5,6 +5,7 @@ using Polecat.Metadata;
 using Polecat.Schema.Identity.Sequences;
 using Polecat.Serialization;
 using Polecat.Storage;
+using Weasel.Core.Sequences;
 
 namespace Polecat.Internal;
 
@@ -25,6 +26,11 @@ internal class DocumentProvider
 
     public DocumentMapping Mapping { get; }
     internal ISequence? Sequence { get; set; }
+
+    // #273: the store's sequence source, used by the shared Weasel.Core.Identity generation strategy
+    // (via DocumentMapping.AssignIdIfMissing). Set by the registry; present whenever a SequenceFactory
+    // is configured (always, in practice).
+    internal ISequenceSource? SequenceSource { get; set; }
 
     public string QualifiedTableName => Mapping.QualifiedTableName;
 
@@ -161,38 +167,12 @@ internal class DocumentProvider
 
     private void AssignIdIfNeeded(object document)
     {
-        // #218: auto-assign a new Guid when the id is default. This applies to BOTH a plain
-        // `Guid Id` property and strongly typed Guid wrappers — GetId/SetId already resolve the
-        // inner Guid for either, so gating on InnerIdType (not IsStrongTypedId) is what was missing:
-        // previously a plain Guid id fell through to the numeric branch and was never assigned,
-        // so documents persisted with Guid.Empty.
-        if (Mapping.InnerIdType == typeof(Guid))
+        // #273: id generation now runs through the shared Weasel.Core.Identity strategy resolved on the
+        // mapping (Guid → UUIDv7, int/long → Hi-Lo, strong-typed wrappers handled, string left external),
+        // replacing Polecat's bespoke per-type branching so single-doc and bulk-insert stay consistent.
+        if (SequenceSource is not null)
         {
-            var currentId = Mapping.GetId(document);
-            if ((Guid)currentId == Guid.Empty)
-            {
-                Mapping.SetId(document, SequentialGuid.NewGuid());
-            }
-
-            return;
-        }
-
-        if (Sequence == null || !Mapping.IsNumericId) return;
-
-        var numericId = Mapping.GetId(document);
-        if (Mapping.InnerIdType == typeof(int))
-        {
-            if ((int)numericId <= 0)
-            {
-                Mapping.SetId(document, Sequence.NextInt());
-            }
-        }
-        else if (Mapping.InnerIdType == typeof(long))
-        {
-            if ((long)numericId <= 0)
-            {
-                Mapping.SetId(document, Sequence.NextLong());
-            }
+            Mapping.AssignIdIfMissing(document, SequenceSource);
         }
     }
 }

--- a/src/Polecat/Internal/DocumentProviderRegistry.cs
+++ b/src/Polecat/Internal/DocumentProviderRegistry.cs
@@ -64,10 +64,17 @@ internal class DocumentProviderRegistry
 
             var provider = new DocumentProvider(mapping);
 
-            if (mapping.IsNumericId && _sequenceFactory != null)
+            if (_sequenceFactory != null)
             {
-                var settings = mapping.HiloSettings ?? _options.HiloSequenceDefaults;
-                provider.Sequence = _sequenceFactory.Hilo(type, settings);
+                // #273: the sequence source drives the shared identity generation strategy for every
+                // id shape (Guid strategies ignore it; Hi-Lo strategies resolve their sequence from it).
+                provider.SequenceSource = _sequenceFactory;
+
+                if (mapping.IsNumericId)
+                {
+                    var settings = mapping.HiloSettings ?? _options.HiloSequenceDefaults;
+                    provider.Sequence = _sequenceFactory.Hilo(type, settings);
+                }
             }
 
             return provider;

--- a/src/Polecat/Internal/IIdentityAssigner.cs
+++ b/src/Polecat/Internal/IIdentityAssigner.cs
@@ -1,0 +1,26 @@
+using Weasel.Core.Identity;
+using Weasel.Core.Sequences;
+
+namespace Polecat.Internal;
+
+/// <summary>
+///     #273: non-generic adapter over Weasel.Core's generic <see cref="IIdentification{TDoc,TId}" />
+///     strategy, so Polecat's object-based <see cref="Polecat.Storage.DocumentMapping" /> can route its
+///     id-generation path through the shared identity runtime. Resolved once per document type.
+/// </summary>
+internal interface IIdentityAssigner
+{
+    void AssignIfMissing(object document, ISequenceSource sequences);
+}
+
+internal sealed class IdentityAssigner<TDoc, TId> : IIdentityAssigner
+    where TDoc : notnull
+    where TId : notnull
+{
+    private readonly IIdentification<TDoc, TId> _identification;
+
+    public IdentityAssigner(IIdentification<TDoc, TId> identification) => _identification = identification;
+
+    public void AssignIfMissing(object document, ISequenceSource sequences)
+        => _identification.AssignIfMissing((TDoc)document, sequences);
+}

--- a/src/Polecat/Schema/Identity/Sequences/SequenceFactory.cs
+++ b/src/Polecat/Schema/Identity/Sequences/SequenceFactory.cs
@@ -1,9 +1,12 @@
 using System.Collections.Concurrent;
 using Polecat.Internal;
+using Weasel.Core.Sequences;
 
 namespace Polecat.Schema.Identity.Sequences;
 
-internal class SequenceFactory
+// #273: implements the Weasel.Core ISequenceSource seam (SequenceFor(Type) -> ISequence, already
+// present) so the shared Weasel.Core.Identity strategies can resolve Hi-Lo sequences through it.
+internal class SequenceFactory : ISequenceSource
 {
     private readonly ConcurrentDictionary<string, ISequence> _sequences = new();
     private readonly ConnectionFactory _connectionFactory;

--- a/src/Polecat/Storage/DocumentMapping.cs
+++ b/src/Polecat/Storage/DocumentMapping.cs
@@ -3,9 +3,12 @@ using System.Reflection;
 using JasperFx;
 using JasperFx.Core.Reflection;
 using Polecat.Attributes;
+using Polecat.Internal;
 using Polecat.Metadata;
 using Polecat.Schema.Identity.Sequences;
 using Polecat.Storage.Metadata;
+using Weasel.Core.Identity;
+using Weasel.Core.Sequences;
 
 namespace Polecat.Storage;
 
@@ -34,6 +37,10 @@ internal class DocumentMapping
     private readonly Action<object, object> _idSetter;
     private readonly Func<object, object>? _idUnwrapper;
     private readonly Func<object, object>? _idWrapper;
+
+    // #273: the shared Weasel.Core.Identity generation strategy for this document type, wrapped in a
+    // non-generic adapter. Null for externally-assigned ids (string) that Polecat never auto-generates.
+    private readonly IIdentityAssigner? _identityAssigner;
 
     public DocumentMapping(Type documentType, StoreOptions options)
     {
@@ -69,6 +76,9 @@ internal class DocumentMapping
         {
             (_idUnwrapper, _idWrapper) = BuildStrongTypedIdConverters(ValueTypeId);
         }
+
+        // Resolve the shared Weasel.Core.Identity generation strategy for this id shape.
+        _identityAssigner = BuildIdentityAssigner();
 
         // Read HiloSequenceAttribute if present on numeric ID types
         if (IsNumericId)
@@ -360,6 +370,61 @@ internal class DocumentMapping
         {
             _idSetter(document, id);
         }
+    }
+
+    /// <summary>
+    ///     #273: generate and assign an id if the document doesn't have one, via the shared
+    ///     Weasel.Core.Identity strategy for this id shape. No-op for externally-assigned (string) ids.
+    /// </summary>
+    public void AssignIdIfMissing(object document, ISequenceSource sequences)
+        => _identityAssigner?.AssignIfMissing(document, sequences);
+
+    /// <summary>
+    ///     Picks and constructs the Weasel.Core.Identity strategy matching this document's id shape:
+    ///     strong-typed wrapper → ValueTypeIdentification; Guid → SequentialGuidIdentification (UUIDv7);
+    ///     int / long → Hi-Lo; string (externally assigned) → none.
+    /// </summary>
+    [RequiresUnreferencedCode("Closes the generic Weasel.Core.Identity strategy over the document + id types.")]
+    private IIdentityAssigner? BuildIdentityAssigner()
+    {
+        if (ValueTypeId != null)
+        {
+            var strategyType = typeof(ValueTypeIdentification<,,>)
+                .MakeGenericType(_documentType, ValueTypeId.OuterType, ValueTypeId.SimpleType);
+            var strategy = Activator.CreateInstance(strategyType, _idProperty, ValueTypeId, _documentType)!;
+            return CreateAssigner(_documentType, ValueTypeId.OuterType, strategy);
+        }
+
+        if (IdType == typeof(Guid))
+        {
+            var strategy = Activator.CreateInstance(
+                typeof(SequentialGuidIdentification<>).MakeGenericType(_documentType), _idProperty)!;
+            return CreateAssigner(_documentType, typeof(Guid), strategy);
+        }
+
+        if (IdType == typeof(int))
+        {
+            var strategy = Activator.CreateInstance(
+                typeof(HiloIntIdentification<>).MakeGenericType(_documentType), _idProperty, _documentType)!;
+            return CreateAssigner(_documentType, typeof(int), strategy);
+        }
+
+        if (IdType == typeof(long))
+        {
+            var strategy = Activator.CreateInstance(
+                typeof(HiloLongIdentification<>).MakeGenericType(_documentType), _idProperty, _documentType)!;
+            return CreateAssigner(_documentType, typeof(long), strategy);
+        }
+
+        // string ids are externally assigned in Polecat — no auto-generation.
+        return null;
+    }
+
+    [RequiresUnreferencedCode("Closes IdentityAssigner<TDoc,TId> over the document + id types.")]
+    private static IIdentityAssigner CreateAssigner(Type documentType, Type idType, object identification)
+    {
+        var assignerType = typeof(IdentityAssigner<,>).MakeGenericType(documentType, idType);
+        return (IIdentityAssigner)Activator.CreateInstance(assignerType, identification)!;
     }
 
     // JasperFx's LambdaBuilder / ValueTypeInfo generate the FEC accessor delegates (the same helpers


### PR DESCRIPTION
Part of #273. Polecat now consumes the shared **`Weasel.Core.Identity`** runtime (Weasel 9.4.0) for document-id generation instead of its own per-type branching — the first Polecat consumer of the lifted closed-shape identity family (weasel#321/#322).

### What changed
- **`SequenceFactory : ISequenceSource`** — it already had `SequenceFor(Type) → ISequence`, so this is just the base interface (mirrors Marten's `ISequences`).
- **`Internal/IIdentityAssigner`** — a non-generic adapter over `IIdentification<TDoc,TId>`, so Polecat's object-based `DocumentMapping` can drive the generic strategy.
- **`DocumentMapping`** resolves the strategy per id shape at construction: Guid → `SequentialGuidIdentification` (UUIDv7), int/long → `HiloInt/LongIdentification`, strong-typed wrapper → `ValueTypeIdentification`, string → external (none). Exposes `AssignIdIfMissing`.
- **`DocumentProvider.AssignIdIfNeeded`** and **both `AdvancedOperations` bulk-insert paths** now route through `mapping.AssignIdIfMissing(doc, provider.SequenceSource)` — single-doc and bulk generation stay consistent (this also **fixes a pre-existing bulk-insert gap** where plain Guid ids weren't auto-assigned).

### Behavior change
Default Guid document ids are now **UUIDv7** (`Guid.CreateVersion7()`) instead of Polecat's comb Guid, matching the shared mechanism (weasel#322). Both are time-ordered / index-friendly.

### Verification
Against **released Weasel 9.4.0**: library + `Polecat.AotSmoke` (warnings-as-errors) build clean; **246/246** id-surface tests green (strong-typed IDs incl. builder-pattern, HiLo, CRUD, bulk insert, identity map).

🤖 Generated with [Claude Code](https://claude.com/claude-code)