### PR TITLE
feat: implement Weasel.Storage.IStorageSession on Polecat sessions (#273)

### DIFF
--- a/src/Polecat.Tests/Storage/storage_session_seam_tests.cs
+++ b/src/Polecat.Tests/Storage/storage_session_seam_tests.cs
@@ -1,0 +1,178 @@
+using Microsoft.Data.SqlClient;
+using Polecat.Tests.Harness;
+using Weasel.Storage;
+
+namespace Polecat.Tests.Storage;
+
+/// <summary>
+///     Polecat sessions implement the dialect-neutral Weasel.Storage.IStorageSession — the
+///     operation/session context of the shared closed-shape storage runtime (#273). StorageFor
+///     stays guarded until Polecat's document storage retargets onto the shared bases (phases D/E).
+/// </summary>
+public class storage_session_seam_tests : OneOffConfigurationsContext
+{
+    [Fact]
+    public async Task sessions_are_the_shared_storage_session_seam()
+    {
+        await using var query = theStore.QuerySession();
+        query.ShouldBeAssignableTo<IStorageSession>();
+
+        await using var lightweight = theStore.LightweightSession();
+        lightweight.ShouldBeAssignableTo<IStorageSession>();
+
+        await using var identity = theStore.IdentitySession();
+        identity.ShouldBeAssignableTo<IStorageSession>();
+    }
+
+    [Fact]
+    public async Task serializer_database_and_versions_are_wired()
+    {
+        await using var session = theStore.LightweightSession();
+        var seam = (IStorageSession)session;
+
+        // The default Serializer implements IStorageSerializer natively — no adapter wrapping
+        seam.Serializer.ShouldBeSameAs(theStore.Options.Serializer);
+        seam.Database.ShouldBeSameAs(theDatabase);
+
+        seam.Versions.StoreVersion<Target, Guid>(Guid.NewGuid(), Guid.NewGuid());
+        var id = Guid.NewGuid();
+        var version = Guid.NewGuid();
+        seam.Versions.StoreVersion<Target, Guid>(id, version);
+        seam.Versions.VersionFor<Target, Guid>(id).ShouldBe(version);
+
+        seam.Versions.StoreRevision<Target, Guid>(id, 42);
+        seam.Versions.RevisionFor<Target, Guid>(id).ShouldBe(42);
+
+        seam.Versions.ClearVersion<Target, Guid>(id);
+        seam.Versions.VersionFor<Target, Guid>(id).ShouldBeNull();
+
+        seam.ChangeTrackers.ShouldBeEmpty();
+        seam.ItemMap.ShouldBeEmpty();
+        seam.Concurrency.ShouldBe(ConcurrencyChecks.Enabled);
+    }
+
+    [Fact]
+    public async Task execute_reader_async_routes_db_command_through_the_session()
+    {
+        await using var session = theStore.QuerySession();
+        var seam = (IStorageSession)session;
+
+        var command = new SqlCommand("SELECT 42");
+        await using var reader = await seam.ExecuteReaderAsync(command);
+
+        (await reader.ReadAsync()).ShouldBeTrue();
+        reader.GetInt32(0).ShouldBe(42);
+    }
+
+    [Fact]
+    public async Task execute_reader_async_rejects_non_sqlclient_commands()
+    {
+        await using var session = theStore.QuerySession();
+        var seam = (IStorageSession)session;
+
+        await using var foreign = new NotASqlCommand();
+        await Should.ThrowAsync<ArgumentException>(() => seam.ExecuteReaderAsync(foreign));
+    }
+
+    private sealed class NotASqlCommand : System.Data.Common.DbCommand
+    {
+        public override string CommandText { get; set; } = string.Empty;
+        public override int CommandTimeout { get; set; }
+        public override System.Data.CommandType CommandType { get; set; }
+        public override bool DesignTimeVisible { get; set; }
+        public override System.Data.UpdateRowSource UpdatedRowSource { get; set; }
+        protected override System.Data.Common.DbConnection? DbConnection { get; set; }
+        protected override System.Data.Common.DbParameterCollection DbParameterCollection => null!;
+        protected override System.Data.Common.DbTransaction? DbTransaction { get; set; }
+        public override void Cancel() { }
+        public override int ExecuteNonQuery() => 0;
+        public override object? ExecuteScalar() => null;
+        public override void Prepare() { }
+        protected override System.Data.Common.DbParameter CreateDbParameter() => null!;
+        protected override System.Data.Common.DbDataReader ExecuteDbDataReader(System.Data.CommandBehavior behavior) => null!;
+    }
+
+    [Fact]
+    public async Task metadata_context_flows_the_session_metadata()
+    {
+        ConfigureStore(opts =>
+        {
+            opts.Events.EnableCorrelationId = true;
+            opts.Events.EnableHeaders = true;
+        });
+
+        await using var session = theStore.LightweightSession();
+        var seam = (IStorageSession)session;
+
+        session.CorrelationId = "corr-1";
+        session.LastModifiedBy = "jeremy";
+        session.SetHeader("k", "v");
+
+        seam.CorrelationId.ShouldBe("corr-1");
+        seam.CurrentUserName.ShouldBe("jeremy");
+        seam.Headers!["k"].ShouldBe("v");
+        seam.CorrelationIdEnabled.ShouldBeTrue();
+        seam.CausationIdEnabled.ShouldBeFalse();
+        seam.HeadersEnabled.ShouldBeTrue();
+        seam.UserNameEnabled.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task identity_map_session_routes_mark_as_loaded_into_the_identity_map()
+    {
+        await theStore.Advanced.Clean.CompletelyRemoveAllAsync();
+
+        var target = new Target { Number = 7 };
+
+        await using (var setup = theStore.LightweightSession())
+        {
+            setup.Store(target);
+            await setup.SaveChangesAsync();
+        }
+
+        await using var session = theStore.IdentitySession();
+        var seam = (IStorageSession)session;
+
+        var replacement = new Target { Id = target.Id, Number = 99 };
+        seam.MarkAsDocumentLoaded(replacement.Id, replacement);
+
+        // The identity map should now return the marked instance instead of loading from the db
+        var loaded = await session.LoadAsync<Target>(target.Id);
+        loaded.ShouldBeSameAs(replacement);
+    }
+
+    [Fact]
+    public async Task lightweight_session_ignores_identity_map_hooks()
+    {
+        await using var session = theStore.LightweightSession();
+        var seam = (IStorageSession)session;
+
+        // no-op, must not throw
+        seam.MarkAsDocumentLoaded(Guid.NewGuid(), new Target());
+        seam.MarkAsAddedForStorage(Guid.NewGuid(), new Target());
+    }
+
+    [Fact]
+    public async Task next_temp_table_name_is_session_unique_and_incrementing()
+    {
+        await using var session = theStore.QuerySession();
+        var seam = (IStorageSession)session;
+
+        var first = seam.NextTempTableName();
+        var second = seam.NextTempTableName();
+
+        first.ShouldStartWith("#pc_temp_");
+        second.ShouldNotBe(first);
+    }
+
+    [Fact]
+    public async Task storage_for_is_guarded_until_closed_shape_storage_lands()
+    {
+        await using var session = theStore.QuerySession();
+        var seam = (IStorageSession)session;
+
+        Should.Throw<NotSupportedException>(() => seam.StorageFor(typeof(Target)))
+            .Message.ShouldContain("polecat#273");
+        Should.Throw<NotSupportedException>(() => seam.StorageFor<Target>());
+    }
+}

--- a/src/Polecat/DocumentStore.cs
+++ b/src/Polecat/DocumentStore.cs
@@ -27,6 +27,8 @@ public partial class DocumentStore : IDocumentStore
         _tableEnsurer = new DocumentTableEnsurer(_connectionFactory, options);
         _tableEnsurer.SetProviderRegistry(_providers);
         Database = new PolecatDatabase(options);
+        // #273: sessions surface the database through Weasel.Storage.IStorageSession.Database.
+        options.StorageDatabase = Database;
 
         // Wire up sequence factory for HiLo ID generation
         Sequences = new SequenceFactory(options, _connectionFactory);

--- a/src/Polecat/Internal/IdentityMapDocumentSession.cs
+++ b/src/Polecat/Internal/IdentityMapDocumentSession.cs
@@ -114,4 +114,18 @@ internal class IdentityMapDocumentSession : DocumentSessionBase
 
         return map;
     }
+
+    // #273: shared-runtime identity-map hooks (Weasel.Storage.IStorageSession). The closed-shape
+    // selectors call these when materializing/queueing documents; route them into the bespoke
+    // identity map so both paths agree until phase E makes the shared runtime authoritative.
+
+    public override void MarkAsAddedForStorage(object id, object document)
+    {
+        GetOrCreateTypeMap(document.GetType())[id] = document;
+    }
+
+    public override void MarkAsDocumentLoaded(object id, object document)
+    {
+        GetOrCreateTypeMap(document.GetType())[id] = document;
+    }
 }

