### PR TITLE
feat: descriptor builder slice 3 — update slot order fix + partitioned documents (#273)

### DIFF
--- a/src/Polecat.Tests/Storage/sqlserver_descriptor_builder_tests.cs
+++ b/src/Polecat.Tests/Storage/sqlserver_descriptor_builder_tests.cs
@@ -284,6 +284,113 @@ public class sqlserver_descriptor_builder_tests : OneOffConfigurationsContext
         public string Extra { get; set; } = string.Empty;
     }
 
+    // Partition functions/schemes are database-global objects named from the table; a
+    // dedicated doc type keeps this test's objects distinct from document_range_partitioning_tests.
+    public class DescriptorMetricsSample
+    {
+        public Guid Id { get; set; }
+        public DateTimeOffset BucketEnd { get; set; }
+        public string Metric { get; set; } = string.Empty;
+        public double Value { get; set; }
+    }
+
+    // ---- Slice 3: update-op slot order + partitioned documents ----
+
+    [Fact]
+    public async Task shared_update_operation_binds_the_update_slot_order()
+    {
+        // The update ops bind data -> binders -> id -> [tenant] -> [partition] -> guard,
+        // NOT the upsert order — this test locks the UpdateSql slot layout.
+        await using var bootstrap = theStore.LightweightSession();
+        var doc = new Target { Id = Guid.NewGuid(), Number = 1, Color = "red" };
+        bootstrap.Store(doc);
+        await bootstrap.SaveChangesAsync();
+
+        var descriptor = descriptorFor<Target>();
+        await using var raw = theStore.LightweightSession();
+        var session = (IStorageSession)raw;
+
+        doc.Number = 99;
+        var update = new UnversionedClosedShapeUpdateOperation<Target, Guid>(
+            doc, doc.Id, session.TenantId, descriptor);
+        await executeAsync(update, session);
+
+        var loaded = await loadViaSharedSelectorAsync(descriptor, doc.Id, session);
+        loaded.ShouldNotBeNull();
+        loaded.Number.ShouldBe(99);
+
+        // Updating a nonexistent document -> zero rows -> missing-document error
+        var ghost = new Target { Id = Guid.NewGuid(), Number = 1 };
+        var missing = new UnversionedClosedShapeUpdateOperation<Target, Guid>(
+            ghost, ghost.Id, session.TenantId, descriptor);
+        await Should.ThrowAsync<Exception>(() => executeAsync(missing, session));
+    }
+
+    [Fact]
+    public async Task shared_numeric_update_operation_guards_and_increments()
+    {
+        await using var bootstrap = theStore.LightweightSession();
+        var doc = new RevisionedDoc { Id = Guid.NewGuid(), Name = "u1" };
+        bootstrap.Store(doc);
+        await bootstrap.SaveChangesAsync(); // bespoke pipeline writes revision 1
+
+        var descriptor = descriptorFor<RevisionedDoc>();
+        await using var raw = theStore.LightweightSession();
+        var session = (IStorageSession)raw;
+
+        doc.Name = "u2";
+        var revisions = new Dictionary<Guid, long>();
+        var update = new NumericClosedShapeUpdateOperation<RevisionedDoc, Guid>(
+            doc, doc.Id, session.TenantId, descriptor, revisions) { Revision = 0 };
+        await executeAsync(update, session);
+        doc.Version.ShouldBe(2); // auto-incremented past the bespoke pipeline's 1
+
+        var stale = new NumericClosedShapeUpdateOperation<RevisionedDoc, Guid>(
+            doc, doc.Id, session.TenantId, descriptor, revisions) { Revision = 1 };
+        await Should.ThrowAsync<JasperFx.ConcurrencyException>(() => executeAsync(stale, session));
+    }
+
+    [Fact]
+    public async Task partitioned_descriptor_round_trips_and_updates_in_partition()
+    {
+        var jan = new DateTimeOffset(2026, 1, 31, 0, 0, 0, TimeSpan.Zero);
+        var feb = new DateTimeOffset(2026, 2, 28, 0, 0, 0, TimeSpan.Zero);
+        ConfigureStore(opts =>
+            opts.Schema.For<DescriptorMetricsSample>().PartitionByRange(x => x.BucketEnd, jan, feb));
+
+        await using var bootstrap = theStore.LightweightSession();
+        bootstrap.Store(new DescriptorMetricsSample { BucketEnd = jan, Metric = "seed" });
+        await bootstrap.SaveChangesAsync(); // force partitioned table creation
+
+        var descriptor = descriptorFor<DescriptorMetricsSample>();
+        descriptor.PartitionPkBinders.Length.ShouldBe(1);
+        descriptor.PartitionPkBinders[0].ColumnName.ShouldBe("bucket_end");
+        descriptor.UpsertSql.ShouldContain("t.bucket_end = s.bucket_end");
+        descriptor.UpdateSql.ShouldContain("t.bucket_end = s.bucket_end_pk");
+
+        await using var raw = theStore.LightweightSession();
+        var session = (IStorageSession)raw;
+
+        var doc = new DescriptorMetricsSample
+        {
+            Id = Guid.NewGuid(), BucketEnd = jan, Metric = "cpu", Value = 0.5
+        };
+        var upsert = new UnversionedClosedShapeUpsertOperation<DescriptorMetricsSample, Guid>(
+            doc, doc.Id, session.TenantId, descriptor, OperationRole.Upsert);
+        await executeAsync(upsert, session);
+
+        // Shared update targets the same partition row
+        doc.Value = 0.9;
+        var update = new UnversionedClosedShapeUpdateOperation<DescriptorMetricsSample, Guid>(
+            doc, doc.Id, session.TenantId, descriptor);
+        await executeAsync(update, session);
+
+        await using var check = theStore.QuerySession();
+        var loaded = await check.LoadAsync<DescriptorMetricsSample>(doc.Id);
+        loaded.ShouldNotBeNull();
+        loaded.Value.ShouldBe(0.9);
+    }
+
     [Fact]
     public async Task insert_only_descriptor_sql_signals_id_collision_with_zero_rows()
     {

--- a/src/Polecat/Storage/PolecatPartitionColumnBinder.cs
+++ b/src/Polecat/Storage/PolecatPartitionColumnBinder.cs
@@ -1,0 +1,68 @@
+using System.Data.Common;
+using Weasel.Storage;
+
+namespace Polecat.Storage;
+
+/// <summary>
+///     Client-side write binder for a range-partitioned document's partition column (#211,
+///     #273 phase D slice 3). Binds <see cref="DocumentPartitioning.GetValue" /> on every
+///     write; also serves as the descriptor's partition-PK binder so the shared update
+///     operations can target the correct partition row (Marten bug #4223 analog — the MERGE
+///     ON clause carries the partition predicate).
+/// </summary>
+internal sealed class PolecatPartitionColumnBinder<TDoc> : IDocumentMetadataBinder<TDoc>
+    where TDoc : notnull
+{
+    private readonly DocumentPartitioning _partitioning;
+
+    public PolecatPartitionColumnBinder(DocumentPartitioning partitioning)
+    {
+        _partitioning = partitioning;
+    }
+
+    public string ColumnName => _partitioning.ColumnName;
+
+    public string ValueSql => "?";
+
+    public void BindParameter(DbParameter parameter, TDoc document, IStorageSession session)
+    {
+        var value = _partitioning.GetValue(document);
+        parameter.Value = value ?? DBNull.Value;
+        // The SqlServer command builder pre-types fresh parameters as strings; retype from
+        // the partition value's CLR type so SqlClient doesn't coerce (e.g. DateTimeOffset).
+        parameter.DbType = value switch
+        {
+            int => System.Data.DbType.Int32,
+            long => System.Data.DbType.Int64,
+            Guid => System.Data.DbType.Guid,
+            bool => System.Data.DbType.Boolean,
+            DateTimeOffset => System.Data.DbType.DateTimeOffset,
+            DateTime => System.Data.DbType.DateTime2,
+            DateOnly => System.Data.DbType.Date,
+            decimal => System.Data.DbType.Decimal,
+            double => System.Data.DbType.Double,
+            _ => System.Data.DbType.String
+        };
+    }
+
+    public void Apply(DbDataReader reader, int columnOrdinal, TDoc document, IStorageSession session)
+    {
+        // The canonical value lives in the document's JSON; the duplicated partition column
+        // is never projected back.
+    }
+
+    public BulkColumnValue GetBulkValue(TDoc document)
+    {
+        var value = _partitioning.GetValue(document);
+        var type = value switch
+        {
+            int => StorageColumnType.Int,
+            long => StorageColumnType.Long,
+            Guid => StorageColumnType.Guid,
+            bool => StorageColumnType.Boolean,
+            DateTimeOffset or DateTime => StorageColumnType.Timestamp,
+            _ => StorageColumnType.String
+        };
+        return new BulkColumnValue(value ?? DBNull.Value, type);
+    }
+}

--- a/src/Polecat/Storage/SqlServerDocumentStorageDescriptorBuilder.cs
+++ b/src/Polecat/Storage/SqlServerDocumentStorageDescriptorBuilder.cs
@@ -46,12 +46,6 @@ internal static class SqlServerDocumentStorageDescriptorBuilder
         where TDoc : notnull
         where TId : notnull
     {
-        if (mapping.HasPartitionColumn)
-        {
-            throw new NotSupportedException(
-                "Closed-shape descriptors for partitioned documents land in a later #273 increment.");
-        }
-
         var dialect = SqlServerStorageDialect<TId>.Instance;
         var writeBinders = new List<IDocumentMetadataBinder<TDoc>>();
         var readBinders = new List<IDocumentMetadataBinder<TDoc>>();
@@ -166,6 +160,16 @@ internal static class SqlServerDocumentStorageDescriptorBuilder
             writeBinders.Add(new DocumentSoftDeletedAtBinder<TDoc>("deleted_at", dialect, member: null));
         }
 
+        // Range-partitioned documents (#211): the duplicated partition column is written on
+        // every save and participates in the MERGE ON clause so updates target the correct
+        // partition row (Marten #4223 analog).
+        PolecatPartitionColumnBinder<TDoc>? partitionBinder = null;
+        if (mapping.HasPartitionColumn)
+        {
+            partitionBinder = new PolecatPartitionColumnBinder<TDoc>(mapping.Partitioning!);
+            writeBinders.Add(partitionBinder);
+        }
+
         var writeArray = writeBinders.ToArray();
         var readArray = readBinders.ToArray();
         // QueryOnly's SELECT omits guid_version when it has no mapped member (always the case
@@ -181,10 +185,11 @@ internal static class SqlServerDocumentStorageDescriptorBuilder
                 ? ConcurrencyMode.Numeric
                 : ConcurrencyMode.Off;
 
-        var upsertSql = BuildMergeSql(mapping, writeArray, revisionBinder, isConjoined, concurrencyMode, guarded: concurrencyMode != ConcurrencyMode.Off, insertOnly: false);
-        var insertSql = BuildMergeSql(mapping, writeArray, revisionBinder, isConjoined, concurrencyMode, guarded: false, insertOnly: true);
-        var updateSql = BuildUpdateSql(mapping, writeArray, revisionBinder, isConjoined, concurrencyMode);
-        var overwriteSql = BuildMergeSql(mapping, writeArray, revisionBinder, isConjoined, concurrencyMode, guarded: false, insertOnly: false);
+        var partitionColumn = partitionBinder?.ColumnName;
+        var upsertSql = BuildMergeSql(mapping, writeArray, revisionBinder, partitionColumn, isConjoined, concurrencyMode, guarded: concurrencyMode != ConcurrencyMode.Off, insertOnly: false);
+        var insertSql = BuildMergeSql(mapping, writeArray, revisionBinder, partitionColumn, isConjoined, concurrencyMode, guarded: false, insertOnly: true);
+        var updateSql = BuildUpdateSql(mapping, writeArray, revisionBinder, partitionColumn, isConjoined, concurrencyMode);
+        var overwriteSql = BuildMergeSql(mapping, writeArray, revisionBinder, partitionColumn, isConjoined, concurrencyMode, guarded: false, insertOnly: false);
 
         return new DocumentStorageDescriptor<TDoc, TId>(
             identification,
@@ -205,7 +210,10 @@ internal static class SqlServerDocumentStorageDescriptorBuilder
             versionReadIndex: versionReadIndex,
             resolveDocumentType: resolveDocumentType,
             docTypeReadIndex: docTypeReadIndex,
-            tableName: mapping.QualifiedTableName);
+            tableName: mapping.QualifiedTableName,
+            partitionPkBinders: partitionBinder is null
+                ? null
+                : new IDocumentMetadataBinder<TDoc>[] { partitionBinder });
     }
 
     private static void AddSessionMetadataBinder<TDoc>(
@@ -244,6 +252,7 @@ internal static class SqlServerDocumentStorageDescriptorBuilder
         DocumentMapping mapping,
         IReadOnlyList<IDocumentMetadataBinder<TDoc>> binders,
         IDocumentMetadataBinder<TDoc>? revisionBinder,
+        string? partitionColumn,
         bool isConjoined,
         ConcurrencyMode mode,
         bool guarded,
@@ -282,6 +291,11 @@ internal static class SqlServerDocumentStorageDescriptorBuilder
         var onClause = isConjoined
             ? "t.id = s.id AND t.tenant_id = s.tenant_id"
             : "t.id = s.id";
+        if (partitionColumn is not null)
+        {
+            // Partition column is in the PK; the predicate keeps MERGE on the right partition row.
+            onClause += $" AND t.{partitionColumn} = s.{partitionColumn}";
+        }
 
         // INSERT branch. Off/Optimistic: version literal 1 + created_at. Numeric: the version
         // value is the revision CASE over the source columns (auto -> initial revision 1).
@@ -367,16 +381,19 @@ internal static class SqlServerDocumentStorageDescriptorBuilder
     }
 
     /// <summary>
