### PR TITLE
feat: extend shared Weasel.Core.ISerializer base (#273)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -50,8 +50,8 @@
         <PackageVersion Include="Shouldly" Version="4.3.0" />
         <PackageVersion Include="xunit" Version="2.9.3" />
         <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.4" />
-        <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.4.0" />
-        <PackageVersion Include="Weasel.SqlServer" Version="9.4.0" />
+        <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.5.0" />
+        <PackageVersion Include="Weasel.SqlServer" Version="9.5.0" />
 
         <!-- Strongly typed IDs -->
         <PackageVersion Include="StronglyTypedId" Version="1.0.0-beta08" />

--- a/src/Polecat.Tests/GlobalUsings.cs
+++ b/src/Polecat.Tests/GlobalUsings.cs
@@ -12,3 +12,6 @@ global using IVersioned = JasperFx.Metadata.IVersioned;
 global using ITracked = JasperFx.Metadata.ITracked;
 global using RemoveAction = JasperFx.Events.RemoveAction;
 global using TrackLevel = JasperFx.OpenTelemetry.TrackLevel;
+
+// #273: Polecat.Serialization.ISerializer now extends Weasel.Core.ISerializer; alias to the subtype.
+global using ISerializer = Polecat.Serialization.ISerializer;

--- a/src/Polecat/GlobalUsings.cs
+++ b/src/Polecat/GlobalUsings.cs
@@ -30,3 +30,7 @@ global using TrackLevel = JasperFx.OpenTelemetry.TrackLevel;
 global using ISequence = Weasel.Core.Sequences.ISequence;
 global using IReadOnlyHiloSettings = Weasel.Core.Sequences.IReadOnlyHiloSettings;
 global using HiloSettings = Weasel.Core.Sequences.HiloSettings;
+//   #273: Polecat.Serialization.ISerializer now extends the shared Weasel.Core.ISerializer base.
+//     Alias the unqualified name to Polecat's richer subtype so files importing both namespaces
+//     keep resolving ISerializer to Polecat's (which carries the string-based overloads too).
+global using ISerializer = Polecat.Serialization.ISerializer;

--- a/src/Polecat/Serialization/ISerializer.cs
+++ b/src/Polecat/Serialization/ISerializer.cs
@@ -1,39 +1,22 @@
-using System.Data.Common;
 using System.Diagnostics.CodeAnalysis;
-using Weasel.Core;
 
 namespace Polecat.Serialization;
 
 /// <summary>
-///     Serialization abstraction for Polecat. Uses System.Text.Json exclusively.
+///     Serialization abstraction for Polecat. Uses System.Text.Json exclusively. Extends the shared
+///     <see cref="Weasel.Core.ISerializer" /> (the intersection both Critter Stack document stores rely
+///     on) with Polecat's string-based deserialization overloads.
 /// </summary>
 /// <remarks>
-///     The default <see cref="Serializer"/> implementation routes through
-///     <c>System.Text.Json.JsonSerializer</c>, which the .NET trimmer cannot
-///     statically analyse. AOT-publishing apps should plug in a custom
-///     <c>ISerializer</c> implementation backed by an STJ source-generator
-///     context (<c>JsonSerializerContext</c>) rather than the reflection-based
-///     default.
+///     The default <see cref="Serializer" /> implementation routes through
+///     <c>System.Text.Json.JsonSerializer</c>, which the .NET trimmer cannot statically analyse.
+///     AOT-publishing apps should plug in a custom <c>ISerializer</c> implementation backed by an STJ
+///     source-generator context (<c>JsonSerializerContext</c>) rather than the reflection-based default.
+///     The shared base is intentionally unannotated (for Marten parity); the concrete
+///     <see cref="Serializer" /> carries its own trim/AOT suppressions.
 /// </remarks>
-public interface ISerializer
+public interface ISerializer : Weasel.Core.ISerializer
 {
-    /// <summary>
-    ///     The enum storage strategy.
-    /// </summary>
-    EnumStorage EnumStorage { get; }
-
-    /// <summary>
-    ///     The property naming casing strategy.
-    /// </summary>
-    Casing Casing { get; }
-
-    /// <summary>
-    ///     Serialize an object to a JSON string.
-    /// </summary>
-    [RequiresUnreferencedCode("Default ISerializer uses STJ reflection over document.GetType()'s properties; AOT consumers should supply a source-generator-backed ISerializer impl.")]
-    [RequiresDynamicCode("Default ISerializer uses STJ reflection which requires runtime code generation.")]
-    string ToJson(object document);
-
     /// <summary>
     ///     Deserialize a JSON string to an object of type T.
     /// </summary>
@@ -47,46 +30,4 @@ public interface ISerializer
     [RequiresUnreferencedCode("Default ISerializer uses STJ reflection; AOT consumers should supply a source-generator-backed ISerializer impl.")]
     [RequiresDynamicCode("Default ISerializer uses STJ reflection which requires runtime code generation.")]
     object FromJson(Type type, string json);
-
-    /// <summary>
-    ///     Deserialize from a Stream.
-    /// </summary>
-    [RequiresUnreferencedCode("Default ISerializer uses STJ reflection; AOT consumers should supply a source-generator-backed ISerializer impl.")]
-    [RequiresDynamicCode("Default ISerializer uses STJ reflection which requires runtime code generation.")]
-    T FromJson<T>(Stream stream);
-
-    /// <summary>
-    ///     Deserialize from a Stream to the specified type.
-    /// </summary>
-    [RequiresUnreferencedCode("Default ISerializer uses STJ reflection; AOT consumers should supply a source-generator-backed ISerializer impl.")]
-    [RequiresDynamicCode("Default ISerializer uses STJ reflection which requires runtime code generation.")]
-    object FromJson(Type type, Stream stream);
-
-    /// <summary>
-    ///     Deserialize from a DbDataReader column.
-    /// </summary>
-    [RequiresUnreferencedCode("Default ISerializer uses STJ reflection; AOT consumers should supply a source-generator-backed ISerializer impl.")]
-    [RequiresDynamicCode("Default ISerializer uses STJ reflection which requires runtime code generation.")]
-    T FromJson<T>(DbDataReader reader, int index);
-
-    /// <summary>
-    ///     Deserialize from a DbDataReader column to the specified type.
-    /// </summary>
-    [RequiresUnreferencedCode("Default ISerializer uses STJ reflection; AOT consumers should supply a source-generator-backed ISerializer impl.")]
-    [RequiresDynamicCode("Default ISerializer uses STJ reflection which requires runtime code generation.")]
-    object FromJson(Type type, DbDataReader reader, int index);
-
-    /// <summary>
-    ///     Async deserialize from a Stream.
-    /// </summary>
-    [RequiresUnreferencedCode("Default ISerializer uses STJ reflection; AOT consumers should supply a source-generator-backed ISerializer impl.")]
-    [RequiresDynamicCode("Default ISerializer uses STJ reflection which requires runtime code generation.")]
-    ValueTask<T> FromJsonAsync<T>(Stream stream, CancellationToken cancellationToken = default);
-
-    /// <summary>
-    ///     Async deserialize from a Stream to the specified type.
-    /// </summary>
-    [RequiresUnreferencedCode("Default ISerializer uses STJ reflection; AOT consumers should supply a source-generator-backed ISerializer impl.")]
-    [RequiresDynamicCode("Default ISerializer uses STJ reflection which requires runtime code generation.")]
-    ValueTask<object> FromJsonAsync(Type type, Stream stream, CancellationToken cancellationToken = default);
 }

--- a/src/Polecat/Serialization/Serializer.cs
+++ b/src/Polecat/Serialization/Serializer.cs
@@ -76,8 +76,16 @@ public class Serializer : ISerializer
         configure(_options);
     }
 
