### PR TITLE
feat: E2e — unit-of-work currency flips to Weasel.Storage.IStorageOperation (#273)

### DIFF
--- a/src/Polecat.Tests/Session/eject_operations.cs
+++ b/src/Polecat.Tests/Session/eject_operations.cs
@@ -46,7 +46,7 @@ public class eject_operations : IntegrationContext
 
         theSession.Eject(doc2);
         theSession.PendingChanges.Operations.Count.ShouldBe(1);
-        theSession.PendingChanges.Operations[0].DocumentId!.ShouldBe(doc1.Id);
+        ((Polecat.Internal.IStorageOperation)theSession.PendingChanges.Operations[0]).DocumentId!.ShouldBe(doc1.Id);
     }
 
     [Fact]

--- a/src/Polecat/Events/Daemon/PolecatProjectionBatch.cs
+++ b/src/Polecat/Events/Daemon/PolecatProjectionBatch.cs
@@ -28,7 +28,7 @@ internal class PolecatProjectionBatch : IProjectionBatch<IDocumentSession, IQuer
     private readonly ShardExecutionMode _mode;
     private readonly ResiliencePipeline _resilience;
     private readonly ConcurrentBag<IDocumentSession> _sessions = new();
-    private readonly ConcurrentQueue<IStorageOperation> _progressOps = new();
+    private readonly ConcurrentQueue<Weasel.Storage.IStorageOperation> _progressOps = new();
 
     // The change set committed by this batch, populated during ExecuteAsync. Exposed so the
     // subscription runner can hand it to the IChangeListener returned by ProcessEventsAsync.