--- a/src/Polecat/Internal/PolecatVersionTracker.cs
+++ b/src/Polecat/Internal/PolecatVersionTracker.cs
@@ -1,0 +1,71 @@
+using Weasel.Storage;
+
+namespace Polecat.Internal;
+
+/// <summary>
+///     Session-scoped document version/revision bookkeeping behind the shared
+///     <see cref="IVersionTracker" /> seam of the closed-shape storage runtime (#273).
+///     Today Polecat carries versions on the documents themselves (<c>IVersioned</c> /
+///     <c>IRevisioned</c>); the shared closed-shape selectors and storages record and consult
+///     versions here instead, so this becomes the authoritative session store once Polecat's
+///     document storage retargets onto the shared bases (phase E).
+/// </summary>
+internal class PolecatVersionTracker : IVersionTracker
+{
+    private readonly Dictionary<Type, object> _versions = new();
+    private readonly Dictionary<Type, object> _revisions = new();
+
+    public Dictionary<TId, Guid> ForType<TDoc, TId>() where TId : notnull
+    {
+        if (_versions.TryGetValue(typeof(TDoc), out var raw) && raw is Dictionary<TId, Guid> existing)
+        {
+            return existing;
+        }
+
+        var fresh = new Dictionary<TId, Guid>();
+        _versions[typeof(TDoc)] = fresh;
+        return fresh;
+    }
+
+    public Dictionary<TId, long> RevisionsFor<TDoc, TId>() where TId : notnull
+    {
+        if (_revisions.TryGetValue(typeof(TDoc), out var raw) && raw is Dictionary<TId, long> existing)
+        {
+            return existing;
+        }
+
+        var fresh = new Dictionary<TId, long>();
+        _revisions[typeof(TDoc)] = fresh;
+        return fresh;
+    }
+
+    public Guid? VersionFor<TDoc, TId>(TId id) where TId : notnull
+    {
+        return ForType<TDoc, TId>().TryGetValue(id, out var version) ? version : null;
+    }
+
+    public long? RevisionFor<TDoc, TId>(TId id) where TId : notnull
+    {
+        return RevisionsFor<TDoc, TId>().TryGetValue(id, out var revision) ? revision : null;
+    }
+
+    public void StoreVersion<TDoc, TId>(TId id, Guid guid) where TId : notnull
+    {
+        ForType<TDoc, TId>()[id] = guid;
+    }
+
+    public void StoreRevision<TDoc, TId>(TId id, long revision) where TId : notnull
+    {
+        RevisionsFor<TDoc, TId>()[id] = revision;
+    }
+
+    public void ClearVersion<TDoc, TId>(TId id) where TId : notnull
+    {
+        ForType<TDoc, TId>().Remove(id);
+    }
+
+    public void ClearRevision<TDoc, TId>(TId id) where TId : notnull
+    {
+        RevisionsFor<TDoc, TId>().Remove(id);
+    }
+}