-    [RequiresUnreferencedCode("STJ JsonSerializer.Serialize uses reflection over document's runtime type.")]
-    [RequiresDynamicCode("STJ JsonSerializer.Serialize requires runtime code generation for non-source-generated types.")]
+    // #273: the shared members inherited from Weasel.Core.ISerializer are intentionally unannotated
+    // (Marten parity), so their reflection-based STJ bodies suppress the RUC/RDC warnings here rather
+    // than propagating a caller-facing contract the base doesn't declare. AOT consumers supply a
+    // source-generator-backed ISerializer. The two string-based overloads below are Polecat-only
+    // (not on the shared base), so they keep the propagating [RequiresUnreferencedCode]/[RequiresDynamicCode].
+    private const string SharedSerializerSuppression =
+        "Reflection-based STJ serialize/deserialize is Polecat's documented default; the shared Weasel.Core.ISerializer base is intentionally unannotated for Marten parity, so RUC/RDC is not propagated. AOT consumers supply a source-generator-backed ISerializer.";
+
+    [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode", Justification = SharedSerializerSuppression)]
+    [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = SharedSerializerSuppression)]
     public string ToJson(object document)
     {
         return JsonSerializer.Serialize(document, document.GetType(), _options);
@@ -97,45 +105,45 @@ public class Serializer : ISerializer
         return JsonSerializer.Deserialize(json, type, _options)!;
     }
 
