### PR TITLE
feat: converge IStorageOperation onto Weasel.Storage.IStorageOperation (#273)

### DIFF
--- a/src/Polecat.Tests/Storage/storage_operation_seam_tests.cs
+++ b/src/Polecat.Tests/Storage/storage_operation_seam_tests.cs
@@ -1,0 +1,66 @@
+using Microsoft.Data.SqlClient;
+using Polecat.Internal.Operations;
+using Weasel.SqlServer;
+
+namespace Polecat.Tests.Storage;
+
+/// <summary>
+///     Polecat.Internal.IStorageOperation is converged onto the dialect-neutral
+///     Weasel.Storage.IStorageOperation (#273): the shared two-arg ConfigureCommand bridges to
+///     Polecat's one-arg SqlServer overload via a default interface method.
+/// </summary>
+public class storage_operation_seam_tests
+{
+    [Fact]
+    public void polecat_operations_are_shared_storage_operations()
+    {
+        var operation = new ExecuteSqlStorageOperation("SELECT 1");
+
+        operation.ShouldBeAssignableTo<Weasel.Storage.IStorageOperation>();
+        operation.ShouldBeAssignableTo<Weasel.Core.IStorageOperation>();
+    }
+
+    [Fact]
+    public void shared_configure_command_bridges_to_the_sqlserver_overload()
+    {
+        var operation = new ExecuteSqlStorageOperation("SELECT ?", 42);
+        var seam = (Weasel.Storage.IStorageOperation)operation;
+
+        // Same builder type Polecat's execution pipeline hands operations
+        var builder = new BatchBuilder();
+
+        // Session goes unused — Polecat operations are fully bound at construction
+        seam.ConfigureCommand(builder, null!);
+
+        var batch = builder.Compile();
+        batch.BatchCommands.Count.ShouldBe(1);
+        batch.BatchCommands[0].CommandText.ShouldContain("SELECT");
+        batch.BatchCommands[0].Parameters.Count.ShouldBe(1);
+        batch.BatchCommands[0].Parameters[0].Value.ShouldBe(42);
+    }
+
+    [Fact]
+    public void shared_configure_command_rejects_non_sqlserver_builders()
+    {
+        var operation = new ExecuteSqlStorageOperation("SELECT 1");
+        var seam = (Weasel.Storage.IStorageOperation)operation;
+
+        var foreign = new NotASqlServerBuilder();
+        Should.Throw<ArgumentException>(() => seam.ConfigureCommand(foreign, null!));
+    }
+
+    private sealed class NotASqlServerBuilder : Weasel.Core.ICommandBuilder
+    {
+        public string TenantId { get; set; } = string.Empty;
+        public string? LastParameterName => null;
+        public void Append(string sql) { }
+        public void Append(char character) { }
+        public void AppendParameters(params object[] parameters) { }
+        public System.Data.Common.DbParameter[] AppendWithDbParameters(string text) => [];
+        public System.Data.Common.DbParameter[] AppendWithDbParameters(string text, char placeholder) => [];
+        public void StartNewCommand() { }
+        public void AddParameters(object parameters) { }
+        public void AddParameters(IDictionary<string, object?> parameters) { }
+        public void AddParameters<T>(IDictionary<string, T> parameters) { }
+    }
+}

--- a/src/Polecat/Internal/IStorageOperation.cs
+++ b/src/Polecat/Internal/IStorageOperation.cs
@@ -4,8 +4,32 @@ using Weasel.SqlServer;
 
 namespace Polecat.Internal;
 
-public interface IStorageOperation : Weasel.Core.IStorageOperation
+// #273: converged onto the dialect-neutral Weasel.Storage.IStorageOperation (which itself
+// extends Weasel.Core.IStorageOperation), so Polecat operations satisfy the shared closed-shape
+// runtime's operation contract. Polecat operations capture all their state at construction and
+// only need the SqlServer command builder, so the shared two-arg ConfigureCommand is bridged
+// with a default interface method — no change to the ~30 concrete operations.
+public interface IStorageOperation : Weasel.Storage.IStorageOperation
 {
     object? DocumentId => null;
     void ConfigureCommand(ICommandBuilder builder);
+
+    /// <summary>
+    ///     Shared-runtime entry point. Polecat's execution pipeline always hands operations a
+    ///     Weasel.SqlServer builder (CommandBuilder / BatchBuilder), so the dialect-neutral
+    ///     builder is downcast; the session goes unused because Polecat operations are fully
+    ///     bound at construction.
+    /// </summary>
+    void Weasel.Storage.IStorageOperation.ConfigureCommand(
+        Weasel.Core.ICommandBuilder builder, Weasel.Storage.IStorageSession session)
+    {
+        if (builder is not ICommandBuilder sqlServerBuilder)
+        {
+            throw new ArgumentException(
+                $"Polecat operations require a Weasel.SqlServer command builder; got {builder.GetType().FullName}.",
+                nameof(builder));
+        }
+
+        ConfigureCommand(sqlServerBuilder);
+    }
 }


### PR DESCRIPTION
Part of #273 — fourth contract-adoption increment (after #278/#279/#280), phase C.

`Polecat.Internal.IStorageOperation` now extends the dialect-neutral **`Weasel.Storage.IStorageOperation`**, so every Polecat operation satisfies the shared closed-shape runtime's operation contract.

The shared two-arg `ConfigureCommand(Weasel.Core.ICommandBuilder, IStorageSession)` bridges to Polecat's one-arg SqlServer overload via a **default interface method**: Polecat operations capture all their state at construction, and the execution pipeline always hands them a Weasel.SqlServer builder — so the bridge downcasts (clear `ArgumentException` otherwise) and ignores the session. **No change to any of the ~30 concrete operations.**

With this, phase C's contract adoption is complete: Polecat implements every `Weasel.Storage` contract implementable before the concrete closed-shape bases move (marten#4821 story 6) — `IStorageSerializer` (#278), `IStorageDatabase` (#279), `IStorageSession` (#280), `IStorageOperation` (this PR). The remaining guards (`IProviderGraph`, `StorageFor`) unlock with phases D/E.

## Verification
- 3 new tests (`storage_operation_seam_tests`): seam assignability, two-arg → one-arg bridge through the real `BatchBuilder` (compiled `SqlBatch` carries the SQL + bound parameter), non-SqlServer builder rejection.
- **Full suite green: 1366 passed / 0 failed** (net10) against dockerized SQL Server 2025.

🤖 Generated with [Claude Code](https://claude.com/claude-code)