--- a/src/Polecat/Internal/QuerySession.StorageSession.cs
+++ b/src/Polecat/Internal/QuerySession.StorageSession.cs
@@ -1,0 +1,110 @@
+using System.Data.Common;
+using Microsoft.Data.SqlClient;
+using Polecat.Serialization;
+using Polecat.Storage;
+using Weasel.Storage;
+
+namespace Polecat.Internal;
+
+// #273: Polecat sessions implement the dialect-neutral Weasel.Storage.IStorageSession —
+// the operation/session context of the shared closed-shape storage runtime (weasel#329/#331).
+// The members the shared runtime can use today map onto Polecat's existing session internals;
+// StorageFor stays guarded until Polecat's document storage retargets onto the shared
+// IDocumentStorage bases (phases D/E), which is also when the bespoke identity map and
+// document-held versions migrate onto ItemMap / Versions as the authoritative stores.
+internal partial class QuerySession : IStorageSession
+{
+    private IStorageSerializer? _storageSerializer;
+    private PolecatVersionTracker? _versionTracker;
+    private List<IChangeTracker>? _changeTrackers;
+    private Dictionary<Type, object>? _itemMap;
+    private int _tempTableNumber;
+
+    IStorageSerializer IStorageSession.Serializer => _storageSerializer ??= StorageSerializerAdapter.For(Serializer);
+
+    IStorageDatabase IStorageSession.Database =>
+        Options.StorageDatabase ?? throw new InvalidOperationException(
+            "StoreOptions.StorageDatabase has not been wired; sessions must be created through DocumentStore.");
+
+    IVersionTracker IStorageSession.Versions => _versionTracker ??= new PolecatVersionTracker();
+
+    /// <summary>
+    ///     Polecat has no dirty tracking by design (Lightweight and IdentityMap sessions only),
+    ///     so no change trackers are ever registered. The shared runtime iterates an empty list.
+    /// </summary>
+    IList<IChangeTracker> IStorageSession.ChangeTrackers => _changeTrackers ??= new List<IChangeTracker>();
+
+    /// <summary>
+    ///     The closed-shape identity map (Dictionary&lt;TId, TDoc&gt; per document type, boxed).
+    ///     Owned by the shared runtime's selectors; Polecat's bespoke identity map remains the
+    ///     authoritative store until phase E unifies them.
+    /// </summary>
+    Dictionary<Type, object> IStorageSession.ItemMap => _itemMap ??= new Dictionary<Type, object>();
+
+    ConcurrencyChecks IStorageSession.Concurrency => ConcurrencyChecks.Enabled;
+
+    IDocumentStorage IStorageSession.StorageFor(Type documentType) => throw ClosedShapeStorageNotAvailable();
+
+    IDocumentStorage<T> IStorageSession.StorageFor<T>() => throw ClosedShapeStorageNotAvailable();
+
+    private static NotSupportedException ClosedShapeStorageNotAvailable()
+    {
+        return new NotSupportedException(
+            "Closed-shape IDocumentStorage is not available until Polecat's document storage retargets onto the shared Weasel.Storage bases (JasperFx/polecat#273).");
+    }
+
+    /// <summary>
+    ///     Identity-map hook for documents newly queued for storage. No-op outside identity-map
+    ///     sessions; <see cref="IdentityMapDocumentSession" /> overrides.
+    /// </summary>
+    public virtual void MarkAsAddedForStorage(object id, object document)
+    {
+    }
+
+    /// <summary>
+    ///     Identity-map hook for documents loaded from the database. No-op outside identity-map
+    ///     sessions; <see cref="IdentityMapDocumentSession" /> overrides.
+    /// </summary>
+    public virtual void MarkAsDocumentLoaded(object id, object document)
+    {
+    }
+
+    /// <summary>
+    ///     Db-neutral execution seam of the shared runtime. Delegates to Polecat's existing
+    ///     resilience-pipeline-wrapped reader execution; Polecat sessions only speak SqlClient.
+    /// </summary>
+    public Task<DbDataReader> ExecuteReaderAsync(DbCommand command, CancellationToken token = default)
+    {
+        if (command is not SqlCommand sqlCommand)
+        {
+            throw new ArgumentException(
+                $"Polecat sessions execute Microsoft.Data.SqlClient commands; got {command.GetType().FullName}.",
+                nameof(command));
+        }
+
+        return ExecuteReaderAsync(sqlCommand, token);
+    }
+
+    public string NextTempTableName()
+    {
+        return $"#pc_temp_{++_tempTableNumber}";
+    }
+
+    // ---- IMetadataContext (the base of IStorageSession) ----
+    // TenantId / CorrelationId / CausationId / Headers already live on QuerySession.
+
+    /// <summary>
+    ///     The shared-runtime name for the session's user metadata; same state as
+    ///     <see cref="LastModifiedBy" />.
+    /// </summary>
+    public string? CurrentUserName
+    {
+        get => LastModifiedBy;
+        set => LastModifiedBy = value;
+    }
+
+    public bool CorrelationIdEnabled => Options.Events.EnableCorrelationId;
+    public bool CausationIdEnabled => Options.Events.EnableCausationId;
+    public bool HeadersEnabled => Options.Events.EnableHeaders;
+    public bool UserNameEnabled => Options.Events.EnableUserName;
+}