-    ///     Update-only SQL, same MERGE shape without the NOT MATCHED branch so slot order
-    ///     stays identical to upsert. Numeric mode: the revision binder's two client-loop
-    ///     slots ride the <c>rev0</c>/<c>rev1</c> source columns and the shared update
-    ///     operation binds the trailing guard pair. Zero rows = missing document or
-    ///     concurrency violation.
+    ///     Update-only SQL. The shared update operations bind a DIFFERENT slot order than the
+    ///     upserts (<c>ClosedShapeUpdateOperation.BindPreConcurrencyParameters</c>): data →
+    ///     client-side binders → id → tenant (when conjoined) → partition PK binders →
+    ///     trailing concurrency guard. The MERGE USING tuple is laid out in exactly that
+    ///     order; the partition PK travels as a second source column (<c>{col}_pk</c>) since
+    ///     the ordinary binder slot already carries it for the SET list. Zero rows = missing
+    ///     document or concurrency violation.
     /// </summary>
     private static string BuildUpdateSql<TDoc>(
         DocumentMapping mapping,
         IReadOnlyList<IDocumentMetadataBinder<TDoc>> binders,
         IDocumentMetadataBinder<TDoc>? revisionBinder,
+        string? partitionColumn,
         bool isConjoined,
         ConcurrencyMode mode)
         where TDoc : notnull