-    [RequiresUnreferencedCode("STJ JsonSerializer.Deserialize<T> uses reflection over T.")]
-    [RequiresDynamicCode("STJ JsonSerializer.Deserialize requires runtime code generation for non-source-generated types.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode", Justification = SharedSerializerSuppression)]
+    [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = SharedSerializerSuppression)]
     public T FromJson<T>(Stream stream)
     {
         return JsonSerializer.Deserialize<T>(stream, _options)!;
     }
 
-    [RequiresUnreferencedCode("STJ JsonSerializer.Deserialize uses reflection over the supplied type.")]
-    [RequiresDynamicCode("STJ JsonSerializer.Deserialize requires runtime code generation for non-source-generated types.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode", Justification = SharedSerializerSuppression)]
+    [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = SharedSerializerSuppression)]
     public object FromJson(Type type, Stream stream)
     {
         return JsonSerializer.Deserialize(stream, type, _options)!;
     }
 
-    [RequiresUnreferencedCode("STJ JsonSerializer.Deserialize<T> uses reflection over T.")]
-    [RequiresDynamicCode("STJ JsonSerializer.Deserialize requires runtime code generation for non-source-generated types.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode", Justification = SharedSerializerSuppression)]
+    [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = SharedSerializerSuppression)]
     public T FromJson<T>(DbDataReader reader, int index)
     {
         var json = reader.GetString(index);
         return FromJson<T>(json);
     }
 
-    [RequiresUnreferencedCode("STJ JsonSerializer.Deserialize uses reflection over the supplied type.")]
-    [RequiresDynamicCode("STJ JsonSerializer.Deserialize requires runtime code generation for non-source-generated types.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode", Justification = SharedSerializerSuppression)]
+    [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = SharedSerializerSuppression)]
     public object FromJson(Type type, DbDataReader reader, int index)
     {
         var json = reader.GetString(index);
         return FromJson(type, json);
     }
 
-    [RequiresUnreferencedCode("STJ JsonSerializer.DeserializeAsync<T> uses reflection over T.")]
-    [RequiresDynamicCode("STJ JsonSerializer.DeserializeAsync requires runtime code generation for non-source-generated types.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode", Justification = SharedSerializerSuppression)]
+    [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = SharedSerializerSuppression)]
     public async ValueTask<T> FromJsonAsync<T>(Stream stream, CancellationToken cancellationToken = default)
     {
         return (await JsonSerializer.DeserializeAsync<T>(stream, _options, cancellationToken))!;
     }
 
-    [RequiresUnreferencedCode("STJ JsonSerializer.DeserializeAsync uses reflection over the supplied type.")]
-    [RequiresDynamicCode("STJ JsonSerializer.DeserializeAsync requires runtime code generation for non-source-generated types.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode", Justification = SharedSerializerSuppression)]
+    [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = SharedSerializerSuppression)]
     public async ValueTask<object> FromJsonAsync(Type type, Stream stream,
         CancellationToken cancellationToken = default)
     {


### PR DESCRIPTION
Part of #273. Polecat's `ISerializer` now extends the shared **`Weasel.Core.ISerializer`** base (Weasel 9.5.0, weasel#323) — the second dedupe after the identity family, and the **serializer seam** for the closed-shape W2 cut (Marten's `IStorageSession.Serializer` can retarget onto the same base, marten#4810).

### What changed
- `Polecat.Serialization.ISerializer : Weasel.Core.ISerializer` — the 7 shared members (`EnumStorage`, `Casing`, `ToJson`, `FromJson<T>`/`FromJson(Type)` over `Stream` + `DbDataReader`, async `Stream` overloads) move to the base; Polecat keeps its 2 string-based `FromJson` overloads.
- The shared base is **intentionally unannotated** (Marten parity), so the 7 shared `Serializer` impl methods switch from propagating `[RequiresUnreferencedCode]`/`[RequiresDynamicCode]` to `[UnconditionalSuppressMessage]` (one shared justification const). The 2 string overloads stay `[RUC]`/`[RDC]`.
- `GlobalUsings` alias `ISerializer` → `Polecat.Serialization.ISerializer` (main + test projects) so unqualified references keep resolving to Polecat's richer subtype.

### AOT tradeoff (intended)
Callers of the 7 shared serializer methods no longer get the propagated `RUC/RDC` warning (suppressed internally instead). Polecat's AOT story already relies on consumers supplying a source-gen serializer, and the AOT smoke is unaffected.

### Verification (released Weasel 9.5.0)
Library + `Polecat.AotSmoke` (warnings-as-errors) build clean; **182** serializer-exercising tests green (Documents, Patching, Serialization, StreamJson).

🤖 Generated with [Claude Code](https://claude.com/claude-code)