### PR TITLE
feat: implement Weasel.Storage.IStorageDatabase on PolecatDatabase (#273)

### DIFF
--- a/src/Polecat.Tests/Storage/storage_database_seam_tests.cs
+++ b/src/Polecat.Tests/Storage/storage_database_seam_tests.cs
@@ -1,0 +1,74 @@
+using Microsoft.Data.SqlClient;
+using Polecat.Tests.Harness;
+using Weasel.Storage;
+
+namespace Polecat.Tests.Storage;
+
+/// <summary>
+///     PolecatDatabase implements the dialect-neutral Weasel.Storage.IStorageDatabase seam of the
+///     shared closed-shape storage runtime (#273): sequence resolution, connection creation, and
+///     raw SQL execution. The closed-shape IProviderGraph stays unavailable until Polecat's
+///     document storage retargets onto the shared bases (phases D/E).
+/// </summary>
+public class storage_database_seam_tests : OneOffConfigurationsContext
+{
+    private IStorageDatabase theSeam => theDatabase;
+
+    [Fact]
+    public void polecat_database_is_the_shared_storage_database_seam()
+    {
+        theDatabase.ShouldBeAssignableTo<IStorageDatabase>();
+    }
+
+    [Fact]
+    public async Task create_storage_connection_returns_an_openable_sql_connection()
+    {
+        await using var conn = theSeam.CreateStorageConnection();
+
+        conn.ShouldBeOfType<SqlConnection>();
+        conn.State.ShouldBe(System.Data.ConnectionState.Closed);
+
+        await conn.OpenAsync();
+        conn.State.ShouldBe(System.Data.ConnectionState.Open);
+    }
+
+    [Fact]
+    public async Task run_sql_async_executes_against_the_database()
+    {
+        var tableName = $"dbo.pc_seam_smoke_{Guid.NewGuid():N}";
+
+        await theSeam.RunSqlAsync($"CREATE TABLE {tableName} (id INT NOT NULL)");
+
+        try
+        {
+            await using var conn = await OpenConnectionAsync();
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = $"SELECT OBJECT_ID('{tableName}')";
+            var objectId = await cmd.ExecuteScalarAsync();
+            objectId.ShouldNotBe(DBNull.Value);
+        }
+        finally
+        {
+            await theSeam.RunSqlAsync($"DROP TABLE IF EXISTS {tableName}");
+        }
+    }
+
+    [Fact]
+    public async Task sequence_for_resolves_the_hilo_sequence_for_a_numeric_id_document()
+    {
+        // Force provider + schema creation so the Hi-Lo table exists
+        await theStore.Advanced.Clean.CompletelyRemoveAllAsync();
+
+        var sequence = theSeam.SequenceFor(typeof(IntDoc));
+
+        sequence.ShouldNotBeNull();
+        sequence.NextInt().ShouldBeGreaterThan(0);
+    }
+
+    [Fact]
+    public void provider_graph_is_not_supported_until_closed_shape_storage_lands()
+    {
+        var ex = Should.Throw<NotSupportedException>(() => theSeam.Providers);
+        ex.Message.ShouldContain("polecat#273");
+    }
+}

--- a/src/Polecat/Storage/PolecatDatabase.cs
+++ b/src/Polecat/Storage/PolecatDatabase.cs
@@ -25,7 +25,7 @@ namespace Polecat.Storage;
 ///     Implements IEventDatabase for async daemon infrastructure.
 /// </summary>
 public class PolecatDatabase : DatabaseBase<SqlConnection>, IEventDatabase, IProjectionDatabase,
-    ICrossTenantRebuildSource
+    ICrossTenantRebuildSource, Weasel.Storage.IStorageDatabase
 {
     private readonly StoreOptions _options;
     private readonly EventGraph _events;
@@ -440,4 +440,47 @@ public class PolecatDatabase : DatabaseBase<SqlConnection>, IEventDatabase, IPro
             _options.ResiliencePipeline);
         return new PolecatProjectionDaemon(store, this, loggerFactory, detector);
     }
