### PR TITLE
chore: bump Weasel + Weasel.Storage to 9.16.0 (unblocks event dialect; #273)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -54,9 +54,9 @@
              storage contracts extracted from Marten (marten#4821/#4830, weasel#329/#331) —
              IStorageSession / IStorageDatabase / IStorageSerializer / IDocumentStorage /
              IStorageDialect. This is the shared runtime Polecat retargets onto for #273. -->
-        <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.13.0" />
-        <PackageVersion Include="Weasel.SqlServer" Version="9.13.0" />
-        <PackageVersion Include="Weasel.Storage" Version="9.13.0" />
+        <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.16.0" />
+        <PackageVersion Include="Weasel.SqlServer" Version="9.16.0" />
+        <PackageVersion Include="Weasel.Storage" Version="9.16.0" />
 
         <!-- Strongly typed IDs -->
         <PackageVersion Include="StronglyTypedId" Version="1.0.0-beta08" />

--- a/src/Polecat.Tests/Storage/storage_operation_seam_tests.cs
+++ b/src/Polecat.Tests/Storage/storage_operation_seam_tests.cs
@@ -56,6 +56,9 @@ public class storage_operation_seam_tests
         public void Append(string sql) { }
         public void Append(char character) { }
         public void AppendParameters(params object[] parameters) { }
+        // Weasel 9.16.0 (weasel#339): dialect-neutral grouped-parameter seam on Weasel.Core.ICommandBuilder.
+        public System.Data.Common.DbParameter AppendParameter(object value) => throw new NotSupportedException();
+        public Weasel.Core.IGroupedParameterBuilder CreateGroupedParameterBuilder(char? separator = null) => throw new NotSupportedException();
         public System.Data.Common.DbParameter[] AppendWithDbParameters(string text) => [];
         public System.Data.Common.DbParameter[] AppendWithDbParameters(string text, char placeholder) => [];
         public void StartNewCommand() { }

--- a/src/Polecat/Linq/Joins/AliasingCommandBuilder.cs
+++ b/src/Polecat/Linq/Joins/AliasingCommandBuilder.cs
@@ -41,6 +41,13 @@ internal class AliasingCommandBuilder : ICommandBuilder
     public SqlParameter AppendParameter(object? value, SqlDbType? dbType) => _inner.AppendParameter(value, dbType);
     public void AppendParameters(params object[] parameters) => _inner.AppendParameters(parameters);
     public IGroupedParameterBuilder CreateGroupedParameterBuilder(char? seperator = null) => _inner.CreateGroupedParameterBuilder(seperator);
+
+    // Weasel 9.16.0 (weasel#339): the SqlServer ICommandBuilder members now `new`-shadow the
+    // dialect-neutral Weasel.Core.ICommandBuilder declarations (which return DbParameter /
+    // Weasel.Core.IGroupedParameterBuilder). Satisfy the Core contract explicitly by delegating
+    // to the inner builder — the SqlClient-typed overloads above satisfy the SqlServer shadows.
+    System.Data.Common.DbParameter Weasel.Core.ICommandBuilder.AppendParameter(object value) => _inner.AppendParameter(value);
+    Weasel.Core.IGroupedParameterBuilder Weasel.Core.ICommandBuilder.CreateGroupedParameterBuilder(char? seperator) => _inner.CreateGroupedParameterBuilder(seperator);
     public SqlParameter[] AppendWithParameters(string text) => _inner.AppendWithParameters(JoinStatement.AliasLocator(text, _alias));
     public SqlParameter[] AppendWithParameters(string text, char placeholder) => _inner.AppendWithParameters(JoinStatement.AliasLocator(text, _alias), placeholder);
     // Weasel 9.7.0 (weasel#324): dialect-neutral DbParameter[] variants on the shared Weasel.Core.ICommandBuilder.


### PR DESCRIPTION
Rolls the Weasel family (Weasel, Weasel.SqlServer, Weasel.Storage, Weasel.EntityFrameworkCore) from **9.13.0 → 9.16.0**.

## Why
9.16.0 relocates the closed-shape **event-storage** hierarchy — `EventStorage<TId>`, `IEventStoreSqlDialect`, and the three append-mode descriptors (Rich / Quick / QuickWithServerTimestamps) — into `Weasel.Storage` (marten#4821 event E2/E3). That is the gate for Polecat's SQL Server **event dialect**, the marquee remaining item of #273.

## Compile changes
9.16.0's dialect-neutral grouped-parameter seam (weasel#339) makes the SqlServer `ICommandBuilder` members `new`-shadow the `Weasel.Core.ICommandBuilder` declarations (which return `DbParameter` / `Weasel.Core.IGroupedParameterBuilder`). Implementers must now satisfy **both** contracts:
- `AliasingCommandBuilder` — explicit `Weasel.Core.ICommandBuilder` implementations of `AppendParameter(object)` and `CreateGroupedParameterBuilder`, delegating to the inner builder (the SqlClient-typed overloads satisfy the shadows).
- `storage_operation_seam_tests` test double — stubs the two new Core members.

## Verification
Full net10 suite green: **1405 passed / 0 failed / 3 skipped**.

Part of #273.

🤖 Generated with [Claude Code](https://claude.com/claude-code)