### PR TITLE
fix: strongly-typed id documents store id as inner primitive type (#296)

### DIFF
--- a/src/Polecat.Tests/StrongTypedId/strong_typed_id_column_type_tests.cs
+++ b/src/Polecat.Tests/StrongTypedId/strong_typed_id_column_type_tests.cs
@@ -1,0 +1,184 @@
+using Microsoft.Data.SqlClient;
+using Polecat.TestUtils;
+using Polecat.Tests.Harness;
+using Shouldly;
+
+namespace Polecat.Tests.StrongTypedId;
+
+// #296: strongly-typed id documents must persist the id column as the INNER primitive type
+// (uniqueidentifier / int / bigint), not varchar(250) derived from the wrapper type. Otherwise the
+// shared writeable selectors — used by Lightweight/IdentityMap database reads — throw
+// InvalidCastException when they read the inner value via GetFieldValue<TInner> against a varchar
+// column. QueryOnly reads (QuerySession) exclude the id column and so never tripped this, which is
+// why the earlier smoke tests loaded through a QuerySession and stayed green.
+[Collection("integration")]
+public class strong_typed_id_column_type_tests : IntegrationContext
+{
+    public strong_typed_id_column_type_tests(DefaultStoreFixture fixture) : base(fixture)
+    {
+    }
+
+    public override async Task InitializeAsync()
+    {
+        await StoreOptions(opts => { opts.DatabaseSchemaName = "strong_id_column"; });
+    }
+
+    [Fact]
+    public async Task guid_wrapper_id_column_is_uniqueidentifier()
+    {
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Store(new Invoice { Name = "Schema" });
+            await session.SaveChangesAsync();
+        }
+
+        var columns = await SchemaInspector.GetColumnInfoAsync("pc_doc_invoice", "strong_id_column");
+        var id = columns.Single(c => c.Name == "id");
+        id.TypeName.ShouldBe("uniqueidentifier");
+    }
+
+    [Fact]
+    public async Task int_wrapper_id_column_is_int()
+    {
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Store(new OrderItem { Name = "Schema" });
+            await session.SaveChangesAsync();
+        }
+
+        var columns = await SchemaInspector.GetColumnInfoAsync("pc_doc_orderitem", "strong_id_column");
+        columns.Single(c => c.Name == "id").TypeName.ShouldBe("int");
+    }
+
+    [Fact]
+    public async Task long_wrapper_id_column_is_bigint()
+    {
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Store(new Issue { Name = "Schema" });
+            await session.SaveChangesAsync();
+        }
+
+        var columns = await SchemaInspector.GetColumnInfoAsync("pc_doc_issue", "strong_id_column");
+        columns.Single(c => c.Name == "id").TypeName.ShouldBe("bigint");
+    }
+
+    [Fact]
+    public async Task string_wrapper_id_column_stays_varchar()
+    {
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Store(new Team { Id = new TeamId("t-1"), Name = "Schema" });
+            await session.SaveChangesAsync();
+        }
+
+        var columns = await SchemaInspector.GetColumnInfoAsync("pc_doc_team", "strong_id_column");
+        columns.Single(c => c.Name == "id").TypeName.ShouldBe("varchar");
+    }
+
+    // The core regression: a Lightweight database read (fresh session, empty identity map so the
+    // read must hit the writeable selector) of a wrapper-id document previously threw
+    // InvalidCastException. With the inner-typed id column it round-trips.
+    [Fact]
+    public async Task lightweight_database_read_of_guid_wrapper_id_round_trips()
+    {
+        var invoice = new Invoice { Name = "Loaded" };
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Store(invoice);
+            await session.SaveChangesAsync();
+        }
+
+        await using var fresh = theStore.LightweightSession();
+        var loaded = await fresh.LoadAsync<Invoice>(invoice.Id.Value);
+        loaded.ShouldNotBeNull();
+        loaded!.Name.ShouldBe("Loaded");
+    }
+
+    [Fact]
+    public async Task lightweight_database_read_of_int_wrapper_id_round_trips()
+    {
+        var item = new OrderItem { Name = "Loaded" };
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Store(item);
+            await session.SaveChangesAsync();
+        }
+
+        await using var fresh = theStore.LightweightSession();
+        var loaded = await fresh.LoadAsync<OrderItem>(item.Id.Value);
+        loaded.ShouldNotBeNull();
+        loaded!.Name.ShouldBe("Loaded");
+    }
+
+    [Fact]
+    public async Task lightweight_database_read_of_long_wrapper_id_round_trips()
+    {
+        var issue = new Issue { Name = "Loaded" };
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Store(issue);
+            await session.SaveChangesAsync();
+        }
+
+        await using var fresh = theStore.LightweightSession();
+        var loaded = await fresh.LoadAsync<Issue>(issue.Id.Value);
+        loaded.ShouldNotBeNull();
+        loaded!.Name.ShouldBe("Loaded");
+    }
+
+    // The migration story: a legacy table created before #296 carries a varchar(250) id column
+    // holding the guid as a string. The first document access (which runs the lazy schema ensure
+    // before any read/write — see QuerySession.LoadInternalAsync) converts it to uniqueidentifier
+    // in place (drop PK, ALTER COLUMN, re-add PK) — data preserved — so the pre-existing row is then
+    // readable through the Lightweight writeable selector. (Weasel's bulk ApplyAll leaves the PK
+    // column type alone; the conversion is the ensurer's job and always precedes real document I/O.)
+    [Fact]
+    public async Task migrates_legacy_varchar_id_column_in_place_preserving_data()
+    {
+        const string schema = "strong_id_migrate";
+        var legacyId = new Guid("11111111-1111-1111-1111-111111111111");
+
+        await using (var conn = new SqlConnection(ConnectionSource.ConnectionString))
+        {
+            await conn.OpenAsync();
+            await ExecuteAsync(conn, $"IF SCHEMA_ID('{schema}') IS NULL EXEC('CREATE SCHEMA {schema}')");
+            await ExecuteAsync(conn, $"DROP TABLE IF EXISTS {schema}.pc_doc_invoice");
+            // Legacy shape: id is varchar(250) as pre-#296 tables were created.
+            await ExecuteAsync(conn, $"""
+                CREATE TABLE {schema}.pc_doc_invoice (
+                    id varchar(250) NOT NULL,
+                    data json NOT NULL,
+                    version bigint NOT NULL,
+                    last_modified datetimeoffset NOT NULL DEFAULT SYSDATETIMEOFFSET(),
+                    created_at datetimeoffset NOT NULL DEFAULT SYSDATETIMEOFFSET(),
+                    dotnet_type varchar(500) NULL,
+                    tenant_id varchar(250) NOT NULL DEFAULT '*DEFAULT*',
+                    CONSTRAINT pkey_pc_doc_invoice_id PRIMARY KEY (id));
+                """);
+            // Polecat serializes with CamelCase by default, so the legacy body uses camelCase keys.
+            var json = "{\"id\":{\"value\":\"" + legacyId + "\"},\"name\":\"Legacy\"}";
+            await ExecuteAsync(conn,
+                $"INSERT INTO {schema}.pc_doc_invoice (id, data, version) VALUES ('{legacyId}', '{json}', 1);");
+        }
+
+        await StoreOptions(opts => { opts.DatabaseSchemaName = schema; });
+
+        // First document access triggers the lazy ensure, which converts the id column in place,
+        // then loads the pre-existing row through the Lightweight writeable selector.
+        await using var session = theStore.LightweightSession();
+        var loaded = await session.LoadAsync<Invoice>(legacyId);
+        loaded.ShouldNotBeNull();
+        loaded!.Name.ShouldBe("Legacy");
+
+        var columns = await SchemaInspector.GetColumnInfoAsync("pc_doc_invoice", schema);
+        columns.Single(c => c.Name == "id").TypeName.ShouldBe("uniqueidentifier");
+    }
+
+    private static async Task ExecuteAsync(SqlConnection conn, string sql)
+    {
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = sql;
+        await cmd.ExecuteNonQueryAsync();
+    }
+}

