### PR TITLE
feat: E2e — SubClassPolecatStorage + all subclass paths through the closed-shape layer (#273)

### DIFF
--- a/src/Polecat/Internal/DocumentSessionBase.cs
+++ b/src/Polecat/Internal/DocumentSessionBase.cs
@@ -92,30 +92,16 @@ internal abstract class DocumentSessionBase : QuerySession, IDocumentSession
     {
         SyncMetadata(document);
         var provider = _providers.GetProvider<T>();
-        if (TryBuildClosedShapeWrite(document, provider, WriteKind.Upsert, out var adapter))
-        {
-            _workTracker.Add(adapter);
-            OnDocumentStored(typeof(T), provider.Mapping.GetId(document), document);
-            return;
-        }
-
-        var op = provider.BuildUpsert(document, Serializer, TenantId, BuildMetadataValues(provider.Mapping));
-        _workTracker.Add(op);
+        _workTracker.Add(BuildClosedShapeWrite(document, provider, WriteKind.Upsert));
         OnDocumentStored(typeof(T), provider.Mapping.GetId(document), document);
     }
 
-    // #273 E2b: root non-numeric documents write through the shared closed-shape operations
-    // (wrapped for the bespoke unit-of-work currency until E2e). Numeric-revision documents
-    // stay bespoke pending E2c's version-guard parity, as do subclasses (E2e).
-    private bool TryBuildClosedShapeWrite<T>(T document, DocumentProvider provider, WriteKind kind,
-        out Operations.ClosedShapeOperationAdapter adapter) where T : notnull
+    // #273 E2b/E2c/E2e: every document write goes through the shared closed-shape operations
+    // (wrapped for the bespoke unit-of-work currency until the op-currency flip); subclass
+    // types resolve a SubClassPolecatStorage delegating to the hierarchy root's storage.
+    private Operations.ClosedShapeOperationAdapter BuildClosedShapeWrite<T>(T document, DocumentProvider provider,
+        WriteKind kind) where T : notnull
     {
-        adapter = null!;
-        if (provider.Mapping.DocumentType != typeof(T))
-        {
-            return false;
-        }
-
         var session = (Weasel.Storage.IStorageSession)this;
         var storage = (Weasel.Storage.IDocumentStorage<T>)session.StorageFor<T>();
         storage.Store(session, document); // id assignment + identity-map/version bookkeeping
@@ -139,8 +125,7 @@ internal abstract class DocumentSessionBase : QuerySession, IDocumentSession
             };
         }
 
-        adapter = new Operations.ClosedShapeOperationAdapter(op, session, document, provider.Mapping.GetId(document));
-        return true;
+        return new Operations.ClosedShapeOperationAdapter(op, session, document, provider.Mapping.GetId(document));
     }
 
     private enum WriteKind
@@ -205,15 +190,7 @@ internal abstract class DocumentSessionBase : QuerySession, IDocumentSession
     {
         SyncMetadata(document);
         var provider = _providers.GetProvider<T>();
-        if (TryBuildClosedShapeWrite(document, provider, WriteKind.Insert, out var adapter))
-        {
-            _workTracker.Add(adapter);
-            OnDocumentStored(typeof(T), provider.Mapping.GetId(document), document);
-            return;
-        }
-
-        var op = provider.BuildInsert(document, Serializer, TenantId, BuildMetadataValues(provider.Mapping));
-        _workTracker.Add(op);
+        _workTracker.Add(BuildClosedShapeWrite(document, provider, WriteKind.Insert));
         OnDocumentStored(typeof(T), provider.Mapping.GetId(document), document);
     }
 
