### PR TITLE
feat: E2c — deletes + numeric revisions through the shared operations (#273)

### DIFF
--- a/src/Polecat.Tests/Storage/sqlserver_descriptor_builder_tests.cs
+++ b/src/Polecat.Tests/Storage/sqlserver_descriptor_builder_tests.cs
@@ -220,16 +220,23 @@ public class sqlserver_descriptor_builder_tests : OneOffConfigurationsContext
         await executeAsync(second, session);
         doc.Version.ShouldBe(2);
 
-        // Explicit stale revision (not greater than current) -> ConcurrencyException
+        // POLECAT numeric semantics (#273 E2c): the explicit revision is an EQUALITY
+        // expectation against the current version (bespoke-pipeline parity), and version
+        // always auto-increments — unlike Marten's explicit-greater rule.
         var stale = new NumericClosedShapeUpsertOperation<RevisionedDoc, Guid>(
             doc, doc.Id, session.TenantId, descriptor, OperationRole.Upsert, revisions) { Revision = 1 };
         await Should.ThrowAsync<JasperFx.ConcurrencyException>(() => executeAsync(stale, session));
 
-        // Explicit higher revision wins
+        // A jump past the current version is also a mismatch
         var jump = new NumericClosedShapeUpsertOperation<RevisionedDoc, Guid>(
             doc, doc.Id, session.TenantId, descriptor, OperationRole.Upsert, revisions) { Revision = 10 };
-        await executeAsync(jump, session);
-        doc.Version.ShouldBe(10);
+        await Should.ThrowAsync<JasperFx.ConcurrencyException>(() => executeAsync(jump, session));
+
+        // Matching the current version succeeds and increments
+        var match = new NumericClosedShapeUpsertOperation<RevisionedDoc, Guid>(
+            doc, doc.Id, session.TenantId, descriptor, OperationRole.Upsert, revisions) { Revision = 2 };
+        await executeAsync(match, session);
+        doc.Version.ShouldBe(3);
     }
 
     [Fact]

--- a/src/Polecat/Internal/DocumentSessionBase.cs
+++ b/src/Polecat/Internal/DocumentSessionBase.cs
@@ -111,7 +111,7 @@ internal abstract class DocumentSessionBase : QuerySession, IDocumentSession
         out Operations.ClosedShapeOperationAdapter adapter) where T : notnull
     {
         adapter = null!;
-        if (provider.Mapping.DocumentType != typeof(T) || provider.Mapping.UseNumericRevisions)
+        if (provider.Mapping.DocumentType != typeof(T))
         {
             return false;
         }
@@ -126,6 +126,18 @@ internal abstract class DocumentSessionBase : QuerySession, IDocumentSession
             WriteKind.Update => storage.Update(document, session, TenantId),
             _ => storage.Upsert(document, session, TenantId)
         };
+
+        // Numeric revisions: the doc-carried version is the equality expectation (0 = new/auto),
+        // matching the bespoke pipeline's expectedRevision capture.
+        if (op is Weasel.Storage.IRevisionedOperation revisioned)
+        {
+            revisioned.Revision = document switch
+            {
+                ILongVersioned longVersioned => longVersioned.Version,
+                IRevisioned rev => rev.Version,
+                _ => 0
+            };
+        }
 
         adapter = new Operations.ClosedShapeOperationAdapter(op, session, document, provider.Mapping.GetId(document));
         return true;