--- a/src/Polecat.Tests/StrongTypedId/strong_typed_id_column_type_tests.cs
+++ b/src/Polecat.Tests/StrongTypedId/strong_typed_id_column_type_tests.cs
@@ -144,11 +144,13 @@ public class strong_typed_id_column_type_tests : IntegrationContext
             await conn.OpenAsync();
             await ExecuteAsync(conn, $"IF SCHEMA_ID('{schema}') IS NULL EXEC('CREATE SCHEMA {schema}')");
             await ExecuteAsync(conn, $"DROP TABLE IF EXISTS {schema}.pc_doc_invoice");
-            // Legacy shape: id is varchar(250) as pre-#296 tables were created.
+            // Legacy shape: id is varchar(250) as pre-#296 tables were created. The data column type
+            // follows the engine — native json on SQL Server 2025, nvarchar(max) on Azure SQL Edge.
+            var dataType = ConnectionSource.SupportsNativeJson ? "json" : "nvarchar(max)";
             await ExecuteAsync(conn, $"""
                 CREATE TABLE {schema}.pc_doc_invoice (
                     id varchar(250) NOT NULL,
-                    data json NOT NULL,
+                    data {dataType} NOT NULL,
                     version bigint NOT NULL,
                     last_modified datetimeoffset NOT NULL DEFAULT SYSDATETIMEOFFSET(),
                     created_at datetimeoffset NOT NULL DEFAULT SYSDATETIMEOFFSET(),

--- a/src/Polecat/Internal/DocumentTableEnsurer.cs
+++ b/src/Polecat/Internal/DocumentTableEnsurer.cs
@@ -86,6 +86,12 @@ internal class DocumentTableEnsurer
             // never reconciled afterward, so a later schema apply can't clobber the partitions the
             // app/DBA manages at runtime (SPLIT new months, SWITCH/DROP old ones for retention).
             var table = new DocumentTable(provider.Mapping);
+
+            // #296: strongly-typed-id tables created before the inner-type fix carry a varchar(250)
+            // id column, which trips InvalidCastException in the shared writeable selectors (they
+            // read GetFieldValue<TInner>). Convert it to the inner primitive type in place — drop
+            // PK, ALTER COLUMN, re-add PK — before Weasel diffs the table, so the diff stays clean.
+            await ConvertStrongTypedIdColumnIfNeededAsync(conn, provider.Mapping, table, token);
             var autoCreate = provider.Mapping.Partitioning is { ExternallyManaged: true }
                 ? AutoCreate.CreateOnly
                 : AutoCreate.CreateOrUpdate;
@@ -189,6 +195,64 @@ internal class DocumentTableEnsurer
                     SELECT 1 FROM sys.columns c
                     WHERE c.object_id = @oid AND c.name = 'version' AND TYPE_NAME(c.system_type_id) = 'int')
                     ALTER TABLE {qualifiedTableName} ALTER COLUMN [version] bigint NOT NULL;
+            END
+            """;
+        await cmd.ExecuteNonQueryAsync(token);
+    }
+
+    /// <summary>
+    ///     #296: converts a legacy <c>varchar(250)</c> id column on a strongly-typed-id table to the
+    ///     inner primitive type (<c>uniqueidentifier</c>/<c>int</c>/<c>bigint</c>) in place, so the
+    ///     shared writeable selectors (which read the inner value via <c>GetFieldValue&lt;TInner&gt;</c>)
+    ///     can materialize it. Drops the primary key, widens the column — existing guid/numeric string
+    ///     values convert implicitly — then restores the primary key from the modeled definition. A
+    ///     no-op once the column is already the native type (or the table is absent), and skipped for
+    ///     string-backed wrappers (they legitimately stay <c>varchar(250)</c>) and partitioned tables
+    ///     (whose clustered-PK/partition-scheme coupling makes an in-place rebuild unsafe — those keep
+    ///     the correct type from creation and any pre-existing table is a manual migration).
+    /// </summary>
+    private static async Task ConvertStrongTypedIdColumnIfNeededAsync(SqlConnection conn,
+        DocumentMapping mapping, DocumentTable table, CancellationToken token)
+    {
+        if (!mapping.IsStrongTypedId || mapping.Partitioning is not null)
+        {
+            return;
+        }
+
+        var targetType = mapping.InnerIdType == typeof(Guid) ? "uniqueidentifier"
+            : mapping.InnerIdType == typeof(int) ? "int"
+            : mapping.InnerIdType == typeof(long) ? "bigint"
+            : null;
+        if (targetType is null)
+        {
+            return; // string-backed wrapper — the varchar(250) column is correct.
+        }
+
+        var qualifiedTableName = mapping.QualifiedTableName;
+        var pkColumnList = string.Join(", ", table.PrimaryKeyColumns.Select(c => $"[{c}]"));
+
+        // The table/PK names are derived from the document type (not user input) and inlined; only
+        // the discovered PK-constraint name needs dynamic SQL (SQL Server forbids function calls
+        // inside EXEC(...), hence SET-then-EXEC). ALTER COLUMN of a PK member requires dropping the
+        // key first, so the whole convert runs as one guarded batch.
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"""
+            DECLARE @oid int = OBJECT_ID('{qualifiedTableName}');
+            IF @oid IS NOT NULL AND EXISTS (
+                SELECT 1 FROM sys.columns c
+                WHERE c.object_id = @oid AND c.name = 'id'
+                  AND TYPE_NAME(c.system_type_id) IN ('varchar', 'nvarchar', 'char', 'nchar'))
+            BEGIN
+                DECLARE @pk sysname, @sql nvarchar(max);
+                SELECT @pk = kc.name FROM sys.key_constraints kc
+                    WHERE kc.parent_object_id = @oid AND kc.type = 'PK';
+                IF @pk IS NOT NULL
+                BEGIN
+                    SET @sql = 'ALTER TABLE {qualifiedTableName} DROP CONSTRAINT ' + QUOTENAME(@pk);
+                    EXEC(@sql);
+                END
+                ALTER TABLE {qualifiedTableName} ALTER COLUMN [id] {targetType} NOT NULL;
+                ALTER TABLE {qualifiedTableName} ADD CONSTRAINT {table.PrimaryKeyName} PRIMARY KEY ({pkColumnList});
             END
             """;
         await cmd.ExecuteNonQueryAsync(token);

--- a/src/Polecat/Storage/DocumentTable.cs
+++ b/src/Polecat/Storage/DocumentTable.cs
@@ -20,9 +20,14 @@ internal class DocumentTable : Table
             AddColumn(JasperFx.StorageConstants.TenantIdColumn, "varchar(250)").AsPrimaryKey().NotNull();
         }
 