@@ -221,34 +198,18 @@ internal abstract class DocumentSessionBase : QuerySession, IDocumentSession
     {
         SyncMetadata(document);
         var provider = _providers.GetProvider<T>();
-        if (TryBuildClosedShapeWrite(document, provider, WriteKind.Update, out var adapter))
-        {
-            _workTracker.Add(adapter);
-            OnDocumentStored(typeof(T), provider.Mapping.GetId(document), document);
-            return;
-        }
-
-        var op = provider.BuildUpdate(document, Serializer, TenantId, BuildMetadataValues(provider.Mapping));
-        _workTracker.Add(op);
+        _workTracker.Add(BuildClosedShapeWrite(document, provider, WriteKind.Update));
         OnDocumentStored(typeof(T), provider.Mapping.GetId(document), document);
     }
 
     public void Delete<T>(T document) where T : notnull
     {
         var provider = _providers.GetProvider<T>();
-        if (provider.Mapping.DocumentType == typeof(T))
-        {
-            var session = (Weasel.Storage.IStorageSession)this;
-            var storage = (Weasel.Storage.IDocumentStorage<T>)session.StorageFor<T>();
-            var deletion = storage.DeleteForDocument(document, TenantId);
-            _workTracker.Add(new Operations.ClosedShapeOperationAdapter(
-                deletion, session, document, provider.Mapping.GetId(document)));
-        }
-        else
-        {
-            var op = provider.BuildDeleteByDocument(document, TenantId);
-            _workTracker.Add(op);
-        }
+        var session = (Weasel.Storage.IStorageSession)this;
+        var storage = (Weasel.Storage.IDocumentStorage<T>)session.StorageFor<T>();
+        var deletion = storage.DeleteForDocument(document, TenantId);
+        _workTracker.Add(new Operations.ClosedShapeOperationAdapter(
+            deletion, session, document, provider.Mapping.GetId(document)));
 
         // Sync ISoftDeleted properties in memory
         if (document is ISoftDeleted softDeleted && provider.Mapping.DeleteStyle == DeleteStyle.SoftDelete)
@@ -278,22 +239,13 @@ internal abstract class DocumentSessionBase : QuerySession, IDocumentSession
         DeleteByObjectId<T>(id);
     }
 
-    // #273 E2c: root-document deletions route through the closed-shape storage layer.
+    // #273 E2c/E2e: all by-id deletions route through the closed-shape storage layer.
     private void DeleteByObjectId<T>(object id) where T : class
     {
-        var provider = _providers.GetProvider<T>();
-        if (provider.Mapping.DocumentType == typeof(T))
-        {
-            var session = (Weasel.Storage.IStorageSession)this;
-            var storage = (Polecat.Storage.ClosedShape.IPolecatObjectStorage<T>)session.StorageFor<T>();
-            _workTracker.Add(new Operations.ClosedShapeOperationAdapter(
-                storage.DeletionForObjectId(id, TenantId), session, id, id));
-        }
-        else
-        {
-            var op = provider.BuildDeleteById(id, TenantId);
-            _workTracker.Add(op);
-        }
+        var session = (Weasel.Storage.IStorageSession)this;
+        var storage = (Polecat.Storage.ClosedShape.IPolecatObjectStorage<T>)session.StorageFor<T>();
+        _workTracker.Add(new Operations.ClosedShapeOperationAdapter(
+            storage.DeletionForObjectId(id, TenantId), session, id, id));
     }
 
     public void HardDelete<T>(T document) where T : notnull

--- a/src/Polecat/Internal/QuerySession.cs
+++ b/src/Polecat/Internal/QuerySession.cs
@@ -246,61 +246,12 @@ internal partial class QuerySession : IQuerySession
         var provider = _providers.GetProvider<T>();
         await _tableEnsurer.EnsureTableAsync(provider, token);
 