+
+    // ---- Weasel.Storage.IStorageDatabase (#273) ----
+    // The dialect-neutral database seam of the shared closed-shape storage runtime
+    // (weasel#329/#331). Sessions expose this through IStorageSession.Database once they
+    // retarget onto the shared contract.
+
+    /// <summary>
+    ///     The closed-shape provider graph. Not available until Polecat's document storage
+    ///     retargets onto the shared <c>Weasel.Storage</c> bases (#273 phases D/E) — Polecat's
+    ///     current per-type providers do not yet implement <c>IDocumentStorage&lt;T&gt;</c>.
+    /// </summary>
+    Weasel.Storage.IProviderGraph Weasel.Storage.IStorageDatabase.Providers =>
+        throw new NotSupportedException(
+            "The closed-shape IProviderGraph is not available until Polecat's document storage retargets onto the shared Weasel.Storage bases (JasperFx/polecat#273).");
+
+    /// <summary>
+    ///     Creates an unopened connection to this database (shared-runtime counterpart of
+    ///     <see cref="DatabaseBase{T}.CreateConnection" />). Callers own the connection and are
+    ///     responsible for resilience around its use.
+    /// </summary>
+    public System.Data.Common.DbConnection CreateStorageConnection() => CreateConnection();
+
+    public Task RunSqlAsync(string sql, CancellationToken ct = default)
+    {
+        // Like the rest of PolecatDatabase's direct access, this owns its own connection and
+        // wraps the work in Options.ResiliencePipeline directly.
+        return _resilience.ExecuteAsync(static async (state, token) =>
+        {
+            var (connectionString, sqlText) = state;
+            await using var conn = new SqlConnection(connectionString);
+            await conn.OpenAsync(token);
+
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = sqlText;
+            await cmd.ExecuteNonQueryAsync(token);
+        }, (_connectionString, sql), ct).AsTask();
+    }
+
+    /// <summary>
+    ///     Resolves the Hi-Lo sequence for a document type through the store's single
+    ///     <see cref="SequenceFactory" /> (which caches Hi-Lo state per sequence).
+    /// </summary>
+    public ISequence SequenceFor(Type documentType) => RequireStore().Sequences.SequenceFor(documentType);
 }


### PR DESCRIPTION
Part of #273 — second contract-adoption increment (after #278's `IStorageSerializer`), phase C of the plan.

`PolecatDatabase` now implements the dialect-neutral **`Weasel.Storage.IStorageDatabase`** seam:

| Member | Implementation |
|---|---|
| `SequenceFor(Type)` (`ISequenceSource`) | Delegates to the store's single `SequenceFactory` (caches Hi-Lo state per sequence) via the existing `Store` back-reference |
| `CreateStorageConnection()` | `DatabaseBase.CreateConnection()` surfaced through the shared contract (unopened `SqlConnection`) |
| `RunSqlAsync(string, ct)` | Owns its connection, wrapped in `Options.ResiliencePipeline` directly — same pattern as the rest of `PolecatDatabase`'s direct access |
| `Providers` | Explicit interface impl throwing `NotSupportedException` pointing at #273 — the closed-shape `IProviderGraph` is `DocumentProvider<T>`-shaped (QueryOnly/Lightweight/IdentityMap/DirtyTracking `IDocumentStorage<T>` flavors), which is phase D/E material |

Next increment: sessions implementing `Weasel.Storage.IStorageSession` (`ExecuteReaderAsync(DbCommand)` onto the pipeline-wrapped execution, `IVersionTracker` over Polecat's version tracking).

## Verification
- 5 new integration tests (`storage_database_seam_tests`): seam assignability, openable connection, `RunSqlAsync` round-trip (CREATE/DROP TABLE), Hi-Lo `SequenceFor(typeof(IntDoc))`, `Providers` guard.
- **Full suite green: 1354 passed / 0 failed** (net10) against dockerized SQL Server 2025.

🤖 Generated with [Claude Code](https://claude.com/claude-code)