### PR TITLE
chore: bump JasperFx family 2.18.0 → 2.20.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,8 +22,8 @@
              IEventDatabase.QueryDeadLetterEventsAsync (dead-letter row drill-in), DeadLetterEvent.TenantId,
              and the tenant-aware daemon surface. Polecat implements the dead-letter row query + per-tenant
              FetchDeadLetterCountsAsync below. -->
-        <PackageVersion Include="JasperFx" Version="2.18.0" />
-        <PackageVersion Include="JasperFx.Events" Version="2.18.0" />
+        <PackageVersion Include="JasperFx" Version="2.20.0" />
+        <PackageVersion Include="JasperFx.Events" Version="2.20.0" />
         <!-- Pin the sibling JasperFx packages for parity with Marten 9's matrix
              even though Polecat doesn't currently reference them directly —
              keeps the lockstep matrix coherent when transitive resolution
@@ -31,7 +31,7 @@
              RuntimeCompiler 5.x line is the active continuation of the 4.x
              lineage; do not pin against the parallel stale 2.0.x series. -->
         <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.18.0" />
+        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.20.0" />
         <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
@@ -62,7 +62,7 @@
         <PackageVersion Include="StronglyTypedId" Version="1.0.0-beta08" />
 
         <!-- Source generators (matched to JasperFx.Events above) -->
-        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.18.0" />
+        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.20.0" />
 
         <!-- Build automation -->
         <PackageVersion Include="Nuke.Common" Version="9.0.4" />


### PR DESCRIPTION
Parity bump with Marten 9's dependency matrix (marten#4856 moved Marten to JasperFx 2.20.0). The 2.19.x/2.20.0 line carries daemon work: `DistributesAgentsPerTenant` for sharded + per-tenant-partitioned stores, and `ProjectionDeleted` emission for DeleteEvent-driven deletions in composite projections (jasperfx#484 / #483).

Bumped together (matched versions, per the pin policy comment in `Directory.Packages.props`): `JasperFx`, `JasperFx.Events`, `JasperFx.SourceGenerator`, `JasperFx.Events.SourceGenerator`.

## Verification
- **Full suite green: 1366 passed / 0 failed** (net10) against dockerized SQL Server 2025.

🤖 Generated with [Claude Code](https://claude.com/claude-code)