### PR TITLE
feat: E2a — session loads through the closed-shape storage layer (#273)

### DIFF
--- a/src/Polecat/Internal/QuerySession.StorageSession.cs
+++ b/src/Polecat/Internal/QuerySession.StorageSession.cs
@@ -82,7 +82,7 @@ internal partial class QuerySession : IStorageSession
     ///     Db-neutral execution seam of the shared runtime. Delegates to Polecat's existing
     ///     resilience-pipeline-wrapped reader execution; Polecat sessions only speak SqlClient.
     /// </summary>
-    public Task<DbDataReader> ExecuteReaderAsync(DbCommand command, CancellationToken token = default)
+    public async Task<DbDataReader> ExecuteReaderAsync(DbCommand command, CancellationToken token = default)
     {
         if (command is not SqlCommand sqlCommand)
         {
@@ -91,7 +91,20 @@ internal partial class QuerySession : IStorageSession
                 nameof(command));
         }
 
-        return ExecuteReaderAsync(sqlCommand, token);
+        // The bespoke pipeline logs at its call sites; the closed-shape paths execute through
+        // this seam, so it owns the session-logger notifications (#273 E2a).
+        Logger.OnBeforeExecute(sqlCommand.CommandText);
+        try
+        {
+            var reader = await ExecuteReaderAsync(sqlCommand, token).ConfigureAwait(false);
+            Logger.LogSuccess(sqlCommand.CommandText);
+            return reader;
+        }
+        catch (Exception ex)
+        {
+            Logger.LogFailure(sqlCommand.CommandText, ex);
+            throw;
+        }
     }
 
     public string NextTempTableName()

--- a/src/Polecat/Internal/QuerySession.cs
+++ b/src/Polecat/Internal/QuerySession.cs
@@ -246,6 +246,22 @@ internal partial class QuerySession : IQuerySession
         var provider = _providers.GetProvider<T>();
         await _tableEnsurer.EnsureTableAsync(provider, token);
 