@@ -224,8 +236,19 @@ internal abstract class DocumentSessionBase : QuerySession, IDocumentSession
     public void Delete<T>(T document) where T : notnull
     {
         var provider = _providers.GetProvider<T>();
-        var op = provider.BuildDeleteByDocument(document, TenantId);
-        _workTracker.Add(op);
+        if (provider.Mapping.DocumentType == typeof(T))
+        {
+            var session = (Weasel.Storage.IStorageSession)this;
+            var storage = (Weasel.Storage.IDocumentStorage<T>)session.StorageFor<T>();
+            var deletion = storage.DeleteForDocument(document, TenantId);
+            _workTracker.Add(new Operations.ClosedShapeOperationAdapter(
+                deletion, session, document, provider.Mapping.GetId(document)));
+        }
+        else
+        {
+            var op = provider.BuildDeleteByDocument(document, TenantId);
+            _workTracker.Add(op);
+        }
 
         // Sync ISoftDeleted properties in memory
         if (document is ISoftDeleted softDeleted && provider.Mapping.DeleteStyle == DeleteStyle.SoftDelete)
@@ -237,30 +260,40 @@ internal abstract class DocumentSessionBase : QuerySession, IDocumentSession
 
     public void Delete<T>(Guid id) where T : class
     {
-        var provider = _providers.GetProvider<T>();
-        var op = provider.BuildDeleteById(id, TenantId);
-        _workTracker.Add(op);
+        DeleteByObjectId<T>(id);
     }
 
     public void Delete<T>(string id) where T : class
     {
-        var provider = _providers.GetProvider<T>();
-        var op = provider.BuildDeleteById(id, TenantId);
-        _workTracker.Add(op);
+        DeleteByObjectId<T>(id);
     }
 
     public void Delete<T>(int id) where T : class
     {
-        var provider = _providers.GetProvider<T>();
-        var op = provider.BuildDeleteById(id, TenantId);
-        _workTracker.Add(op);
+        DeleteByObjectId<T>(id);
     }
 
     public void Delete<T>(long id) where T : class
     {
+        DeleteByObjectId<T>(id);
+    }
+
+    // #273 E2c: root-document deletions route through the closed-shape storage layer.
+    private void DeleteByObjectId<T>(object id) where T : class
+    {
         var provider = _providers.GetProvider<T>();
-        var op = provider.BuildDeleteById(id, TenantId);
-        _workTracker.Add(op);
+        if (provider.Mapping.DocumentType == typeof(T))
+        {
+            var session = (Weasel.Storage.IStorageSession)this;
+            var storage = (Polecat.Storage.ClosedShape.IPolecatObjectStorage<T>)session.StorageFor<T>();
+            _workTracker.Add(new Operations.ClosedShapeOperationAdapter(
+                storage.DeletionForObjectId(id, TenantId), session, id, id));
+        }
+        else
+        {
+            var op = provider.BuildDeleteById(id, TenantId);
+            _workTracker.Add(op);
+        }
     }
 
     public void HardDelete<T>(T document) where T : notnull

--- a/src/Polecat/Storage/ClosedShape/PolecatDocumentStorage.cs
+++ b/src/Polecat/Storage/ClosedShape/PolecatDocumentStorage.cs
@@ -32,6 +32,7 @@ internal interface IPolecatObjectStorage<TDoc> where TDoc : notnull
 {
     Task<TDoc?> LoadByObjectIdAsync(object id, IStorageSession session, CancellationToken token);
     Task<IReadOnlyList<TDoc>> LoadManyByObjectIdsAsync(IReadOnlyList<object> ids, IStorageSession session, CancellationToken token);
+    IDeletion DeletionForObjectId(object id, string tenantId);
 }
 
 internal abstract class PolecatDocumentStorage<TDoc, TId> : IDocumentStorage<TDoc, TId>, IPolecatObjectStorage<TDoc>
@@ -342,6 +343,8 @@ internal abstract class PolecatDocumentStorage<TDoc, TId> : IDocumentStorage<TDo
     ///     strongly-typed-id documents; wrap when TId is the wrapper type.
     /// </summary>
     private TId NormalizeId(object id) => id is TId typed ? typed : (TId)_mapping.WrapId(id);
+
+    public IDeletion DeletionForObjectId(object id, string tenantId) => DeleteForId(NormalizeId(id), tenantId);
 }
 
 /// <summary>Fixed-SQL operation fragment (delete fragments on the shared contract).</summary>