@@ -85,7 +85,7 @@ internal class PolecatProjectionBatch : IProjectionBatch<IDocumentSession, IQuer
     public async Task ExecuteAsync(CancellationToken token)
     {
         // Collect all operations outside the lambda to keep state simple
-        var allOps = new List<IStorageOperation>();
+        var allOps = new List<Weasel.Storage.IStorageOperation>();
         var tableEnsurer = new DocumentTableEnsurer(
             new ConnectionFactory(_connectionString), _store.Options);
 
@@ -188,7 +188,9 @@ internal class PolecatProjectionBatch : IProjectionBatch<IDocumentSession, IQuer
                         foreach (var operation in ops)
                         {
                             if (commandIndex > 0) builder.StartNewCommand();
-                            operation.ConfigureCommand(builder);
+                            // Every daemon-batch op carries its own session context (bespoke
+                            // ops are fully bound; adapters captured their tenant session).
+                            StorageOperationExecution.Configure(operation, builder, session: null);
                             commandIndex++;
                         }
 

--- a/src/Polecat/IWorkTracker.cs
+++ b/src/Polecat/IWorkTracker.cs
@@ -12,9 +12,10 @@ namespace Polecat;
 public interface IWorkTracker : IChangeSet
 {
     /// <summary>
-    ///     All pending storage operations.
+    ///     All pending storage operations, in the shared closed-shape currency
+    ///     (#273 E2e: <see cref="Weasel.Storage.IStorageOperation" />).
     /// </summary>
-    IReadOnlyList<IStorageOperation> Operations { get; }
+    IReadOnlyList<Weasel.Storage.IStorageOperation> Operations { get; }
 
     /// <summary>
     ///     All pending stream actions (event appends/starts).

--- a/src/Polecat/Internal/DocumentSessionBase.cs
+++ b/src/Polecat/Internal/DocumentSessionBase.cs
@@ -539,7 +539,8 @@ internal abstract class DocumentSessionBase : QuerySession, IDocumentSession
                 for (var i = 0; i < operations.Count; i++)
                 {
                     if (i > 0) builder.StartNewCommand();
-                    operations[i].ConfigureCommand(builder);
+                    Operations.StorageOperationExecution.Configure(
+                        operations[i], builder, (Weasel.Storage.IStorageSession)this);
                 }
 
                 builder.Compile();
@@ -582,7 +583,8 @@ internal abstract class DocumentSessionBase : QuerySession, IDocumentSession
                     var insertOp = operations.FirstOrDefault(op => op.Role() == OperationRole.Insert);
                     if (insertOp != null)
                     {
-                        throw new DocumentAlreadyExistsException(insertOp.DocumentType, insertOp.DocumentId!);
+                        var documentId = insertOp is IStorageOperation bespoke ? bespoke.DocumentId : null;
+                        throw new DocumentAlreadyExistsException(insertOp.DocumentType, documentId!);
                     }
 
                     throw;

--- a/src/Polecat/Internal/OpenTelemetry/TracingSessionDecorator.cs
+++ b/src/Polecat/Internal/OpenTelemetry/TracingSessionDecorator.cs
@@ -27,7 +27,8 @@ internal static class TracingSessionDecorator
     /// <summary>
     ///     Adds verbose operation events to an activity if verbose tracking is enabled.
     /// </summary>
-    public static void AddOperationEvents(Activity? activity, IEnumerable<IStorageOperation> operations,
+    public static void AddOperationEvents(Activity? activity,
+        IEnumerable<Weasel.Storage.IStorageOperation> operations,
         OpenTelemetryOptions options)
     {
         if (activity == null) return;

--- a/src/Polecat/Internal/Operations/StorageOperationExecution.cs
+++ b/src/Polecat/Internal/Operations/StorageOperationExecution.cs
@@ -1,0 +1,27 @@
+namespace Polecat.Internal.Operations;
+
+/// <summary>
+///     Flush-time dispatch over the shared operation currency (#273 E2e). Bespoke Polecat
+///     operations — including the closed-shape adapter, which forwards to its captured
+///     (possibly tenant-scoped) session — configure through their one-arg entry point; raw
+///     shared operations need the executing session handed in. The async daemon's batch
+///     flush aggregates operations from multiple tenant sessions and has no single session
+///     in scope, so it passes null and relies on every queued operation carrying its own
+///     session context.
+/// </summary>
+internal static class StorageOperationExecution
+{
+    internal static void Configure(Weasel.Storage.IStorageOperation op, ICommandBuilder builder,
+        Weasel.Storage.IStorageSession? session)
+    {
+        if (op is IStorageOperation bespoke)
+        {
+            bespoke.ConfigureCommand(builder);
+            return;
+        }
+
+        op.ConfigureCommand(builder, session ?? throw new InvalidOperationException(
+            $"Operation {op.GetType().FullName} requires an executing session, but this execution " +
+            "path (the async daemon batch) has none — queue it through a session-bound adapter."));
+    }
+}

--- a/src/Polecat/Internal/WorkTracker.cs
+++ b/src/Polecat/Internal/WorkTracker.cs
@@ -9,14 +9,14 @@ namespace Polecat.Internal;
 /// </summary>
 internal class WorkTracker : IWorkTracker
 {
-    private readonly List<IStorageOperation> _operations = [];
-    private ImmutableList<IStorageOperation>? _operationsSnapshot;
+    private readonly List<Weasel.Storage.IStorageOperation> _operations = [];
+    private ImmutableList<Weasel.Storage.IStorageOperation>? _operationsSnapshot;
 
     private readonly List<StreamAction> _streams = [];
     private ImmutableList<StreamAction>? _streamsSnapshot;
     private readonly Lock _stateLock = new();
 
-    public IReadOnlyList<IStorageOperation> Operations
+    public IReadOnlyList<Weasel.Storage.IStorageOperation> Operations
     {
         get
         {
@@ -57,7 +57,7 @@ internal class WorkTracker : IWorkTracker
     public IEnumerable<StreamAction> GetStreams() => Streams;
     public IChangeSet Clone() => new ChangeSet(Operations, Streams);
 
-    public void Add(IStorageOperation operation)
+    public void Add(Weasel.Storage.IStorageOperation operation)
     {
         lock (_stateLock)
         {
@@ -107,8 +107,8 @@ internal class WorkTracker : IWorkTracker
         {
             var removed = _operations.RemoveAll(op =>
                 op.DocumentType == documentType
-                && op.DocumentId != null
-                && op.DocumentId.Equals(id));
+                && OperationIdentity(op) is { } opId
+                && opId.Equals(id));
 
             if (removed > 0)
                 _operationsSnapshot = null;
@@ -125,4 +125,17 @@ internal class WorkTracker : IWorkTracker
                 _operationsSnapshot = null;
         }
     }
+
+    /// <summary>
+    ///     Per-operation document identity for eject matching over the shared currency
+    ///     (#273 E2e): bespoke Polecat operations (including the closed-shape adapter)
+    ///     carry DocumentId; shared deletions carry Id.
+    /// </summary>
+    private static object? OperationIdentity(Weasel.Storage.IStorageOperation op)
+        => op switch
+        {
+            IStorageOperation bespoke => bespoke.DocumentId,
+            Weasel.Storage.IDeletion deletion => deletion.Id,
+            _ => null
+        };
 }

--- a/src/Polecat/Services/ChangeSet.cs
+++ b/src/Polecat/Services/ChangeSet.cs
@@ -14,10 +14,10 @@ namespace Polecat.Services;
 /// </summary>
 internal sealed class ChangeSet : IChangeSet
 {
-    private readonly IReadOnlyList<IStorageOperation> _operations;
+    private readonly IReadOnlyList<Weasel.Storage.IStorageOperation> _operations;
     private readonly IReadOnlyList<StreamAction> _streams;
 
-    public ChangeSet(IReadOnlyList<IStorageOperation> operations, IReadOnlyList<StreamAction> streams)
+    public ChangeSet(IReadOnlyList<Weasel.Storage.IStorageOperation> operations, IReadOnlyList<StreamAction> streams)
     {
         _operations = operations;
         _streams = streams;
@@ -33,20 +33,41 @@ internal sealed class ChangeSet : IChangeSet
     // Already an immutable snapshot, so cloning is a no-op copy of the same backing lists.
     public IChangeSet Clone() => new ChangeSet(_operations, _streams);
 
-    internal static IEnumerable<object> UpdatedFrom(IEnumerable<IStorageOperation> operations)
-        => operations.OfType<IDocumentStorageOperation>()
+    internal static IEnumerable<object> UpdatedFrom(IEnumerable<Weasel.Storage.IStorageOperation> operations)
+        => operations
             .Where(x => x.Role() is OperationRole.Update or OperationRole.Upsert)
-            .Select(x => x.Document);
+            .Select(DocumentOf)
+            .Where(d => d is not null)!;
 
-    internal static IEnumerable<object> InsertedFrom(IEnumerable<IStorageOperation> operations)
-        => operations.OfType<IDocumentStorageOperation>()
+    internal static IEnumerable<object> InsertedFrom(IEnumerable<Weasel.Storage.IStorageOperation> operations)
+        => operations
             .Where(x => x.Role() == OperationRole.Insert)
-            .Select(x => x.Document);
+            .Select(DocumentOf)
+            .Where(d => d is not null)!;
 
-    internal static IEnumerable<IDeletion> DeletedFrom(IEnumerable<IStorageOperation> operations)
+    internal static IEnumerable<IDeletion> DeletedFrom(IEnumerable<Weasel.Storage.IStorageOperation> operations)
         => operations
             .Where(x => x.Role() == OperationRole.Deletion)
-            .Select(x => (IDeletion)new Deletion(x.DocumentType, x.DocumentId));
+            .Select(x => (IDeletion)new Deletion(x.DocumentType, IdentityOf(x)));
+
+    // #273 E2e: the unit of work speaks the shared currency. Bespoke Polecat operations
+    // (including the closed-shape adapter) and raw shared operations both surface their
+    // document / identity here.
+    private static object? DocumentOf(Weasel.Storage.IStorageOperation op)
+        => op switch
+        {
+            IDocumentStorageOperation bespoke => bespoke.Document,
+            Weasel.Storage.IDocumentStorageOperation shared => shared.Document,
+            _ => null
+        };
+
+    private static object? IdentityOf(Weasel.Storage.IStorageOperation op)
+        => op switch
+        {
+            IStorageOperation bespoke => bespoke.DocumentId,
+            Weasel.Storage.IDeletion deletion => deletion.Id,
+            _ => null
+        };
 }
 
 /// <summary>


### PR DESCRIPTION
## #273 phase E2e (op-currency flip — final punch-list increment)

The session unit of work now speaks the shared closed-shape operation contract end to end:

- **`IWorkTracker.Operations`** (public), **`WorkTracker`**, **`ChangeSet`**, the OpenTelemetry decorator, and the async daemon's batch queue all hold `Weasel.Storage.IStorageOperation`. Bespoke event-side ops and `ClosedShapeOperationAdapter` flow through as subtypes — no change to the ~20 remaining bespoke op classes.
- **Flush-time dispatch** (`StorageOperationExecution.Configure`): bespoke ops configure through their one-arg entry point (the adapter forwards to its captured — possibly tenant-scoped — session); raw shared ops get the executing session. The daemon batch passes no session by design: it aggregates ops from multiple tenant sessions, each carrying its own context.
- **Eject + change-set derivation** handle both currencies: bespoke `DocumentId`/`Document` and shared `IDeletion.Id`/`IDocumentStorageOperation.Document`.
- `WorkTracker.cs` (the mixed-EOL file) was edited with per-line-ending preservation — the diff touches only the intended lines.

**Public break**: the element type of `IWorkTracker.Operations` (the #269 listener-surface ripple). `IChangeSet` — `Updated`/`Inserted`/`Deleted`/events — is unchanged.

Full suite: **1400 passed / 3 skipped** (net10.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)