### PR TITLE
feat: SqlServerStorageDialect — first phase D brick (Weasel 9.10.0) (#273)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -54,9 +54,9 @@
              storage contracts extracted from Marten (marten#4821/#4830, weasel#329/#331) —
              IStorageSession / IStorageDatabase / IStorageSerializer / IDocumentStorage /
              IStorageDialect. This is the shared runtime Polecat retargets onto for #273. -->
-        <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.9.0" />
-        <PackageVersion Include="Weasel.SqlServer" Version="9.9.0" />
-        <PackageVersion Include="Weasel.Storage" Version="9.9.0" />
+        <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.10.0" />
+        <PackageVersion Include="Weasel.SqlServer" Version="9.10.0" />
+        <PackageVersion Include="Weasel.Storage" Version="9.10.0" />
 
         <!-- Strongly typed IDs -->
         <PackageVersion Include="StronglyTypedId" Version="1.0.0-beta08" />

--- a/src/Polecat.Tests/Storage/sqlserver_storage_dialect_tests.cs
+++ b/src/Polecat.Tests/Storage/sqlserver_storage_dialect_tests.cs
@@ -1,0 +1,147 @@
+using System.Data;
+using Microsoft.Data.SqlClient;
+using Polecat.Storage;
+using Polecat.Tests.Harness;
+using Weasel.SqlServer;
+using Weasel.Storage;
+
+namespace Polecat.Tests.Storage;
+
+/// <summary>
+///     SqlServerStorageDialect is the SQL Server IStorageDialect of the shared closed-shape
+///     storage runtime (#273 phase D): named-parameter load commands, OPENJSON id arrays,
+///     StorageColumnType → SqlDbType mapping, undefined-table detection.
+/// </summary>
+public class sqlserver_storage_dialect_tests : OneOffConfigurationsContext
+{
+    private readonly IStorageDialect theDialect = SqlServerStorageDialect<Guid>.Instance;
+
+    [Fact]
+    public void build_load_command_binds_id_and_tenant()
+    {
+        var id = Guid.NewGuid();
+        var command = theDialect.BuildLoadCommand("SELECT data FROM t WHERE id = @id AND tenant_id = @tenant_id", id, "t1");
+
+        var sql = command.ShouldBeOfType<SqlCommand>();
+        sql.Parameters.Count.ShouldBe(2);
+        sql.Parameters["id"].Value.ShouldBe(id);
+        sql.Parameters["id"].SqlDbType.ShouldBe(SqlDbType.UniqueIdentifier);
+        sql.Parameters["tenant_id"].Value.ShouldBe("t1");
+    }
+
+    [Fact]
+    public void build_load_command_omits_tenant_when_null()
+    {
+        var command = theDialect.BuildLoadCommand("SELECT 1", Guid.NewGuid(), null);
+        command.Parameters.Count.ShouldBe(1);
+    }
+
+    [Theory]
+    [InlineData(StorageColumnType.String, SqlDbType.NVarChar)]
+    [InlineData(StorageColumnType.Guid, SqlDbType.UniqueIdentifier)]
+    [InlineData(StorageColumnType.Long, SqlDbType.BigInt)]
+    [InlineData(StorageColumnType.Int, SqlDbType.Int)]
+    [InlineData(StorageColumnType.Boolean, SqlDbType.Bit)]
+    [InlineData(StorageColumnType.Timestamp, SqlDbType.DateTimeOffset)]
+    [InlineData(StorageColumnType.Json, SqlDbType.NVarChar)]
+    public void set_parameter_type_maps_storage_column_types(StorageColumnType storageType, SqlDbType expected)
+    {
+        var parameter = new SqlParameter();
+        theDialect.SetParameterType(parameter, storageType);
+        parameter.SqlDbType.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void set_id_parameter_type_uses_the_provider_mapping()
+    {
+        var parameter = new SqlParameter();
+        theDialect.SetIdParameterType(parameter, typeof(long));
+        parameter.SqlDbType.ShouldBe(SqlDbType.BigInt);
+    }
+
+    [Fact]
+    public void by_id_filter_renders_the_id_predicate()
+    {
+        var id = Guid.NewGuid();
+        var fragment = theDialect.ByIdFilter(id);
+
+        var builder = new CommandBuilder();
+        fragment.Apply(builder);
+        var command = builder.Compile();
+
+        command.CommandText.ShouldBe("id = @p0");
+        command.Parameters[0].Value.ShouldBe(id);
+        command.Parameters[0].SqlDbType.ShouldBe(SqlDbType.UniqueIdentifier);
+    }
+
+    [Fact]
+    public async Task is_undefined_table_detects_error_208()
+    {
+        await using var conn = await OpenConnectionAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = "SELECT * FROM dbo.pc_no_such_table_ever";
+
+        var ex = await Should.ThrowAsync<SqlException>(() => cmd.ExecuteScalarAsync());
+        theDialect.IsUndefinedTable(ex).ShouldBeTrue();
+        theDialect.IsUndefinedTable(new InvalidOperationException("nope")).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task openjson_id_array_round_trips_guids_against_sql_server()
+    {
+        var ids = new[] { Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid() };
+        var parameter = theDialect.CreateIdArrayParameter(ids, typeof(Guid));
+
+        var command = theDialect.BuildLoadManyCommand(
+            "SELECT value FROM OPENJSON(@ids)", parameter, null);
+
+        await using var conn = await OpenConnectionAsync();
+        command.Connection = (SqlConnection)conn;
+
+        var returned = new List<Guid>();
+        await using var reader = await command.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            returned.Add(Guid.Parse(reader.GetString(0)));
+        }
+
+        returned.ShouldBe(ids);
+    }
+
+    [Fact]
+    public async Task openjson_id_array_round_trips_longs_and_strings()
+    {
+        var longDialect = SqlServerStorageDialect<long>.Instance;
+        var longParam = longDialect.CreateIdArrayParameter(new[] { 1L, 42L, long.MaxValue }, typeof(long));
+
+        var stringDialect = SqlServerStorageDialect<string>.Instance;
+        var stringParam = stringDialect.CreateIdArrayParameter(new[] { "a", "quo\"te", "c" }, typeof(string));
+
+        await using var conn = await OpenConnectionAsync();
+
+        await using (var cmd = new SqlCommand("SELECT CAST(value AS BIGINT) FROM OPENJSON(@ids)", (SqlConnection)conn))
+        {
+            cmd.Parameters.Add((SqlParameter)longParam);
+            var values = new List<long>();
+            await using var reader = await cmd.ExecuteReaderAsync();
+            while (await reader.ReadAsync()) values.Add(reader.GetInt64(0));
+            values.ShouldBe([1L, 42L, long.MaxValue]);
+        }
+
+        await using (var cmd = new SqlCommand("SELECT value FROM OPENJSON(@ids)", (SqlConnection)conn))
+        {
+            cmd.Parameters.Add((SqlParameter)stringParam);
+            var values = new List<string>();
+            await using var reader = await cmd.ExecuteReaderAsync();
+            while (await reader.ReadAsync()) values.Add(reader.GetString(0));
+            values.ShouldBe(["a", "quo\"te", "c"]);
+        }
+    }
+
+    [Fact]
+    public void id_array_parameter_rejects_unsupported_id_types()
+    {
+        Should.Throw<ArgumentOutOfRangeException>(() =>
+            theDialect.CreateIdArrayParameter(new[] { 1.5, 2.5 }, typeof(double)));
+    }
+}

--- a/src/Polecat/Storage/SqlServerStorageDialect.cs
+++ b/src/Polecat/Storage/SqlServerStorageDialect.cs
@@ -1,0 +1,145 @@
+using System.Buffers;
+using System.Data;
+using System.Text.Json;
+using Microsoft.Data.SqlClient;
+using Weasel.SqlServer;
+using Weasel.SqlServer.SqlGeneration;
+using Weasel.Storage;
+
+namespace Polecat.Storage;
+
+/// <summary>
+///     SQL Server implementation of the shared closed-shape storage runtime's
+///     <see cref="IStorageDialect" /> strategy (#273 phase D) — the per-database-engine half of
+///     document load/parameter binding. Mirrors Marten's <c>PostgresStorageDialect&lt;TId&gt;</c>.
+///     SQL conventions (named <c>@id</c>/<c>@tenant_id</c>/<c>@ids</c> parameters, OPENJSON for
+///     id arrays) are co-designed with the SQL Server <c>DocumentStorageDescriptor</c> builder
+///     that generates the loader SQL.
+/// </summary>
+internal sealed class SqlServerStorageDialect<TId> : IStorageDialect
+{
+    public static readonly IStorageDialect Instance = new SqlServerStorageDialect<TId>();
+
+    private static readonly SqlDbType IdParameterType =
+        SqlServerProvider.Instance.ToParameterType(typeof(TId));
+
+    private SqlServerStorageDialect()
+    {
+    }
+
+    public System.Data.Common.DbCommand BuildLoadCommand(string loaderSql, object rawId, string? tenant)
+    {
+        var command = new SqlCommand(loaderSql);
+        command.Parameters.Add(new SqlParameter("id", rawId) { SqlDbType = IdParameterType });
+        if (tenant is not null)
+        {
+            command.Parameters.Add(new SqlParameter("tenant_id", tenant) { SqlDbType = SqlDbType.NVarChar });
+        }
+
+        return command;
+    }
+
+    /// <summary>
+    ///     SQL Server has no array parameters; ids travel as a JSON array string the load-many SQL
+    ///     unpacks with <c>OPENJSON(@ids)</c>. The JSON is written manually (scalar ids only) so
+    ///     the dialect stays trim/AOT-clean — no reflection-based serialization.
+    /// </summary>
+    public System.Data.Common.DbParameter CreateIdArrayParameter(Array rawIds, Type rawSqlType)
+    {
+        return new SqlParameter("ids", WriteIdsAsJsonArray(rawIds)) { SqlDbType = SqlDbType.NVarChar };
+    }
+
+    public System.Data.Common.DbCommand BuildLoadManyCommand(string loadArraySql,
+        System.Data.Common.DbParameter idArrayParameter, string? tenant)
+    {
+        var command = new SqlCommand(loadArraySql);
+        command.Parameters.Add((SqlParameter)idArrayParameter);
+        if (tenant is not null)
+        {
+            command.Parameters.Add(new SqlParameter("tenant_id", tenant) { SqlDbType = SqlDbType.NVarChar });
+        }
+
+        return command;
+    }
+
+    public Weasel.Core.SqlGeneration.ISqlFragment ByIdFilter(object rawId) => new SqlServerByIdFilter(rawId, IdParameterType);
+
+    /// <summary>SQL Server error 208: "Invalid object name '%s'."</summary>
+    public bool IsUndefinedTable(Exception exception)
+        => exception is SqlException sql && sql.Number == 208;
+
+    public void SetParameterType(System.Data.Common.DbParameter parameter, StorageColumnType type)
+        => ((SqlParameter)parameter).SqlDbType = type switch
+        {
+            StorageColumnType.String => SqlDbType.NVarChar,
+            StorageColumnType.Guid => SqlDbType.UniqueIdentifier,
+            StorageColumnType.Long => SqlDbType.BigInt,
+            StorageColumnType.Int => SqlDbType.Int,
+            StorageColumnType.Boolean => SqlDbType.Bit,
+            StorageColumnType.Timestamp => SqlDbType.DateTimeOffset,
+            // Polecat binds JSON as string values throughout; SQL Server 2025's native JSON
+            // column type (and nvarchar-backed JSON) accepts nvarchar input.
+            StorageColumnType.Json => SqlDbType.NVarChar,
+            _ => throw new ArgumentOutOfRangeException(nameof(type))
+        };
+
+    public void SetIdParameterType(System.Data.Common.DbParameter parameter, Type rawSqlType)
+        => ((SqlParameter)parameter).SqlDbType = SqlServerProvider.Instance.ToParameterType(rawSqlType);
+
+    private static string WriteIdsAsJsonArray(Array rawIds)
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        using (var writer = new Utf8JsonWriter(buffer))
+        {
+            writer.WriteStartArray();
+            foreach (var id in rawIds)
+            {
+                switch (id)
+                {
+                    case Guid guid:
+                        writer.WriteStringValue(guid);
+                        break;
+                    case string text:
+                        writer.WriteStringValue(text);
+                        break;
+                    case int number:
+                        writer.WriteNumberValue(number);
+                        break;
+                    case long number:
+                        writer.WriteNumberValue(number);
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException(nameof(rawIds),
+                            $"Unsupported raw id type {id?.GetType().FullName ?? "null"}; expected Guid, string, int, or long.");
+                }
+            }
+
+            writer.WriteEndArray();
+        }
+
+        return System.Text.Encoding.UTF8.GetString(buffer.WrittenSpan);
+    }
+}
+
+/// <summary>
+///     "id = @p" filter over the shared SQL-generation contract, the SQL Server counterpart of
+///     Marten's <c>ByIdFilter</c>. Implements the Weasel.SqlServer fragment interface (whose
+///     default interface method bridges the shared <c>Weasel.Core.SqlGeneration.ISqlFragment</c>).
+/// </summary>
+internal sealed class SqlServerByIdFilter : ISqlFragment
+{
+    private readonly CommandParameter _parameter;
+
+    public SqlServerByIdFilter(object value, SqlDbType dbType)
+    {
+        _parameter = new CommandParameter(value, dbType);
+    }
+
+    public void Apply(CommandBuilder builder)
+    {
+        builder.Append("id = ");
+        _parameter.Apply(builder);
+    }
+
+    public bool Contains(string sqlText) => false;
+}


### PR DESCRIPTION
Part of #273 — **phase D starts**. Weasel.Storage 9.10.0 (weasel#333 = marten#4821 story-6 **INC-1**) moved the closed-shape descriptor core into the shared library (`DocumentStorageDescriptor<TDoc,TId>`, `IDocumentMetadataBinder<TDoc>` + version/revision binders, concrete `ChangeTracker`, `ClosedShapeProjectionLoader`). The descriptor is fully dialect-parameterized, so the SQL Server `IStorageDialect` is now buildable against a released contract.

## What's here
- **Pins**: Weasel 9.9.0 → **9.10.0**.
- **`SqlServerStorageDialect<TId>`** — the SQL Server counterpart of Marten's `PostgresStorageDialect<TId>`:

| Member | SQL Server answer |
|---|---|
| `BuildLoadCommand` / `BuildLoadManyCommand` | Named `@id` / `@tenant_id` parameters (Polecat's existing convention) |
| `CreateIdArrayParameter` | **JSON array string + `OPENJSON(@ids)`** — SQL Server has no array parameters. JSON written manually (scalar ids only) so the dialect adds no trim/AOT surface |
| `SetParameterType` | `StorageColumnType` → `SqlDbType` (`Timestamp`→`DateTimeOffset`, `Json`→`NVarChar` per Polecat's JSON-as-string binding) |
| `ByIdFilter` | `SqlServerByIdFilter` over the shared SQL-generation contract (Weasel.SqlServer `CommandParameter`) |
| `IsUndefinedTable` | `SqlException.Number == 208` |

Loader-SQL conventions are co-designed with the upcoming SQL Server `DocumentStorageDescriptor` builder (next phase D brick, queued behind story-6 INC-2's `DocumentStorage` base move).

## Verification
- 15 new tests incl. **live OPENJSON round-trips** (Guid / long / string-with-quotes) and real error-208 detection against dockerized SQL Server 2025.
- **Full suite green: 1381 passed / 0 failed** (net10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)