### PR TITLE
feat: phase E1 — Polecat closed-shape storage layer over the shared runtime (#273)

### DIFF
--- a/src/Polecat.Tests/Storage/closed_shape_storage_tests.cs
+++ b/src/Polecat.Tests/Storage/closed_shape_storage_tests.cs
@@ -1,0 +1,221 @@
+using Polecat.Tests.Harness;
+using Weasel.Storage;
+
+namespace Polecat.Tests.Storage;
+
+/// <summary>
+///     #273 phase E1: end-to-end round-trips through the closed-shape storage layer resolved via
+///     the shared seams (IStorageSession.StorageFor / IProviderGraph) — the shared runtime doing
+///     real document work against SQL Server while the bespoke pipeline still drives sessions.
+/// </summary>
+public class closed_shape_storage_tests : OneOffConfigurationsContext
+{
+    private async Task executeAsync(IStorageSession session, Weasel.Storage.IStorageOperation operation)
+    {
+        var builder = new Weasel.SqlServer.BatchBuilder { TenantId = session.TenantId };
+        operation.ConfigureCommand(builder, session);
+        var batch = builder.Compile();
+
+        await using var conn = new Microsoft.Data.SqlClient.SqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        batch.Connection = conn;
+
+        var exceptions = new List<Exception>();
+        await using (var reader = await batch.ExecuteReaderAsync())
+        {
+            await operation.PostprocessAsync(reader, exceptions, CancellationToken.None);
+        }
+
+        foreach (var ex in exceptions) throw ex;
+    }
+
+    private async Task<T> bootstrapAsync<T>(T doc) where T : notnull
+    {
+        await using var session = theStore.LightweightSession();
+        session.Store(doc);
+        await session.SaveChangesAsync();
+        return doc;
+    }
+
+    [Fact]
+    public async Task upsert_and_load_round_trip_through_storage_for()
+    {
+        await bootstrapAsync(new Target { Number = 1 }); // table creation
+
+        await using var raw = theStore.LightweightSession();
+        var session = (IStorageSession)raw;
+        var storage = (IDocumentStorage<Target, Guid>)session.StorageFor<Target>();
+
+        var doc = new Target { Number = 42, Color = "green" };
+        storage.Store(session, doc);
+        doc.Id.ShouldNotBe(Guid.Empty); // sequential Guid assigned by the shared identity strategy
+
+        await executeAsync(session, storage.Upsert(doc, session, session.TenantId));
+
+        var loaded = await storage.LoadAsync(doc.Id, session, CancellationToken.None);
+        loaded.ShouldNotBeNull();
+        loaded.Number.ShouldBe(42);
+
+        // Bespoke pipeline agrees
+        await using var check = theStore.QuerySession();
+        (await check.LoadAsync<Target>(doc.Id)).ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task load_many_round_trips_openjson_ids()
+    {
+        await bootstrapAsync(new Target { Number = 1 });
+
+        await using var raw = theStore.LightweightSession();
+        var session = (IStorageSession)raw;
+        var storage = (IDocumentStorage<Target, Guid>)session.StorageFor<Target>();
+
+        var docs = Enumerable.Range(0, 5).Select(i => new Target { Number = 100 + i }).ToArray();
+        foreach (var doc in docs)
+        {
+            storage.Store(session, doc);
+            await executeAsync(session, storage.Upsert(doc, session, session.TenantId));
+        }
+
+        var ids = docs.Select(d => d.Id).ToArray();
+        var loaded = await storage.LoadManyAsync(ids, session, CancellationToken.None);
+        loaded.Count.ShouldBe(5);
+        loaded.Select(d => d.Number).OrderBy(n => n).ShouldBe([100, 101, 102, 103, 104]);
+    }
+
+    [Fact]
+    public async Task identity_map_flavor_returns_same_reference_and_serves_from_map()
+    {
+        var seed = await bootstrapAsync(new Target { Number = 7, Color = "map" });
+
+        await using var raw = theStore.IdentitySession();
+        var session = (IStorageSession)raw;
+        var storage = (IDocumentStorage<Target, Guid>)session.StorageFor<Target>();
+
+        var first = await storage.LoadAsync(seed.Id, session, CancellationToken.None);
+        var second = await storage.LoadAsync(seed.Id, session, CancellationToken.None);
+
+        first.ShouldNotBeNull();
+        second.ShouldBeSameAs(first); // second hit came from the shared ItemMap
+        session.ItemMap.ContainsKey(typeof(Target)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task optimistic_storage_round_trips_versions_through_session_tracker()
+    {
+        await bootstrapAsync(new VersionedDoc { Name = "seed" });
+
+        await using var raw = theStore.LightweightSession();
+        var session = (IStorageSession)raw;
+        var storage = (IDocumentStorage<VersionedDoc, Guid>)session.StorageFor<VersionedDoc>();
+
+        var doc = new VersionedDoc { Id = Guid.NewGuid(), Name = "v1" };
+        await executeAsync(session, storage.Upsert(doc, session, session.TenantId));
+
+        // The shared operation stored the new version in the session tracker
+        var tracked = storage.VersionFor(doc, session);
+        tracked.ShouldNotBeNull();
+
+        // Second upsert with the tracked version succeeds
+        doc.Name = "v2";
+        await executeAsync(session, storage.Upsert(doc, session, session.TenantId));
+
+        // A different session with a stale expectation gets a concurrency violation
+        await using var rawStale = theStore.LightweightSession();
+        var staleSession = (IStorageSession)rawStale;
+        var staleStorage = (IDocumentStorage<VersionedDoc, Guid>)staleSession.StorageFor<VersionedDoc>();
+        staleSession.Versions.StoreVersion<VersionedDoc, Guid>(doc.Id, Guid.NewGuid());
+        await Should.ThrowAsync<JasperFx.ConcurrencyException>(
+            () => executeAsync(staleSession, staleStorage.Upsert(doc, staleSession, staleSession.TenantId)));
+    }
+
+    [Fact]
+    public async Task numeric_storage_auto_increments_and_tracks_revisions()
+    {
+        await bootstrapAsync(new RevisionedDoc { Name = "seed" });
+
+        await using var raw = theStore.LightweightSession();
+        var session = (IStorageSession)raw;
+        var storage = (IDocumentStorage<RevisionedDoc, Guid>)session.StorageFor<RevisionedDoc>();
+
+        var doc = new RevisionedDoc { Id = Guid.NewGuid(), Name = "r1" };
+        await executeAsync(session, storage.Upsert(doc, session, session.TenantId));
+        doc.Version.ShouldBe(1);
+        session.Versions.RevisionFor<RevisionedDoc, Guid>(doc.Id).ShouldBe(1);
+
+        doc.Name = "r2";
+        await executeAsync(session, storage.Upsert(doc, session, session.TenantId));
+        doc.Version.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task deletions_hard_and_soft_work_through_the_shared_contract()
+    {
+        // Hard delete
+        var target = await bootstrapAsync(new Target { Number = 5 });
+        await using var raw = theStore.LightweightSession();
+        var session = (IStorageSession)raw;
+        var storage = (IDocumentStorage<Target, Guid>)session.StorageFor<Target>();
+
+        await executeAsync(session, storage.DeleteForId(target.Id, session.TenantId));
+        (await storage.LoadAsync(target.Id, session, CancellationToken.None)).ShouldBeNull();
+
+        // Soft delete: row survives, loads filter it out
+        var soft = await bootstrapAsync(new SoftDeletedDoc { Name = "bye" });
+        var softStorage = (IDocumentStorage<SoftDeletedDoc, Guid>)session.StorageFor<SoftDeletedDoc>();
+        await executeAsync(session, softStorage.DeleteForId(soft.Id, session.TenantId));
+
+        (await softStorage.LoadAsync(soft.Id, session, CancellationToken.None)).ShouldBeNull();
+        await using var check = theStore.QuerySession();
+        (await check.LoadAsync<SoftDeletedDoc>(soft.Id)).ShouldBeNull(); // bespoke agrees
+
+        // Hard delete punches through the soft-delete style
+        await executeAsync(session, softStorage.HardDeleteForId(soft.Id, session.TenantId));
+    }
+
+    [Fact]
+    public async Task int_and_string_id_documents_resolve_and_round_trip()
+    {
+        await bootstrapAsync(new IntDoc { Name = "seed" });
+        await bootstrapAsync(new StringDoc { Id = "seed", Name = "seed" });
+
+        await using var raw = theStore.LightweightSession();
+        var session = (IStorageSession)raw;
+
+        // Hi-Lo int id assigned through the shared identity strategy + ISequenceSource
+        var intStorage = (IDocumentStorage<IntDoc, int>)session.StorageFor<IntDoc>();
+        var intDoc = new IntDoc { Name = "closed-shape" };
+        intStorage.Store(session, intDoc);
+        intDoc.Id.ShouldBeGreaterThan(0);
+        await executeAsync(session, intStorage.Upsert(intDoc, session, session.TenantId));
+        (await intStorage.LoadAsync(intDoc.Id, session, CancellationToken.None)).ShouldNotBeNull();
+
+        var stringStorage = (IDocumentStorage<StringDoc, string>)session.StorageFor<StringDoc>();
+        var stringDoc = new StringDoc { Id = "cs-1", Name = "closed-shape" };
+        await executeAsync(session, stringStorage.Upsert(stringDoc, session, session.TenantId));
+        (await stringStorage.LoadAsync("cs-1", session, CancellationToken.None)).ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task hierarchy_round_trips_subclasses_through_the_hierarchical_selector()
+    {
+        ConfigureStore(opts => opts.Schema.For<Target>().AddSubClass<HierTarget>());
+        await bootstrapAsync(new Target { Number = 1 });
+
+        await using var raw = theStore.LightweightSession();
+        var session = (IStorageSession)raw;
+        var storage = (IDocumentStorage<Target, Guid>)session.StorageFor<Target>();
+
+        var child = new HierTarget { Number = 9, Extra = "sub" };
+        storage.Store(session, child);
+        await executeAsync(session, storage.Upsert(child, session, session.TenantId));
+
+        var loaded = await storage.LoadAsync(child.Id, session, CancellationToken.None);
+        loaded.ShouldBeOfType<HierTarget>().Extra.ShouldBe("sub");
+    }
+
+    public class HierTarget : Target
+    {
+        public string Extra { get; set; } = string.Empty;
+    }
+}

--- a/src/Polecat.Tests/Storage/storage_database_seam_tests.cs
+++ b/src/Polecat.Tests/Storage/storage_database_seam_tests.cs
@@ -66,9 +66,13 @@ public class storage_database_seam_tests : OneOffConfigurationsContext
     }
 
     [Fact]
-    public void provider_graph_is_not_supported_until_closed_shape_storage_lands()
+    public void provider_graph_resolves_closed_shape_providers()
     {
-        var ex = Should.Throw<NotSupportedException>(() => theSeam.Providers);
-        ex.Message.ShouldContain("polecat#273");
+        // #273 phase E1: the graph lazily builds the four closed-shape storage flavors
+        var provider = theSeam.Providers.StorageFor<Polecat.Tests.Harness.Target>();
+        provider.QueryOnly.ShouldNotBeNull();
+        provider.Lightweight.ShouldNotBeNull();
+        provider.IdentityMap.ShouldNotBeNull();
+        provider.DirtyTracking.ShouldBeSameAs(provider.IdentityMap); // no dirty tracking by design
     }
 }

--- a/src/Polecat.Tests/Storage/storage_session_seam_tests.cs
+++ b/src/Polecat.Tests/Storage/storage_session_seam_tests.cs
@@ -166,13 +166,19 @@ public class storage_session_seam_tests : OneOffConfigurationsContext
     }
 
     [Fact]
-    public async Task storage_for_is_guarded_until_closed_shape_storage_lands()
+    public async Task storage_for_resolves_the_session_flavor()
     {
-        await using var session = theStore.QuerySession();
-        var seam = (IStorageSession)session;
+        // #273 phase E1: flavor tracks the session kind
+        var provider = theStore.Options.Providers.ClosedShapeGraph.StorageFor<Target>();
 
-        Should.Throw<NotSupportedException>(() => seam.StorageFor(typeof(Target)))
-            .Message.ShouldContain("polecat#273");
-        Should.Throw<NotSupportedException>(() => seam.StorageFor<Target>());
+        await using var query = theStore.QuerySession();
+        ((IStorageSession)query).StorageFor<Target>().ShouldBeSameAs(provider.QueryOnly);
+        ((IStorageSession)query).StorageFor(typeof(Target)).ShouldBeSameAs(provider.QueryOnly);
+
+        await using var lightweight = theStore.LightweightSession();
+        ((IStorageSession)lightweight).StorageFor<Target>().ShouldBeSameAs(provider.Lightweight);
+
+        await using var identity = theStore.IdentitySession();
+        ((IStorageSession)identity).StorageFor<Target>().ShouldBeSameAs(provider.IdentityMap);
     }
 }

--- a/src/Polecat/Internal/DocumentProviderRegistry.cs
+++ b/src/Polecat/Internal/DocumentProviderRegistry.cs
@@ -18,6 +18,14 @@ internal class DocumentProviderRegistry
     private readonly ConcurrentDictionary<Type, DocumentProvider> _providers = new();
     private readonly StoreOptions _options;
     private SequenceFactory? _sequenceFactory;
+    private Storage.ClosedShape.PolecatProviderGraph? _closedShapeGraph;
+
+    /// <summary>
+    ///     #273 phase E1: the shared-runtime IProviderGraph over this registry — lazily builds
+    ///     closed-shape DocumentProvider&lt;T&gt; per document type.
+    /// </summary>
+    internal Storage.ClosedShape.PolecatProviderGraph ClosedShapeGraph
+        => _closedShapeGraph ??= new Storage.ClosedShape.PolecatProviderGraph(this);
 
     public DocumentProviderRegistry(StoreOptions options)
     {

--- a/src/Polecat/Internal/DocumentSessionBase.cs
+++ b/src/Polecat/Internal/DocumentSessionBase.cs
@@ -1074,6 +1074,11 @@ internal abstract class DocumentSessionBase : QuerySession, IDocumentSession
         // No-op in lightweight session
     }
 
+    // #273 phase E1: document sessions resolve the Lightweight closed-shape storage flavor.
+    internal override Weasel.Storage.IDocumentStorage<T> SelectClosedShapeStorage<T>(
+        Weasel.Storage.DocumentProvider<T> provider)
+        => provider.Lightweight;
+
     private void SyncMetadata(object document)
     {
         if (document is ITracked tracked)

--- a/src/Polecat/Internal/IdentityMapDocumentSession.cs
+++ b/src/Polecat/Internal/IdentityMapDocumentSession.cs
@@ -119,6 +119,11 @@ internal class IdentityMapDocumentSession : DocumentSessionBase
     // selectors call these when materializing/queueing documents; route them into the bespoke
     // identity map so both paths agree until phase E makes the shared runtime authoritative.
 
+    // #273 phase E1: identity-map sessions resolve the IdentityMap closed-shape flavor.
+    internal override Weasel.Storage.IDocumentStorage<T> SelectClosedShapeStorage<T>(
+        Weasel.Storage.DocumentProvider<T> provider)
+        => provider.IdentityMap;
+
     public override void MarkAsAddedForStorage(object id, object document)
     {
         GetOrCreateTypeMap(document.GetType())[id] = document;

--- a/src/Polecat/Internal/QuerySession.StorageSession.cs
+++ b/src/Polecat/Internal/QuerySession.StorageSession.cs
@@ -43,15 +43,24 @@ internal partial class QuerySession : IStorageSession
 
     ConcurrencyChecks IStorageSession.Concurrency => ConcurrencyChecks.Enabled;
 
-    IDocumentStorage IStorageSession.StorageFor(Type documentType) => throw ClosedShapeStorageNotAvailable();
+    // #273 phase E1: closed-shape storage resolution. The flavor tracks the session kind —
+    // QuerySession -> QueryOnly, DocumentSessionBase (lightweight) -> Lightweight,
+    // IdentityMapDocumentSession -> IdentityMap.
 
-    IDocumentStorage<T> IStorageSession.StorageFor<T>() => throw ClosedShapeStorageNotAvailable();
+    IDocumentStorage IStorageSession.StorageFor(Type documentType)
+        => (IDocumentStorage)typeof(QuerySession)
+            .GetMethod(nameof(ClosedShapeStorageFor), System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+            .MakeGenericMethod(documentType)
+            .Invoke(this, null)!;
 
-    private static NotSupportedException ClosedShapeStorageNotAvailable()
-    {
-        return new NotSupportedException(
-            "Closed-shape IDocumentStorage is not available until Polecat's document storage retargets onto the shared Weasel.Storage bases (JasperFx/polecat#273).");
-    }
+    IDocumentStorage<T> IStorageSession.StorageFor<T>() => ClosedShapeStorageFor<T>();
+
+    private IDocumentStorage<T> ClosedShapeStorageFor<T>() where T : notnull
+        => SelectClosedShapeStorage(Providers.ClosedShapeGraph.StorageFor<T>());
+
+    internal virtual IDocumentStorage<T> SelectClosedShapeStorage<T>(Weasel.Storage.DocumentProvider<T> provider)
+        where T : notnull
+        => provider.QueryOnly;
 
     /// <summary>
     ///     Identity-map hook for documents newly queued for storage. No-op outside identity-map

--- a/src/Polecat/Storage/ClosedShape/PolecatClosedShapeRegistration.cs
+++ b/src/Polecat/Storage/ClosedShape/PolecatClosedShapeRegistration.cs
@@ -1,0 +1,159 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using JasperFx.Core.Reflection;
+using Weasel.Core.Identity;
+using Weasel.Storage;
+
+namespace Polecat.Storage.ClosedShape;
+
+/// <summary>
+///     Builds the closed-shape <see cref="DocumentProvider{T}" /> (the four storage flavors) for
+///     a document type from its Polecat <see cref="DocumentMapping" /> — the Polecat analog of
+///     Marten's <c>ClosedShapeRegistration</c> (#273 phase E1). Identity strategies come from the
+///     shared <c>Weasel.Core.Identity</c> family (#276): sequential GUIDs, externally-assigned
+///     strings, Hi-Lo int/long, and strongly-typed value ids.
+/// </summary>
+[UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+    Justification = "Closes the shared identity strategies + storage generics over runtime document/id types via MakeGenericMethod once per document type at registration — the same pattern as DocumentMapping's id accessors and Marten's ClosedShapeRegistration. AOT consumers register document types explicitly per the AOT publishing guide.")]
+[UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
+    Justification = "Same as IL3050 — registration-time generic closing over registered document types.")]
+[UnconditionalSuppressMessage("Trimming", "IL2060:MakeGenericMethod",
+    Justification = "Same as IL3050.")]
+internal static class PolecatClosedShapeRegistration
+{
+    internal static object BuildProviderFor(DocumentMapping mapping)
+    {
+        var buildTyped = typeof(PolecatClosedShapeRegistration)
+            .GetMethod(nameof(BuildTypedProvider), BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        if (mapping.ValueTypeId is { } vt)
+        {
+            var identification = typeof(ValueTypeIdentification<,,>)
+                .MakeGenericType(mapping.DocumentType, vt.OuterType, vt.SimpleType)
+                .GetConstructors()[0]
+                .Invoke(new object[] { mapping.IdMember, vt, mapping.DocumentType });
+            return buildTyped.MakeGenericMethod(mapping.DocumentType, vt.OuterType)
+                .Invoke(null, new[] { mapping, identification })!;
+        }
+
+        object strategy = mapping.IdType switch
+        {
+            var t when t == typeof(Guid) =>
+                new object[] { typeof(SequentialGuidIdentification<>), mapping.IdMember },
+            var t when t == typeof(string) =>
+                new object[] { typeof(StringIdentification<>), mapping.IdMember },
+            var t when t == typeof(int) =>
+                new object[] { typeof(HiloIntIdentification<>), mapping.IdMember, mapping.DocumentType },
+            var t when t == typeof(long) =>
+                new object[] { typeof(HiloLongIdentification<>), mapping.IdMember, mapping.DocumentType },
+            _ => throw new NotSupportedException(
+                $"Unsupported id type {mapping.IdType.FullName} for closed-shape storage.")
+        };
+
+        var parts = (object[])strategy;
+        var strategyType = ((Type)parts[0]).MakeGenericType(mapping.DocumentType);
+        var identificationInstance = Activator.CreateInstance(strategyType, parts.Skip(1).ToArray())!;
+        return buildTyped.MakeGenericMethod(mapping.DocumentType, mapping.IdType)
+            .Invoke(null, new[] { mapping, identificationInstance })!;
+    }
+
+    private static DocumentProvider<TDoc> BuildTypedProvider<TDoc, TId>(
+        DocumentMapping mapping,
+        IIdentification<TDoc, TId> identification)
+        where TDoc : notnull
+        where TId : notnull
+    {
+        var descriptor = SqlServerDocumentStorageDescriptorBuilder.Build(
+            mapping, identification, mapping.StoreOptions);
+
+        var queryOnly = new QueryOnlyPolecatStorage<TDoc, TId>(mapping, descriptor);
+        var lightweight = BuildLightweight(mapping, descriptor);
+        var identityMap = BuildIdentityMap(mapping, descriptor);
+
+        // Polecat has no dirty tracking by design — the DirtyTracking slot gets the
+        // IdentityMap storage (the closest tracking mode Polecat offers).
+        return new DocumentProvider<TDoc>(queryOnly, lightweight, identityMap, identityMap);
+    }
+
+    private static LightweightPolecatStorage<TDoc, TId> BuildLightweight<TDoc, TId>(
+        DocumentMapping mapping, DocumentStorageDescriptor<TDoc, TId> descriptor)
+        where TDoc : notnull
+        where TId : notnull
+        => descriptor.ConcurrencyMode switch
+        {
+            ConcurrencyMode.Optimistic => new OptimisticLightweightPolecatStorage<TDoc, TId>(mapping, descriptor),
+            ConcurrencyMode.Numeric => new NumericLightweightPolecatStorage<TDoc, TId>(mapping, descriptor),
+            _ => new UnversionedLightweightPolecatStorage<TDoc, TId>(mapping, descriptor)
+        };
+
+    private static IdentityMapPolecatStorage<TDoc, TId> BuildIdentityMap<TDoc, TId>(
+        DocumentMapping mapping, DocumentStorageDescriptor<TDoc, TId> descriptor)
+        where TDoc : notnull
+        where TId : notnull
+        => descriptor.ConcurrencyMode switch
+        {
+            ConcurrencyMode.Optimistic => new OptimisticIdentityMapPolecatStorage<TDoc, TId>(mapping, descriptor),
+            ConcurrencyMode.Numeric => new NumericIdentityMapPolecatStorage<TDoc, TId>(mapping, descriptor),
+            _ => new UnversionedIdentityMapPolecatStorage<TDoc, TId>(mapping, descriptor)
+        };
+}
+
+/// <summary>
+///     Polecat's <see cref="IProviderGraph" /> — lazily builds and caches the closed-shape
+///     <see cref="DocumentProvider{T}" /> per document type over the bespoke registry's mappings.
+/// </summary>
+internal sealed class PolecatProviderGraph : IProviderGraph
+{
+    private readonly Internal.DocumentProviderRegistry _registry;
+    private readonly Dictionary<Type, object> _providers = new();
+    private readonly object _lock = new();
+
+    public PolecatProviderGraph(Internal.DocumentProviderRegistry registry)
+    {
+        _registry = registry;
+    }
+
+    public DocumentProvider<T> StorageFor<T>() where T : notnull
+    {
+        lock (_lock)
+        {
+            if (_providers.TryGetValue(typeof(T), out var cached))
+            {
+                return (DocumentProvider<T>)cached;
+            }
+
+            var mapping = _registry.GetProvider(typeof(T)).Mapping;
+            var provider = (DocumentProvider<T>)PolecatClosedShapeRegistration.BuildProviderFor(mapping);
+            _providers[typeof(T)] = provider;
+            return provider;
+        }
+    }
+
+    public void Append<T>(DocumentProvider<T> provider) where T : notnull
+    {
+        lock (_lock)
+        {
+            _providers[typeof(T)] = provider;
+        }
+    }
+
+    /// <summary>Non-generic lookup for <c>IStorageSession.StorageFor(Type)</c>.</summary>
+    [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+        Justification = "Closes StorageFor<T> over a registered document type; cached per type.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2060:MakeGenericMethod", Justification = "Same as IL3050.")]
+    internal object ProviderFor(Type documentType)
+    {
+        lock (_lock)
+        {
+            if (_providers.TryGetValue(documentType, out var cached))
+            {
+                return cached;
+            }
+        }
+
+        return typeof(PolecatProviderGraph)
+            .GetMethod(nameof(StorageFor))!
+            .MakeGenericMethod(documentType)
+            .Invoke(this, null)!;
+    }
+}

--- a/src/Polecat/Storage/ClosedShape/PolecatClosedShapeStorages.cs
+++ b/src/Polecat/Storage/ClosedShape/PolecatClosedShapeStorages.cs
@@ -1,0 +1,460 @@
+using Weasel.Core;
+using Weasel.Storage;
+
+namespace Polecat.Storage.ClosedShape;
+
+// #273 phase E1: the flavor/mode composition matrix over PolecatDocumentStorage, mirroring
+// Marten's ClosedShape layer. Flavors differ in identity-map behavior + selector family;
+// modes differ in which shared write operations they create (and which session version
+// dictionaries those bind). Polecat has no dirty tracking, so the DocumentProvider's
+// DirtyTracking slot is filled with the IdentityMap storage.
+
+// ---- flavor bases ----
+
+internal abstract class LightweightPolecatStorage<TDoc, TId> : PolecatDocumentStorage<TDoc, TId>
+    where TDoc : notnull
+    where TId : notnull
+{
+    protected LightweightPolecatStorage(DocumentMapping mapping, DocumentStorageDescriptor<TDoc, TId> descriptor)
+        : base(mapping, descriptor)
+    {
+    }
+
+    public override Task<TDoc?> LoadAsync(TId id, IStorageSession session, CancellationToken token)
+        => QueryOneAsync(id, session, token);
+
+    public override Task<IReadOnlyList<TDoc>> LoadManyAsync(TId[] ids, IStorageSession session, CancellationToken token)
+        => QueryManyAsync(ids, session, token);
+}
+
+internal abstract class IdentityMapPolecatStorage<TDoc, TId> : PolecatDocumentStorage<TDoc, TId>
+    where TDoc : notnull
+    where TId : notnull
+{
+    protected IdentityMapPolecatStorage(DocumentMapping mapping, DocumentStorageDescriptor<TDoc, TId> descriptor)
+        : base(mapping, descriptor)
+    {
+    }
+
+    public override async Task<TDoc?> LoadAsync(TId id, IStorageSession session, CancellationToken token)
+    {
+        if (TryGetFromMap(session, id, out var cached))
+        {
+            return cached;
+        }
+
+        return await QueryOneAsync(id, session, token).ConfigureAwait(false);
+    }
+
+    public override async Task<IReadOnlyList<TDoc>> LoadManyAsync(TId[] ids, IStorageSession session,
+        CancellationToken token)
+    {
+        var results = new List<TDoc>(ids.Length);
+        var missing = new List<TId>();
+        foreach (var id in ids)
+        {
+            if (TryGetFromMap(session, id, out var cached))
+            {
+                results.Add(cached);
+            }
+            else
+            {
+                missing.Add(id);
+            }
+        }
+
+        if (missing.Count > 0)
+        {
+            results.AddRange(await QueryManyAsync(missing.ToArray(), session, token).ConfigureAwait(false));
+        }
+
+        return results;
+    }
+
+    private static bool TryGetFromMap(IStorageSession session, TId id, out TDoc document)
+    {
+        if (session.ItemMap.TryGetValue(typeof(TDoc), out var raw)
+            && raw is Dictionary<TId, TDoc> map
+            && map.TryGetValue(id, out document!))
+        {
+            return true;
+        }
+
+        document = default!;
+        return false;
+    }
+
+    public override void Store(IStorageSession session, TDoc document)
+    {
+        base.Store(session, document);
+        AddToMap(session, document);
+    }
+
+    public override void Store(IStorageSession session, TDoc document, Guid? version)
+    {
+        base.Store(session, document, version);
+        AddToMap(session, document);
+    }
+
+    public override void Store(IStorageSession session, TDoc document, long revision)
+    {
+        base.Store(session, document, revision);
+        AddToMap(session, document);
+    }
+
+    private void AddToMap(IStorageSession session, TDoc document)
+    {
+        var id = Identity(document);
+        if (!session.ItemMap.TryGetValue(typeof(TDoc), out var raw) || raw is not Dictionary<TId, TDoc> map)
+        {
+            map = new Dictionary<TId, TDoc>();
+            session.ItemMap[typeof(TDoc)] = map;
+        }
+
+        map[id] = document;
+    }
+}
+
+// ---- Unversioned mode ----
+
+internal sealed class UnversionedLightweightPolecatStorage<TDoc, TId> : LightweightPolecatStorage<TDoc, TId>
+    where TDoc : notnull
+    where TId : notnull
+{
+    public UnversionedLightweightPolecatStorage(DocumentMapping mapping,
+        DocumentStorageDescriptor<TDoc, TId> descriptor) : base(mapping, descriptor)
+    {
+    }
+
+    public override Weasel.Storage.IStorageOperation Insert(TDoc document, IStorageSession session, string tenantId)
+        => new UnversionedClosedShapeInsertOperation<TDoc, TId>(document, Identity(document), tenantId, _descriptor);
+
+    public override Weasel.Storage.IStorageOperation Update(TDoc document, IStorageSession session, string tenantId)
+        => new UnversionedClosedShapeUpdateOperation<TDoc, TId>(document, Identity(document), tenantId, _descriptor);
+
+    public override Weasel.Storage.IStorageOperation Upsert(TDoc document, IStorageSession session, string tenantId)
+        => new UnversionedClosedShapeUpsertOperation<TDoc, TId>(document, Identity(document), tenantId, _descriptor, OperationRole.Upsert);
+
+    public override Weasel.Storage.IStorageOperation Overwrite(TDoc document, IStorageSession session, string tenantId)
+        => new UnversionedClosedShapeOverwriteOperation<TDoc, TId>(document, Identity(document), tenantId, _descriptor);
+
+    public override Weasel.Storage.IStorageOperation OverwriteProjected(TDoc document, string tenantId)
+        => new UnversionedClosedShapeOverwriteOperation<TDoc, TId>(document, Identity(document), tenantId, _descriptor);
+
+    public override Weasel.Storage.IStorageOperation UpsertProjected(TDoc document, string tenantId)
+        => new UnversionedClosedShapeUpsertOperation<TDoc, TId>(document, Identity(document), tenantId, _descriptor, OperationRole.Upsert);
+
+    public override Weasel.Storage.IStorageOperation InsertProjected(TDoc document, string tenantId)
+        => new UnversionedClosedShapeInsertOperation<TDoc, TId>(document, Identity(document), tenantId, _descriptor);
+
+    public override Weasel.Storage.IStorageOperation UpdateProjected(TDoc document, string tenantId)
+        => new UnversionedClosedShapeUpdateOperation<TDoc, TId>(document, Identity(document), tenantId, _descriptor);
+
+    public override ISelector BuildSelector(IStorageSession session)
+        => _descriptor.ResolveDocumentType is not null
+            ? new HierarchicalUnversionedClosedShapeLightweightSelector<TDoc, TId>(session, _descriptor)
+            : new FlatUnversionedClosedShapeLightweightSelector<TDoc, TId>(session, _descriptor);
+}
+
+internal sealed class UnversionedIdentityMapPolecatStorage<TDoc, TId> : IdentityMapPolecatStorage<TDoc, TId>
+    where TDoc : notnull
+    where TId : notnull
+{
+    public UnversionedIdentityMapPolecatStorage(DocumentMapping mapping,
+        DocumentStorageDescriptor<TDoc, TId> descriptor) : base(mapping, descriptor)
+    {
+    }
+
+    public override Weasel.Storage.IStorageOperation Insert(TDoc document, IStorageSession session, string tenantId)
+        => new UnversionedClosedShapeInsertOperation<TDoc, TId>(document, Identity(document), tenantId, _descriptor);
+
+    public override Weasel.Storage.IStorageOperation Update(TDoc document, IStorageSession session, string tenantId)
+        => new UnversionedClosedShapeUpdateOperation<TDoc, TId>(document, Identity(document), tenantId, _descriptor);
+
+    public override Weasel.Storage.IStorageOperation Upsert(TDoc document, IStorageSession session, string tenantId)
+        => new UnversionedClosedShapeUpsertOperation<TDoc, TId>(document, Identity(document), tenantId, _descriptor, OperationRole.Upsert);
+
+    public override Weasel.Storage.IStorageOperation Overwrite(TDoc document, IStorageSession session, string tenantId)
+        => new UnversionedClosedShapeOverwriteOperation<TDoc, TId>(document, Identity(document), tenantId, _descriptor);
+
+    public override Weasel.Storage.IStorageOperation OverwriteProjected(TDoc document, string tenantId)
+        => new UnversionedClosedShapeOverwriteOperation<TDoc, TId>(document, Identity(document), tenantId, _descriptor);
+
+    public override Weasel.Storage.IStorageOperation UpsertProjected(TDoc document, string tenantId)
+        => new UnversionedClosedShapeUpsertOperation<TDoc, TId>(document, Identity(document), tenantId, _descriptor, OperationRole.Upsert);
+
+    public override Weasel.Storage.IStorageOperation InsertProjected(TDoc document, string tenantId)
+        => new UnversionedClosedShapeInsertOperation<TDoc, TId>(document, Identity(document), tenantId, _descriptor);
+
+    public override Weasel.Storage.IStorageOperation UpdateProjected(TDoc document, string tenantId)
+        => new UnversionedClosedShapeUpdateOperation<TDoc, TId>(document, Identity(document), tenantId, _descriptor);
+
+    public override ISelector BuildSelector(IStorageSession session)
+        => _descriptor.ResolveDocumentType is not null
+            ? new HierarchicalUnversionedClosedShapeIdentityMapSelector<TDoc, TId>(session, _descriptor)
+            : new FlatUnversionedClosedShapeIdentityMapSelector<TDoc, TId>(session, _descriptor);
+}
+
+// ---- Optimistic mode ----
+
+internal sealed class OptimisticLightweightPolecatStorage<TDoc, TId> : LightweightPolecatStorage<TDoc, TId>
+    where TDoc : notnull
+    where TId : notnull
+{
+    public OptimisticLightweightPolecatStorage(DocumentMapping mapping,
+        DocumentStorageDescriptor<TDoc, TId> descriptor) : base(mapping, descriptor)
+    {
+    }
+
+    private Dictionary<TId, Guid> Versions(IStorageSession session) => session.Versions.ForType<TDoc, TId>();
+
+    public override Weasel.Storage.IStorageOperation Insert(TDoc document, IStorageSession session, string tenantId)
+        => new OptimisticClosedShapeInsertOperation<TDoc, TId>(document, Identity(document), tenantId, _descriptor, Versions(session));
+
+    public override Weasel.Storage.IStorageOperation Update(TDoc document, IStorageSession session, string tenantId)
+        => new OptimisticClosedShapeUpdateOperation<TDoc, TId>(document, Identity(document), tenantId, _descriptor, Versions(session));
+
+    public override Weasel.Storage.IStorageOperation Upsert(TDoc document, IStorageSession session, string tenantId)
+        => new OptimisticClosedShapeUpsertOperation<TDoc, TId>(document, Identity(document), tenantId, _descriptor, OperationRole.Upsert, Versions(session));
+
+    public override Weasel.Storage.IStorageOperation Overwrite(TDoc document, IStorageSession session, string tenantId)
+        => new OptimisticClosedShapeOverwriteOperation<TDoc, TId>(document, Identity(document), tenantId, _descriptor, Versions(session));
+
+    public override Weasel.Storage.IStorageOperation OverwriteProjected(TDoc document, string tenantId)
+        => new OptimisticClosedShapeOverwriteOperation<TDoc, TId>(document, Identity(document), tenantId, _descriptor, null);
+
+    public override Weasel.Storage.IStorageOperation UpsertProjected(TDoc document, string tenantId)
+        => new OptimisticClosedShapeUpsertOperation<TDoc, TId>(document, Identity(document), tenantId, _descriptor, OperationRole.Upsert, null);
+
+    public override Weasel.Storage.IStorageOperation InsertProjected(TDoc document, string tenantId)
+        => new OptimisticClosedShapeInsertOperation<TDoc, TId>(document, Identity(document), tenantId, _descriptor, null);
+
+    public override Weasel.Storage.IStorageOperation UpdateProjected(TDoc document, string tenantId)
+        => new OptimisticClosedShapeUpdateOperation<TDoc, TId>(document, Identity(document), tenantId, _descriptor, null);
+
+    public override ISelector BuildSelector(IStorageSession session)
+        => _descriptor.ResolveDocumentType is not null
+            ? new HierarchicalOptimisticClosedShapeLightweightSelector<TDoc, TId>(session, _descriptor)
+            : new FlatOptimisticClosedShapeLightweightSelector<TDoc, TId>(session, _descriptor);
+}
+
+internal sealed class OptimisticIdentityMapPolecatStorage<TDoc, TId> : IdentityMapPolecatStorage<TDoc, TId>
+    where TDoc : notnull
+    where TId : notnull
+{
+    public OptimisticIdentityMapPolecatStorage(DocumentMapping mapping,
+        DocumentStorageDescriptor<TDoc, TId> descriptor) : base(mapping, descriptor)
+    {
+    }
+
+    private Dictionary<TId, Guid> Versions(IStorageSession session) => session.Versions.ForType<TDoc, TId>();
+
+    public override Weasel.Storage.IStorageOperation Insert(TDoc document, IStorageSession session, string tenantId)
+        => new OptimisticClosedShapeInsertOperation<TDoc, TId>(document, Identity(document), tenantId, _descriptor, Versions(session));
+
+    public override Weasel.Storage.IStorageOperation Update(TDoc document, IStorageSession session, string tenantId)
+        => new OptimisticClosedShapeUpdateOperation<TDoc, TId>(document, Identity(document), tenantId, _descriptor, Versions(session));
+
+    public override Weasel.Storage.IStorageOperation Upsert(TDoc document, IStorageSession session, string tenantId)
+        => new OptimisticClosedShapeUpsertOperation<TDoc, TId>(document, Identity(document), tenantId, _descriptor, OperationRole.Upsert, Versions(session));
+
+    public override Weasel.Storage.IStorageOperation Overwrite(TDoc document, IStorageSession session, string tenantId)
+        => new OptimisticClosedShapeOverwriteOperation<TDoc, TId>(document, Identity(document), tenantId, _descriptor, Versions(session));
+
+    public override Weasel.Storage.IStorageOperation OverwriteProjected(TDoc document, string tenantId)
+        => new OptimisticClosedShapeOverwriteOperation<TDoc, TId>(document, Identity(document), tenantId, _descriptor, null);
+
+    public override Weasel.Storage.IStorageOperation UpsertProjected(TDoc document, string tenantId)
+        => new OptimisticClosedShapeUpsertOperation<TDoc, TId>(document, Identity(document), tenantId, _descriptor, OperationRole.Upsert, null);
+
+    public override Weasel.Storage.IStorageOperation InsertProjected(TDoc document, string tenantId)
+        => new OptimisticClosedShapeInsertOperation<TDoc, TId>(document, Identity(document), tenantId, _descriptor, null);
+
+    public override Weasel.Storage.IStorageOperation UpdateProjected(TDoc document, string tenantId)
+        => new OptimisticClosedShapeUpdateOperation<TDoc, TId>(document, Identity(document), tenantId, _descriptor, null);
+
+    public override ISelector BuildSelector(IStorageSession session)
+        => _descriptor.ResolveDocumentType is not null
+            ? new HierarchicalOptimisticClosedShapeIdentityMapSelector<TDoc, TId>(session, _descriptor)
+            : new FlatOptimisticClosedShapeIdentityMapSelector<TDoc, TId>(session, _descriptor);
+}
+
+// ---- Numeric mode ----
+
+internal sealed class NumericLightweightPolecatStorage<TDoc, TId> : LightweightPolecatStorage<TDoc, TId>
+    where TDoc : notnull
+    where TId : notnull
+{
+    public NumericLightweightPolecatStorage(DocumentMapping mapping,
+        DocumentStorageDescriptor<TDoc, TId> descriptor) : base(mapping, descriptor)
+    {
+    }
+
+    private Dictionary<TId, long> Revisions(IStorageSession session) => session.Versions.RevisionsFor<TDoc, TId>();
+
+    public override Weasel.Storage.IStorageOperation Insert(TDoc document, IStorageSession session, string tenantId)
+        => new NumericClosedShapeInsertOperation<TDoc, TId>(document, Identity(document), tenantId, _descriptor, Revisions(session));
+
+    public override Weasel.Storage.IStorageOperation Update(TDoc document, IStorageSession session, string tenantId)
+        => new NumericClosedShapeUpdateOperation<TDoc, TId>(document, Identity(document), tenantId, _descriptor, Revisions(session));
+
+    public override Weasel.Storage.IStorageOperation Upsert(TDoc document, IStorageSession session, string tenantId)
+        => new NumericClosedShapeUpsertOperation<TDoc, TId>(document, Identity(document), tenantId, _descriptor, OperationRole.Upsert, Revisions(session));
+
+    public override Weasel.Storage.IStorageOperation Overwrite(TDoc document, IStorageSession session, string tenantId)
+        => new NumericClosedShapeOverwriteOperation<TDoc, TId>(document, Identity(document), tenantId, _descriptor, Revisions(session));
+
+    public override Weasel.Storage.IStorageOperation OverwriteProjected(TDoc document, string tenantId)
+        => new NumericClosedShapeOverwriteOperation<TDoc, TId>(document, Identity(document), tenantId, _descriptor, null);
+
+    public override Weasel.Storage.IStorageOperation UpsertProjected(TDoc document, string tenantId)
+        => new NumericClosedShapeUpsertOperation<TDoc, TId>(document, Identity(document), tenantId, _descriptor, OperationRole.Upsert, null);
+
+    public override Weasel.Storage.IStorageOperation InsertProjected(TDoc document, string tenantId)
+        => new NumericClosedShapeInsertOperation<TDoc, TId>(document, Identity(document), tenantId, _descriptor, null);
+
+    public override Weasel.Storage.IStorageOperation UpdateProjected(TDoc document, string tenantId)
+        => new NumericClosedShapeUpdateOperation<TDoc, TId>(document, Identity(document), tenantId, _descriptor, null);
+
+    public override ISelector BuildSelector(IStorageSession session)
+        => _descriptor.ResolveDocumentType is not null
+            ? new HierarchicalNumericClosedShapeLightweightSelector<TDoc, TId>(session, _descriptor)
+            : new FlatNumericClosedShapeLightweightSelector<TDoc, TId>(session, _descriptor);
+}
+
+internal sealed class NumericIdentityMapPolecatStorage<TDoc, TId> : IdentityMapPolecatStorage<TDoc, TId>
+    where TDoc : notnull
+    where TId : notnull
+{
+    public NumericIdentityMapPolecatStorage(DocumentMapping mapping,
+        DocumentStorageDescriptor<TDoc, TId> descriptor) : base(mapping, descriptor)
+    {
+    }
+
+    private Dictionary<TId, long> Revisions(IStorageSession session) => session.Versions.RevisionsFor<TDoc, TId>();
+
+    public override Weasel.Storage.IStorageOperation Insert(TDoc document, IStorageSession session, string tenantId)
+        => new NumericClosedShapeInsertOperation<TDoc, TId>(document, Identity(document), tenantId, _descriptor, Revisions(session));
+
+    public override Weasel.Storage.IStorageOperation Update(TDoc document, IStorageSession session, string tenantId)
+        => new NumericClosedShapeUpdateOperation<TDoc, TId>(document, Identity(document), tenantId, _descriptor, Revisions(session));
+
+    public override Weasel.Storage.IStorageOperation Upsert(TDoc document, IStorageSession session, string tenantId)
+        => new NumericClosedShapeUpsertOperation<TDoc, TId>(document, Identity(document), tenantId, _descriptor, OperationRole.Upsert, Revisions(session));
+
+    public override Weasel.Storage.IStorageOperation Overwrite(TDoc document, IStorageSession session, string tenantId)
+        => new NumericClosedShapeOverwriteOperation<TDoc, TId>(document, Identity(document), tenantId, _descriptor, Revisions(session));
+
+    public override Weasel.Storage.IStorageOperation OverwriteProjected(TDoc document, string tenantId)
+        => new NumericClosedShapeOverwriteOperation<TDoc, TId>(document, Identity(document), tenantId, _descriptor, null);
+
+    public override Weasel.Storage.IStorageOperation UpsertProjected(TDoc document, string tenantId)
+        => new NumericClosedShapeUpsertOperation<TDoc, TId>(document, Identity(document), tenantId, _descriptor, OperationRole.Upsert, null);
+
+    public override Weasel.Storage.IStorageOperation InsertProjected(TDoc document, string tenantId)
+        => new NumericClosedShapeInsertOperation<TDoc, TId>(document, Identity(document), tenantId, _descriptor, null);
+
+    public override Weasel.Storage.IStorageOperation UpdateProjected(TDoc document, string tenantId)
+        => new NumericClosedShapeUpdateOperation<TDoc, TId>(document, Identity(document), tenantId, _descriptor, null);
+
+    public override ISelector BuildSelector(IStorageSession session)
+        => _descriptor.ResolveDocumentType is not null
+            ? new HierarchicalNumericClosedShapeIdentityMapSelector<TDoc, TId>(session, _descriptor)
+            : new FlatNumericClosedShapeIdentityMapSelector<TDoc, TId>(session, _descriptor);
+}
+
+// ---- QueryOnly flavor (single class; op factories dispatch on mode) ----
+
+internal sealed class QueryOnlyPolecatStorage<TDoc, TId> : PolecatDocumentStorage<TDoc, TId>
+    where TDoc : notnull
+    where TId : notnull
+{
+    public QueryOnlyPolecatStorage(DocumentMapping mapping, DocumentStorageDescriptor<TDoc, TId> descriptor)
+        : base(mapping, descriptor)
+    {
+    }
+
+    protected override IDocumentMetadataBinder<TDoc>[] ReadBinders() => _descriptor.QueryOnlyReadBinders;
+
+    public override Task<TDoc?> LoadAsync(TId id, IStorageSession session, CancellationToken token)
+        => QueryOneAsync(id, session, token);
+
+    public override Task<IReadOnlyList<TDoc>> LoadManyAsync(TId[] ids, IStorageSession session, CancellationToken token)
+        => QueryManyAsync(ids, session, token);
+
+    public override ISelector BuildSelector(IStorageSession session)
+        => _descriptor.ResolveDocumentType is not null
+            ? new HierarchicalClosedShapeQueryOnlySelector<TDoc, TId>(session, _descriptor)
+            : new FlatClosedShapeQueryOnlySelector<TDoc, TId>(session, _descriptor);
+
+    public override Weasel.Storage.IStorageOperation Insert(TDoc document, IStorageSession session, string tenantId)
+        => CreateOp(document, session, tenantId, OpKind.Insert);
+
+    public override Weasel.Storage.IStorageOperation Update(TDoc document, IStorageSession session, string tenantId)
+        => CreateOp(document, session, tenantId, OpKind.Update);
+
+    public override Weasel.Storage.IStorageOperation Upsert(TDoc document, IStorageSession session, string tenantId)
+        => CreateOp(document, session, tenantId, OpKind.Upsert);
+
+    public override Weasel.Storage.IStorageOperation Overwrite(TDoc document, IStorageSession session, string tenantId)
+        => CreateOp(document, session, tenantId, OpKind.Overwrite);
+
+    public override Weasel.Storage.IStorageOperation OverwriteProjected(TDoc document, string tenantId)
+        => CreateOp(document, null, tenantId, OpKind.Overwrite);
+
+    public override Weasel.Storage.IStorageOperation UpsertProjected(TDoc document, string tenantId)
+        => CreateOp(document, null, tenantId, OpKind.Upsert);
+
+    public override Weasel.Storage.IStorageOperation InsertProjected(TDoc document, string tenantId)
+        => CreateOp(document, null, tenantId, OpKind.Insert);
+
+    public override Weasel.Storage.IStorageOperation UpdateProjected(TDoc document, string tenantId)
+        => CreateOp(document, null, tenantId, OpKind.Update);
+
+    private enum OpKind
+    {
+        Insert,
+        Update,
+        Upsert,
+        Overwrite
+    }
+
+    private Weasel.Storage.IStorageOperation CreateOp(TDoc document, IStorageSession? session, string tenantId,
+        OpKind kind)
+    {
+        var id = Identity(document);
+        switch (_descriptor.ConcurrencyMode)
+        {
+            case ConcurrencyMode.Optimistic:
+            {
+                var versions = session?.Versions.ForType<TDoc, TId>();
+                return kind switch
+                {
+                    OpKind.Insert => new OptimisticClosedShapeInsertOperation<TDoc, TId>(document, id, tenantId, _descriptor, versions),
+                    OpKind.Update => new OptimisticClosedShapeUpdateOperation<TDoc, TId>(document, id, tenantId, _descriptor, versions),
+                    OpKind.Overwrite => new OptimisticClosedShapeOverwriteOperation<TDoc, TId>(document, id, tenantId, _descriptor, versions),
+                    _ => new OptimisticClosedShapeUpsertOperation<TDoc, TId>(document, id, tenantId, _descriptor, OperationRole.Upsert, versions)
+                };
+            }
+            case ConcurrencyMode.Numeric:
+            {
+                var revisions = session?.Versions.RevisionsFor<TDoc, TId>();
+                return kind switch
+                {
+                    OpKind.Insert => new NumericClosedShapeInsertOperation<TDoc, TId>(document, id, tenantId, _descriptor, revisions),
+                    OpKind.Update => new NumericClosedShapeUpdateOperation<TDoc, TId>(document, id, tenantId, _descriptor, revisions),
+                    OpKind.Overwrite => new NumericClosedShapeOverwriteOperation<TDoc, TId>(document, id, tenantId, _descriptor, revisions),
+                    _ => new NumericClosedShapeUpsertOperation<TDoc, TId>(document, id, tenantId, _descriptor, OperationRole.Upsert, revisions)
+                };
+            }
+            default:
+                return kind switch
+                {
+                    OpKind.Insert => new UnversionedClosedShapeInsertOperation<TDoc, TId>(document, id, tenantId, _descriptor),
+                    OpKind.Update => new UnversionedClosedShapeUpdateOperation<TDoc, TId>(document, id, tenantId, _descriptor),
+                    OpKind.Overwrite => new UnversionedClosedShapeOverwriteOperation<TDoc, TId>(document, id, tenantId, _descriptor),
+                    _ => new UnversionedClosedShapeUpsertOperation<TDoc, TId>(document, id, tenantId, _descriptor, OperationRole.Upsert)
+                };
+        }
+    }
+}

--- a/src/Polecat/Storage/ClosedShape/PolecatDocumentStorage.cs
+++ b/src/Polecat/Storage/ClosedShape/PolecatDocumentStorage.cs
@@ -1,0 +1,395 @@
+using System.Data.Common;
+using JasperFx;
+using Microsoft.Data.SqlClient;
+using Weasel.Core;
+using Weasel.Core.SqlGeneration;
+using Weasel.SqlServer;
+using Weasel.Storage;
+
+namespace Polecat.Storage.ClosedShape;
+
+/// <summary>
+///     Polecat's implementation of the shared closed-shape <see cref="IDocumentStorage{T,TId}" />
+///     contract (#273 phase E1), composed from the released Weasel.Storage pieces: the SQL Server
+///     descriptor (#286–#288), <see cref="SqlServerStorageDialect{TId}" /> (#283), and the shared
+///     selectors/write operations (Weasel.Storage 9.13.0). The per-store layer mirrors Marten's:
+///     thin flavor/mode compositions over a common base — Marten's 559-line
+///     <c>DocumentStorage</c> stays Marten-local because this layer is deliberately per-store.
+/// </summary>
+/// <remarks>
+///     E1 scope: the storage layer is reachable through the shared seams
+///     (<c>IStorageSession.StorageFor</c> / <c>IStorageDatabase.Providers</c>) while Polecat's
+///     bespoke pipeline still drives sessions. LINQ-facing members (<c>FilterDocuments</c>,
+///     <c>SelectFields</c>, fragments) are minimal-but-correct; the full LINQ retarget is E2+.
+///     Subclass (hierarchy child) storage is also E2.
+/// </remarks>
+internal abstract class PolecatDocumentStorage<TDoc, TId> : IDocumentStorage<TDoc, TId>
+    where TDoc : notnull
+    where TId : notnull
+{
+    protected readonly DocumentMapping _mapping;
+    protected readonly DocumentStorageDescriptor<TDoc, TId> _descriptor;
+    private readonly string _loaderSql;
+    private readonly string _loadManySql;
+    private readonly string[] _selectFields;
+    private readonly IOperationFragment _deleteFragment;
+    private readonly IOperationFragment _hardDeleteFragment;
+
+    protected PolecatDocumentStorage(DocumentMapping mapping, DocumentStorageDescriptor<TDoc, TId> descriptor)
+    {
+        _mapping = mapping;
+        _descriptor = descriptor;
+
+        // Read layout must match the shared selectors: id=0, data=1, metadata from 2
+        // (QueryOnly narrows via QueryOnlyReadBinders — see SelectFields()).
+        var readColumns = new List<string> { "id", "data" };
+        readColumns.AddRange(ReadBinders().Select(b => b.ColumnName));
+        _selectFields = readColumns.ToArray();
+
+        var select = $"SELECT {string.Join(", ", _selectFields)} FROM {_mapping.QualifiedTableName}";
+        // Polecat filters tenant_id on every load (the column is always present; default
+        // tenant id for single-tenant stores), matching the bespoke pipeline.
+        _loaderSql = $"{select} WHERE id = @id AND tenant_id = @tenant_id{SoftDeleteFilterSql()}";
+        _loadManySql =
+            $"{select} WHERE id IN (SELECT value FROM OPENJSON(@ids)) AND tenant_id = @tenant_id{SoftDeleteFilterSql()}";
+
+        _deleteFragment = _mapping.DeleteStyle == DeleteStyle.SoftDelete
+            ? new HardCodedOperationFragment(
+                $"UPDATE {_mapping.QualifiedTableName} SET is_deleted = 1, deleted_at = SYSDATETIMEOFFSET()",
+                OperationRole.Deletion)
+            : new HardCodedOperationFragment(
+                $"DELETE FROM {_mapping.QualifiedTableName}", OperationRole.Deletion);
+        _hardDeleteFragment = new HardCodedOperationFragment(
+            $"DELETE FROM {_mapping.QualifiedTableName}", OperationRole.Deletion);
+    }
+
+    /// <summary>Read binders backing this flavor's SELECT (QueryOnly overrides).</summary>
+    protected virtual IDocumentMetadataBinder<TDoc>[] ReadBinders() => _descriptor.ReadBinders;
+
+    private string SoftDeleteFilterSql()
+        => _mapping.DeleteStyle == DeleteStyle.SoftDelete ? " AND is_deleted = 0" : string.Empty;
+
+    // ---- identity ----
+
+    public Type SourceType => typeof(TDoc);
+    public Type IdType => typeof(TId);
+    public Type DocumentType => typeof(TDoc);
+    public Type SelectedType => typeof(TDoc);
+
+    public TId Identity(TDoc document) => _descriptor.Identification.Identity(document);
+
+    public object IdentityFor(TDoc document) => Identity(document);
+
+    public TId AssignIdentity(TDoc document, string tenantId, IStorageDatabase database)
+        => _descriptor.Identification.AssignIfMissing(document, database);
+
+    public void SetIdentity(TDoc document, TId identity) => _mapping.SetRawId(document, identity);
+
+    public object RawIdentityValue(object id) => _descriptor.Identification.ToRawSqlValue((TId)id);
+
+    public object RawIdentityValue(TId id) => _descriptor.Identification.ToRawSqlValue(id);
+
+    public void SetIdentityFromString(TDoc document, string identityString)
+        => SetIdentity(document, (TId)ConvertIdentity(identityString, typeof(TId)));
+
+    public void SetIdentityFromGuid(TDoc document, Guid identityGuid)
+        => SetIdentity(document, typeof(TId) == typeof(Guid)
+            ? (TId)(object)identityGuid
+            : (TId)ConvertIdentity(identityGuid.ToString(), typeof(TId)));
+
+    private static object ConvertIdentity(string raw, Type idType)
+    {
+        if (idType == typeof(string)) return raw;
+        if (idType == typeof(Guid)) return Guid.Parse(raw);
+        if (idType == typeof(int)) return int.Parse(raw);
+        if (idType == typeof(long)) return long.Parse(raw);
+        throw new NotSupportedException(
+            $"Cannot convert identity string to {idType.FullName}; strongly-typed id string conversion lands with the E2 subclass/LINQ work.");
+    }
+
+    // ---- storage facts ----
+
+    public bool UseOptimisticConcurrency => _descriptor.ConcurrencyMode == ConcurrencyMode.Optimistic;
+    public bool UseNumericRevisions => _descriptor.ConcurrencyMode == ConcurrencyMode.Numeric;
+    public TenancyStyle TenancyStyle => _mapping.TenancyStyle;
+    public DbObjectName TableName => DbObjectName.Parse(SqlServerProvider.Instance, _mapping.QualifiedTableName);
+    public IOperationFragment DeleteFragment => _deleteFragment;
+    public IOperationFragment HardDeleteFragment => _hardDeleteFragment;
+    public IReadOnlyList<IDuplicatedField> DuplicatedFields => Array.Empty<IDuplicatedField>();
+
+    // ---- select clause (E1-minimal; full LINQ retarget is E2) ----
+
+    public string FromObject => _mapping.QualifiedTableName;
+    public string[] SelectFields() => _selectFields;
+
+    public void Apply(Weasel.Core.ICommandBuilder builder)
+    {
+        builder.Append("SELECT ");
+        builder.Append(string.Join(", ", _selectFields));
+        builder.Append(" FROM ");
+        builder.Append(_mapping.QualifiedTableName);
+    }
+
+    public abstract ISelector BuildSelector(IStorageSession session);
+
+    public ISqlFragment FilterDocuments(ISqlFragment query, IStorageSession session)
+    {
+        var filters = new List<ISqlFragment> { query };
+        filters.Add(new HardCodedFilter($"d.tenant_id = '{session.TenantId.Replace("'", "''")}'"));
+        if (_mapping.DeleteStyle == DeleteStyle.SoftDelete)
+        {
+            filters.Add(new HardCodedFilter("d.is_deleted = 0"));
+        }
+
+        return filters.Count == 1 ? query : new AllOfFilter(filters);
+    }
+
+    public ISqlFragment? DefaultWhereFragment()
+        => _mapping.DeleteStyle == DeleteStyle.SoftDelete ? new HardCodedFilter("d.is_deleted = 0") : null;
+
+    public ISqlFragment ByIdFilter(TId id) => _descriptor.Dialect.ByIdFilter(RawIdentityValue(id));
+
+    // ---- load paths ----
+
+    public DbCommand BuildLoadCommand(TId id, string tenantId)
+        => _descriptor.Dialect.BuildLoadCommand(_loaderSql, RawIdentityValue(id), tenantId);
+
+    public DbCommand BuildLoadManyCommand(TId[] ids, string tenantId)
+        => _descriptor.Dialect.BuildLoadManyCommand(_loadManySql, BuildManyIdParameter(ids), tenantId);
+
+    protected DbParameter BuildManyIdParameter(TId[] ids)
+        => _descriptor.Dialect.CreateIdArrayParameter(
+            Array.ConvertAll(ids, id => RawIdentityValue(id)),
+            _descriptor.Identification.RawSqlType);
+
+    public abstract Task<TDoc?> LoadAsync(TId id, IStorageSession session, CancellationToken token);
+
+    public abstract Task<IReadOnlyList<TDoc>> LoadManyAsync(TId[] ids, IStorageSession session, CancellationToken token);
+
+    protected async Task<TDoc?> QueryOneAsync(TId id, IStorageSession session, CancellationToken token)
+    {
+        var command = BuildLoadCommand(id, session.TenantId);
+        var selector = (ISelector<TDoc>)BuildSelector(session);
+        await using var reader = await session.ExecuteReaderAsync(command, token).ConfigureAwait(false);
+        if (!await reader.ReadAsync(token).ConfigureAwait(false))
+        {
+            return default;
+        }
+
+        return await selector.ResolveAsync(reader, token).ConfigureAwait(false);
+    }
+
+    protected async Task<IReadOnlyList<TDoc>> QueryManyAsync(TId[] ids, IStorageSession session,
+        CancellationToken token)
+    {
+        var command = BuildLoadManyCommand(ids, session.TenantId);
+        var selector = (ISelector<TDoc>)BuildSelector(session);
+        var list = new List<TDoc>();
+        await using var reader = await session.ExecuteReaderAsync(command, token).ConfigureAwait(false);
+        while (await reader.ReadAsync(token).ConfigureAwait(false))
+        {
+            list.Add(await selector.ResolveAsync(reader, token).ConfigureAwait(false));
+        }
+
+        return list;
+    }
+
+    public Task<TDoc?> LoadProjectedAsync(TId id, IStorageDatabase database, string tenantId, CancellationToken token)
+        => ClosedShapeProjectionLoader<TDoc, TId>.LoadAsync(
+            BuildLoadCommand(id, tenantId), _descriptor, _descriptor.Serializer, database, token);
+
+    public Task<IReadOnlyList<TDoc>> LoadManyProjectedAsync(TId[] ids, IStorageDatabase database, string tenantId,
+        CancellationToken token)
+        => ClosedShapeProjectionLoader<TDoc, TId>.LoadManyAsync(
+            BuildLoadManyCommand(ids, tenantId), _descriptor, _descriptor.Serializer, database, token);
+
+    // ---- session bookkeeping ----
+
+    public virtual void Store(IStorageSession session, TDoc document)
+    {
+        var id = AssignIdentity(document, session.TenantId, session.Database);
+        session.MarkAsAddedForStorage(id, document);
+    }
+
+    public virtual void Store(IStorageSession session, TDoc document, Guid? version)
+    {
+        var id = AssignIdentity(document, session.TenantId, session.Database);
+        if (version.HasValue)
+        {
+            session.Versions.StoreVersion<TDoc, TId>(id, version.Value);
+        }
+        else
+        {
+            session.Versions.ClearVersion<TDoc, TId>(id);
+        }
+
+        session.MarkAsAddedForStorage(id, document);
+    }
+
+    public virtual void Store(IStorageSession session, TDoc document, long revision)
+    {
+        var id = AssignIdentity(document, session.TenantId, session.Database);
+        session.Versions.StoreRevision<TDoc, TId>(id, revision);
+        session.MarkAsAddedForStorage(id, document);
+    }
+
+    public Guid? VersionFor(TDoc document, IStorageSession session)
+        => session.Versions.VersionFor<TDoc, TId>(Identity(document));
+
+    public virtual void Eject(IStorageSession session, TDoc document)
+    {
+        var id = Identity(document);
+        EjectById(session, id);
+    }
+
+    public virtual void EjectById(IStorageSession session, object id)
+    {
+        if (session.ItemMap.TryGetValue(typeof(TDoc), out var raw) && raw is Dictionary<TId, TDoc> map)
+        {
+            map.Remove((TId)id);
+        }
+
+        session.Versions.ClearVersion<TDoc, TId>((TId)id);
+        session.Versions.ClearRevision<TDoc, TId>((TId)id);
+    }
+
+    public void RemoveDirtyTracker(IStorageSession session, object id)
+    {
+        // Polecat has no dirty tracking by design — nothing registered, nothing to remove.
+    }
+
+    // ---- write operations (mode concretions supply these) ----
+
+    public abstract Weasel.Storage.IStorageOperation Insert(TDoc document, IStorageSession session, string tenantId);
+    public abstract Weasel.Storage.IStorageOperation Update(TDoc document, IStorageSession session, string tenantId);
+    public abstract Weasel.Storage.IStorageOperation Upsert(TDoc document, IStorageSession session, string tenantId);
+    public abstract Weasel.Storage.IStorageOperation Overwrite(TDoc document, IStorageSession session, string tenantId);
+    public abstract Weasel.Storage.IStorageOperation OverwriteProjected(TDoc document, string tenantId);
+    public abstract Weasel.Storage.IStorageOperation UpsertProjected(TDoc document, string tenantId);
+    public abstract Weasel.Storage.IStorageOperation InsertProjected(TDoc document, string tenantId);
+    public abstract Weasel.Storage.IStorageOperation UpdateProjected(TDoc document, string tenantId);
+
+    // ---- deletions ----
+
+    public IDeletion DeleteForDocument(TDoc document, string tenantId)
+        => BuildDeletion(document, Identity(document), tenantId, hard: _mapping.DeleteStyle != DeleteStyle.SoftDelete);
+
+    public IDeletion HardDeleteForDocument(TDoc document, string tenantId)
+        => BuildDeletion(document, Identity(document), tenantId, hard: true);
+
+    public IDeletion DeleteForId(TId id, string tenantId)
+        => BuildDeletion(default, id, tenantId, hard: _mapping.DeleteStyle != DeleteStyle.SoftDelete);
+
+    public IDeletion HardDeleteForId(TId id, string tenantId)
+        => BuildDeletion(default, id, tenantId, hard: true);
+
+    private IDeletion BuildDeletion(TDoc? document, TId id, string tenantId, bool hard)
+    {
+        var sql = hard
+            ? $"DELETE FROM {_mapping.QualifiedTableName} WHERE id = ? AND tenant_id = ?"
+            : $"UPDATE {_mapping.QualifiedTableName} SET is_deleted = 1, deleted_at = SYSDATETIMEOFFSET() WHERE id = ? AND tenant_id = ? AND is_deleted = 0";
+        return new ClosedShapeDeletion<TDoc, TId>(sql, document, id, RawIdentityValue(id), tenantId,
+            _descriptor, typeof(TDoc));
+    }
+
+    public async Task TruncateDocumentStorageAsync(IStorageDatabase database, CancellationToken ct = default)
+    {
+        await database.RunSqlAsync($"DELETE FROM {_mapping.QualifiedTableName}", ct).ConfigureAwait(false);
+    }
+
+    public bool Contains(string sqlText) => false;
+}
+
+/// <summary>Fixed-SQL operation fragment (delete fragments on the shared contract).</summary>
+internal sealed class HardCodedOperationFragment : IOperationFragment
+{
+    private readonly string _sql;
+    private readonly OperationRole _role;
+
+    public HardCodedOperationFragment(string sql, OperationRole role)
+    {
+        _sql = sql;
+        _role = role;
+    }
+
+    public void Apply(Weasel.Core.ICommandBuilder builder) => builder.Append(_sql);
+
+    public OperationRole Role() => _role;
+}
+
+/// <summary>Fixed-SQL WHERE filter over the shared SQL-generation contract.</summary>
+internal sealed class HardCodedFilter : ISqlFragment
+{
+    private readonly string _sql;
+
+    public HardCodedFilter(string sql) => _sql = sql;
+
+    public void Apply(Weasel.Core.ICommandBuilder builder) => builder.Append(_sql);
+}
+
+/// <summary>AND-combination of filters.</summary>
+internal sealed class AllOfFilter : ICompoundFragment
+{
+    private readonly IReadOnlyList<ISqlFragment> _filters;
+
+    public AllOfFilter(IReadOnlyList<ISqlFragment> filters) => _filters = filters;
+
+    public IEnumerable<ISqlFragment> Children => _filters;
+
+    public void Apply(Weasel.Core.ICommandBuilder builder)
+    {
+        builder.Append("(");
+        for (var i = 0; i < _filters.Count; i++)
+        {
+            if (i > 0) builder.Append(" AND ");
+            _filters[i].Apply(builder);
+        }
+
+        builder.Append(")");
+    }
+}
+
+/// <summary>
+///     Closed-shape deletion (hard DELETE or soft UPDATE) over the shared operation contract.
+///     Binds id then tenant via <c>?</c> slots; no result set (<see cref="NoDataReturnedCall" />).
+/// </summary>
+internal sealed class ClosedShapeDeletion<TDoc, TId> : IDeletion, NoDataReturnedCall
+    where TDoc : notnull
+    where TId : notnull
+{
+    private readonly string _sql;
+    private readonly object _rawId;
+    private readonly string _tenantId;
+    private readonly DocumentStorageDescriptor<TDoc, TId> _descriptor;
+    private readonly Type _documentType;
+
+    public ClosedShapeDeletion(string sql, TDoc? document, TId id, object rawId, string tenantId,
+        DocumentStorageDescriptor<TDoc, TId> descriptor, Type documentType)
+    {
+        _sql = sql;
+        _rawId = rawId;
+        _tenantId = tenantId;
+        _descriptor = descriptor;
+        _documentType = documentType;
+        Document = document!;
+        Id = id;
+    }
+
+    public object Document { get; set; }
+    public object Id { get; set; }
+    public Type DocumentType => _documentType;
+
+    public OperationRole Role() => OperationRole.Deletion;
+
+    public void ConfigureCommand(Weasel.Core.ICommandBuilder builder, IStorageSession session)
+    {
+        var parameters = builder.AppendWithDbParameters(_sql, '?');
+        parameters[0].Value = _rawId;
+        _descriptor.Dialect.SetIdParameterType(parameters[0], _descriptor.Identification.RawSqlType);
+        parameters[1].Value = _tenantId;
+        _descriptor.Dialect.SetParameterType(parameters[1], StorageColumnType.String);
+    }
+
+    public Task PostprocessAsync(DbDataReader reader, IList<Exception> exceptions, CancellationToken token)
+        => Task.CompletedTask;
+}

--- a/src/Polecat/Storage/DocumentMapping.cs
+++ b/src/Polecat/Storage/DocumentMapping.cs
@@ -45,6 +45,7 @@ internal class DocumentMapping
     public DocumentMapping(Type documentType, StoreOptions options)
     {
         _documentType = documentType;
+        StoreOptions = options;
 
         _idProperty = FindIdProperty(documentType)
             ?? throw new InvalidOperationException(
@@ -168,6 +169,10 @@ internal class DocumentMapping
     ///     Non-null when the Id property is a strongly typed value wrapper.
     /// </summary>
     public ValueTypeInfo? ValueTypeId { get; }
+
+    // #273 phase E1: surfaced for the closed-shape registration layer.
+    internal StoreOptions StoreOptions { get; }
+    internal PropertyInfo IdMember => _idProperty;
 
     /// <summary>
     ///     True when the Id property uses a strongly typed wrapper.
@@ -376,6 +381,12 @@ internal class DocumentMapping
     ///     #273: generate and assign an id if the document doesn't have one, via the shared
     ///     Weasel.Core.Identity strategy for this id shape. No-op for externally-assigned (string) ids.
     /// </summary>
+    /// <summary>
+    ///     The compiled (FEC) raw id setter — used by the closed-shape storage layer's
+    ///     IIdentitySetter implementation (#273 phase E1).
+    /// </summary>
+    internal void SetRawId(object document, object id) => _idSetter(document, id);
+
     public void AssignIdIfMissing(object document, ISequenceSource sequences)
         => _identityAssigner?.AssignIfMissing(document, sequences);
 

--- a/src/Polecat/Storage/PolecatDatabase.cs
+++ b/src/Polecat/Storage/PolecatDatabase.cs
@@ -447,13 +447,10 @@ public class PolecatDatabase : DatabaseBase<SqlConnection>, IEventDatabase, IPro
     // retarget onto the shared contract.
 
     /// <summary>
-    ///     The closed-shape provider graph. Not available until Polecat's document storage
-    ///     retargets onto the shared <c>Weasel.Storage</c> bases (#273 phases D/E) — Polecat's
-    ///     current per-type providers do not yet implement <c>IDocumentStorage&lt;T&gt;</c>.
+    ///     The closed-shape provider graph (#273 phase E1) — lazily builds the shared-runtime
+    ///     storage flavors per document type over the registry's mappings.
     /// </summary>
-    Weasel.Storage.IProviderGraph Weasel.Storage.IStorageDatabase.Providers =>
-        throw new NotSupportedException(
-            "The closed-shape IProviderGraph is not available until Polecat's document storage retargets onto the shared Weasel.Storage bases (JasperFx/polecat#273).");
+    Weasel.Storage.IProviderGraph Weasel.Storage.IStorageDatabase.Providers => _options.Providers.ClosedShapeGraph;
 
     /// <summary>
     ///     Creates an unopened connection to this database (shared-runtime counterpart of


### PR DESCRIPTION
Part of #273 — **phase E begins**. Marten's story-6 extraction turned out to be complete from Weasel's side (the `DocumentStorage` base matrix isn't moving — it's the deliberately per-store layer, as Marten's own thin compositions show). This PR is Polecat's per-store layer:

## What's here
- **`PolecatDocumentStorage<TDoc,TId>`** — the `IDocumentStorage<T,TId>` base over descriptor + dialect + mapping: identity via the shared `Weasel.Core.Identity` strategies, load paths through the dialect's named-parameter/OPENJSON commands + **shared selectors**, `ClosedShapeProjectionLoader` for projected paths, closed-shape deletions, fragments, session bookkeeping (`ItemMap`/`IVersionTracker`). LINQ-facing members minimal-but-correct (full LINQ retarget = E2).
- **Flavor/mode matrix** — Lightweight + IdentityMap × Unversioned/Optimistic/Numeric, plus QueryOnly; `DirtyTracking` slot = IdentityMap (Polecat has no dirty tracking by design). Op factories create the **shared** closed-shape write operations bound to session version/revision dictionaries.
- **`PolecatClosedShapeRegistration` + `PolecatProviderGraph`** — lazily builds `DocumentProvider<T>` per type; identity dispatch covers sequential Guid, string, Hi-Lo int/long, and **strongly-typed ids** (`ValueTypeIdentification`).
- **Seams live**: `IStorageDatabase.Providers` and `IStorageSession.StorageFor` return real storages (flavor tracks session kind: Query→QueryOnly, Lightweight→Lightweight, Identity→IdentityMap). The `NotSupportedException` guards are gone.

The bespoke pipeline still drives sessions — E2 retargets it (and LINQ, subclass storage, typed-id polish).

## Verification
- 8 new end-to-end tests through `StorageFor`: upsert/load round-trip (+bespoke agreement), OPENJSON loadMany, identity-map same-reference semantics via shared `ItemMap`, optimistic versions through the session tracker + cross-session stale rejection, numeric auto-increment + write-back, hard/soft deletes (+bespoke agreement), Hi-Lo int + string ids, hierarchy subclass dispatch through the hierarchical selector.
- Updated the two former guard tests to assert real resolution.
- **Full suite green: 1399 passed / 0 failed** (net10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)