### PR TITLE
chore: bump Weasel 9.11.0 → 9.12.0 (story-6 INC-3: shared metadata binders)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -54,9 +54,9 @@
              storage contracts extracted from Marten (marten#4821/#4830, weasel#329/#331) —
              IStorageSession / IStorageDatabase / IStorageSerializer / IDocumentStorage /
              IStorageDialect. This is the shared runtime Polecat retargets onto for #273. -->
-        <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.11.0" />
-        <PackageVersion Include="Weasel.SqlServer" Version="9.11.0" />
-        <PackageVersion Include="Weasel.Storage" Version="9.11.0" />
+        <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.12.0" />
+        <PackageVersion Include="Weasel.SqlServer" Version="9.12.0" />
+        <PackageVersion Include="Weasel.Storage" Version="9.12.0" />
 
         <!-- Strongly typed IDs -->
         <PackageVersion Include="StronglyTypedId" Version="1.0.0-beta08" />


### PR DESCRIPTION
Part of #273. Weasel.Storage 9.12.0 (weasel#335 = marten#4821 story-6 **INC-3**) moves the 13 concrete closed-shape **metadata binders** into the shared library (version/revision, tenant, soft-delete, correlation/causation/headers, doc-type, dotnet-type, created-at, last-modified[-by]).

Building blocks now all released for the next phase-D brick — the **SQL Server `DocumentStorageDescriptor` builder**: descriptor shape (INC-1), selector matrix + read layout (INC-2), binders (INC-3), `SqlServerStorageDialect` (#283), `Weasel.Core.Identity` (#276). Slot conventions for the upsert SQL confirmed from the closed-shape operations (tenant → id → data → binders, `?` placeholders via `AppendWithDbParameters`).

## Verification
- **Full suite green: 1381 passed / 0 failed** (net10) against dockerized SQL Server 2025.

🤖 Generated with [Claude Code](https://claude.com/claude-code)