### PR TITLE
Bump JasperFx + JasperFx.Events to 2.24.0 (cross-product rebuild cap, jasperfx#498)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,8 +22,8 @@
              IEventDatabase.QueryDeadLetterEventsAsync (dead-letter row drill-in), DeadLetterEvent.TenantId,
              and the tenant-aware daemon surface. Polecat implements the dead-letter row query + per-tenant
              FetchDeadLetterCountsAsync below. -->
-        <PackageVersion Include="JasperFx" Version="2.23.0" />
-        <PackageVersion Include="JasperFx.Events" Version="2.23.0" />
+        <PackageVersion Include="JasperFx" Version="2.24.0" />
+        <PackageVersion Include="JasperFx.Events" Version="2.24.0" />
         <!-- Pin the sibling JasperFx packages for parity with Marten 9's matrix
              even though Polecat doesn't currently reference them directly —
              keeps the lockstep matrix coherent when transitive resolution


### PR DESCRIPTION
Consumes **JasperFx 2.24.0** — the intra-projection tenant/shard cross-product rebuild cap (jasperfx#497 / jasperfx#498, epic jasperfx#486 WS3 follow-up).

Pure pin bump (`JasperFx` + `JasperFx.Events` 2.23.0 → 2.24.0; source-generator pins unchanged). Polecat + Polecat.Tests Release build clean locally.

Marten companion: JasperFx/marten#4899.

🤖 Generated with [Claude Code](https://claude.com/claude-code)