### PR TITLE
chore: bump Weasel 9.10.0 → 9.11.0 (story-6 INC-2: shared selectors)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -54,9 +54,9 @@
              storage contracts extracted from Marten (marten#4821/#4830, weasel#329/#331) —
              IStorageSession / IStorageDatabase / IStorageSerializer / IDocumentStorage /
              IStorageDialect. This is the shared runtime Polecat retargets onto for #273. -->
-        <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.10.0" />
-        <PackageVersion Include="Weasel.SqlServer" Version="9.10.0" />
-        <PackageVersion Include="Weasel.Storage" Version="9.10.0" />
+        <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.11.0" />
+        <PackageVersion Include="Weasel.SqlServer" Version="9.11.0" />
+        <PackageVersion Include="Weasel.Storage" Version="9.11.0" />
 
         <!-- Strongly typed IDs -->
         <PackageVersion Include="StronglyTypedId" Version="1.0.0-beta08" />


### PR DESCRIPTION
Part of #273. Weasel.Storage 9.11.0 (weasel#334 = marten#4821 story-6 **INC-2**) moves the complete closed-shape **selector matrix** into the shared library — 34 selector classes (Flat/Hierarchical × Unversioned/Optimistic/Numeric × QueryOnly/Lightweight/IdentityMap/DirtyTracking) plus `IDocumentSelector`.

Selectors are instantiated by the `DocumentStorage` bases / descriptor builders, which are still Marten-local (story-6 INC-3) — so nothing new is consumable Polecat-side yet. This keeps the pin current so the INC-3 adoption lands as a clean diff.

## Verification
- **Full suite green: 1381 passed / 0 failed** (net10) against dockerized SQL Server 2025.

🤖 Generated with [Claude Code](https://claude.com/claude-code)