--- a/src/Polecat/Serialization/StorageSerializerAdapter.cs
+++ b/src/Polecat/Serialization/StorageSerializerAdapter.cs
@@ -1,0 +1,90 @@
+using System.Buffers;
+using System.Data.Common;
+using System.Text;
+using Weasel.Storage;
+
+namespace Polecat.Serialization;
+
+/// <summary>
+///     Adapts any Polecat <see cref="ISerializer" /> to the dialect-neutral
+///     <see cref="IStorageSerializer" /> seam of the shared closed-shape storage runtime (#273).
+///     The default <see cref="Serializer" /> implements the seam natively and never needs this;
+///     the adapter covers user-supplied serializers, deriving the seam-only members
+///     (<c>ToCleanJson</c>, <c>WriteTo</c>, <c>WriteToParameter</c>, async reader reads) from the
+///     shared <c>Weasel.Core.ISerializer</c> members every Polecat serializer already carries.
+/// </summary>
+internal sealed class StorageSerializerAdapter : IStorageSerializer
+{
+    private readonly ISerializer _inner;
+
+    private StorageSerializerAdapter(ISerializer inner)
+    {
+        _inner = inner;
+    }
+
+    /// <summary>
+    ///     Returns the serializer itself when it already implements the seam (the default
+    ///     <see cref="Serializer" /> does), otherwise wraps it.
+    /// </summary>
+    public static IStorageSerializer For(ISerializer serializer)
+    {
+        return serializer as IStorageSerializer ?? new StorageSerializerAdapter(serializer);
+    }
+
+    public string ToJson(object? document)
+    {
+        return document is null ? "null" : _inner.ToJson(document);
+    }
+
+    /// <summary>
+    ///     STJ-only Polecat has no type-metadata pollution to strip; "clean" JSON is plain JSON.
+    /// </summary>
+    public string ToCleanJson(object? document) => ToJson(document);
+
+    public void WriteTo(IBufferWriter<byte> writer, object? value)
+    {
+        var json = ToJson(value);
+        writer.Write(Encoding.UTF8.GetBytes(json));
+    }
+
+    /// <summary>
+    ///     Polecat binds JSON as string parameter values throughout (SQL Server 2025's native JSON
+    ///     column type accepts nvarchar input), so this stays dialect-neutral.
+    /// </summary>
+    public void WriteToParameter(DbParameter parameter, object? value)
+    {
+        parameter.Value = value is null ? DBNull.Value : ToJson(value);
+    }
+
+    public T FromJson<T>(Stream stream) => _inner.FromJson<T>(stream);
+
+    public object FromJson(Type type, Stream stream) => _inner.FromJson(type, stream);
+
+    public T FromJson<T>(DbDataReader reader, int index) => _inner.FromJson<T>(reader, index);
+
+    public object FromJson(Type type, DbDataReader reader, int index) => _inner.FromJson(type, reader, index);
+
+    public ValueTask<T> FromJsonAsync<T>(Stream stream, CancellationToken cancellationToken = default)
+        => _inner.FromJsonAsync<T>(stream, cancellationToken);
+
+    public ValueTask<object> FromJsonAsync(Type type, Stream stream, CancellationToken cancellationToken = default)
+        => _inner.FromJsonAsync(type, stream, cancellationToken);
+
+    public async ValueTask<T> FromJsonAsync<T>(DbDataReader reader, int index,
+        CancellationToken cancellationToken = default)
+    {
+        // Route through the unannotated Stream overload rather than the RUC-annotated
+        // string overloads so the adapter adds no trim/AOT surface of its own.
+        await Task.CompletedTask; // row is already buffered; stream access is synchronous
+        await using var stream = reader.GetStream(index);
+        return _inner.FromJson<T>(stream);
+    }
+
+    public async ValueTask<object> FromJsonAsync(Type type, DbDataReader reader, int index,
+        CancellationToken cancellationToken = default)
+    {
+        await Task.CompletedTask;
+        await using var stream = reader.GetStream(index);
+        return _inner.FromJson(type, stream);
+    }
+}