+        // #273 E2a: root documents load through the closed-shape storage layer (shared
+        // selectors + dialect commands over the descriptor). Subclass loads (provider routed
+        // to the parent mapping) stay on the legacy path until SubClassDocumentStorage (E2e).
+        if (provider.Mapping.DocumentType == typeof(T))
+        {
+            var storage = (Polecat.Storage.ClosedShape.IPolecatObjectStorage<T>)
+                ((Weasel.Storage.IStorageSession)this).StorageFor<T>();
+            return await storage.LoadByObjectIdAsync(id, this, token);
+        }
+
+        return await LegacyLoadInternalAsync<T>(provider, id, token);
+    }
+
+    private async Task<T?> LegacyLoadInternalAsync<T>(DocumentProvider provider, object id, CancellationToken token)
+        where T : class
+    {
         await using var cmd = new SqlCommand();
         cmd.CommandText = provider.LoadSql;
         cmd.Parameters.AddWithValue("@id", id);
@@ -307,6 +323,20 @@ internal partial class QuerySession : IQuerySession
         var provider = _providers.GetProvider<T>();
         await _tableEnsurer.EnsureTableAsync(provider, token);
 
+        // #273 E2a: root documents load through the closed-shape storage layer.
+        if (provider.Mapping.DocumentType == typeof(T))
+        {
+            var storage = (Polecat.Storage.ClosedShape.IPolecatObjectStorage<T>)
+                ((Weasel.Storage.IStorageSession)this).StorageFor<T>();
+            return await storage.LoadManyByObjectIdsAsync(ids, this, token);
+        }
+
+        return await LegacyLoadManyInternalAsync<T>(provider, ids, token);
+    }
+
+    private async Task<IReadOnlyList<T>> LegacyLoadManyInternalAsync<T>(DocumentProvider provider, List<object> ids,
+        CancellationToken token) where T : class
+    {
         await using var cmd = new SqlCommand();
 
         var paramNames = new string[ids.Count];

--- a/src/Polecat/Storage/ClosedShape/PolecatClosedShapeStorages.cs
+++ b/src/Polecat/Storage/ClosedShape/PolecatClosedShapeStorages.cs
@@ -376,6 +376,8 @@ internal sealed class QueryOnlyPolecatStorage<TDoc, TId> : PolecatDocumentStorag
 
     protected override IDocumentMetadataBinder<TDoc>[] ReadBinders() => _descriptor.QueryOnlyReadBinders;
 
+    protected override bool IncludeIdInSelect => false;
+
     public override Task<TDoc?> LoadAsync(TId id, IStorageSession session, CancellationToken token)
         => QueryOneAsync(id, session, token);
 

--- a/src/Polecat/Storage/ClosedShape/PolecatDocumentStorage.cs
+++ b/src/Polecat/Storage/ClosedShape/PolecatDocumentStorage.cs
@@ -23,7 +23,18 @@ namespace Polecat.Storage.ClosedShape;
 ///     <c>SelectFields</c>, fragments) are minimal-but-correct; the full LINQ retarget is E2+.
 ///     Subclass (hierarchy child) storage is also E2.
 /// </remarks>
-internal abstract class PolecatDocumentStorage<TDoc, TId> : IDocumentStorage<TDoc, TId>
+/// <summary>
+///     Non-generic-id load bridge for the session pipeline (#273 E2a): QuerySession's load
+///     internals carry ids as <c>object</c>, so this closes the gap without the session
+///     needing the TId generic argument.
+/// </summary>
+internal interface IPolecatObjectStorage<TDoc> where TDoc : notnull
+{
+    Task<TDoc?> LoadByObjectIdAsync(object id, IStorageSession session, CancellationToken token);
+    Task<IReadOnlyList<TDoc>> LoadManyByObjectIdsAsync(IReadOnlyList<object> ids, IStorageSession session, CancellationToken token);
+}
+
+internal abstract class PolecatDocumentStorage<TDoc, TId> : IDocumentStorage<TDoc, TId>, IPolecatObjectStorage<TDoc>
     where TDoc : notnull
     where TId : notnull
 {
@@ -40,9 +51,16 @@ internal abstract class PolecatDocumentStorage<TDoc, TId> : IDocumentStorage<TDo
         _mapping = mapping;
         _descriptor = descriptor;
 
-        // Read layout must match the shared selectors: id=0, data=1, metadata from 2
-        // (QueryOnly narrows via QueryOnlyReadBinders — see SelectFields()).
-        var readColumns = new List<string> { "id", "data" };
+        // Read layout must match the shared selectors: writeable flavors read id=0, data=1,
+        // metadata from 2; the QueryOnly selectors EXCLUDE id (data=0, metadata from 1) and
+        // narrow the binder set via QueryOnlyReadBinders.
+        var readColumns = new List<string>();
+        if (IncludeIdInSelect)
+        {
+            readColumns.Add("id");
+        }
+
+        readColumns.Add("data");
         readColumns.AddRange(ReadBinders().Select(b => b.ColumnName));
         _selectFields = readColumns.ToArray();
 
@@ -65,6 +83,9 @@ internal abstract class PolecatDocumentStorage<TDoc, TId> : IDocumentStorage<TDo
 
     /// <summary>Read binders backing this flavor's SELECT (QueryOnly overrides).</summary>
     protected virtual IDocumentMetadataBinder<TDoc>[] ReadBinders() => _descriptor.ReadBinders;
+
+    /// <summary>The QueryOnly selectors read data at column 0 with no id column.</summary>
+    protected virtual bool IncludeIdInSelect => true;
 
     private string SoftDeleteFilterSql()
         => _mapping.DeleteStyle == DeleteStyle.SoftDelete ? " AND is_deleted = 0" : string.Empty;
@@ -298,6 +319,29 @@ internal abstract class PolecatDocumentStorage<TDoc, TId> : IDocumentStorage<TDo
     }
 
     public bool Contains(string sqlText) => false;
+
+    // ---- IPolecatObjectStorage bridge (#273 E2a) ----
+
+    public Task<TDoc?> LoadByObjectIdAsync(object id, IStorageSession session, CancellationToken token)
+        => LoadAsync(NormalizeId(id), session, token);
+
+    public Task<IReadOnlyList<TDoc>> LoadManyByObjectIdsAsync(IReadOnlyList<object> ids, IStorageSession session,
+        CancellationToken token)
+    {
+        var typed = new TId[ids.Count];
+        for (var i = 0; i < ids.Count; i++)
+        {
+            typed[i] = NormalizeId(ids[i]);
+        }
+
+        return LoadManyAsync(typed, session, token);
+    }
+
+    /// <summary>
+    ///     Session load internals carry raw inner values (Guid/string/int/long) even for
+    ///     strongly-typed-id documents; wrap when TId is the wrapper type.
+    /// </summary>
+    private TId NormalizeId(object id) => id is TId typed ? typed : (TId)_mapping.WrapId(id);
 }
 
 /// <summary>Fixed-SQL operation fragment (delete fragments on the shared contract).</summary>

--- a/src/Polecat/Storage/DocumentMapping.cs
+++ b/src/Polecat/Storage/DocumentMapping.cs
@@ -387,6 +387,12 @@ internal class DocumentMapping
     /// </summary>
     internal void SetRawId(object document, object id) => _idSetter(document, id);
 
