### PR TITLE
feat: SqlServerDocumentStorageDescriptorBuilder slice 1 (Weasel 9.13.0) (#273)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -54,9 +54,9 @@
              storage contracts extracted from Marten (marten#4821/#4830, weasel#329/#331) —
              IStorageSession / IStorageDatabase / IStorageSerializer / IDocumentStorage /
              IStorageDialect. This is the shared runtime Polecat retargets onto for #273. -->
-        <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.12.0" />
-        <PackageVersion Include="Weasel.SqlServer" Version="9.12.0" />
-        <PackageVersion Include="Weasel.Storage" Version="9.12.0" />
+        <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.13.0" />
+        <PackageVersion Include="Weasel.SqlServer" Version="9.13.0" />
+        <PackageVersion Include="Weasel.Storage" Version="9.13.0" />
 
         <!-- Strongly typed IDs -->
         <PackageVersion Include="StronglyTypedId" Version="1.0.0-beta08" />

--- a/src/Polecat.Tests/Storage/sqlserver_descriptor_builder_tests.cs
+++ b/src/Polecat.Tests/Storage/sqlserver_descriptor_builder_tests.cs
@@ -1,0 +1,212 @@
+using System.Data.Common;
+using Microsoft.Data.SqlClient;
+using OperationRole = Weasel.Core.OperationRole;
+using Polecat.Storage;
+using Polecat.Tests.Harness;
+using Weasel.Core.Identity;
+using Weasel.SqlServer;
+using Weasel.Storage;
+
+namespace Polecat.Tests.Storage;
+
+/// <summary>
+///     End-to-end verification of SqlServerDocumentStorageDescriptorBuilder (#273 phase D
+///     slice 1) through the SHARED closed-shape runtime pieces: descriptors executed by the
+///     shared write operations (Weasel.Storage 9.13.0 INC-4), bound through a real Polecat
+///     IStorageSession, against real pc tables, read back via the shared selectors — all
+///     without Polecat's bespoke operations touching the rows.
+/// </summary>
+public class sqlserver_descriptor_builder_tests : OneOffConfigurationsContext
+{
+    private DocumentStorageDescriptor<TDoc, Guid> descriptorFor<TDoc>() where TDoc : notnull
+    {
+        var provider = theStore.Options.Providers.GetProvider(typeof(TDoc));
+        var identification = new SequentialGuidIdentification<TDoc>(typeof(TDoc).GetProperty("Id")!);
+        return SqlServerDocumentStorageDescriptorBuilder.Build<TDoc, Guid>(
+            provider.Mapping, identification, theStore.Options);
+    }
+
+    private async Task<int> executeAsync(Weasel.Storage.IStorageOperation operation, IStorageSession session)
+    {
+        var builder = new BatchBuilder { TenantId = session.TenantId };
+        operation.ConfigureCommand(builder, session);
+        var batch = builder.Compile();
+
+        await using var conn = new SqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        batch.Connection = conn;
+
+        var exceptions = new List<Exception>();
+        await using (var reader = await batch.ExecuteReaderAsync())
+        {
+            await operation.PostprocessAsync(reader, exceptions, CancellationToken.None);
+        }
+
+        foreach (var ex in exceptions)
+        {
+            throw ex;
+        }
+
+        return exceptions.Count;
+    }
+
+    private async Task<TDoc?> loadViaSharedSelectorAsync<TDoc>(
+        DocumentStorageDescriptor<TDoc, Guid> descriptor, Guid id, IStorageSession session)
+        where TDoc : notnull
+    {
+        var readColumns = new List<string> { "id", "data" };
+        readColumns.AddRange(descriptor.ReadBinders.Select(b => b.ColumnName));
+
+        var command = descriptor.Dialect.BuildLoadCommand(
+            $"SELECT {string.Join(", ", readColumns)} FROM {descriptor.TableName} WHERE id = @id",
+            id, tenant: null);
+
+        await using var conn = new SqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        command.Connection = (SqlConnection)conn;
+
+        var selector = new TestLightweightSelector<TDoc>(session, descriptor);
+        await using var reader = await command.ExecuteReaderAsync();
+        if (!await reader.ReadAsync())
+        {
+            return default;
+        }
+
+        return await selector.ResolveAsync(reader, CancellationToken.None);
+    }
+
+    private sealed class TestLightweightSelector<TDoc> : UnversionedClosedShapeLightweightSelector<TDoc, Guid>
+        where TDoc : notnull
+    {
+        public TestLightweightSelector(IStorageSession session, DocumentStorageDescriptor<TDoc, Guid> descriptor)
+            : base(session, descriptor)
+        {
+        }
+
+        protected override TDoc ReadDocument(DbDataReader reader)
+            => _serializer.FromJson<TDoc>(reader, DataColumn);
+
+        protected override async ValueTask<TDoc> ReadDocumentAsync(DbDataReader reader, CancellationToken token)
+            => await _serializer.FromJsonAsync<TDoc>(reader, DataColumn, token);
+    }
+
+    [Fact]
+    public void builder_produces_merge_sql_with_slot_aligned_parameters()
+    {
+        // Force table + provider creation
+        theStore.Options.Providers.GetProvider(typeof(Target)).ShouldNotBeNull();
+
+        var descriptor = descriptorFor<Target>();
+
+        descriptor.ConcurrencyMode.ShouldBe(ConcurrencyMode.Off);
+        descriptor.IsConjoined.ShouldBeFalse();
+
+        // Single-tenant: tenant travels as an ordinary client-side binder
+        descriptor.ClientSideWriteBinders.Select(b => b.ColumnName)
+            .ShouldContain("tenant_id");
+
+        // ? slots in the USING row = id + data + client-side binders
+        var expectedSlots = 2 + descriptor.ClientSideWriteBinders.Length;
+        descriptor.UpsertSql.Count(c => c == '?').ShouldBe(expectedSlots);
+
+        descriptor.UpsertSql.ShouldContain("MERGE");
+        descriptor.UpsertSql.ShouldContain("WHEN MATCHED THEN UPDATE");
+        descriptor.UpsertSql.ShouldContain("WHEN NOT MATCHED THEN INSERT");
+        descriptor.UpsertSql.ShouldContain("SYSDATETIMEOFFSET()");
+        descriptor.UpsertSql.ShouldContain("version = t.version + 1");
+        descriptor.InsertSql.ShouldNotContain("WHEN MATCHED");
+    }
+
+    [Fact]
+    public async Task shared_upsert_operation_round_trips_through_polecat_session()
+    {
+        await using var bootstrap = theStore.LightweightSession();
+        bootstrap.Store(new Target { Number = 1 }); // force table creation
+        await bootstrap.SaveChangesAsync();
+
+        var descriptor = descriptorFor<Target>();
+        await using var raw = theStore.LightweightSession();
+        var session = (IStorageSession)raw;
+
+        var doc = new Target { Id = Guid.NewGuid(), Number = 42, Color = "teal" };
+        var upsert = new UnversionedClosedShapeUpsertOperation<Target, Guid>(
+            doc, doc.Id, session.TenantId, descriptor, OperationRole.Upsert);
+        await executeAsync(upsert, session);
+
+        // Update the same row through a second shared upsert
+        doc.Number = 43;
+        var second = new UnversionedClosedShapeUpsertOperation<Target, Guid>(
+            doc, doc.Id, session.TenantId, descriptor, OperationRole.Upsert);
+        await executeAsync(second, session);
+
+        var loaded = await loadViaSharedSelectorAsync(descriptor, doc.Id, session);
+        loaded.ShouldNotBeNull();
+        loaded.Number.ShouldBe(43);
+        loaded.Color.ShouldBe("teal");
+
+        // And Polecat's own bespoke pipeline sees the same row
+        await using var check = theStore.QuerySession();
+        var viaPolecat = await check.LoadAsync<Target>(doc.Id);
+        viaPolecat.ShouldNotBeNull();
+        viaPolecat.Number.ShouldBe(43);
+    }
+
+    [Fact]
+    public async Task optimistic_descriptor_enforces_guid_version_guard()
+    {
+        await using var bootstrap = theStore.LightweightSession();
+        bootstrap.Store(new VersionedDoc { Name = "seed" }); // force table creation
+        await bootstrap.SaveChangesAsync();
+
+        var descriptor = descriptorFor<VersionedDoc>();
+        descriptor.ConcurrencyMode.ShouldBe(ConcurrencyMode.Optimistic);
+        descriptor.VersionBinder.ShouldNotBeNull();
+
+        await using var raw = theStore.LightweightSession();
+        var session = (IStorageSession)raw;
+
+        var doc = new VersionedDoc { Id = Guid.NewGuid(), Name = "first" };
+        var versions = new Dictionary<Guid, Guid>();
+
+        // Initial save: no expectation, row doesn't exist -> INSERT branch fires
+        var insert = new OptimisticClosedShapeUpsertOperation<VersionedDoc, Guid>(
+            doc, doc.Id, session.TenantId, descriptor, OperationRole.Upsert, versions);
+        await executeAsync(insert, session);
+        versions.ContainsKey(doc.Id).ShouldBeTrue();
+
+        // Update with the correct expected version succeeds
+        doc.Name = "second";
+        var goodUpdate = new OptimisticClosedShapeUpsertOperation<VersionedDoc, Guid>(
+            doc, doc.Id, session.TenantId, descriptor, OperationRole.Upsert, versions);
+        await executeAsync(goodUpdate, session);
+
+        // Update with a stale expected version raises ConcurrencyException
+        var stale = new Dictionary<Guid, Guid> { [doc.Id] = Guid.NewGuid() };
+        var badUpdate = new OptimisticClosedShapeUpsertOperation<VersionedDoc, Guid>(
+            doc, doc.Id, session.TenantId, descriptor, OperationRole.Upsert, stale);
+        await Should.ThrowAsync<JasperFx.ConcurrencyException>(() => executeAsync(badUpdate, session));
+    }
+
+    [Fact]
+    public async Task insert_only_descriptor_sql_signals_id_collision_with_zero_rows()
+    {
+        await using var bootstrap = theStore.LightweightSession();
+        bootstrap.Store(new Target { Number = 1 });
+        await bootstrap.SaveChangesAsync();
+
+        var descriptor = descriptorFor<Target>();
+        await using var raw = theStore.LightweightSession();
+        var session = (IStorageSession)raw;
+
+        var doc = new Target { Id = Guid.NewGuid(), Number = 7 };
+        var insert = new UnversionedClosedShapeInsertOperation<Target, Guid>(
+            doc, doc.Id, session.TenantId, descriptor);
+        await executeAsync(insert, session);
+
+        // Second insert with the same id: zero rows from OUTPUT -> the shared operation
+        // surfaces a DocumentAlreadyExistsException (or reports via exceptions list)
+        var duplicate = new UnversionedClosedShapeInsertOperation<Target, Guid>(
+            doc, doc.Id, session.TenantId, descriptor);
+        await Should.ThrowAsync<Exception>(() => executeAsync(duplicate, session));
+    }
+}

--- a/src/Polecat/Storage/PolecatTenantIdBinder.cs
+++ b/src/Polecat/Storage/PolecatTenantIdBinder.cs
@@ -1,0 +1,47 @@
+using System.Data.Common;
+using System.Reflection;
+using JasperFx.Core.Reflection;
+using Weasel.Storage;
+
+namespace Polecat.Storage;
+
+/// <summary>
+///     Write-capable tenant-id binder for Polecat's always-present <c>tenant_id</c> column
+///     (#273 phase D). The shared <see cref="DocumentTenantIdBinder{TDoc}" /> is read-only
+///     because Marten binds the tenant inline via the conjoined parameter slot; Polecat's
+///     single-tenant tables still carry <c>tenant_id</c> (default tenant id), so this binder
+///     writes the session's tenant through the ordinary client-side binder loop instead.
+/// </summary>
+internal sealed class PolecatTenantIdBinder<TDoc> : IDocumentMetadataBinder<TDoc>
+    where TDoc : notnull
+{
+    private readonly Action<TDoc, string>? _setter;
+
+    public PolecatTenantIdBinder(string columnName, MemberInfo? tenantIdMember)
+    {
+        ColumnName = columnName;
+        if (tenantIdMember is not null)
+        {
+            _setter = LambdaBuilder.Setter<TDoc, string>(tenantIdMember);
+        }
+    }
+
+    public string ColumnName { get; }
+
+    public string ValueSql => "?";
+
+    public void BindParameter(DbParameter parameter, TDoc document, IStorageSession session)
+    {
+        parameter.Value = session.TenantId;
+        parameter.DbType = System.Data.DbType.String;
+    }
+
+    public void Apply(DbDataReader reader, int columnOrdinal, TDoc document, IStorageSession session)
+    {
+        if (_setter is null || reader.IsDBNull(columnOrdinal)) return;
+        _setter(document, reader.GetString(columnOrdinal));
+    }
+
+    /// <summary>Bulk insert binds tenant per batch, not per document.</summary>
+    public BulkColumnValue GetBulkValue(TDoc document) => BulkColumnValue.TypedNull(StorageColumnType.String);
+}

--- a/src/Polecat/Storage/SqlServerDocumentStorageDescriptorBuilder.cs
+++ b/src/Polecat/Storage/SqlServerDocumentStorageDescriptorBuilder.cs
@@ -1,0 +1,321 @@
+using JasperFx;
+using Weasel.Core.Identity;
+using Weasel.Storage;
+
+namespace Polecat.Storage;
+
+/// <summary>
+///     Builds a <see cref="DocumentStorageDescriptor{TDoc,TId}" /> from a Polecat
+///     <see cref="DocumentMapping" /> — the SQL Server counterpart of Marten's
+///     <c>DocumentStorageDescriptorBuilder</c> (#273 phase D, slice 1). Produces the binder
+///     arrays and MERGE-based SQL in lockstep: column order and <c>?</c> parameter-slot order
+///     must agree exactly with the shared closed-shape write operations, which bind
+///     [tenant when conjoined] → id → data → each client-side binder → trailing concurrency
+///     guard (see <c>ClosedShapeUpsertOperation.BindPreOnConflictParameters</c>).
+/// </summary>
+/// <remarks>
+///     Slice 1 scope: Off + Optimistic concurrency, no hierarchy, no partitioning, no soft
+///     delete, no numeric revisions. Polecat divergences from Marten handled here:
+///     <list type="bullet">
+///         <item>
+///             <c>tenant_id</c> is ALWAYS present in pc tables. Conjoined mappings use the
+///             shared operations' leading tenant slot; single-tenant mappings instead put a
+///             session-sourced <see cref="DocumentTenantIdBinder{TDoc}" /> in the write binder
+///             array so the default tenant id is written through the ordinary binder loop.
+///         </item>
+///         <item>
+///             The always-present numeric <c>version</c> column is maintained as literal SQL
+///             (1 on insert, +1 on update) — it is not the concurrency vehicle. Optimistic
+///             concurrency rides the separate <c>guid_version</c> column via the descriptor's
+///             version binder, matching Polecat's existing operations.
+///         </item>
+///         <item>
+///             <c>last_modified</c>/<c>created_at</c> are server-side via
+///             <c>SYSDATETIMEOFFSET()</c> (weasel#336 injectable timestamp SQL).
+///         </item>
+///     </list>
+/// </remarks>
+internal static class SqlServerDocumentStorageDescriptorBuilder
+{
+    private const string ServerTimestamp = "SYSDATETIMEOFFSET()";
+
+    public static DocumentStorageDescriptor<TDoc, TId> Build<TDoc, TId>(
+        DocumentMapping mapping,
+        IIdentification<TDoc, TId> identification,
+        StoreOptions options)
+        where TDoc : notnull
+        where TId : notnull
+    {
+        if (mapping.IsHierarchy())
+        {
+            throw new NotSupportedException(
+                "Closed-shape descriptors for hierarchical documents land in a later #273 increment.");
+        }
+
+        if (mapping.UseNumericRevisions || mapping.DeleteStyle == DeleteStyle.SoftDelete ||
+            mapping.HasPartitionColumn)
+        {
+            throw new NotSupportedException(
+                "Closed-shape descriptors for numeric revisions / soft deletes / partitioned documents land in a later #273 increment.");
+        }
+
+        var dialect = SqlServerStorageDialect<TId>.Instance;
+        var writeBinders = new List<IDocumentMetadataBinder<TDoc>>();
+        var readBinders = new List<IDocumentMetadataBinder<TDoc>>();
+
+        DocumentVersionBinder<TDoc>? versionBinder = null;
+        var versionReadIndex = -1;
+        var isConjoined = mapping.TenancyStyle == TenancyStyle.Conjoined;
+
+        // tenant_id: pc tables always carry it. Conjoined uses the shared operations'
+        // leading tenant parameter slot (NOT a binder); single-tenant writes the session's
+        // (default) tenant id through a regular binder slot.
+        if (!isConjoined)
+        {
+            // Shared DocumentTenantIdBinder is read-only (Marten binds tenant inline);
+            // Polecat's write-capable binder sources the session's tenant id.
+            writeBinders.Add(new PolecatTenantIdBinder<TDoc>(
+                mapping.Metadata.TenantId.Name, mapping.Metadata.TenantId.Member));
+        }
+        else if (mapping.Metadata.TenantId.Member is not null)
+        {
+            readBinders.Add(new DocumentTenantIdBinder<TDoc>(
+                mapping.Metadata.TenantId.Name, mapping.Metadata.TenantId.Member));
+        }
+
+        // guid_version: the optimistic-concurrency vehicle (uniqueidentifier), separate from
+        // the always-present numeric version column that MERGE maintains as literal SQL.
+        if (mapping.UseOptimisticConcurrency)
+        {
+            versionBinder = new DocumentVersionBinder<TDoc>("guid_version", dialect, versionMember: null);
+            writeBinders.Add(versionBinder);
+            versionReadIndex = readBinders.Count;
+            readBinders.Add(versionBinder);
+        }
+
+        // dotnet_type: always written, never selected (matches Polecat's current SELECTs).
+        writeBinders.Add(new DocumentDotNetTypeBinder<TDoc>(mapping.Metadata.DotNetType.Name, dialect));
+
+        // last_modified: always in the table, server-side value.
+        var lastModified = new DocumentLastModifiedBinder<TDoc>(
+            mapping.Metadata.LastModified.Name, mapping.Metadata.LastModified.Member, ServerTimestamp);
+        writeBinders.Add(lastModified);
+        if (mapping.Metadata.LastModified.Member is not null)
+        {
+            readBinders.Add(lastModified);
+        }
+
+        // created_at: read-only projection; the INSERT branch bakes SYSDATETIMEOFFSET().
+        if (mapping.Metadata.CreatedAt.Member is not null)
+        {
+            readBinders.Add(new DocumentCreatedAtBinder<TDoc>(
+                mapping.Metadata.CreatedAt.Name, mapping.Metadata.CreatedAt.Member, ServerTimestamp));
+        }
+
+        // Opt-in session-sourced metadata (#241): write slot when enabled, read slot only
+        // with a mapped member.
+        AddSessionMetadataBinder(writeBinders, readBinders, mapping.Metadata.CorrelationId,
+            (name, member) => new DocumentCorrelationIdBinder<TDoc>(name, dialect, member));
+        AddSessionMetadataBinder(writeBinders, readBinders, mapping.Metadata.CausationId,
+            (name, member) => new DocumentCausationIdBinder<TDoc>(name, dialect, member));
+        AddSessionMetadataBinder(writeBinders, readBinders, mapping.Metadata.LastModifiedBy,
+            (name, member) => new DocumentLastModifiedByBinder<TDoc>(name, dialect, member));
+
+        if (mapping.Metadata.Headers.Enabled)
+        {
+            // Headers: write-only — the member value comes from the JSON data column.
+            writeBinders.Add(new DocumentHeadersBinder<TDoc>(
+                mapping.Metadata.Headers.Name, dialect, mapping.Metadata.Headers.Member));
+        }
+
+        var writeArray = writeBinders.ToArray();
+        var readArray = readBinders.ToArray();
+        // QueryOnly's SELECT omits guid_version when it has no mapped member (always the case
+        // in slice 1) so its read set drops that binder — mirrors Marten's #4602 rule.
+        var queryOnlyReadArray = versionReadIndex >= 0
+            ? readArray.Where((_, i) => i != versionReadIndex).ToArray()
+            : readArray;
+        var clientSide = writeArray.Where(b => !b.IsServerSide).ToArray();
+
+        var concurrencyMode = mapping.UseOptimisticConcurrency
+            ? ConcurrencyMode.Optimistic
+            : ConcurrencyMode.Off;
+
+        var upsertSql = BuildMergeSql(mapping, writeArray, isConjoined, concurrencyMode, guarded: concurrencyMode != ConcurrencyMode.Off, insertOnly: false);
+        var insertSql = BuildMergeSql(mapping, writeArray, isConjoined, concurrencyMode, guarded: false, insertOnly: true);
+        var updateSql = BuildUpdateSql(mapping, writeArray, isConjoined, concurrencyMode);
+        var overwriteSql = BuildMergeSql(mapping, writeArray, isConjoined, concurrencyMode, guarded: false, insertOnly: false);
+
+        return new DocumentStorageDescriptor<TDoc, TId>(
+            identification,
+            serializer: Serialization.StorageSerializerAdapter.For(options.Serializer),
+            dialect: SqlServerStorageDialect<TId>.Instance,
+            clientSideWriteBinders: clientSide,
+            writeBinders: writeArray,
+            readBinders: readArray,
+            queryOnlyReadBinders: queryOnlyReadArray,
+            upsertSql: upsertSql,
+            insertSql: insertSql,
+            updateSql: updateSql,
+            overwriteSql: overwriteSql,
+            isConjoined: isConjoined,
+            concurrencyMode: concurrencyMode,
+            versionBinder: versionBinder,
+            revisionBinder: null,
+            versionReadIndex: versionReadIndex,
+            resolveDocumentType: null,
+            docTypeReadIndex: -1,
+            tableName: mapping.QualifiedTableName);
+    }
+
+    private static void AddSessionMetadataBinder<TDoc>(
+        List<IDocumentMetadataBinder<TDoc>> writeBinders,
+        List<IDocumentMetadataBinder<TDoc>> readBinders,
+        Metadata.MetadataColumn column,
+        Func<string, System.Reflection.MemberInfo?, IDocumentMetadataBinder<TDoc>> create)
+        where TDoc : notnull
+    {
+        if (!column.Enabled)
+        {
+            return;
+        }
+
+        var binder = create(column.Name, column.Member);
+        writeBinders.Add(binder);
+        if (column.Member is not null)
+        {
+            readBinders.Add(binder);
+        }
+    }
+
+    /// <summary>
+    ///     The MERGE statement serving upsert (guarded or not) and insert-only. Client-side
+    ///     binder values travel in the USING row so both branches reference <c>s.{col}</c>;
+    ///     server-side values are baked as literals per branch. The always-present numeric
+    ///     <c>version</c> column is 1 on insert and <c>t.version + 1</c> on update. Zero rows
+    ///     from OUTPUT signals a concurrency violation (guarded upsert) or an id collision
+    ///     (insert-only) to the shared operations.
+    /// </summary>
+    private static string BuildMergeSql<TDoc>(
+        DocumentMapping mapping,
+        IReadOnlyList<IDocumentMetadataBinder<TDoc>> binders,
+        bool isConjoined,
+        ConcurrencyMode mode,
+        bool guarded,
+        bool insertOnly)
+        where TDoc : notnull
+    {
+        var table = mapping.QualifiedTableName;
+
+        // USING row: [tenant] id, data, then client-side binder columns — parameter slot order.
+        var usingColumns = new List<string>();
+        if (isConjoined)
+        {
+            usingColumns.Add("tenant_id");
+        }
+
+        usingColumns.Add("id");
+        usingColumns.Add("data");
+        usingColumns.AddRange(binders.Where(b => !b.IsServerSide).Select(b => b.ColumnName));
+
+        var usingValues = string.Join(", ", usingColumns.Select(_ => "?"));
+        var sourceColumns = string.Join(", ", usingColumns);
+
+        var onClause = isConjoined
+            ? "t.id = s.id AND t.tenant_id = s.tenant_id"
+            : "t.id = s.id";
+
+        // INSERT branch: USING columns + version/created_at/last modified server-side extras.
+        var insertColumns = new List<string>(usingColumns) { "version", "created_at" };
+        var insertValues = new List<string>(usingColumns.Select(c => $"s.{c}")) { "1", ServerTimestamp };
+        foreach (var binder in binders.Where(b => b.IsServerSide))
+        {
+            insertColumns.Add(binder.ColumnName);
+            insertValues.Add(binder.ValueSql);
+        }
+
+        var insertClause =
+            $"WHEN NOT MATCHED THEN INSERT ({string.Join(", ", insertColumns)}) VALUES ({string.Join(", ", insertValues)})";
+
+        if (insertOnly)
+        {
+            return $"MERGE {table} WITH (HOLDLOCK) AS t " +
+                   $"USING (VALUES ({usingValues})) AS s ({sourceColumns}) ON {onClause} " +
+                   $"{insertClause} " +
+                   $"OUTPUT {OutputColumn(mode)};";
+        }
+
+        // UPDATE branch: data + client-side binder columns from s, server-side as literals,
+        // numeric version incremented. created_at is never touched on update.
+        var updateAssignments = new List<string> { "data = s.data", "version = t.version + 1" };
+        updateAssignments.AddRange(binders.Where(b => !b.IsServerSide && b.ColumnName != "tenant_id")
+            .Select(b => $"{b.ColumnName} = s.{b.ColumnName}"));
+        updateAssignments.AddRange(binders.Where(b => b.IsServerSide)
+            .Select(b => $"{b.ColumnName} = {b.ValueSql}"));
+
+        // Optimistic guard: expected guid_version is the trailing parameter slot; a NULL
+        // expectation (document never loaded in this session) skips the check, matching the
+        // shared operation's DBNull binding.
+        var guard = guarded && mode == ConcurrencyMode.Optimistic
+            ? " AND t.guid_version = ?"
+            : string.Empty;
+
+        return $"MERGE {table} WITH (HOLDLOCK) AS t " +
+               $"USING (VALUES ({usingValues})) AS s ({sourceColumns}) ON {onClause} " +
+               $"WHEN MATCHED{guard} THEN UPDATE SET {string.Join(", ", updateAssignments)} " +
+               $"{insertClause} " +
+               $"OUTPUT {OutputColumn(mode)};";
+    }
+
+    /// <summary>
+    ///     Update-only SQL. Parameter order per the shared update operations: [tenant] id,
+    ///     data, client binders, then the optimistic guard pair. Zero rows = missing document
+    ///     or concurrency violation.
+    /// </summary>
+    private static string BuildUpdateSql<TDoc>(
+        DocumentMapping mapping,
+        IReadOnlyList<IDocumentMetadataBinder<TDoc>> binders,
+        bool isConjoined,
+        ConcurrencyMode mode)
+        where TDoc : notnull
+    {
+        var table = mapping.QualifiedTableName;
+
+        // Reuse the MERGE shape without the NOT MATCHED branch so the slot order stays
+        // identical to upsert — the shared ClosedShapeUpdateOperations bind exactly like
+        // the upserts.
+        var usingColumns = new List<string>();
+        if (isConjoined)
+        {
+            usingColumns.Add("tenant_id");
+        }
+
+        usingColumns.Add("id");
+        usingColumns.Add("data");
+        usingColumns.AddRange(binders.Where(b => !b.IsServerSide).Select(b => b.ColumnName));
+
+        var usingValues = string.Join(", ", usingColumns.Select(_ => "?"));
+        var sourceColumns = string.Join(", ", usingColumns);
+        var onClause = isConjoined
+            ? "t.id = s.id AND t.tenant_id = s.tenant_id"
+            : "t.id = s.id";
+
+        var updateAssignments = new List<string> { "data = s.data", "version = t.version + 1" };
+        updateAssignments.AddRange(binders.Where(b => !b.IsServerSide && b.ColumnName != "tenant_id")
+            .Select(b => $"{b.ColumnName} = s.{b.ColumnName}"));
+        updateAssignments.AddRange(binders.Where(b => b.IsServerSide)
+            .Select(b => $"{b.ColumnName} = {b.ValueSql}"));
+
+        var guard = mode == ConcurrencyMode.Optimistic
+            ? " AND t.guid_version = ?"
+            : string.Empty;
+
+        return $"MERGE {table} WITH (HOLDLOCK) AS t " +
+               $"USING (VALUES ({usingValues})) AS s ({sourceColumns}) ON {onClause} " +
+               $"WHEN MATCHED{guard} THEN UPDATE SET {string.Join(", ", updateAssignments)} " +
+               $"OUTPUT {OutputColumn(mode)};";
+    }
+
+    private static string OutputColumn(ConcurrencyMode mode)
+        => mode == ConcurrencyMode.Optimistic ? "inserted.guid_version" : "inserted.id";
+}


### PR DESCRIPTION
Part of #273 — second phase-D brick, and a milestone: **the shared closed-shape runtime wrote its first SQL Server rows.**

Weasel.Storage 9.13.0 (story-6 **INC-4**, weasel#337) moved the closed-shape **write operations** into the shared library, and weasel#336 made the binder server-timestamp SQL injectable — so the SQL Server descriptor builder is both buildable and verifiable end-to-end against released contracts.

## What's here
- **Pins**: Weasel 9.12.0 → **9.13.0**.
- **`SqlServerDocumentStorageDescriptorBuilder`** — `DocumentMapping` → `DocumentStorageDescriptor<TDoc,TId>` with MERGE-based upsert / insert-only / update / overwrite SQL, `?` slots aligned to the shared operations' binding order (`[tenant if conjoined] → id → data → client-side binders → trailing optimistic guard`).
- **Polecat divergences handled**: `tenant_id` always present (conjoined = leading slot; single-tenant = new write-capable **`PolecatTenantIdBinder`**, since the shared one is read-only by Marten's design); numeric `version` column maintained as literal SQL (`1` on insert, `t.version + 1` on update); optimistic concurrency rides `guid_version` via the descriptor's version binder; `SYSDATETIMEOFFSET()` server-side timestamps.
- **Slice 1 scope**: Off + Optimistic concurrency. Hierarchy / numeric revisions / soft delete / partitioning throw `NotSupportedException` pending later increments.

## Verification (the interesting part)
4 end-to-end tests where the **shared** `Unversioned`/`Optimistic` closed-shape upsert + insert operations execute these descriptors **through a real Polecat `IStorageSession`** against real `pc` tables, read back via the **shared** `UnversionedClosedShapeLightweightSelector`:
- upsert → update → read-back round-trip (and Polecat's bespoke pipeline reads the same row)
- optimistic guard: stale expected `guid_version` → `ConcurrencyException` (zero-row OUTPUT detection)
- insert-only: duplicate id → zero rows → surfaced error
- MERGE SQL shape + slot-count assertions

**Full suite green: 1385 passed / 0 failed** (net10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)