--- a/src/Polecat/StoreOptions.cs
+++ b/src/Polecat/StoreOptions.cs
@@ -201,6 +201,11 @@ public class StoreOptions
     /// </summary>
     internal DocumentProviderRegistry Providers { get; set; } = null!;
 
+    // #273: back-reference to the store's PolecatDatabase (set by DocumentStore construction,
+    // same pattern as Providers above) so sessions can expose it through the shared
+    // Weasel.Storage.IStorageSession.Database seam.
+    internal Storage.PolecatDatabase? StorageDatabase { get; set; }
+
     /// <summary>
     ///     The Polly resilience pipeline used for all SQL execution.
     ///     Defaults to retry on transient SQL Server errors.


### PR DESCRIPTION
Part of #273 — third contract-adoption increment (after #278 `IStorageSerializer`, #279 `IStorageDatabase`), phase C.

`QuerySession` — and thereby every Polecat session — now implements the dialect-neutral **`Weasel.Storage.IStorageSession`**, the operation/session context of the shared closed-shape storage runtime:

| Member | Implementation |
|---|---|
| `Serializer` | `StorageSerializerAdapter.For()` — the default `Serializer` implements the seam natively (returned as-is, verified by test); user-supplied serializers get a thin adapter that derives `ToCleanJson`/`WriteTo`/`WriteToParameter`/async reader reads from the shared `Weasel.Core.ISerializer` members |
| `Database` | The store's `PolecatDatabase` via `StoreOptions.StorageDatabase` (wired in `DocumentStore` construction — same pattern as `Options.Providers`) |
| `Versions` | New `PolecatVersionTracker` — a complete `IVersionTracker` implementation the closed-shape selectors/storages will populate come phase E (today Polecat carries versions on the documents themselves) |
| `ChangeTrackers` | Always empty — Polecat has no dirty tracking by design |
| `ItemMap` | Session-owned dictionary for the shared runtime's selectors; Polecat's bespoke identity map stays authoritative until phase E unifies them |
| `MarkAsAddedForStorage` / `MarkAsDocumentLoaded` | Virtual no-ops on `QuerySession`; `IdentityMapDocumentSession` routes them into its identity map (verified: a marked document is returned by a subsequent `LoadAsync`) |
| `ExecuteReaderAsync(DbCommand)` | Delegates to the existing resilience-pipeline-wrapped `SqlCommand` execution; clear `ArgumentException` for non-SqlClient commands |
| `IMetadataContext` | `TenantId`/`CorrelationId`/`CausationId`/`Headers` already lived on the session; `CurrentUserName` bridges `LastModifiedBy`; `*Enabled` flags map to `Options.Events.Enable*` |
| `StorageFor(Type)` / `StorageFor<T>()` | `NotSupportedException` guard until phases D/E (same policy as `IStorageDatabase.Providers` in #279) |
| `NextTempTableName()` | `#pc_temp_{n}`, session-scoped counter |

With this, Polecat implements every `Weasel.Storage` contract that is implementable before the concrete closed-shape bases move (marten#4821 story 6). Next increment: converge `Polecat.Internal.IStorageOperation` onto `Weasel.Storage.IStorageOperation` via a default-interface-method bridge.

## Verification
- 9 new tests (`storage_session_seam_tests`): seam assignability across all three session flavors, serializer identity (no adapter for the default), database/versions wiring, `ExecuteReaderAsync` round-trip + non-SqlClient rejection, metadata flow with `Enable*` flags, identity-map hook routing (+ lightweight no-op), temp-table naming, `StorageFor` guards.
- **Full suite green: 1363 passed / 0 failed** (net10) against dockerized SQL Server 2025.

🤖 Generated with [Claude Code](https://claude.com/claude-code)