+    /// <summary>
+    ///     Wraps a raw inner id value (Guid/string/int/long) into the strongly-typed wrapper when
+    ///     this mapping uses one; pass-through otherwise (#273 E2a load bridge).
+    /// </summary>
+    internal object WrapId(object rawId) => _idWrapper is not null ? _idWrapper(rawId) : rawId;
+
     public void AssignIdIfMissing(object document, ISequenceSource sequences)
         => _identityAssigner?.AssignIfMissing(document, sequences);
 

--- a/src/Polecat/Storage/SqlServerDocumentStorageDescriptorBuilder.cs
+++ b/src/Polecat/Storage/SqlServerDocumentStorageDescriptorBuilder.cs
@@ -72,24 +72,37 @@ internal static class SqlServerDocumentStorageDescriptorBuilder
         // tenant_id: pc tables always carry it. Conjoined uses the shared operations'
         // leading tenant parameter slot (NOT a binder); single-tenant writes the session's
         // (default) tenant id through a regular binder slot.
+        // Parity with the bespoke load path: ITenanted documents get tenant_id applied on load.
+        var tenantMember = mapping.Metadata.TenantId.Member
+                           ?? (typeof(Polecat.Metadata.ITenanted).IsAssignableFrom(typeof(TDoc))
+                               ? typeof(TDoc).GetProperty(nameof(Polecat.Metadata.ITenanted.TenantId))
+                               : null);
         if (!isConjoined)
         {
             // Shared DocumentTenantIdBinder is read-only (Marten binds tenant inline);
             // Polecat's write-capable binder sources the session's tenant id.
-            writeBinders.Add(new PolecatTenantIdBinder<TDoc>(
-                mapping.Metadata.TenantId.Name, mapping.Metadata.TenantId.Member));
+            var tenantBinder = new PolecatTenantIdBinder<TDoc>(mapping.Metadata.TenantId.Name, tenantMember);
+            writeBinders.Add(tenantBinder);
+            if (tenantMember is not null)
+            {
+                readBinders.Add(tenantBinder);
+            }
         }
-        else if (mapping.Metadata.TenantId.Member is not null)
+        else if (tenantMember is not null)
         {
-            readBinders.Add(new DocumentTenantIdBinder<TDoc>(
-                mapping.Metadata.TenantId.Name, mapping.Metadata.TenantId.Member));
+            readBinders.Add(new DocumentTenantIdBinder<TDoc>(mapping.Metadata.TenantId.Name, tenantMember));
         }
 
         // guid_version: the optimistic-concurrency vehicle (uniqueidentifier), separate from
         // the always-present numeric version column that MERGE maintains as literal SQL.
         if (mapping.UseOptimisticConcurrency)
         {
-            versionBinder = new DocumentVersionBinder<TDoc>("guid_version", dialect, versionMember: null);
+            // Parity with the bespoke load path: IVersioned documents get guid_version
+            // applied to their Version member on every load.
+            var versionMember = typeof(IVersioned).IsAssignableFrom(typeof(TDoc))
+                ? typeof(TDoc).GetProperty(nameof(IVersioned.Version))
+                : null;
+            versionBinder = new DocumentVersionBinder<TDoc>("guid_version", dialect, versionMember);
             writeBinders.Add(versionBinder);
             versionReadIndex = readBinders.Count;
             readBinders.Add(versionBinder);
@@ -120,10 +133,15 @@ internal static class SqlServerDocumentStorageDescriptorBuilder
         }
 
         // created_at: read-only projection; the INSERT branch bakes SYSDATETIMEOFFSET().
-        if (mapping.Metadata.CreatedAt.Member is not null)
+        // Parity: ICreated documents get created_at applied on load.
+        var createdMember = mapping.Metadata.CreatedAt.Member
+                            ?? (typeof(Polecat.Metadata.ICreated).IsAssignableFrom(typeof(TDoc))
+                                ? typeof(TDoc).GetProperty(nameof(Polecat.Metadata.ICreated.CreatedAt))
+                                : null);
+        if (createdMember is not null)
         {
             readBinders.Add(new DocumentCreatedAtBinder<TDoc>(
-                mapping.Metadata.CreatedAt.Name, mapping.Metadata.CreatedAt.Member, ServerTimestamp));
+                mapping.Metadata.CreatedAt.Name, createdMember, ServerTimestamp));
         }
 
         // Opt-in session-sourced metadata (#241): write slot when enabled, read slot only
@@ -172,9 +190,11 @@ internal static class SqlServerDocumentStorageDescriptorBuilder
 
         var writeArray = writeBinders.ToArray();
         var readArray = readBinders.ToArray();