-        var idColumnType = mapping.IdType == typeof(Guid) ? "uniqueidentifier"
-            : mapping.IdType == typeof(int) ? "int"
-            : mapping.IdType == typeof(long) ? "bigint"
+        // #296: strongly-typed ids persist their INNER primitive value (ValueTypeIdentification
+        // unwraps to TInner on write and reads GetFieldValue<TInner> on read), so the id column
+        // must be the inner type — uniqueidentifier/int/bigint — NOT varchar(250) derived from the
+        // wrapper type. A varchar id column trips InvalidCastException in the shared writeable
+        // selectors on any Lightweight/IdentityMap database read of a wrapper-id document.
+        var idColumnType = mapping.InnerIdType == typeof(Guid) ? "uniqueidentifier"
+            : mapping.InnerIdType == typeof(int) ? "int"
+            : mapping.InnerIdType == typeof(long) ? "bigint"
             : "varchar(250)";
 
         AddColumn("id", idColumnType).AsPrimaryKey().NotNull();


### PR DESCRIPTION
## Problem
`DocumentTable` derived the id column type from `mapping.IdType` — the **wrapper** type of a strongly-typed id — so every wrapper-id table got `varchar(250)` even when the inner value is `Guid`/`int`/`long`.

`ValueTypeIdentification` persists and reads the **inner** value (`ToRawSqlValue` unwraps to `TInner`; `ReadIdFromReader` reads `GetFieldValue<TInner>`), so the shared writeable selectors threw `InvalidCastException` on any **Lightweight/IdentityMap** database read of a wrapper-id document (e.g. `LightweightSession.LoadAsync<Invoice>(id)`). QueryOnly reads exclude the id column, which is why the existing smoke tests (loading through a `QuerySession`) stayed green and the bug was latent.

## Fix
- **`DocumentTable`**: map the id column from `mapping.InnerIdType` (`uniqueidentifier`/`int`/`bigint`; string-backed wrappers stay `varchar(250)`).
- **`DocumentTableEnsurer.ConvertStrongTypedIdColumnIfNeededAsync`**: convert a legacy `varchar` id column to the inner type **in place** (drop PK → `ALTER COLUMN` → re-add PK) before the schema diff. It runs on the lazy first-use ensure, which always precedes real document I/O (`QuerySession.LoadInternalAsync` ensures the table first), so an upgrading app's first document access converts the table transparently — data preserved (guid/numeric string values convert implicitly). Skipped for string-backed wrappers and partitioned tables.

## Tests
- id column type per inner type (guid→uniqueidentifier, int→int, long→bigint, string→varchar)
- Lightweight database round-trips for guid/int/long wrappers (the previously-throwing writeable-selector path)
- in-place migration over a pre-seeded legacy `varchar` id table, asserting conversion + data survival

Closes #296. Part of #273.

🤖 Generated with [Claude Code](https://claude.com/claude-code)