-        // #273 E2a: root documents load through the closed-shape storage layer (shared
-        // selectors + dialect commands over the descriptor). Subclass loads (provider routed
-        // to the parent mapping) stay on the legacy path until SubClassDocumentStorage (E2e).
-        if (provider.Mapping.DocumentType == typeof(T))
-        {
-            var storage = (Polecat.Storage.ClosedShape.IPolecatObjectStorage<T>)
-                ((Weasel.Storage.IStorageSession)this).StorageFor<T>();
-            return await storage.LoadByObjectIdAsync(id, this, token);
-        }
-
-        return await LegacyLoadInternalAsync<T>(provider, id, token);
-    }
-
-    private async Task<T?> LegacyLoadInternalAsync<T>(DocumentProvider provider, object id, CancellationToken token)
-        where T : class
-    {
-        await using var cmd = new SqlCommand();
-        cmd.CommandText = provider.LoadSql;
-        cmd.Parameters.AddWithValue("@id", id);
-        cmd.Parameters.AddWithValue("@tenant_id", TenantId);
-
-        Logger.OnBeforeExecute(cmd.CommandText);
-        try
-        {
-            await using var reader = await ExecuteReaderAsync(cmd, token);
-            Logger.LogSuccess(cmd.CommandText);
-
-            if (await reader.ReadAsync(token))
-            {
-                var json = reader.GetString(1); // data column
-                T doc;
-                if (provider.DocTypeColumnIndex >= 0)
-                {
-                    var docType = reader.GetString(provider.DocTypeColumnIndex);
-                    var resolvedType = provider.Mapping.TypeFor(docType);
-                    doc = (T)Serializer.FromJson(resolvedType, json);
-                }
-                else
-                {
-                    doc = Serializer.FromJson<T>(json);
-                }
-
-                SyncVersionProperties(doc, reader, provider);
-                SyncCreatedAt(doc, reader);
-                SyncTenantId(doc, reader);
-                return doc;
-            }
-
-            return null;
-        }
-        catch (Exception ex)
-        {
-            Logger.LogFailure(cmd.CommandText, ex);
-            throw;
-        }
+        // #273 E2a/E2e: all document loads route through the closed-shape storage layer
+        // (shared selectors + dialect commands over the descriptor); subclass types resolve
+        // a SubClassPolecatStorage wrapping the hierarchy root's storage.
+        var storage = (Polecat.Storage.ClosedShape.IPolecatObjectStorage<T>)
+            ((Weasel.Storage.IStorageSession)this).StorageFor<T>();
+        return await storage.LoadByObjectIdAsync(id, this, token);
     }
 
     public async Task<IReadOnlyList<T>> LoadManyAsync<T>(IEnumerable<Guid> ids, CancellationToken token = default)
@@ -323,70 +274,10 @@ internal partial class QuerySession : IQuerySession
         var provider = _providers.GetProvider<T>();
         await _tableEnsurer.EnsureTableAsync(provider, token);
 
-        // #273 E2a: root documents load through the closed-shape storage layer.
-        if (provider.Mapping.DocumentType == typeof(T))
-        {
-            var storage = (Polecat.Storage.ClosedShape.IPolecatObjectStorage<T>)
-                ((Weasel.Storage.IStorageSession)this).StorageFor<T>();
-            return await storage.LoadManyByObjectIdsAsync(ids, this, token);
-        }
-
-        return await LegacyLoadManyInternalAsync<T>(provider, ids, token);
-    }
-
-    private async Task<IReadOnlyList<T>> LegacyLoadManyInternalAsync<T>(DocumentProvider provider, List<object> ids,
-        CancellationToken token) where T : class
-    {
-        await using var cmd = new SqlCommand();
-
-        var paramNames = new string[ids.Count];
-        for (var i = 0; i < ids.Count; i++)
-        {
-            paramNames[i] = $"@id{i}";
-            cmd.Parameters.AddWithValue(paramNames[i], ids[i]);
-        }
-
-        var softDeleteFilter = provider.Mapping.DeleteStyle == DeleteStyle.SoftDelete
-            ? " AND is_deleted = 0"
-            : "";
-        cmd.CommandText = $"{provider.SelectSql} WHERE id IN ({string.Join(", ", paramNames)}) AND tenant_id = @tenant_id{softDeleteFilter};";
-        cmd.Parameters.AddWithValue("@tenant_id", TenantId);
-
-        Logger.OnBeforeExecute(cmd.CommandText);
-        try
-        {
-            var results = new List<T>();
-            await using var reader = await ExecuteReaderAsync(cmd, token);
-            Logger.LogSuccess(cmd.CommandText);
-
-            while (await reader.ReadAsync(token))
-            {
-                var json = reader.GetString(1); // data column
-                T doc;
-                if (provider.DocTypeColumnIndex >= 0)
-                {
-                    var docType = reader.GetString(provider.DocTypeColumnIndex);
-                    var resolvedType = provider.Mapping.TypeFor(docType);
-                    doc = (T)Serializer.FromJson(resolvedType, json);
-                }
-                else
-                {
-                    doc = Serializer.FromJson<T>(json);
-                }
-
-                SyncVersionProperties(doc, reader, provider);
-                SyncCreatedAt(doc, reader);
-                SyncTenantId(doc, reader);
-                results.Add(doc);
-            }
-
-            return results;
-        }
-        catch (Exception ex)
-        {
-            Logger.LogFailure(cmd.CommandText, ex);
-            throw;
-        }
+        // #273 E2a/E2e: all document loads route through the closed-shape storage layer.
+        var storage = (Polecat.Storage.ClosedShape.IPolecatObjectStorage<T>)
+            ((Weasel.Storage.IStorageSession)this).StorageFor<T>();
+        return await storage.LoadManyByObjectIdsAsync(ids, this, token);
     }
 
     public IPolecatQueryable<T> Query<T>() where T : class