--- a/src/Polecat/Storage/SqlServerDocumentStorageDescriptorBuilder.cs
+++ b/src/Polecat/Storage/SqlServerDocumentStorageDescriptorBuilder.cs
@@ -325,8 +325,10 @@ internal static class SqlServerDocumentStorageDescriptorBuilder
         {
             if (column == "rev0")
             {
+                // Bespoke parity: INSERT always starts at revision 1 regardless of the
+                // doc-carried value (the expectation only applies to existing rows).
                 insertColumns.Add("version");
-                insertValues.Add("CASE WHEN s.rev0 = 0 THEN 1 ELSE s.rev1 END");
+                insertValues.Add("1");
             }
             else if (column != "rev1")
             {
@@ -365,7 +367,10 @@ internal static class SqlServerDocumentStorageDescriptorBuilder
         var updateAssignments = new List<string> { "data = s.data" };
         if (numeric)
         {
-            updateAssignments.Add("version = CASE WHEN ? = 0 THEN t.version + 1 ELSE ? END");
+            // POLECAT numeric semantics (deliberate divergence from Marten's explicit-greater
+            // rule): the doc-carried revision is an EQUALITY expectation and version always
+            // auto-increments. Explicit path sets ? + 1 to match the bespoke pipeline.
+            updateAssignments.Add("version = CASE WHEN ? = 0 THEN t.version + 1 ELSE ? + 1 END");
         }
         else
         {
@@ -387,10 +392,10 @@ internal static class SqlServerDocumentStorageDescriptorBuilder
         }
         else if (numeric)
         {
-            // Auto-increment (? = 0) always wins; explicit revisions only when greater than
-            // current. Guarded and unguarded numeric upserts share the shape — the shared
-            // numeric ops always bind the four trailing slots.
-            guard = " AND (? = 0 OR t.version < ?)";
+            // Equality expectation (Polecat parity): auto (? = 0) always wins; an explicit
+            // revision must MATCH the current version. The shared numeric ops always bind the
+            // four trailing slots, so the shape is constant whether guarded or not.
+            guard = " AND (? = 0 OR t.version = ?)";
         }
 
         return $"MERGE {table} WITH (HOLDLOCK) AS t " +
@@ -464,7 +469,7 @@ internal static class SqlServerDocumentStorageDescriptorBuilder
 
         var updateAssignments = new List<string> { "data = s.data" };
         updateAssignments.Add(numeric
-            ? "version = CASE WHEN s.rev0 = 0 THEN t.version + 1 ELSE s.rev1 END"
+            ? "version = CASE WHEN s.rev0 = 0 THEN t.version + 1 ELSE s.rev1 + 1 END"
             : "version = t.version + 1");
         updateAssignments.AddRange(binders
             .Where(b => !b.IsServerSide && b.ColumnName != "tenant_id" && !ReferenceEquals(b, revisionBinder))
@@ -475,7 +480,7 @@ internal static class SqlServerDocumentStorageDescriptorBuilder
         var guard = mode switch
         {
             ConcurrencyMode.Optimistic => " AND t.guid_version = ?",
-            ConcurrencyMode.Numeric => " AND (? = 0 OR t.version < ?)",
+            ConcurrencyMode.Numeric => " AND (? = 0 OR t.version = ?)",
             _ => string.Empty
         };
 


### PR DESCRIPTION
Part of #273, phase E2 (E2c). Two moves:

## Numeric revisions join the closed-shape path
The one semantic divergence between the pipelines is reconciled **in the descriptor SQL** (which is Polecat's to define): the doc-carried revision is an **equality expectation** against the current version (`(? = 0 OR t.version = ?)`), version always auto-increments (explicit path sets `? + 1`), INSERT always starts at 1 — exactly the bespoke `expectedRevision` contract, deliberately diverging from Marten's explicit-greater rule. The session sets `IRevisionedOperation.Revision` from the doc member.

## Deletes through the shared `IDeletion`
`Delete<T>(document)` + all four by-id overloads route root documents through the closed-shape deletions (soft UPDATE / hard DELETE, typed `?` slots); the object-id bridge gains `DeletionForObjectId` with the same raw-vs-wrapper normalization as loads. Subclasses stay bespoke until E2e.

## Verification
- Descriptor-suite numeric tests updated to the Polecat semantics (jump-past-current rejected; matching revision increments to +1).
- **Full suite green: 1399 passed / 0 failed** (net10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)