### PR TITLE
chore: upgrade to Weasel 9.9.0 + reference Weasel.Storage (#273)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -50,8 +50,13 @@
         <PackageVersion Include="Shouldly" Version="4.3.0" />
         <PackageVersion Include="xunit" Version="2.9.3" />
         <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.4" />
-        <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.5.0" />
-        <PackageVersion Include="Weasel.SqlServer" Version="9.5.0" />
+        <!-- Weasel 9.8.0/9.9.0 introduce Weasel.Storage: the dialect-neutral closed-shape
+             storage contracts extracted from Marten (marten#4821/#4830, weasel#329/#331) —
+             IStorageSession / IStorageDatabase / IStorageSerializer / IDocumentStorage /
+             IStorageDialect. This is the shared runtime Polecat retargets onto for #273. -->
+        <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.9.0" />
+        <PackageVersion Include="Weasel.SqlServer" Version="9.9.0" />
+        <PackageVersion Include="Weasel.Storage" Version="9.9.0" />
 
         <!-- Strongly typed IDs -->
         <PackageVersion Include="StronglyTypedId" Version="1.0.0-beta08" />

--- a/src/Polecat.Tests/Serialization/SerializerTests.cs
+++ b/src/Polecat.Tests/Serialization/SerializerTests.cs
@@ -79,6 +79,60 @@ public class SerializerTests
         json.ShouldNotContain("\"name\":");
     }
 
+    // ---- Weasel.Storage.IStorageSerializer seam (#273) ----
+
+    [Fact]
+    public void is_the_shared_storage_serializer_seam()
+    {
+        _serializer.ShouldBeAssignableTo<Weasel.Storage.IStorageSerializer>();
+    }
+
+    [Fact]
+    public void to_json_of_null_yields_json_null()
+    {
+        _serializer.ToJson(null).ShouldBe("null");
+    }
+
+    [Fact]
+    public void to_clean_json_matches_to_json_for_stj()
+    {
+        var doc = new TestDocument { Id = Guid.NewGuid(), Name = "Clean", Count = 3 };
+
+        _serializer.ToCleanJson(doc).ShouldBe(_serializer.ToJson(doc));
+    }
+
+    [Fact]
+    public void write_to_buffer_writer_produces_the_same_json()
+    {
+        var doc = new TestDocument { Id = Guid.NewGuid(), Name = "Buffered", Count = 9 };
+
+        var buffer = new System.Buffers.ArrayBufferWriter<byte>();
+        _serializer.WriteTo(buffer, doc);
+
+        System.Text.Encoding.UTF8.GetString(buffer.WrittenSpan).ShouldBe(_serializer.ToJson(doc));
+    }
+
+    [Fact]
+    public void write_to_parameter_assigns_json_string_value()
+    {
+        var doc = new TestDocument { Id = Guid.NewGuid(), Name = "Param", Count = 4 };
+        var parameter = new Microsoft.Data.SqlClient.SqlParameter();
+
+        _serializer.WriteToParameter(parameter, doc);
+
+        parameter.Value.ShouldBe(_serializer.ToJson(doc));
+    }
+
+    [Fact]
+    public void write_to_parameter_assigns_dbnull_for_null()
+    {
+        var parameter = new Microsoft.Data.SqlClient.SqlParameter();
+
+        _serializer.WriteToParameter(parameter, null);
+
+        parameter.Value.ShouldBe(DBNull.Value);
+    }
+
     public class TestDocument
     {
         public Guid Id { get; set; }

--- a/src/Polecat/GlobalUsings.cs
+++ b/src/Polecat/GlobalUsings.cs
@@ -34,3 +34,7 @@ global using HiloSettings = Weasel.Core.Sequences.HiloSettings;
 //     Alias the unqualified name to Polecat's richer subtype so files importing both namespaces
 //     keep resolving ISerializer to Polecat's (which carries the string-based overloads too).
 global using ISerializer = Polecat.Serialization.ISerializer;
+//   #273 / Weasel 9.7.0 (weasel#327/#328): a shared dialect-neutral ICommandBuilder was added to
+//     Weasel.Core, and Weasel.SqlServer.ICommandBuilder now derives from it. Polecat's operations
+//     bind SqlParameters, so the unqualified name keeps resolving to the SqlServer subtype.
+global using ICommandBuilder = Weasel.SqlServer.ICommandBuilder;

--- a/src/Polecat/Linq/Joins/AliasingCommandBuilder.cs
+++ b/src/Polecat/Linq/Joins/AliasingCommandBuilder.cs
@@ -43,6 +43,9 @@ internal class AliasingCommandBuilder : ICommandBuilder
     public IGroupedParameterBuilder CreateGroupedParameterBuilder(char? seperator = null) => _inner.CreateGroupedParameterBuilder(seperator);
     public SqlParameter[] AppendWithParameters(string text) => _inner.AppendWithParameters(JoinStatement.AliasLocator(text, _alias));
     public SqlParameter[] AppendWithParameters(string text, char placeholder) => _inner.AppendWithParameters(JoinStatement.AliasLocator(text, _alias), placeholder);
+    // Weasel 9.7.0 (weasel#324): dialect-neutral DbParameter[] variants on the shared Weasel.Core.ICommandBuilder.
+    public System.Data.Common.DbParameter[] AppendWithDbParameters(string text) => _inner.AppendWithDbParameters(JoinStatement.AliasLocator(text, _alias));
+    public System.Data.Common.DbParameter[] AppendWithDbParameters(string text, char placeholder) => _inner.AppendWithDbParameters(JoinStatement.AliasLocator(text, _alias), placeholder);
     public void StartNewCommand() => _inner.StartNewCommand();
 
     // Mirror the RUC annotation that Weasel.SqlServer's ICommandBuilder.AddParameters(object)

--- a/src/Polecat/Polecat.csproj
+++ b/src/Polecat/Polecat.csproj
@@ -37,6 +37,9 @@
         <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
         <PackageReference Include="Polly.Core" />
         <PackageReference Include="Weasel.SqlServer" />
+        <!-- #273: dialect-neutral closed-shape storage contracts extracted from Marten
+             (marten#4821/#4830 → weasel#329/#331) — the shared runtime Polecat retargets onto. -->
+        <PackageReference Include="Weasel.Storage" />
     </ItemGroup>
 
     <!-- #196 (mirrors JasperFx/marten#4557): Bundle the JasperFx.Events.SourceGenerator

--- a/src/Polecat/Serialization/Serializer.cs
+++ b/src/Polecat/Serialization/Serializer.cs
@@ -1,3 +1,4 @@
+using System.Buffers;
 using System.Data.Common;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
@@ -10,7 +11,13 @@ namespace Polecat.Serialization;
 /// <summary>
 ///     Default serializer implementation using System.Text.Json.
 /// </summary>
-public class Serializer : ISerializer
+/// <remarks>
+///     Also implements <see cref="Weasel.Storage.IStorageSerializer" /> — the dialect-neutral
+///     serializer seam of the shared closed-shape storage runtime (weasel#329/#331, #273) — so the
+///     default serializer plugs straight into the shared <c>IStorageSession</c> once Polecat's
+///     sessions retarget onto it.
+/// </remarks>
+public class Serializer : ISerializer, Weasel.Storage.IStorageSerializer
 {
     private JsonSerializerOptions _options;
     private EnumStorage _enumStorage = EnumStorage.AsInteger;
@@ -86,9 +93,63 @@ public class Serializer : ISerializer
 
     [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode", Justification = SharedSerializerSuppression)]
     [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = SharedSerializerSuppression)]
-    public string ToJson(object document)
+    public string ToJson(object? document)
     {
-        return JsonSerializer.Serialize(document, document.GetType(), _options);
+        // object? satisfies both Weasel.Core.ISerializer.ToJson(object) and the wider
+        // Weasel.Storage.IStorageSerializer.ToJson(object?) with a single implementation.
+        return JsonSerializer.Serialize(document, document?.GetType() ?? typeof(object), _options);
+    }
+
+    // ---- Weasel.Storage.IStorageSerializer additions (beyond the Weasel.Core.ISerializer base) ----
+
+    /// <summary>
+    ///     STJ has no type-metadata pollution to strip, so "clean" JSON is identical to
+    ///     <see cref="ToJson" />. (The distinction exists on the shared seam for Newtonsoft's
+    ///     TypeNameHandling.)
+    /// </summary>
+    [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode", Justification = SharedSerializerSuppression)]
+    [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = SharedSerializerSuppression)]
+    public string ToCleanJson(object? document)
+    {
+        return ToJson(document);
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode", Justification = SharedSerializerSuppression)]
+    [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = SharedSerializerSuppression)]
+    public void WriteTo(IBufferWriter<byte> writer, object? value)
+    {
+        using var jsonWriter = new Utf8JsonWriter(writer);
+        JsonSerializer.Serialize(jsonWriter, value, value?.GetType() ?? typeof(object), _options);
+    }
+
+    /// <summary>
+    ///     Writes the value's JSON to a database parameter. Polecat binds JSON as string parameter
+    ///     values throughout (SQL Server 2025's native JSON column type accepts nvarchar input), so
+    ///     this stays dialect-neutral with no SqlClient-specific typing.
+    /// </summary>
+    [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode", Justification = SharedSerializerSuppression)]
+    [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = SharedSerializerSuppression)]
+    public void WriteToParameter(DbParameter parameter, object? value)
+    {
+        parameter.Value = value is null ? DBNull.Value : ToJson(value);
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode", Justification = SharedSerializerSuppression)]
+    [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = SharedSerializerSuppression)]
+    public async ValueTask<T> FromJsonAsync<T>(DbDataReader reader, int index,
+        CancellationToken cancellationToken = default)
+    {
+        var json = await reader.GetFieldValueAsync<string>(index, cancellationToken).ConfigureAwait(false);
+        return FromJson<T>(json);
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode", Justification = SharedSerializerSuppression)]
+    [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = SharedSerializerSuppression)]
+    public async ValueTask<object> FromJsonAsync(Type type, DbDataReader reader, int index,
+        CancellationToken cancellationToken = default)
+    {
+        var json = await reader.GetFieldValueAsync<string>(index, cancellationToken).ConfigureAwait(false);
+        return FromJson(type, json);
     }
 
     [RequiresUnreferencedCode("STJ JsonSerializer.Deserialize<T> uses reflection over T.")]


### PR DESCRIPTION
Part of #273. Brings in the Weasel 9.7.0–9.9.0 line carrying the closed-shape convergence work the Marten agent extracted overnight (marten#4821/#4830 → weasel#324/#327/#328/#329/#331), plus the first adoption increment.

## What's in Weasel 9.9.0 for us
- **Weasel.Storage** (new lib, referenced here): the dialect-neutral closed-shape storage contracts — `IStorageSession`, `IStorageDatabase : ISequenceSource`, `IStorageSerializer`, `IDocumentStorage`/`IDocumentStorage<T>`/`<T,TId>`, `IStorageDialect`, `IStorageOperation : Weasel.Core.IStorageOperation`, selectors/binders vocabulary. This is the shared runtime Polecat retargets onto (phases B→E of #273).
- **Shared `Weasel.Core.ICommandBuilder`**: `Weasel.SqlServer.ICommandBuilder` now derives from it.

## Polecat changes
- Pins: Weasel.SqlServer / Weasel.EntityFrameworkCore 9.5.0 → **9.9.0**; add **Weasel.Storage 9.9.0**.
- `GlobalUsings`: alias unqualified `ICommandBuilder` → `Weasel.SqlServer.ICommandBuilder` (CS0104 from the new shared base; Polecat operations bind `SqlParameter`s).
- `AliasingCommandBuilder`: implement the new `DbParameter[]`-returning `AppendWithDbParameters` members (alias-rewriting delegation, same as the `SqlParameter[]` variants).
- **First adoption increment**: the default `Serializer` implements `Weasel.Storage.IStorageSerializer` (`ToCleanJson`, `WriteTo(IBufferWriter)`, `WriteToParameter(DbParameter)` — JSON bound as string values, matching Polecat's existing parameter binding — and async `DbDataReader` reads). Kept off the `ISerializer` *interface* deliberately: inheriting both `Weasel.Core.ISerializer` and `IStorageSerializer` there would make every overlapping member call ambiguous (CS0121).

## Verification
- Full solution builds Release; **Polecat.Tests 1349 (incl. 6 new IStorageSerializer tests)**, EFCore 37, AspNetCore.Testing 14 — all green (net10) against dockerized SQL Server 2025.

🤖 Generated with [Claude Code](https://claude.com/claude-code)