@@ -479,30 +370,6 @@ internal partial class QuerySession : IQuerySession
         if (provider.Mapping.UseOptimisticConcurrency && doc is IVersioned versioned)
         {
             versioned.Version = reader.GetGuid(7); // guid_version column
-        }
-    }
-
-    /// <summary>
-    ///     Syncs tenant_id from the DB column to ITenanted documents.
-    ///     tenant_id is at column index 6 in SelectSql.
-    /// </summary>
-    internal static void SyncTenantId<T>(T doc, DbDataReader reader) where T : class
-    {
-        if (doc is ITenanted tenanted)
-        {
-            tenanted.TenantId = reader.GetString(6); // tenant_id column
-        }
-    }
-
-    /// <summary>
-    ///     Syncs created_at from the DB column to ICreated documents.
-    ///     created_at is at column index 4 in SelectSql.
-    /// </summary>
-    internal static void SyncCreatedAt<T>(T doc, DbDataReader reader) where T : class
-    {
-        if (doc is ICreated created)
-        {
-            created.CreatedAt = reader.GetFieldValue<DateTimeOffset>(4); // created_at column
         }
     }
 

--- a/src/Polecat/Linq/PolecatLinqQueryProvider.cs
+++ b/src/Polecat/Linq/PolecatLinqQueryProvider.cs
@@ -256,41 +256,19 @@ internal class PolecatLinqQueryProvider : IPolecatAsyncQueryProvider
 
         ApplyModifiedFilters(parser);
 
-        // Materialization shape. Root documents ride the closed-shape QueryOnly storage
-        // (#273 E2d): SELECT columns come from the shared select clause (data first, then
-        // the QueryOnlyReadBinders' columns in binder order) and rows resolve through the
-        // shared QueryOnly selector. Subclass queries stay on the bespoke column shape +
-        // DeserializingSelector until the SubClassDocumentStorage analog (E2e).
+        // Materialization shape (#273 E2d/E2e). Whole-document queries ride the closed-shape
+        // QueryOnly storage: SELECT columns come from the shared select clause (data first,
+        // then the QueryOnlyReadBinders' columns in binder order) and rows resolve through
+        // the shared QueryOnly selector — for subclasses that is a SubClassPolecatStorage
+        // downcasting over the root's hierarchical selector.
         bool syncRevision = provider.Mapping.UseNumericRevisions;
         bool syncGuidVersion = provider.Mapping.UseOptimisticConcurrency;
         bool isHierarchy = provider.Mapping.IsHierarchy();
         Weasel.Storage.ISelectClause? sharedSelectClause = null;
         if (parser.Statement.SelectColumns == "data")
         {
-            if (documentType == provider.Mapping.DocumentType)
-            {
-                sharedSelectClause = _providers.ClosedShapeGraph.QueryOnlySelectClauseFor(documentType);
-                parser.Statement.SelectColumns = string.Join(", ", sharedSelectClause.SelectFields());
-            }
-            else
-            {
-                var cols = "data";
-                if (syncGuidVersion)
-                {
-                    cols = "data, version, guid_version";
-                }
-                else if (syncRevision)
-                {
-                    cols = "data, version";
-                }
-
-                if (isHierarchy)
-                {
-                    cols += ", doc_type";
-                }
-
-                parser.Statement.SelectColumns = cols;
-            }
+            sharedSelectClause = _providers.ClosedShapeGraph.QueryOnlySelectClauseFor(documentType);
+            parser.Statement.SelectColumns = string.Join(", ", sharedSelectClause.SelectFields());
         }
 
         // Add doc_type filter for subclass queries

