### PR TITLE
feat: E2d — LINQ materialization through the shared QueryOnly selector (#273)

### DIFF
--- a/src/Polecat/Linq/PolecatLinqQueryProvider.cs
+++ b/src/Polecat/Linq/PolecatLinqQueryProvider.cs
@@ -256,28 +256,41 @@ internal class PolecatLinqQueryProvider : IPolecatAsyncQueryProvider
 
         ApplyModifiedFilters(parser);
 
-        // Adjust select columns for version syncing on IRevisioned/IVersioned types
+        // Materialization shape. Root documents ride the closed-shape QueryOnly storage
+        // (#273 E2d): SELECT columns come from the shared select clause (data first, then
+        // the QueryOnlyReadBinders' columns in binder order) and rows resolve through the
+        // shared QueryOnly selector. Subclass queries stay on the bespoke column shape +
+        // DeserializingSelector until the SubClassDocumentStorage analog (E2e).
         bool syncRevision = provider.Mapping.UseNumericRevisions;
         bool syncGuidVersion = provider.Mapping.UseOptimisticConcurrency;
         bool isHierarchy = provider.Mapping.IsHierarchy();
+        Weasel.Storage.ISelectClause? sharedSelectClause = null;
         if (parser.Statement.SelectColumns == "data")
         {
-            var cols = "data";
-            if (syncGuidVersion)
+            if (documentType == provider.Mapping.DocumentType)
             {
-                cols = "data, version, guid_version";
+                sharedSelectClause = _providers.ClosedShapeGraph.QueryOnlySelectClauseFor(documentType);
+                parser.Statement.SelectColumns = string.Join(", ", sharedSelectClause.SelectFields());
             }
-            else if (syncRevision)
+            else
             {
-                cols = "data, version";
-            }
+                var cols = "data";
+                if (syncGuidVersion)
+                {
+                    cols = "data, version, guid_version";
+                }
+                else if (syncRevision)
+                {
+                    cols = "data, version";
+                }
 
-            if (isHierarchy)
-            {
-                cols += ", doc_type";
-            }
+                if (isHierarchy)
+                {
+                    cols += ", doc_type";
+                }
 
-            parser.Statement.SelectColumns = cols;
+                parser.Statement.SelectColumns = cols;
+            }
         }
 
         // Add doc_type filter for subclass queries
@@ -296,7 +309,7 @@ internal class PolecatLinqQueryProvider : IPolecatAsyncQueryProvider
         await using var reader = await _session.ExecuteReaderAsync(batch, token);
 
         return await HandleResultAsync<TResult>(reader, parser, documentType, token, syncRevision, syncGuidVersion,
-            isHierarchy ? provider.Mapping : null);
+            isHierarchy ? provider.Mapping : null, sharedSelectClause);
     }
 
     [RequiresDynamicCode("GroupBy execution closes GroupByListHandler<>/ScalarListHandler<> over the projected type via Type.MakeGenericType.")]
@@ -924,7 +937,8 @@ internal class PolecatLinqQueryProvider : IPolecatAsyncQueryProvider
     [RequiresUnreferencedCode("Routes to handler invocations that reflect over handler/result types.")]
     private async Task<TResult> HandleResultAsync<TResult>(
         DbDataReader reader, LinqQueryParser parser, Type documentType, CancellationToken token,
-        bool syncRevision = false, bool syncGuidVersion = false, DocumentMapping? hierarchyMapping = null)
+        bool syncRevision = false, bool syncGuidVersion = false, DocumentMapping? hierarchyMapping = null,
+        Weasel.Storage.ISelectClause? sharedSelectClause = null)
     {
         if (parser.ValueMode == null)
         {
@@ -942,7 +956,8 @@ internal class PolecatLinqQueryProvider : IPolecatAsyncQueryProvider
             }
 
             // Plain list result
-            return await InvokeListHandlerAsync<TResult>(documentType, reader, token, syncRevision, syncGuidVersion, hierarchyMapping);
+            return await InvokeListHandlerAsync<TResult>(documentType, reader, token, syncRevision, syncGuidVersion,
+                hierarchyMapping, sharedSelectClause);
         }
 
         switch (parser.ValueMode)
@@ -953,7 +968,8 @@ internal class PolecatLinqQueryProvider : IPolecatAsyncQueryProvider
                 return await InvokeOneResultHandlerAsync<TResult>(
                     documentType, reader, token, canBeNull: false,
                     canBeMultiples: parser.ValueMode == SingleValueMode.First || parser.ValueMode == SingleValueMode.Last,
-                    syncRevision: syncRevision, syncGuidVersion: syncGuidVersion, hierarchyMapping: hierarchyMapping);
+                    syncRevision: syncRevision, syncGuidVersion: syncGuidVersion, hierarchyMapping: hierarchyMapping,
+                    sharedSelectClause: sharedSelectClause);
 
             case SingleValueMode.FirstOrDefault:
             case SingleValueMode.SingleOrDefault:
@@ -961,7 +977,8 @@ internal class PolecatLinqQueryProvider : IPolecatAsyncQueryProvider
                 return await InvokeOneResultHandlerAsync<TResult>(
                     documentType, reader, token, canBeNull: true,
                     canBeMultiples: parser.ValueMode != SingleValueMode.SingleOrDefault,
-                    syncRevision: syncRevision, syncGuidVersion: syncGuidVersion, hierarchyMapping: hierarchyMapping);
+                    syncRevision: syncRevision, syncGuidVersion: syncGuidVersion, hierarchyMapping: hierarchyMapping,
+                    sharedSelectClause: sharedSelectClause);
 
             case SingleValueMode.Count:
             case SingleValueMode.LongCount:
@@ -986,11 +1003,22 @@ internal class PolecatLinqQueryProvider : IPolecatAsyncQueryProvider
     [RequiresUnreferencedCode("Reflects over handler/selector types (Activator.CreateInstance, MethodInfo.Invoke on HandleAsync, GetProperty on Task<>.Result).")]
     private async Task<TResult> InvokeListHandlerAsync<TResult>(
         Type itemType, DbDataReader reader, CancellationToken token,
-        bool syncRevision = false, bool syncGuidVersion = false, DocumentMapping? hierarchyMapping = null)
+        bool syncRevision = false, bool syncGuidVersion = false, DocumentMapping? hierarchyMapping = null,
+        Weasel.Storage.ISelectClause? sharedSelectClause = null)
     {
-        var selectorType = typeof(DeserializingSelector<>).MakeGenericType(itemType);
-        var selector = Activator.CreateInstance(selectorType, _session.Serializer, syncRevision, syncGuidVersion,
-            hierarchyMapping)!;
+        // #273 E2d: root documents materialize through the shared QueryOnly selector,
+        // whose layout matches the SELECT columns the shared select clause produced.
+        object selector;
+        if (sharedSelectClause != null)
+        {
+            selector = sharedSelectClause.BuildSelector((Weasel.Storage.IStorageSession)_session);
+        }
+        else
+        {
+            var selectorType = typeof(DeserializingSelector<>).MakeGenericType(itemType);
+            selector = Activator.CreateInstance(selectorType, _session.Serializer, syncRevision, syncGuidVersion,
+                hierarchyMapping)!;
+        }
 
         var handlerType = typeof(ListQueryHandler<>).MakeGenericType(itemType);
         var handler = Activator.CreateInstance(handlerType, selector)!;
@@ -1045,11 +1073,21 @@ internal class PolecatLinqQueryProvider : IPolecatAsyncQueryProvider
     private async Task<TResult> InvokeOneResultHandlerAsync<TResult>(
         Type documentType, DbDataReader reader, CancellationToken token,
         bool canBeNull, bool canBeMultiples,
-        bool syncRevision = false, bool syncGuidVersion = false, DocumentMapping? hierarchyMapping = null)
+        bool syncRevision = false, bool syncGuidVersion = false, DocumentMapping? hierarchyMapping = null,
+        Weasel.Storage.ISelectClause? sharedSelectClause = null)
     {
-        var selectorType = typeof(DeserializingSelector<>).MakeGenericType(documentType);
-        var selector = Activator.CreateInstance(selectorType, _session.Serializer, syncRevision, syncGuidVersion,
-            hierarchyMapping)!;
+        // #273 E2d: root documents materialize through the shared QueryOnly selector.
+        object selector;
+        if (sharedSelectClause != null)
+        {
+            selector = sharedSelectClause.BuildSelector((Weasel.Storage.IStorageSession)_session);
+        }
+        else
+        {
+            var selectorType = typeof(DeserializingSelector<>).MakeGenericType(documentType);
+            selector = Activator.CreateInstance(selectorType, _session.Serializer, syncRevision, syncGuidVersion,
+                hierarchyMapping)!;
+        }
 
         var handlerType = typeof(OneResultHandler<>).MakeGenericType(documentType);
         var handler = Activator.CreateInstance(handlerType, selector, canBeNull, canBeMultiples)!;

--- a/src/Polecat/Linq/QueryHandlers/ListQueryHandler.cs
+++ b/src/Polecat/Linq/QueryHandlers/ListQueryHandler.cs
@@ -1,16 +1,17 @@
 using System.Data.Common;
-using Polecat.Linq.Selectors;
 
 namespace Polecat.Linq.QueryHandlers;
 
 /// <summary>
-///     Reads all rows from a query and returns them as a list.
+///     Reads all rows from a query and returns them as a list. Materialization goes through
+///     the shared selector contract — either the closed-shape QueryOnly selector (root
+///     documents, #273 E2d) or Polecat's DeserializingSelector (subclass + event queries).
 /// </summary>
 internal class ListQueryHandler<T> : IQueryHandler<IReadOnlyList<T>> where T : class
 {
-    private readonly DeserializingSelector<T> _selector;
+    private readonly Weasel.Storage.ISelector<T> _selector;
 
-    public ListQueryHandler(DeserializingSelector<T> selector)
+    public ListQueryHandler(Weasel.Storage.ISelector<T> selector)
     {
         _selector = selector;
     }

--- a/src/Polecat/Linq/QueryHandlers/OneResultHandler.cs
+++ b/src/Polecat/Linq/QueryHandlers/OneResultHandler.cs
@@ -1,18 +1,19 @@
 using System.Data.Common;
-using Polecat.Linq.Selectors;
 
 namespace Polecat.Linq.QueryHandlers;
 
 /// <summary>
-///     Reads a single result from a query (First, Single, etc.).
+///     Reads a single result from a query (First, Single, etc.). Materialization goes through
+///     the shared selector contract — either the closed-shape QueryOnly selector (root
+///     documents, #273 E2d) or Polecat's DeserializingSelector (subclass + event queries).
 /// </summary>
 internal class OneResultHandler<T> : IQueryHandler<T?> where T : class
 {
-    private readonly DeserializingSelector<T> _selector;
+    private readonly Weasel.Storage.ISelector<T> _selector;
     private readonly bool _canBeNull;
     private readonly bool _canBeMultiples;
 
-    public OneResultHandler(DeserializingSelector<T> selector, bool canBeNull, bool canBeMultiples)
+    public OneResultHandler(Weasel.Storage.ISelector<T> selector, bool canBeNull, bool canBeMultiples)
     {
         _selector = selector;
         _canBeNull = canBeNull;

--- a/src/Polecat/Linq/Selectors/DeserializingSelector.cs
+++ b/src/Polecat/Linq/Selectors/DeserializingSelector.cs
@@ -11,12 +11,15 @@ namespace Polecat.Linq.Selectors;
 ///     Reads the JSON 'data' column and deserializes it to T.
 ///     Optionally syncs version/revision properties from additional columns.
 ///     Supports polymorphic deserialization for document hierarchies via doc_type column.
+///     Implements the shared <see cref="Weasel.Storage.ISelector{T}" /> contract so the LINQ
+///     query handlers accept it interchangeably with the closed-shape selectors (#273 E2d);
+///     it remains the materializer for subclass queries and the event-store LINQ provider.
 /// </summary>
 [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
     Justification = "Class-level: invokes ISerializer.FromJson, which is annotated RUC because the default STJ-reflection serializer requires unreferenced code. AOT consumers supply a source-generator-backed ISerializer impl per the AOT publishing guide.")]
 [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
     Justification = "Class-level: ISerializer.FromJson is annotated RDC for the same reason as IL2026 above. AOT consumers supply a source-generator-backed ISerializer impl.")]
-internal class DeserializingSelector<T> where T : class
+internal class DeserializingSelector<T> : Weasel.Storage.ISelector<T> where T : class
 {
     private readonly ISerializer _serializer;
     private readonly bool _syncRevision;
@@ -83,4 +86,7 @@ internal class DeserializingSelector<T> where T : class
 
         return doc;
     }
+
+    public Task<T> ResolveAsync(DbDataReader reader, CancellationToken token)
+        => Task.FromResult(Resolve(reader));
 }

--- a/src/Polecat/Storage/ClosedShape/PolecatClosedShapeRegistration.cs
+++ b/src/Polecat/Storage/ClosedShape/PolecatClosedShapeRegistration.cs
@@ -156,4 +156,16 @@ internal sealed class PolecatProviderGraph : IProviderGraph
             .MakeGenericMethod(documentType)
             .Invoke(this, null)!;
     }
