### PR TITLE
feat: E2e — strongly-typed id SetIdentityFromString conversion (#273)

### DIFF
--- a/src/Polecat.Tests/Storage/closed_shape_storage_tests.cs
+++ b/src/Polecat.Tests/Storage/closed_shape_storage_tests.cs
@@ -218,4 +218,32 @@ public class closed_shape_storage_tests : OneOffConfigurationsContext
     {
         public string Extra { get; set; } = string.Empty;
     }
+
+    [Fact]
+    public async Task set_identity_from_string_handles_plain_and_strongly_typed_ids()
+    {
+        await using var raw = theStore.LightweightSession();
+        var session = (IStorageSession)raw;
+
+        // Plain Guid id
+        var guidStorage = (IDocumentStorage<Target, Guid>)session.StorageFor<Target>();
+        var target = new Target();
+        var guid = Guid.NewGuid();
+        guidStorage.SetIdentityFromString(target, guid.ToString());
+        target.Id.ShouldBe(guid);
+
+        // Strongly-typed wrapper id (#273 E2e): the string converts to the inner value
+        // shape, then wraps via the mapping's compiled wrapper.
+        var typedStorage = (IDocumentStorage<StrongTypedId.Invoice, StrongTypedId.InvoiceId>)
+            session.StorageFor<StrongTypedId.Invoice>();
+        var invoice = new StrongTypedId.Invoice();
+        var inner = Guid.NewGuid();
+        typedStorage.SetIdentityFromString(invoice, inner.ToString());
+        invoice.Id.Value.ShouldBe(inner);
+
+        var viaGuid = new StrongTypedId.Invoice();
+        var inner2 = Guid.NewGuid();
+        typedStorage.SetIdentityFromGuid(viaGuid, inner2);
+        viaGuid.Id.Value.ShouldBe(inner2);
+    }
 }

--- a/src/Polecat/Storage/ClosedShape/PolecatDocumentStorage.cs
+++ b/src/Polecat/Storage/ClosedShape/PolecatDocumentStorage.cs
@@ -112,21 +112,28 @@ internal abstract class PolecatDocumentStorage<TDoc, TId> : IDocumentStorage<TDo
     public object RawIdentityValue(TId id) => _descriptor.Identification.ToRawSqlValue(id);
 
     public void SetIdentityFromString(TDoc document, string identityString)
-        => SetIdentity(document, (TId)ConvertIdentity(identityString, typeof(TId)));
+        => SetIdentity(document, ConvertIdentity(identityString));
 
     public void SetIdentityFromGuid(TDoc document, Guid identityGuid)
         => SetIdentity(document, typeof(TId) == typeof(Guid)
             ? (TId)(object)identityGuid
-            : (TId)ConvertIdentity(identityGuid.ToString(), typeof(TId)));
+            : ConvertIdentity(identityGuid.ToString()));
 
-    private static object ConvertIdentity(string raw, Type idType)
+    /// <summary>
+    ///     Converts an identity string to TId. Strongly-typed wrapper ids (#273 E2e) convert
+    ///     the string to the INNER value shape first, then wrap via the mapping's compiled
+    ///     wrapper (WrapId is a pass-through for plain ids, where InnerIdType == TId).
+    /// </summary>
+    private TId ConvertIdentity(string raw)
+        => (TId)_mapping.WrapId(ConvertRawIdentity(raw, _mapping.InnerIdType));
+
+    private static object ConvertRawIdentity(string raw, Type idType)
     {
         if (idType == typeof(string)) return raw;
         if (idType == typeof(Guid)) return Guid.Parse(raw);
         if (idType == typeof(int)) return int.Parse(raw);
         if (idType == typeof(long)) return long.Parse(raw);
-        throw new NotSupportedException(
-            $"Cannot convert identity string to {idType.FullName}; strongly-typed id string conversion lands with the E2 subclass/LINQ work.");
+        throw new NotSupportedException($"Cannot convert identity string to {idType.FullName}.");
     }
 
     // ---- storage facts ----


### PR DESCRIPTION
## #273 phase E2e (typed-id identity-setter gap)

`PolecatDocumentStorage.SetIdentityFromString`/`SetIdentityFromGuid` threw `NotSupportedException` for strongly-typed wrapper ids. They now convert the identity string to the mapping's **inner** value shape (Guid/string/int/long) and wrap it through the mapping's compiled wrapper — `WrapId` is a pass-through for plain ids, so the plain-id behavior is unchanged.

These are shared-contract members (`IIdentitySetter` via `IDocumentStorage<T,TId>`) with no Polecat-internal callers yet; the aggregation-projection paths in JasperFx.Events drive them in Marten. New closed-shape test covers plain Guid, wrapper-from-string, and wrapper-from-Guid.

Full suite: **1400 passed / 3 skipped** (net10.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)