--- a/src/Polecat/Storage/ClosedShape/PolecatClosedShapeRegistration.cs
+++ b/src/Polecat/Storage/ClosedShape/PolecatClosedShapeRegistration.cs
@@ -96,6 +96,37 @@ internal static class PolecatClosedShapeRegistration
             ConcurrencyMode.Numeric => new NumericIdentityMapPolecatStorage<TDoc, TId>(mapping, descriptor),
             _ => new UnversionedIdentityMapPolecatStorage<TDoc, TId>(mapping, descriptor)
         };
+
+    /// <summary>
+    ///     Builds the closed-shape provider for a registered SUBCLASS (#273 E2e): each flavor
+    ///     is a <see cref="SubClassPolecatStorage{T,TRoot,TId}" /> wrapping the hierarchy
+    ///     root's corresponding flavor from <paramref name="rootProvider" />.
+    /// </summary>
+    internal static object BuildSubClassProviderFor(DocumentMapping rootMapping, Type subclassType,
+        object rootProvider)
+    {
+        var idType = rootMapping.ValueTypeId?.OuterType ?? rootMapping.IdType;
+        return typeof(PolecatClosedShapeRegistration)
+            .GetMethod(nameof(BuildTypedSubClassProvider), BindingFlags.NonPublic | BindingFlags.Static)!
+            .MakeGenericMethod(subclassType, rootMapping.DocumentType, idType)
+            .Invoke(null, new[] { rootProvider, rootMapping })!;
+    }
+
+    private static DocumentProvider<T> BuildTypedSubClassProvider<T, TRoot, TId>(
+        DocumentProvider<TRoot> rootProvider, DocumentMapping rootMapping)
+        where T : notnull, TRoot
+        where TRoot : notnull
+        where TId : notnull
+    {
+        SubClassPolecatStorage<T, TRoot, TId> Wrap(IDocumentStorage<TRoot> storage)
+            => new((IDocumentStorage<TRoot, TId>)storage, rootMapping);
+
+        return new DocumentProvider<T>(
+            Wrap(rootProvider.QueryOnly),
+            Wrap(rootProvider.Lightweight),
+            Wrap(rootProvider.IdentityMap),
+            Wrap(rootProvider.DirtyTracking));
+    }
 }
 
 /// <summary>
@@ -122,8 +153,14 @@ internal sealed class PolecatProviderGraph : IProviderGraph
                 return (DocumentProvider<T>)cached;
             }
 
+            // The registry routes subclass types to the hierarchy root's provider, so a
+            // mapping whose DocumentType differs from T marks T as a registered subclass:
+            // wrap the root's flavors in SubClassPolecatStorage (#273 E2e).
             var mapping = _registry.GetProvider(typeof(T)).Mapping;
-            var provider = (DocumentProvider<T>)PolecatClosedShapeRegistration.BuildProviderFor(mapping);
+            var provider = mapping.DocumentType == typeof(T)
+                ? (DocumentProvider<T>)PolecatClosedShapeRegistration.BuildProviderFor(mapping)
+                : (DocumentProvider<T>)PolecatClosedShapeRegistration.BuildSubClassProviderFor(
+                    mapping, typeof(T), ProviderFor(mapping.DocumentType));
             _providers[typeof(T)] = provider;
             return provider;
         }