+
+    /// <summary>
+    ///     Non-generic access to a root document type's QueryOnly storage as the shared
+    ///     select-clause contract — the LINQ provider's materialization seam (#273 E2d).
+    /// </summary>
+    internal Weasel.Storage.ISelectClause QueryOnlySelectClauseFor(Type documentType)
+    {
+        var provider = ProviderFor(documentType);
+        return (Weasel.Storage.ISelectClause)provider.GetType()
+            .GetProperty(nameof(DocumentProvider<object>.QueryOnly))!
+            .GetValue(provider)!;
+    }
 }


### PR DESCRIPTION
## #273 phase E2d

Root-document LINQ queries now materialize through the closed-shape QueryOnly storage instead of the bespoke `DeserializingSelector` path:

- **SELECT columns** for whole-document root queries come from the shared select clause — `data` first, then the `QueryOnlyReadBinders` columns in binder order — so the column layout and the selector are produced by the same descriptor.
- **Row materialization** goes through `storage.BuildSelector(session)` → `FlatClosedShapeQueryOnlySelector` / `HierarchicalClosedShapeQueryOnlySelector` (Weasel.Storage 9.13.0), which also applies the metadata read binders (version/revision sync, tenant/created/modified members) exactly like the E2a session loads.
- `ListQueryHandler`/`OneResultHandler` now accept the shared `Weasel.Storage.ISelector<T>` contract; `DeserializingSelector` implements it and remains the materializer for **subclass queries** (until the SubClassDocumentStorage analog in E2e) and the **event-store LINQ** provider.
- `PolecatProviderGraph.QueryOnlySelectClauseFor(Type)` — non-generic seam handing the LINQ provider a root type's QueryOnly storage as `ISelectClause`.
- Untouched by design: scalar selects, aggregates, complex projections, GroupBy/GroupJoin, JSON-array streaming, batched queries, and LINQ SQL generation (per-store, as in Marten).

Full suite: **1399 passed / 3 skipped** (net10.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)