-        // QueryOnly's SELECT omits guid_version when it has no mapped member (always the case
-        // in slice 1) so its read set drops that binder — mirrors Marten's #4602 rule.
-        var queryOnlyReadArray = versionReadIndex >= 0
+        // QueryOnly's SELECT omits the version/revision binder only when it has no mapped
+        // member — mirrors Marten's #4602 rule.
+        var versionHasMember = (versionBinder is not null && typeof(IVersioned).IsAssignableFrom(typeof(TDoc)))
+                               || revisionBinder is not null;
+        var queryOnlyReadArray = versionReadIndex >= 0 && !versionHasMember
             ? readArray.Where((_, i) => i != versionReadIndex).ToArray()
             : readArray;
         var clientSide = writeArray.Where(b => !b.IsServerSide).ToArray();

--- a/src/Polecat/Storage/SqlServerStorageDialect.cs
+++ b/src/Polecat/Storage/SqlServerStorageDialect.cs
@@ -20,8 +20,17 @@ internal sealed class SqlServerStorageDialect<TId> : IStorageDialect
 {
     public static readonly IStorageDialect Instance = new SqlServerStorageDialect<TId>();
 
-    private static readonly SqlDbType IdParameterType =
-        SqlServerProvider.Instance.ToParameterType(typeof(TId));
+    // NOTE: not derived from typeof(TId) — for strongly-typed ids TId is the wrapper type
+    // while raw sql values are the unwrapped inner (Guid/string/int/long). Type from the
+    // runtime value instead (#273 E2a).
+    private static SqlDbType TypeForRawId(object rawId) => rawId switch
+    {
+        Guid => SqlDbType.UniqueIdentifier,
+        string => SqlDbType.NVarChar,
+        int => SqlDbType.Int,
+        long => SqlDbType.BigInt,
+        _ => SqlServerProvider.Instance.ToParameterType(rawId.GetType())
+    };
 
     private SqlServerStorageDialect()
     {
@@ -30,7 +39,7 @@ internal sealed class SqlServerStorageDialect<TId> : IStorageDialect
     public System.Data.Common.DbCommand BuildLoadCommand(string loaderSql, object rawId, string? tenant)
     {
         var command = new SqlCommand(loaderSql);
-        command.Parameters.Add(new SqlParameter("id", rawId) { SqlDbType = IdParameterType });
+        command.Parameters.Add(new SqlParameter("id", rawId) { SqlDbType = TypeForRawId(rawId) });
         if (tenant is not null)
         {
             command.Parameters.Add(new SqlParameter("tenant_id", tenant) { SqlDbType = SqlDbType.NVarChar });
@@ -62,7 +71,7 @@ internal sealed class SqlServerStorageDialect<TId> : IStorageDialect
         return command;
     }
 
-    public Weasel.Core.SqlGeneration.ISqlFragment ByIdFilter(object rawId) => new SqlServerByIdFilter(rawId, IdParameterType);
+    public Weasel.Core.SqlGeneration.ISqlFragment ByIdFilter(object rawId) => new SqlServerByIdFilter(rawId, TypeForRawId(rawId));
 
     /// <summary>SQL Server error 208: "Invalid object name '%s'."</summary>
     public bool IsUndefinedTable(Exception exception)


### PR DESCRIPTION
Part of #273, phase E2 (staged retarget of the session pipeline; E2a = read side). Root-document `LoadAsync`/`LoadManyAsync` now route through `StorageFor<T>()` → **shared selectors + dialect commands**, replacing the bespoke `LoadSql` + manual metadata sync. Subclass loads keep the legacy path until `SubClassDocumentStorage` (E2e); identity-map sessions stay coherent via the `MarkAsDocumentLoaded` hook routing into the bespoke map.

## Parity defects the full suite caught (the point of staging E2)
| Defect | Fix |
|---|---|
| Shared **QueryOnly selectors read `data` at column 0, no id** (writeable flavors: id=0, data=1) — every `QuerySession.LoadAsync` failed with a Guid→string cast | `QueryOnlyPolecatStorage` builds its SELECT without id (`IncludeIdInSelect` virtual) |
| **Strongly-typed ids**: the dialect typed id parameters from `typeof(TId)` — garbage when `TId` is the wrapper | Type derives from the runtime raw value; the object-id bridge wraps raw inner values via the mapping's compiled wrapper (`DocumentMapping.WrapId`) |
| **Interface-driven load metadata**: bespoke loads apply `guid_version`→`IVersioned.Version`, `tenant_id`→`ITenanted`, `created_at`→`ICreated` regardless of member mapping | Descriptor read binders carry interface-fallback members (+ QueryOnly read set keeps a membered version binder, Marten #4602 rule) |
| **Session logging** bypassed on the new path | The `ExecuteReaderAsync(DbCommand)` seam owns the logger notifications |

Bonus: the typed-id fix closes E1's deferred `ValueTypeIdentification` wiring — strongly-typed-id documents now load through the shared runtime end-to-end.

## Verification
- **Full suite green: 1399 passed / 0 failed** (net10) — every root-document load in the suite exercises the shared runtime now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)