@@ -384,14 +401,9 @@ internal static class SqlServerDocumentStorageDescriptorBuilder
         var table = mapping.QualifiedTableName;
         var numeric = mode == ConcurrencyMode.Numeric;
 
-        var usingColumns = new List<string>();
-        if (isConjoined)
-        {
-            usingColumns.Add("tenant_id");
-        }
-
-        usingColumns.Add("id");
-        usingColumns.Add("data");
+        // USING tuple in the update ops' binding order: data, client binders, id, [tenant],
+        // [partition pk].
+        var usingColumns = new List<string> { "data" };
         foreach (var binder in binders.Where(b => !b.IsServerSide))
         {
             if (numeric && ReferenceEquals(binder, revisionBinder))
@@ -405,11 +417,30 @@ internal static class SqlServerDocumentStorageDescriptorBuilder
             }
         }
 
+        usingColumns.Add("id");
+        if (isConjoined)
+        {
+            usingColumns.Add("tenant_id_pk");
+        }
+
+        if (partitionColumn is not null)
+        {
+            usingColumns.Add($"{partitionColumn}_pk");
+        }
+
         var usingValues = string.Join(", ", usingColumns.Select(_ => "?"));
         var sourceColumns = string.Join(", ", usingColumns);
-        var onClause = isConjoined
-            ? "t.id = s.id AND t.tenant_id = s.tenant_id"
-            : "t.id = s.id";
+
+        var onClause = "t.id = s.id";
+        if (isConjoined)
+        {
+            onClause += " AND t.tenant_id = s.tenant_id_pk";
+        }
+
+        if (partitionColumn is not null)
+        {
+            onClause += $" AND t.{partitionColumn} = s.{partitionColumn}_pk";
+        }
 
         var updateAssignments = new List<string> { "data = s.data" };
         updateAssignments.Add(numeric


### PR DESCRIPTION
Part of #273, phase D — completes `SqlServerDocumentStorageDescriptorBuilder`'s feature matrix (everything Polecat supports; strongly-typed-id wiring is deliberately phase-E provider-registration work).

## The fix (latent bug in #286/#287)
The shared closed-shape **update** operations bind a *different* slot order than the upserts — `ClosedShapeUpdateOperation.BindPreConcurrencyParameters`: **data → client binders → id → tenant (conjoined) → partition PKs → trailing guard** — while `UpdateSql` was generated in upsert order (`[tenant] id data binders`). Slices 1/2 only exercised upsert/insert, so it never fired. `BuildUpdateSql` now lays the MERGE USING tuple out in the update ops' exact order, locked by three update-path tests (unversioned round-trip + missing-doc detection; numeric auto-increment past the bespoke pipeline's revision + stale-revision `ConcurrencyException`).

## Partitioned documents (#211)
- **`PolecatPartitionColumnBinder`**: writes the duplicated partition column on every save (explicit `DbType` from the CLR value — the SqlServer command builder pre-types fresh parameters as strings, which would coerce `DateTimeOffset`), doubles as the descriptor's partition-PK binder.
- MERGE **ON clauses carry the partition predicate** (`t.col = s.col` upsert / `t.col = s.col_pk` update) so updates target the correct partition row — the Marten #4223 analog.
- Live test: range-partitioned doc upserted + updated through the shared operations, read back via Polecat's pipeline.

## Verification
- **Full suite green: 1391 passed / 0 failed** (net10); descriptor suite now 10 tests, all through the shared Weasel.Storage operations against real SQL Server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)