--- a/src/Polecat/Storage/ClosedShape/SubClassPolecatStorage.cs
+++ b/src/Polecat/Storage/ClosedShape/SubClassPolecatStorage.cs
@@ -1,0 +1,214 @@
+using System.Data.Common;
+using JasperFx;
+using Weasel.Core;
+using Weasel.Core.SqlGeneration;
+using Weasel.Storage;
+
+namespace Polecat.Storage.ClosedShape;
+
+/// <summary>
+///     Closed-shape storage for a registered subclass in a document hierarchy — the Polecat
+///     analog of Marten's <c>SubClassDocumentStorage</c> (#273 phase E2e). Every operation
+///     delegates to the parent (hierarchy root) storage, which owns the table, the descriptor,
+///     and the hierarchical selectors; loads downcast the materialized root-typed document to
+///     the subclass (a row holding a different subclass yields null / is filtered out, matching
+///     Marten's semantics). One wrapper instance exists per closed-shape flavor, wrapping the
+///     parent provider's corresponding flavor.
+/// </summary>
+internal sealed class SubClassPolecatStorage<T, TRoot, TId> : IDocumentStorage<T, TId>, IPolecatObjectStorage<T>
+    where T : notnull, TRoot
+    where TRoot : notnull
+    where TId : notnull
+{
+    private readonly IDocumentStorage<TRoot, TId> _parent;
+    private readonly DocumentMapping _mapping;
+    private readonly string _alias;
+
+    public SubClassPolecatStorage(IDocumentStorage<TRoot, TId> parent, DocumentMapping mapping)
+    {
+        _parent = parent;
+        _mapping = mapping;
+        _alias = mapping.AliasFor(typeof(T));
+    }
+
+    private IPolecatObjectStorage<TRoot> ParentBridge => (IPolecatObjectStorage<TRoot>)_parent;
+
+    // ---- identity ----
+
+    public Type SourceType => typeof(TRoot);
+    public Type IdType => typeof(TId);
+    public Type DocumentType => typeof(T);
+    public Type SelectedType => typeof(T);
+
+    public TId Identity(T document) => _parent.Identity(document);
+
+    public object IdentityFor(T document) => _parent.IdentityFor(document);
+
+    public TId AssignIdentity(T document, string tenantId, IStorageDatabase database)
+        => _parent.AssignIdentity(document, tenantId, database);
+
+    public void SetIdentity(T document, TId identity) => _parent.SetIdentity(document, identity);
+
+    public object RawIdentityValue(object id) => _parent.RawIdentityValue(id);
+
+    public object RawIdentityValue(TId id) => _parent.RawIdentityValue(id);
+
+    public void SetIdentityFromString(T document, string identityString)
+        => _parent.SetIdentityFromString(document, identityString);
+
+    public void SetIdentityFromGuid(T document, Guid identityGuid)
+        => _parent.SetIdentityFromGuid(document, identityGuid);
+
+    // ---- storage facts (all the parent's — the subclass shares the root's table + modes) ----
+
+    public bool UseOptimisticConcurrency => _parent.UseOptimisticConcurrency;
+    public bool UseNumericRevisions => _parent.UseNumericRevisions;
+    public TenancyStyle TenancyStyle => _parent.TenancyStyle;
+    public DbObjectName TableName => _parent.TableName;
+    public IOperationFragment DeleteFragment => _parent.DeleteFragment;
+    public IOperationFragment HardDeleteFragment => _parent.HardDeleteFragment;
+    public IReadOnlyList<IDuplicatedField> DuplicatedFields => _parent.DuplicatedFields;
+
+    // ---- select clause ----
+
+    public string FromObject => _mapping.QualifiedTableName;
+    public string[] SelectFields() => _parent.SelectFields();
+
+    public void Apply(Weasel.Core.ICommandBuilder builder) => _parent.Apply(builder);
+
+    public ISelector BuildSelector(IStorageSession session)
+        => new CastingSelector<T, TRoot>((ISelector<TRoot>)_parent.BuildSelector(session));
+
+    public ISqlFragment FilterDocuments(ISqlFragment query, IStorageSession session)
+        => new AllOfFilter(new[] { _parent.FilterDocuments(query, session), DocTypeFilter() });
+
+    public ISqlFragment? DefaultWhereFragment()
+    {
+        var docType = DocTypeFilter();
+        return _parent.DefaultWhereFragment() is { } parentWhere
+            ? new AllOfFilter(new[] { parentWhere, docType })
+            : docType;
+    }
+
+    private HardCodedFilter DocTypeFilter()
+        => new($"d.doc_type = '{_alias.Replace("'", "''")}'");
+
+    public ISqlFragment ByIdFilter(TId id) => _parent.ByIdFilter(id);
+
+    // ---- load paths (delegate to the parent's hierarchical selectors, downcast) ----
+
+    public DbCommand BuildLoadCommand(TId id, string tenantId) => _parent.BuildLoadCommand(id, tenantId);
+
+    public DbCommand BuildLoadManyCommand(TId[] ids, string tenantId) => _parent.BuildLoadManyCommand(ids, tenantId);
+
+    public async Task<T?> LoadAsync(TId id, IStorageSession session, CancellationToken token)
+    {
+        var doc = await _parent.LoadAsync(id, session, token).ConfigureAwait(false);
+        return doc is T subclass ? subclass : default;
+    }
+
+    public async Task<IReadOnlyList<T>> LoadManyAsync(TId[] ids, IStorageSession session, CancellationToken token)
+        => (await _parent.LoadManyAsync(ids, session, token).ConfigureAwait(false)).OfType<T>().ToList();
+
+    public async Task<T?> LoadProjectedAsync(TId id, IStorageDatabase database, string tenantId,
+        CancellationToken token)
+    {
+        var doc = await _parent.LoadProjectedAsync(id, database, tenantId, token).ConfigureAwait(false);
+        return doc is T subclass ? subclass : default;
+    }
+
+    public async Task<IReadOnlyList<T>> LoadManyProjectedAsync(TId[] ids, IStorageDatabase database, string tenantId,
+        CancellationToken token)
+        => (await _parent.LoadManyProjectedAsync(ids, database, tenantId, token).ConfigureAwait(false))
+            .OfType<T>().ToList();
+
+    // ---- session bookkeeping ----
+
+    public void Store(IStorageSession session, T document) => _parent.Store(session, document);
+
+    public void Store(IStorageSession session, T document, Guid? version) => _parent.Store(session, document, version);
+
+    public void Store(IStorageSession session, T document, long revision) => _parent.Store(session, document, revision);
+
+    public Guid? VersionFor(T document, IStorageSession session) => _parent.VersionFor(document, session);
+
+    public void Eject(IStorageSession session, T document) => _parent.Eject(session, document);
+
+    public void EjectById(IStorageSession session, object id) => _parent.EjectById(session, id);
+
+    public void RemoveDirtyTracker(IStorageSession session, object id) => _parent.RemoveDirtyTracker(session, id);
+
+    // ---- write operations ----
+
+    public Weasel.Storage.IStorageOperation Insert(T document, IStorageSession session, string tenantId)
+        => _parent.Insert(document, session, tenantId);
+
+    public Weasel.Storage.IStorageOperation Update(T document, IStorageSession session, string tenantId)
+        => _parent.Update(document, session, tenantId);
+
+    public Weasel.Storage.IStorageOperation Upsert(T document, IStorageSession session, string tenantId)
+        => _parent.Upsert(document, session, tenantId);
+
+    public Weasel.Storage.IStorageOperation Overwrite(T document, IStorageSession session, string tenantId)
+        => _parent.Overwrite(document, session, tenantId);
+
+    public Weasel.Storage.IStorageOperation OverwriteProjected(T document, string tenantId)
+        => _parent.OverwriteProjected(document, tenantId);
+
+    public Weasel.Storage.IStorageOperation UpsertProjected(T document, string tenantId)
+        => _parent.UpsertProjected(document, tenantId);
+
+    public Weasel.Storage.IStorageOperation InsertProjected(T document, string tenantId)
+        => _parent.InsertProjected(document, tenantId);
+
+    public Weasel.Storage.IStorageOperation UpdateProjected(T document, string tenantId)
+        => _parent.UpdateProjected(document, tenantId);
+
+    // ---- deletions ----
+
+    public IDeletion DeleteForDocument(T document, string tenantId) => _parent.DeleteForDocument(document, tenantId);
+
+    public IDeletion HardDeleteForDocument(T document, string tenantId)
+        => _parent.HardDeleteForDocument(document, tenantId);
+
+    public IDeletion DeleteForId(TId id, string tenantId) => _parent.DeleteForId(id, tenantId);
+
+    public IDeletion HardDeleteForId(TId id, string tenantId) => _parent.HardDeleteForId(id, tenantId);
+
+    public Task TruncateDocumentStorageAsync(IStorageDatabase database, CancellationToken ct = default)
+        => database.RunSqlAsync(
+            $"DELETE FROM {_mapping.QualifiedTableName} WHERE doc_type = '{_alias.Replace("'", "''")}'", ct);
+
+    // ---- IPolecatObjectStorage bridge ----
+
+    public async Task<T?> LoadByObjectIdAsync(object id, IStorageSession session, CancellationToken token)
+    {
+        var doc = await ParentBridge.LoadByObjectIdAsync(id, session, token).ConfigureAwait(false);
+        return doc is T subclass ? subclass : default;
+    }
+
+    public async Task<IReadOnlyList<T>> LoadManyByObjectIdsAsync(IReadOnlyList<object> ids, IStorageSession session,
+        CancellationToken token)
+        => (await ParentBridge.LoadManyByObjectIdsAsync(ids, session, token).ConfigureAwait(false))
+            .OfType<T>().ToList();
+
+    public IDeletion DeletionForObjectId(object id, string tenantId) => ParentBridge.DeletionForObjectId(id, tenantId);
+}
+
+/// <summary>
+///     Downcasts a root-typed selector's rows to the subclass type. The LINQ subclass path
+///     always constrains rows with a <c>doc_type</c> filter, so the cast cannot fail there.
+/// </summary>
+internal sealed class CastingSelector<T, TRoot> : ISelector<T>
+    where T : TRoot
+    where TRoot : notnull
+{
+    private readonly ISelector<TRoot> _inner;
+
+    public CastingSelector(ISelector<TRoot> inner) => _inner = inner;
+
+    public T Resolve(DbDataReader reader) => (T)_inner.Resolve(reader)!;
+
+    public async Task<T> ResolveAsync(DbDataReader reader, CancellationToken token)
+        => (T)(await _inner.ResolveAsync(reader, token).ConfigureAwait(false))!;
+}


### PR DESCRIPTION
## #273 phase E2e (increment 1 of the retirement punch-list)

Adds the Polecat analog of Marten's `SubClassDocumentStorage` and removes every remaining subclass fallback, so document hierarchies now run entirely through the shared closed-shape runtime:

- **`SubClassPolecatStorage<T,TRoot,TId>`** — delegates every operation to the hierarchy root's storage (which owns the table, descriptor, and hierarchical selectors); loads downcast the root-typed result (`doc is T`, Marten semantics), LINQ materialization wraps the root selector in a **`CastingSelector<T,TRoot>`**.
- **`PolecatProviderGraph`** detects registered subclasses (registry routes them to the root mapping) and builds a `DocumentProvider<T>` wrapping the root provider's four flavors.
- **Removed fallbacks**: `LegacyLoadInternalAsync`/`LegacyLoadManyInternalAsync` (QuerySession), the `TryBuildClosedShapeWrite` root check (now unconditional `BuildClosedShapeWrite`), the `Delete<T>(doc)`/`DeleteByObjectId` root checks, and the E2d LINQ subclass column-shape fallback. Dead `SyncCreatedAt`/`SyncTenantId` helpers deleted (`SyncVersionProperties` stays — batching still uses it).

Still bespoke (later E2e increments): `StoreObjects`, hard deletes, `NestedTenantSession`, projection storage, batching items, and the bespoke op classes themselves.

Full suite: **1399 passed / 3 skipped** (net10.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)