### PR TITLE
fix: single-tenant document tables have no tenant_id column (#234)

### DIFF
--- a/docs/schema/storage.md
+++ b/docs/schema/storage.md
@@ -4,19 +4,26 @@ Polecat stores documents as JSON in SQL Server 2025 using the native `json` data
 
 ## Document Table Structure
 
-Each document type gets its own table with the prefix `pc_doc_`:
+Each document type gets its own table with the prefix `pc_doc_`. A plain, single-tenant document
+type produces exactly these columns — no `tenant_id` (that is conjoined-tenancy only, see below):
 
 ```sql
 CREATE TABLE dbo.pc_doc_user (
     id uniqueidentifier NOT NULL,
     data json NOT NULL,
-    type nvarchar(250) NULL,
+    version bigint NOT NULL,
     last_modified datetimeoffset NOT NULL DEFAULT SYSDATETIMEOFFSET(),
-    created datetimeoffset NOT NULL DEFAULT SYSDATETIMEOFFSET(),
-    dotnet_type nvarchar(500) NULL,
-    CONSTRAINT pk_pc_doc_user PRIMARY KEY (id)
+    created_at datetimeoffset NOT NULL DEFAULT SYSDATETIMEOFFSET(),
+    dotnet_type varchar(500) NULL,
+    CONSTRAINT pkey_pc_doc_user_id PRIMARY KEY (id)
 );
 ```
+
+The `version` column is always present (a `bigint` that carries optimistic/numeric concurrency
+revisions when configured); `last_modified`, `created_at`, and `dotnet_type` are the standard
+metadata columns. The `tenant_id` column is **only** created for conjoined multi-tenancy — a
+single-tenant store keeps every document under the default tenant implicitly, with no `tenant_id`
+column and no per-query tenant filter.
 
 ## ID Column Types
 

--- a/src/Polecat.Tests/Diagnostics/diagnostic_operations.cs
+++ b/src/Polecat.Tests/Diagnostics/diagnostic_operations.cs
@@ -107,7 +107,8 @@ public class diagnostic_operations : IntegrationContext
 
         sql.ShouldContain("SELECT");
         sql.ShouldContain("pc_doc_user");
-        sql.ShouldContain("tenant_id");
+        // #234: single-tenant queries carry no implicit tenant_id filter.
+        sql.ShouldNotContain("tenant_id");
     }
 
     [Fact]

--- a/src/Polecat.Tests/Reading/advanced_sql_query.cs
+++ b/src/Polecat.Tests/Reading/advanced_sql_query.cs
@@ -44,7 +44,7 @@ public class advanced_sql_query : IntegrationContext
 
         await using var query = theStore.QuerySession();
         var name = (await query.AdvancedSql.QueryAsync<string>(
-            "SELECT JSON_VALUE(data, '$.name') FROM advsql_scalar.pc_doc_advsqldoc WHERE tenant_id = '*DEFAULT*'",
+            "SELECT JSON_VALUE(data, '$.name') FROM advsql_scalar.pc_doc_advsqldoc",
             CancellationToken.None)).First();
 
         name.ShouldBe("Max");
@@ -107,7 +107,7 @@ public class advanced_sql_query : IntegrationContext
 
         await using var query = theStore.QuerySession();
         var docs = await query.AdvancedSql.QueryAsync<AdvSqlDoc>(
-            "SELECT id, data FROM advsql_docs.pc_doc_advsqldoc WHERE tenant_id = '*DEFAULT*' ORDER BY JSON_VALUE(data, '$.name')",
+            "SELECT id, data FROM advsql_docs.pc_doc_advsqldoc ORDER BY JSON_VALUE(data, '$.name')",
             CancellationToken.None);
 
         docs.Count.ShouldBe(2);
@@ -129,7 +129,7 @@ public class advanced_sql_query : IntegrationContext
 
         // Default placeholder '?'
         var name = (await query.AdvancedSql.QueryAsync<string>(
-            "SELECT JSON_VALUE(data, ?) FROM advsql_params.pc_doc_advsqldoc WHERE tenant_id = '*DEFAULT*'",
+            "SELECT JSON_VALUE(data, ?) FROM advsql_params.pc_doc_advsqldoc",
             CancellationToken.None,
             "$.name")).First();
 
@@ -138,7 +138,7 @@ public class advanced_sql_query : IntegrationContext
         // Custom placeholder '^'
         var name2 = (await query.AdvancedSql.QueryAsync<string>(
             '^',
-            "SELECT JSON_VALUE(data, ^) FROM advsql_params.pc_doc_advsqldoc WHERE tenant_id = '*DEFAULT*'",
+            "SELECT JSON_VALUE(data, ^) FROM advsql_params.pc_doc_advsqldoc",
             CancellationToken.None,
             "$.name")).First();
 
@@ -162,7 +162,7 @@ public class advanced_sql_query : IntegrationContext
         await using var query = theStore.QuerySession();
         var names = new List<string>();
         await foreach (var name in query.AdvancedSql.StreamAsync<string>(
-            "SELECT JSON_VALUE(data, '$.name') FROM advsql_stream.pc_doc_advsqldoc WHERE tenant_id = '*DEFAULT*' ORDER BY JSON_VALUE(data, '$.name')",
+            "SELECT JSON_VALUE(data, '$.name') FROM advsql_stream.pc_doc_advsqldoc ORDER BY JSON_VALUE(data, '$.name')",
             CancellationToken.None))
         {
             names.Add(name);
@@ -208,7 +208,7 @@ public class advanced_sql_query : IntegrationContext
 
         await using var query = theStore.QuerySession();
         var results = await query.AdvancedSql.QueryAsync<AdvSqlDoc, long>(
-            "SELECT id, data, COUNT(*) OVER() FROM advsql_doc_scalar.pc_doc_advsqldoc WHERE tenant_id = '*DEFAULT*' ORDER BY JSON_VALUE(data, '$.name')",
+            "SELECT id, data, COUNT(*) OVER() FROM advsql_doc_scalar.pc_doc_advsqldoc ORDER BY JSON_VALUE(data, '$.name')",
             CancellationToken.None);
 
         results.Count.ShouldBe(2);

--- a/src/Polecat.Tests/Storage/document_index_tests.cs
+++ b/src/Polecat.Tests/Storage/document_index_tests.cs
@@ -218,13 +218,12 @@ public class document_index_tests : IntegrationContext
         await StoreOptions(opts =>
         {
             opts.DatabaseSchemaName = "idx_filtered3";
-            // #234: tenant_id exists only under conjoined tenancy; use it as the filtered-index
-            // predicate column here (the test's point is that a filtered index can be created).
-            opts.Events.TenancyStyle = TenancyStyle.Conjoined;
             opts.Schema.For<IndexedProduct>()
                 .Index(x => x.Sku, idx =>
                 {
-                    idx.Predicate = "tenant_id <> 'EXCLUDED'";
+                    // #234: filtered indexes can't reference computed columns; use a regular
+                    // always-present column (dotnet_type) — tenant_id no longer exists single-tenant.
+                    idx.Predicate = "dotnet_type <> 'EXCLUDED'";
                 });
         });
 

--- a/src/Polecat.Tests/Storage/document_index_tests.cs
+++ b/src/Polecat.Tests/Storage/document_index_tests.cs
@@ -218,6 +218,9 @@ public class document_index_tests : IntegrationContext
         await StoreOptions(opts =>
         {
             opts.DatabaseSchemaName = "idx_filtered3";
+            // #234: tenant_id exists only under conjoined tenancy; use it as the filtered-index
+            // predicate column here (the test's point is that a filtered index can be created).
+            opts.Events.TenancyStyle = TenancyStyle.Conjoined;
             opts.Schema.For<IndexedProduct>()
                 .Index(x => x.Sku, idx =>
                 {
@@ -302,6 +305,9 @@ public class document_index_tests : IntegrationContext
         await StoreOptions(opts =>
         {
             opts.DatabaseSchemaName = "idx_tenant2";
+            // #234: a per-tenant index only makes sense under conjoined tenancy (single-tenant
+            // tables have no tenant_id column to include).
+            opts.Events.TenancyStyle = TenancyStyle.Conjoined;
             opts.Schema.For<IndexedProduct>()
                 .UniqueIndex(x => x.Email, idx => idx.TenancyScope = TenancyScope.PerTenant);
         });

--- a/src/Polecat.Tests/Storage/single_tenant_has_no_tenant_id_column_tests.cs
+++ b/src/Polecat.Tests/Storage/single_tenant_has_no_tenant_id_column_tests.cs
@@ -1,0 +1,112 @@
+using JasperFx;
+using Polecat.Linq;
+using Polecat.Tests.Harness;
+using Shouldly;
+
+namespace Polecat.Tests.Storage;
+
+// #234: single-tenant (non-conjoined) document tables do NOT carry a tenant_id column, matching
+// Marten — every document lives under the default tenant implicitly and no per-query tenant filter
+// is applied. Conjoined tenancy still adds tenant_id (as part of the composite primary key).
+[Collection("integration")]
+public class single_tenant_has_no_tenant_id_column_tests : IntegrationContext
+{
+    public single_tenant_has_no_tenant_id_column_tests(DefaultStoreFixture fixture) : base(fixture)
+    {
+    }
+
+    public class Widget
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+    }
+
+    [Fact]
+    public async Task single_tenant_table_has_no_tenant_id_column()
+    {
+        await StoreOptions(opts => { opts.DatabaseSchemaName = "no_tenant_col"; });
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Store(new Widget { Id = Guid.NewGuid(), Name = "A" });
+            await session.SaveChangesAsync();
+        }
+
+        var columns = await SchemaInspector.GetColumnInfoAsync("pc_doc_widget", "no_tenant_col");
+        var names = columns.Select(c => c.Name).ToList();
+
+        names.ShouldNotContain("tenant_id");
+        // The standard columns are still there, including the always-present version column.
+        names.ShouldContain("id");
+        names.ShouldContain("data");
+        names.ShouldContain("version");
+        names.ShouldContain("last_modified");
+        names.ShouldContain("created_at");
+        names.ShouldContain("dotnet_type");
+    }
+
+    [Fact]
+    public async Task conjoined_table_still_has_tenant_id_column()
+    {
+        await StoreOptions(opts =>
+        {
+            opts.DatabaseSchemaName = "with_tenant_col";
+            opts.Events.TenancyStyle = TenancyStyle.Conjoined;
+        });
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Store(new Widget { Id = Guid.NewGuid(), Name = "A" });
+            await session.SaveChangesAsync();
+        }
+
+        var columns = await SchemaInspector.GetColumnInfoAsync("pc_doc_widget", "with_tenant_col");
+        columns.Select(c => c.Name).ShouldContain("tenant_id");
+    }
+
+    // The full document lifecycle must work on a single-tenant table with no tenant_id column:
+    // store, load (Lightweight writeable selector + QueryOnly), LINQ query, metadata, and delete.
+    [Fact]
+    public async Task full_lifecycle_works_without_tenant_id_column()
+    {
+        await StoreOptions(opts => { opts.DatabaseSchemaName = "no_tenant_lifecycle"; });
+
+        var id = Guid.NewGuid();
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Store(new Widget { Id = id, Name = "Original" });
+            await session.SaveChangesAsync();
+        }
+
+        // Lightweight database read (writeable selector).
+        await using (var lightweight = theStore.LightweightSession())
+        {
+            var loaded = await lightweight.LoadAsync<Widget>(id);
+            loaded.ShouldNotBeNull();
+            loaded!.Name.ShouldBe("Original");
+        }
+
+        // QueryOnly + LINQ (no implicit tenant filter).
+        await using (var query = theStore.QuerySession())
+        {
+            var byLinq = await query.Query<Widget>().Where(w => w.Name == "Original").ToListAsync();
+            byLinq.Count.ShouldBe(1);
+
+            var meta = await query.MetadataForAsync(new Widget { Id = id });
+            meta.ShouldNotBeNull();
+            meta!.TenantId.ShouldBe(StorageConstants.DefaultTenantId);
+        }
+
+        // Delete.
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Delete<Widget>(id);
+            await session.SaveChangesAsync();
+        }
+
+        await using (var query = theStore.QuerySession())
+        {
+            (await query.LoadAsync<Widget>(id)).ShouldBeNull();
+        }
+    }
+}

--- a/src/Polecat.Tests/Storage/sqlserver_descriptor_builder_tests.cs
+++ b/src/Polecat.Tests/Storage/sqlserver_descriptor_builder_tests.cs
@@ -101,9 +101,11 @@ public class sqlserver_descriptor_builder_tests : OneOffConfigurationsContext
         descriptor.ConcurrencyMode.ShouldBe(ConcurrencyMode.Off);
         descriptor.IsConjoined.ShouldBeFalse();
 
-        // Single-tenant: tenant travels as an ordinary client-side binder
+        // #234: single-tenant tables have no tenant_id column, so there is no tenant write binder
+        // and the MERGE never references tenant_id.
         descriptor.ClientSideWriteBinders.Select(b => b.ColumnName)
-            .ShouldContain("tenant_id");
+            .ShouldNotContain("tenant_id");
+        descriptor.UpsertSql.ShouldNotContain("tenant_id");
 
         // ? slots in the USING row = id + data + client-side binders
         var expectedSlots = 2 + descriptor.ClientSideWriteBinders.Length;

--- a/src/Polecat/AdvancedOperations.cs
+++ b/src/Polecat/AdvancedOperations.cs
@@ -265,11 +265,18 @@ public class AdvancedOperations
 
         foreach (var (id, json, dotnetType, expectedVersion) in batch)
         {
+            // #234: tenant_id column exists only on conjoined tables.
+            var conjoined = mapping.TenancyStyle == TenancyStyle.Conjoined;
             var pId = $"@p{paramIndex++}";
             var pData = $"@p{paramIndex++}";
             var pType = $"@p{paramIndex++}";
-            var pTenant = $"@p{paramIndex++}";
+            var pTenant = conjoined ? $"@p{paramIndex++}" : null;
             var pExpected = $"@p{paramIndex++}";
+
+            var usingTenant = conjoined ? $", {pTenant} AS tenant_id" : "";
+            var onTenant = conjoined ? " AND target.tenant_id = source.tenant_id" : "";
+            var insertTenantCol = conjoined ? ", tenant_id" : "";
+            var insertTenantVal = conjoined ? $", {pTenant}" : "";
 
             // MERGE pattern from the polecat#48 audit body. The expected_version
             // is part of the USING projection rather than a free-standing
@@ -278,9 +285,9 @@ public class AdvancedOperations
             sb.AppendLine(
                 $"MERGE INTO {mapping.QualifiedTableName} WITH (HOLDLOCK) AS target");
             sb.AppendLine(
-                $"USING (SELECT {pId} AS id, {pTenant} AS tenant_id, {pExpected} AS expected_version) AS source");
+                $"USING (SELECT {pId} AS id{usingTenant}, {pExpected} AS expected_version) AS source");
             sb.AppendLine(
-                "    ON target.id = source.id AND target.tenant_id = source.tenant_id");
+                $"    ON target.id = source.id{onTenant}");
             sb.AppendLine("WHEN MATCHED AND target.version = source.expected_version THEN");
             sb.AppendLine(
                 $"    UPDATE SET data = {pData}, version = target.version + 1,");
@@ -288,15 +295,15 @@ public class AdvancedOperations
                 $"        last_modified = SYSDATETIMEOFFSET(), dotnet_type = {pType}");
             sb.AppendLine("WHEN NOT MATCHED THEN");
             sb.AppendLine(
-                $"    INSERT (id, data, version, last_modified, created_at, dotnet_type, tenant_id)");
+                $"    INSERT (id, data, version, last_modified, created_at, dotnet_type{insertTenantCol})");
             sb.AppendLine(
-                $"    VALUES ({pId}, {pData}, 1, SYSDATETIMEOFFSET(), SYSDATETIMEOFFSET(), {pType}, {pTenant})");
+                $"    VALUES ({pId}, {pData}, 1, SYSDATETIMEOFFSET(), SYSDATETIMEOFFSET(), {pType}{insertTenantVal})");
             sb.AppendLine("OUTPUT inserted.id;");
 
             cmd.Parameters.AddWithValue(pId, id);
             cmd.Parameters.AddWithValue(pData, json);
             cmd.Parameters.AddWithValue(pType, dotnetType);
-            cmd.Parameters.AddWithValue(pTenant, tenantId);
+            if (conjoined) cmd.Parameters.AddWithValue(pTenant!, tenantId);
             cmd.Parameters.AddWithValue(pExpected, expectedVersion);
         }
 
@@ -313,6 +320,10 @@ public class AdvancedOperations
         var sb = new StringBuilder();
         var paramIndex = 0;
 
+        // #234: tenant_id column exists only on conjoined tables.
+        var conjoined = mapping.TenancyStyle == TenancyStyle.Conjoined;
+        var insertTenantCol = conjoined ? ", tenant_id" : "";
+
         switch (mode)
         {
             case BulkInsertMode.InsertsOnly:
@@ -321,17 +332,18 @@ public class AdvancedOperations
                     var pId = $"@p{paramIndex++}";
                     var pData = $"@p{paramIndex++}";
                     var pType = $"@p{paramIndex++}";
-                    var pTenant = $"@p{paramIndex++}";
+                    var pTenant = conjoined ? $"@p{paramIndex++}" : null;
+                    var insertTenantVal = conjoined ? $", {pTenant}" : "";
 
                     sb.AppendLine(
-                        $"INSERT INTO {mapping.QualifiedTableName} (id, data, version, last_modified, created_at, dotnet_type, tenant_id)");
+                        $"INSERT INTO {mapping.QualifiedTableName} (id, data, version, last_modified, created_at, dotnet_type{insertTenantCol})");
                     sb.AppendLine(
-                        $"VALUES ({pId}, {pData}, 1, SYSDATETIMEOFFSET(), SYSDATETIMEOFFSET(), {pType}, {pTenant});");
+                        $"VALUES ({pId}, {pData}, 1, SYSDATETIMEOFFSET(), SYSDATETIMEOFFSET(), {pType}{insertTenantVal});");
 
                     cmd.Parameters.AddWithValue(pId, id);
                     cmd.Parameters.AddWithValue(pData, json);
                     cmd.Parameters.AddWithValue(pType, dotnetType);
-                    cmd.Parameters.AddWithValue(pTenant, tenantId);
+                    if (conjoined) cmd.Parameters.AddWithValue(pTenant!, tenantId);
                 }
 
                 break;
@@ -342,24 +354,27 @@ public class AdvancedOperations
                     var pId = $"@p{paramIndex++}";
                     var pData = $"@p{paramIndex++}";
                     var pType = $"@p{paramIndex++}";
-                    var pTenant = $"@p{paramIndex++}";
+                    var pTenant = conjoined ? $"@p{paramIndex++}" : null;
+                    var usingTenant = conjoined ? $", {pTenant} AS tenant_id" : "";
+                    var onTenant = conjoined ? " AND target.tenant_id = source.tenant_id" : "";
+                    var insertTenantVal = conjoined ? $", {pTenant}" : "";
 
                     sb.AppendLine(
                         $"MERGE INTO {mapping.QualifiedTableName} WITH (HOLDLOCK) AS target");
                     sb.AppendLine(
-                        $"USING (SELECT {pId} AS id, {pTenant} AS tenant_id) AS source");
+                        $"USING (SELECT {pId} AS id{usingTenant}) AS source");
                     sb.AppendLine(
-                        "    ON target.id = source.id AND target.tenant_id = source.tenant_id");
+                        $"    ON target.id = source.id{onTenant}");
                     sb.AppendLine("WHEN NOT MATCHED THEN");
                     sb.AppendLine(
-                        $"    INSERT (id, data, version, last_modified, created_at, dotnet_type, tenant_id)");
+                        $"    INSERT (id, data, version, last_modified, created_at, dotnet_type{insertTenantCol})");
                     sb.AppendLine(
-                        $"    VALUES ({pId}, {pData}, 1, SYSDATETIMEOFFSET(), SYSDATETIMEOFFSET(), {pType}, {pTenant});");
+                        $"    VALUES ({pId}, {pData}, 1, SYSDATETIMEOFFSET(), SYSDATETIMEOFFSET(), {pType}{insertTenantVal});");
 
                     cmd.Parameters.AddWithValue(pId, id);
                     cmd.Parameters.AddWithValue(pData, json);
                     cmd.Parameters.AddWithValue(pType, dotnetType);
-                    cmd.Parameters.AddWithValue(pTenant, tenantId);
+                    if (conjoined) cmd.Parameters.AddWithValue(pTenant!, tenantId);
                 }
 
                 break;
@@ -370,14 +385,17 @@ public class AdvancedOperations
                     var pId = $"@p{paramIndex++}";
                     var pData = $"@p{paramIndex++}";
                     var pType = $"@p{paramIndex++}";
-                    var pTenant = $"@p{paramIndex++}";
+                    var pTenant = conjoined ? $"@p{paramIndex++}" : null;
+                    var usingTenant = conjoined ? $", {pTenant} AS tenant_id" : "";
+                    var onTenant = conjoined ? " AND target.tenant_id = source.tenant_id" : "";
+                    var insertTenantVal = conjoined ? $", {pTenant}" : "";
 
                     sb.AppendLine(
                         $"MERGE INTO {mapping.QualifiedTableName} WITH (HOLDLOCK) AS target");
                     sb.AppendLine(
-                        $"USING (SELECT {pId} AS id, {pTenant} AS tenant_id) AS source");
+                        $"USING (SELECT {pId} AS id{usingTenant}) AS source");
                     sb.AppendLine(
-                        "    ON target.id = source.id AND target.tenant_id = source.tenant_id");
+                        $"    ON target.id = source.id{onTenant}");
                     sb.AppendLine("WHEN MATCHED THEN");
                     sb.AppendLine(
                         $"    UPDATE SET data = {pData}, version = target.version + 1,");
@@ -385,14 +403,14 @@ public class AdvancedOperations
                         $"        last_modified = SYSDATETIMEOFFSET(), dotnet_type = {pType}");
                     sb.AppendLine("WHEN NOT MATCHED THEN");
                     sb.AppendLine(
-                        $"    INSERT (id, data, version, last_modified, created_at, dotnet_type, tenant_id)");
+                        $"    INSERT (id, data, version, last_modified, created_at, dotnet_type{insertTenantCol})");
                     sb.AppendLine(
-                        $"    VALUES ({pId}, {pData}, 1, SYSDATETIMEOFFSET(), SYSDATETIMEOFFSET(), {pType}, {pTenant});");
+                        $"    VALUES ({pId}, {pData}, 1, SYSDATETIMEOFFSET(), SYSDATETIMEOFFSET(), {pType}{insertTenantVal});");
 
                     cmd.Parameters.AddWithValue(pId, id);
                     cmd.Parameters.AddWithValue(pData, json);
                     cmd.Parameters.AddWithValue(pType, dotnetType);
-                    cmd.Parameters.AddWithValue(pTenant, tenantId);
+                    if (conjoined) cmd.Parameters.AddWithValue(pTenant!, tenantId);
                 }
 
                 break;

--- a/src/Polecat/DocumentStore.EventStore.cs
+++ b/src/Polecat/DocumentStore.EventStore.cs
@@ -513,7 +513,7 @@ public partial class DocumentStore : IEventStore<IDocumentSession, IQuerySession
         {
             await Options.ResiliencePipeline.ExecuteAsync(static async (state, ct) =>
             {
-                var (connString, progressionTable, identities, tableNames, tenant) = state;
+                var (connString, progressionTable, identities, tableNames, tenant, isConjoined) = state;
                 await using var conn = new SqlConnection(connString);
                 await conn.OpenAsync(ct);
 
@@ -537,14 +537,18 @@ public partial class DocumentStore : IEventStore<IDocumentSession, IQuerySession
                     delDocs.Transaction = tx;
                     // The projection's doc table is created lazily on first write, so on a first-ever
                     // rebuild it may not exist yet — guard the tenant-scoped delete accordingly.
-                    delDocs.CommandText =
-                        $"IF OBJECT_ID('{tableName}', 'U') IS NOT NULL DELETE FROM {tableName} WHERE tenant_id = @tenant;";
-                    delDocs.Parameters.AddWithValue("@tenant", tenant);
+                    // #234: single-tenant projection tables have no tenant_id column, so the delete
+                    // is unscoped there (only the default tenant's rows exist).
+                    delDocs.CommandText = isConjoined
+                        ? $"IF OBJECT_ID('{tableName}', 'U') IS NOT NULL DELETE FROM {tableName} WHERE tenant_id = @tenant;"
+                        : $"IF OBJECT_ID('{tableName}', 'U') IS NOT NULL DELETE FROM {tableName};";
+                    if (isConjoined) delDocs.Parameters.AddWithValue("@tenant", tenant);
                     await delDocs.ExecuteNonQueryAsync(ct);
                 }
 
                 await tx.CommitAsync(ct);
-            }, (connStr, Events.ProgressionTableName, shardIdentities, publishedTableNames, tenantId), token);
+            }, (connStr, Events.ProgressionTableName, shardIdentities, publishedTableNames, tenantId,
+                Options.Events.TenancyStyle == TenancyStyle.Conjoined), token);
         }
         catch (Exception ex) when (token.IsCancellationRequested && ex is not OperationCanceledException)
         {

--- a/src/Polecat/Internal/Batching/BatchedQueryable.cs
+++ b/src/Polecat/Internal/Batching/BatchedQueryable.cs
@@ -83,8 +83,11 @@ internal class BatchedQueryable<T> : IBatchedQueryable<T> where T : class
             statement.Wheres.Add(fragment);
         }
 
-        // Tenant filter
-        statement.Wheres.Add(new ComparisonFilter("tenant_id", "=", _tenantId));
+        // Tenant filter — #234: only conjoined tables carry a tenant_id column.
+        if (_provider.Mapping.TenancyStyle == TenancyStyle.Conjoined)
+        {
+            statement.Wheres.Add(new ComparisonFilter("tenant_id", "=", _tenantId));
+        }
 
         // Soft delete filter
         if (_provider.Mapping.DeleteStyle == DeleteStyle.SoftDelete)

--- a/src/Polecat/Internal/Batching/CheckExistsBatchQueryItem.cs
+++ b/src/Polecat/Internal/Batching/CheckExistsBatchQueryItem.cs
@@ -28,8 +28,12 @@ internal class CheckExistsBatchQueryItem<T> : IBatchQueryItem where T : class
 
         builder.Append($"SELECT CAST(CASE WHEN EXISTS(SELECT 1 FROM {_provider.Mapping.QualifiedTableName} WHERE id = ");
         builder.AppendParameter(_id);
-        builder.Append(" AND tenant_id = ");
-        builder.AppendParameter(_tenantId);
+        if (_provider.Mapping.TenancyStyle == TenancyStyle.Conjoined) // #234
+        {
+            builder.Append(" AND tenant_id = ");
+            builder.AppendParameter(_tenantId);
+        }
+
         builder.Append(softDeleteFilter);
         builder.Append(") THEN 1 ELSE 0 END AS BIT);\n");
     }

--- a/src/Polecat/Internal/Batching/LoadBatchQueryItem.cs
+++ b/src/Polecat/Internal/Batching/LoadBatchQueryItem.cs
@@ -36,8 +36,12 @@ internal class LoadBatchQueryItem<T> : IBatchQueryItem where T : class
 
         builder.Append($"{_provider.SelectSql} WHERE id = ");
         builder.AppendParameter(_id);
-        builder.Append(" AND tenant_id = ");
-        builder.AppendParameter(_tenantId);
+        if (_provider.Mapping.TenancyStyle == TenancyStyle.Conjoined) // #234
+        {
+            builder.Append(" AND tenant_id = ");
+            builder.AppendParameter(_tenantId);
+        }
+
         builder.Append(softDeleteFilter);
         builder.Append(";\n");
     }

--- a/src/Polecat/Internal/Batching/LoadManyBatchQueryItem.cs
+++ b/src/Polecat/Internal/Batching/LoadManyBatchQueryItem.cs
@@ -47,8 +47,13 @@ internal class LoadManyBatchQueryItem<T> : IBatchQueryItem where T : class
             builder.AppendParameter(_ids[i]);
         }
 
-        builder.Append(") AND tenant_id = ");
-        builder.AppendParameter(_tenantId);
+        builder.Append(")");
+        if (_provider.Mapping.TenancyStyle == TenancyStyle.Conjoined) // #234
+        {
+            builder.Append(" AND tenant_id = ");
+            builder.AppendParameter(_tenantId);
+        }
+
         builder.Append(softDeleteFilter);
         builder.Append(";\n");
     }

--- a/src/Polecat/Internal/DocumentProvider.cs
+++ b/src/Polecat/Internal/DocumentProvider.cs
@@ -34,11 +34,20 @@ internal class DocumentProvider
 
     public string QualifiedTableName => Mapping.QualifiedTableName;
 
+    // #234: tenant_id is present only on conjoined tables. When absent, every trailing column
+    // ordinal shifts down by one, so the read-side ordinals below are computed off tenancy.
+    private bool IsConjoined => Mapping.TenancyStyle == TenancyStyle.Conjoined;
+
     public string SelectSql
     {
         get
         {
-            var baseCols = "id, data, version, last_modified, created_at, dotnet_type, tenant_id";
+            var baseCols = "id, data, version, last_modified, created_at, dotnet_type";
+            if (IsConjoined)
+            {
+                baseCols += ", tenant_id";
+            }
+
             if (Mapping.UseOptimisticConcurrency)
             {
                 baseCols += ", guid_version";
@@ -54,6 +63,12 @@ internal class DocumentProvider
     }
 
     /// <summary>
+    ///     Column index of guid_version in SelectSql (valid only under optimistic concurrency).
+    ///     Base columns id[0]..dotnet_type[5], then tenant_id[6] only when conjoined.
+    /// </summary>
+    public int GuidVersionColumnIndex => 6 + (IsConjoined ? 1 : 0);
+
+    /// <summary>
     ///     Column index of doc_type in SelectSql, or -1 if not a hierarchy.
     /// </summary>
     public int DocTypeColumnIndex
@@ -61,9 +76,7 @@ internal class DocumentProvider
         get
         {
             if (!Mapping.IsHierarchy()) return -1;
-            // Base columns: id[0], data[1], version[2], last_modified[3], created_at[4], dotnet_type[5], tenant_id[6]
-            // Optional: guid_version[7], doc_type[8] OR doc_type[7]
-            return Mapping.UseOptimisticConcurrency ? 8 : 7;
+            return 6 + (IsConjoined ? 1 : 0) + (Mapping.UseOptimisticConcurrency ? 1 : 0);
         }
     }
 
@@ -74,7 +87,8 @@ internal class DocumentProvider
             var softDeleteFilter = Mapping.DeleteStyle == DeleteStyle.SoftDelete
                 ? " AND is_deleted = 0"
                 : "";
-            return $"{SelectSql} WHERE id = @id AND tenant_id = @tenant_id{softDeleteFilter};";
+            var tenantFilter = IsConjoined ? " AND tenant_id = @tenant_id" : "";
+            return $"{SelectSql} WHERE id = @id{tenantFilter}{softDeleteFilter};";
         }
     }
 

--- a/src/Polecat/Internal/Operations/DeleteWhereOperation.cs
+++ b/src/Polecat/Internal/Operations/DeleteWhereOperation.cs
@@ -28,9 +28,15 @@ internal class DeleteWhereOperation : IStorageOperation
 
     public void ConfigureCommand(ICommandBuilder builder)
     {
-        builder.Append($"DELETE FROM {_mapping.QualifiedTableName} WHERE tenant_id = ");
-        builder.AppendParameter(_tenantId);
-        builder.Append(" AND ");
+        // #234: single-tenant tables have no tenant_id column to scope the delete by.
+        builder.Append($"DELETE FROM {_mapping.QualifiedTableName} WHERE ");
+        if (_mapping.TenancyStyle == TenancyStyle.Conjoined)
+        {
+            builder.Append("tenant_id = ");
+            builder.AppendParameter(_tenantId);
+            builder.Append(" AND ");
+        }
+
         _whereFragment.Apply(builder);
         builder.Append(";");
     }

--- a/src/Polecat/Internal/Operations/SoftDeleteWhereOperation.cs
+++ b/src/Polecat/Internal/Operations/SoftDeleteWhereOperation.cs
@@ -29,9 +29,14 @@ internal class SoftDeleteWhereOperation : IStorageOperation
     public void ConfigureCommand(ICommandBuilder builder)
     {
         builder.Append(
-            $"UPDATE {_mapping.QualifiedTableName} SET is_deleted = 1, deleted_at = SYSDATETIMEOFFSET() WHERE tenant_id = ");
-        builder.AppendParameter(_tenantId);
-        builder.Append(" AND ");
+            $"UPDATE {_mapping.QualifiedTableName} SET is_deleted = 1, deleted_at = SYSDATETIMEOFFSET() WHERE ");
+        if (_mapping.TenancyStyle == TenancyStyle.Conjoined) // #234
+        {
+            builder.Append("tenant_id = ");
+            builder.AppendParameter(_tenantId);
+            builder.Append(" AND ");
+        }
+
         _whereFragment.Apply(builder);
         builder.Append(";");
     }

--- a/src/Polecat/Internal/Operations/UnDeleteByIdOperation.cs
+++ b/src/Polecat/Internal/Operations/UnDeleteByIdOperation.cs
@@ -24,9 +24,19 @@ internal class UnDeleteByIdOperation : IStorageOperation
 
     public void ConfigureCommand(ICommandBuilder builder)
     {
-        builder.Append(
-            $"UPDATE {_mapping.QualifiedTableName} SET is_deleted = 0, deleted_at = NULL WHERE id = @id AND tenant_id = @tenant_id;");
-        builder.AddParameters(new Dictionary<string, object?> { ["id"] = _id, ["tenant_id"] = _tenantId });
+        // #234: single-tenant tables have no tenant_id column.
+        if (_mapping.TenancyStyle == TenancyStyle.Conjoined)
+        {
+            builder.Append(
+                $"UPDATE {_mapping.QualifiedTableName} SET is_deleted = 0, deleted_at = NULL WHERE id = @id AND tenant_id = @tenant_id;");
+            builder.AddParameters(new Dictionary<string, object?> { ["id"] = _id, ["tenant_id"] = _tenantId });
+        }
+        else
+        {
+            builder.Append(
+                $"UPDATE {_mapping.QualifiedTableName} SET is_deleted = 0, deleted_at = NULL WHERE id = @id;");
+            builder.AddParameters(new Dictionary<string, object?> { ["id"] = _id });
+        }
     }
 
     public Task PostprocessAsync(DbDataReader reader, IList<Exception> exceptions, CancellationToken token) => Task.CompletedTask;

--- a/src/Polecat/Internal/Operations/UndoDeleteWhereOperation.cs
+++ b/src/Polecat/Internal/Operations/UndoDeleteWhereOperation.cs
@@ -25,9 +25,15 @@ internal class UndoDeleteWhereOperation : IStorageOperation
     public void ConfigureCommand(ICommandBuilder builder)
     {
         builder.Append(
-            $"UPDATE {_mapping.QualifiedTableName} SET is_deleted = 0, deleted_at = NULL WHERE tenant_id = ");
-        builder.AppendParameter(_tenantId);
-        builder.Append(" AND is_deleted = 1 AND ");
+            $"UPDATE {_mapping.QualifiedTableName} SET is_deleted = 0, deleted_at = NULL WHERE ");
+        if (_mapping.TenancyStyle == TenancyStyle.Conjoined) // #234
+        {
+            builder.Append("tenant_id = ");
+            builder.AppendParameter(_tenantId);
+            builder.Append(" AND ");
+        }
+
+        builder.Append("is_deleted = 1 AND ");
         _whereFragment.Apply(builder);
         builder.Append(";");
     }

--- a/src/Polecat/Internal/QuerySession.Metadata.cs
+++ b/src/Polecat/Internal/QuerySession.Metadata.cs
@@ -41,7 +41,10 @@ internal partial class QuerySession
 
         // Build the column list off the mapping. Note: no soft-delete filter — metadata is surfaced
         // even for soft-deleted rows so the caller can see Deleted/DeletedAt.
-        var columns = new List<string> { "id", "version", "last_modified", "created_at", "tenant_id", "dotnet_type" };
+        // #234: tenant_id exists only on conjoined tables.
+        var isConjoined = mapping.TenancyStyle == TenancyStyle.Conjoined;
+        var columns = new List<string> { "id", "version", "last_modified", "created_at", "dotnet_type" };
+        if (isConjoined) columns.Add("tenant_id");
         if (mapping.UseOptimisticConcurrency) columns.Add("guid_version");
         if (mapping.IsHierarchy()) columns.Add("doc_type");
         if (mapping.DeleteStyle == DeleteStyle.SoftDelete)
@@ -58,9 +61,9 @@ internal partial class QuerySession
         await using var cmd = new SqlCommand();
         cmd.CommandText =
             $"SELECT {string.Join(", ", columns)} FROM {mapping.QualifiedTableName} " +
-            "WHERE id = @id AND tenant_id = @tenant_id";
+            (isConjoined ? "WHERE id = @id AND tenant_id = @tenant_id" : "WHERE id = @id");
         cmd.Parameters.AddWithValue("@id", id);
-        cmd.Parameters.AddWithValue("@tenant_id", TenantId);
+        if (isConjoined) cmd.Parameters.AddWithValue("@tenant_id", TenantId);
 
         Logger.OnBeforeExecute(cmd.CommandText);
         try
@@ -75,9 +78,9 @@ internal partial class QuerySession
                 reader.GetInt64(ordinals["version"]),
                 reader.GetFieldValue<DateTimeOffset>(ordinals["last_modified"]),
                 reader.GetFieldValue<DateTimeOffset>(ordinals["created_at"]),
-                reader.IsDBNull(ordinals["tenant_id"])
-                    ? StorageConstants.DefaultTenantId
-                    : reader.GetString(ordinals["tenant_id"]))
+                isConjoined && !reader.IsDBNull(ordinals["tenant_id"])
+                    ? reader.GetString(ordinals["tenant_id"])
+                    : StorageConstants.DefaultTenantId)
             {
                 DotNetType = ReadOptionalString(reader, ordinals, "dotnet_type"),
                 DocumentType = ReadOptionalString(reader, ordinals, "doc_type"),

--- a/src/Polecat/Internal/QuerySession.cs
+++ b/src/Polecat/Internal/QuerySession.cs
@@ -201,9 +201,11 @@ internal partial class QuerySession : IQuerySession
             ? " AND is_deleted = 0"
             : "";
 
-        cmd.CommandText = $"SELECT CAST(CASE WHEN EXISTS(SELECT 1 FROM {provider.Mapping.QualifiedTableName} WHERE id = @id AND tenant_id = @tenant_id{softDeleteFilter}) THEN 1 ELSE 0 END AS BIT);";
+        // #234: tenant_id predicate is conjoined-only.
+        var tenantFilter = provider.Mapping.TenancyStyle == TenancyStyle.Conjoined ? " AND tenant_id = @tenant_id" : "";
+        cmd.CommandText = $"SELECT CAST(CASE WHEN EXISTS(SELECT 1 FROM {provider.Mapping.QualifiedTableName} WHERE id = @id{tenantFilter}{softDeleteFilter}) THEN 1 ELSE 0 END AS BIT);";
         cmd.Parameters.AddWithValue("@id", id);
-        cmd.Parameters.AddWithValue("@tenant_id", TenantId);
+        if (provider.Mapping.TenancyStyle == TenancyStyle.Conjoined) cmd.Parameters.AddWithValue("@tenant_id", TenantId);
 
         Logger.OnBeforeExecute(cmd.CommandText);
         try
@@ -319,9 +321,11 @@ internal partial class QuerySession : IQuerySession
             ? " AND is_deleted = 0"
             : "";
 
-        cmd.CommandText = $"SELECT data FROM {provider.Mapping.QualifiedTableName} WHERE id = @id AND tenant_id = @tenant_id{softDeleteFilter};";
+        // #234: tenant_id predicate is conjoined-only.
+        var tenantFilter = provider.Mapping.TenancyStyle == TenancyStyle.Conjoined ? " AND tenant_id = @tenant_id" : "";
+        cmd.CommandText = $"SELECT data FROM {provider.Mapping.QualifiedTableName} WHERE id = @id{tenantFilter}{softDeleteFilter};";
         cmd.Parameters.AddWithValue("@id", id);
-        cmd.Parameters.AddWithValue("@tenant_id", TenantId);
+        if (provider.Mapping.TenancyStyle == TenancyStyle.Conjoined) cmd.Parameters.AddWithValue("@tenant_id", TenantId);
 
         Logger.OnBeforeExecute(cmd.CommandText);
         try

--- a/src/Polecat/Internal/QuerySession.cs
+++ b/src/Polecat/Internal/QuerySession.cs
@@ -369,7 +369,7 @@ internal partial class QuerySession : IQuerySession
 
         if (provider.Mapping.UseOptimisticConcurrency && doc is IVersioned versioned)
         {
-            versioned.Version = reader.GetGuid(7); // guid_version column
+            versioned.Version = reader.GetGuid(provider.GuidVersionColumnIndex); // guid_version column
         }
     }
 

--- a/src/Polecat/Linq/PolecatLinqQueryProvider.cs
+++ b/src/Polecat/Linq/PolecatLinqQueryProvider.cs
@@ -43,6 +43,11 @@ internal class PolecatLinqQueryProvider : IPolecatAsyncQueryProvider
         _tableEnsurer = tableEnsurer;
     }
 
+    // #234: document tenancy is global (DocumentMapping.TenancyStyle mirrors Events.TenancyStyle),
+    // and only conjoined tables carry a tenant_id column. Every implicit tenant filter — for list,
+    // scalar, aggregate, group-by, and join query shapes — is gated on this.
+    private bool IsConjoinedTenancy => _session.Options.Events.TenancyStyle == TenancyStyle.Conjoined;
+
     // IL2046 — IQueryProvider.CreateQuery(Expression) is not annotated [RUC]/[RDC]
     // in the BCL, but the only AOT-safe implementation is the generic
     // CreateQuery<TElement>(Expression) overload below. The non-generic
@@ -100,7 +105,10 @@ internal class PolecatLinqQueryProvider : IPolecatAsyncQueryProvider
 
         if (parser.IsDistinct) parser.Statement.IsDistinct = true;
 
-        if (!parser.IsAnyTenant)
+        // #234: single-tenant tables have no tenant_id column, so no implicit tenant filter is
+        // applied — every document is under the default tenant. Explicit AnyTenant()/TenantIsOneOf()
+        // are likewise no-ops there. Only conjoined stores filter by tenant_id.
+        if (!parser.IsAnyTenant && provider.Mapping.TenancyStyle == TenancyStyle.Conjoined)
         {
             if (parser.TenantIds != null)
             {
@@ -137,7 +145,7 @@ internal class PolecatLinqQueryProvider : IPolecatAsyncQueryProvider
 
         if (parser.IsDistinct) parser.Statement.IsDistinct = true;
 
-        if (!parser.IsAnyTenant)
+        if (!parser.IsAnyTenant && IsConjoinedTenancy)
         {
             if (parser.TenantIds != null)
             {
@@ -216,7 +224,7 @@ internal class PolecatLinqQueryProvider : IPolecatAsyncQueryProvider
         }
 
         // Add tenant filter (unless AnyTenant was called)
-        if (!parser.IsAnyTenant)
+        if (!parser.IsAnyTenant && IsConjoinedTenancy)
         {
             if (parser.TenantIds != null)
             {
@@ -333,7 +341,7 @@ internal class PolecatLinqQueryProvider : IPolecatAsyncQueryProvider
         }
 
         // Add tenant filter
-        if (!parser.IsAnyTenant)
+        if (!parser.IsAnyTenant && IsConjoinedTenancy)
         {
             if (parser.TenantIds != null)
             {
@@ -447,7 +455,7 @@ internal class PolecatLinqQueryProvider : IPolecatAsyncQueryProvider
         };
 
         // Add tenant filters for both sides
-        if (!parser.IsAnyTenant)
+        if (!parser.IsAnyTenant && IsConjoinedTenancy)
         {
             if (parser.TenantIds != null)
             {

--- a/src/Polecat/Patching/PatchExpression.cs
+++ b/src/Polecat/Patching/PatchExpression.cs
@@ -29,8 +29,11 @@ internal class PatchExpression<T> : IPatchExpression<T>
         {
             builder.Append("id = ");
             builder.AppendParameter(id);
-            builder.Append(" AND tenant_id = ");
-            builder.AppendParameter(tenantId);
+            if (mapping.TenancyStyle == TenancyStyle.Conjoined) // #234
+            {
+                builder.Append(" AND tenant_id = ");
+                builder.AppendParameter(tenantId);
+            }
         });
         session.WorkTracker.Add(operation);
     }
@@ -49,9 +52,13 @@ internal class PatchExpression<T> : IPatchExpression<T>
 
         var operation = new PatchOperation(mapping, _actions, builder =>
         {
-            builder.Append("tenant_id = ");
-            builder.AppendParameter(session.TenantId);
-            builder.Append(" AND ");
+            if (mapping.TenancyStyle == TenancyStyle.Conjoined) // #234
+            {
+                builder.Append("tenant_id = ");
+                builder.AppendParameter(session.TenantId);
+                builder.Append(" AND ");
+            }
+
             fragment.Apply(builder);
         });
         session.WorkTracker.Add(operation);

--- a/src/Polecat/Storage/ClosedShape/PolecatDocumentStorage.cs
+++ b/src/Polecat/Storage/ClosedShape/PolecatDocumentStorage.cs
@@ -96,11 +96,13 @@ internal abstract class PolecatDocumentStorage<TDoc, TId> : IDocumentStorage<TDo
         _selectFields = readColumns.ToArray();
 
         var select = $"SELECT {string.Join(", ", _selectFields)} FROM {_mapping.QualifiedTableName}";
-        // Polecat filters tenant_id on every load (the column is always present; default
-        // tenant id for single-tenant stores), matching the bespoke pipeline.
-        _loaderSql = $"{select} WHERE id = @id AND tenant_id = @tenant_id{SoftDeleteFilterSql()}";
+        // #234: only conjoined tables carry a tenant_id column, so single-tenant loads omit the
+        // tenant predicate entirely (the harmless @tenant_id parameter the dialect still binds is
+        // simply unreferenced by the SQL).
+        var tenantFilter = _mapping.TenancyStyle == TenancyStyle.Conjoined ? " AND tenant_id = @tenant_id" : string.Empty;
+        _loaderSql = $"{select} WHERE id = @id{tenantFilter}{SoftDeleteFilterSql()}";
         _loadManySql =
-            $"{select} WHERE id IN (SELECT value FROM OPENJSON(@ids)) AND tenant_id = @tenant_id{SoftDeleteFilterSql()}";
+            $"{select} WHERE id IN (SELECT value FROM OPENJSON(@ids)){tenantFilter}{SoftDeleteFilterSql()}";
 
         _deleteFragment = _mapping.DeleteStyle == DeleteStyle.SoftDelete
             ? new HardCodedOperationFragment(
@@ -194,7 +196,12 @@ internal abstract class PolecatDocumentStorage<TDoc, TId> : IDocumentStorage<TDo
     public ISqlFragment FilterDocuments(ISqlFragment query, IStorageSession session)
     {
         var filters = new List<ISqlFragment> { query };
-        filters.Add(new HardCodedFilter($"d.tenant_id = '{session.TenantId.Replace("'", "''")}'"));
+        // #234: single-tenant tables have no tenant_id column to filter on.
+        if (_mapping.TenancyStyle == TenancyStyle.Conjoined)
+        {
+            filters.Add(new HardCodedFilter($"d.tenant_id = '{session.TenantId.Replace("'", "''")}'"));
+        }
+
         if (_mapping.DeleteStyle == DeleteStyle.SoftDelete)
         {
             filters.Add(new HardCodedFilter("d.is_deleted = 0"));
@@ -350,11 +357,15 @@ internal abstract class PolecatDocumentStorage<TDoc, TId> : IDocumentStorage<TDo
 
     private IDeletion BuildDeletion(TDoc? document, TId id, string tenantId, bool hard)
     {
+        // #234: single-tenant tables have no tenant_id column, so the tenant predicate (and its
+        // bound parameter) are conjoined-only.
+        var conjoined = _mapping.TenancyStyle == TenancyStyle.Conjoined;
+        var tenantClause = conjoined ? " AND tenant_id = ?" : string.Empty;
         var sql = hard
-            ? $"DELETE FROM {_mapping.QualifiedTableName} WHERE id = ? AND tenant_id = ?"
-            : $"UPDATE {_mapping.QualifiedTableName} SET is_deleted = 1, deleted_at = SYSDATETIMEOFFSET() WHERE id = ? AND tenant_id = ? AND is_deleted = 0";
+            ? $"DELETE FROM {_mapping.QualifiedTableName} WHERE id = ?{tenantClause}"
+            : $"UPDATE {_mapping.QualifiedTableName} SET is_deleted = 1, deleted_at = SYSDATETIMEOFFSET() WHERE id = ?{tenantClause} AND is_deleted = 0";
         return new ClosedShapeDeletion<TDoc, TId>(sql, document, id, RawIdentityValue(id), tenantId,
-            _descriptor, typeof(TDoc));
+            _descriptor, typeof(TDoc), bindTenant: conjoined);
     }
 
     public async Task TruncateDocumentStorageAsync(IStorageDatabase database, CancellationToken ct = default)
@@ -482,15 +493,17 @@ internal sealed class ClosedShapeDeletion<TDoc, TId> : IDeletion, NoDataReturned
     private readonly string _sql;
     private readonly object _rawId;
     private readonly string _tenantId;
+    private readonly bool _bindTenant;
     private readonly DocumentStorageDescriptor<TDoc, TId> _descriptor;
     private readonly Type _documentType;
 
     public ClosedShapeDeletion(string sql, TDoc? document, TId id, object rawId, string tenantId,
-        DocumentStorageDescriptor<TDoc, TId> descriptor, Type documentType)
+        DocumentStorageDescriptor<TDoc, TId> descriptor, Type documentType, bool bindTenant = true)
     {
         _sql = sql;
         _rawId = rawId;
         _tenantId = tenantId;
+        _bindTenant = bindTenant;
         _descriptor = descriptor;
         _documentType = documentType;
         Document = document!;
@@ -508,8 +521,11 @@ internal sealed class ClosedShapeDeletion<TDoc, TId> : IDeletion, NoDataReturned
         var parameters = builder.AppendWithDbParameters(_sql, '?');
         parameters[0].Value = _rawId;
         _descriptor.Dialect.SetIdParameterType(parameters[0], _descriptor.Identification.RawSqlType);
-        parameters[1].Value = _tenantId;
-        _descriptor.Dialect.SetParameterType(parameters[1], StorageColumnType.String);
+        if (_bindTenant)
+        {
+            parameters[1].Value = _tenantId;
+            _descriptor.Dialect.SetParameterType(parameters[1], StorageColumnType.String);
+        }
     }
 
     public Task PostprocessAsync(DbDataReader reader, IList<Exception> exceptions, CancellationToken token)

--- a/src/Polecat/Storage/DocumentTable.cs
+++ b/src/Polecat/Storage/DocumentTable.cs
@@ -73,12 +73,13 @@ internal class DocumentTable : Table
             AddColumn("guid_version", "uniqueidentifier").NotNull().DefaultValueByExpression("NEWID()");
         }
 
-        if (mapping.TenancyStyle != TenancyStyle.Conjoined)
-        {
-            AddColumn(JasperFx.StorageConstants.TenantIdColumn, "varchar(250)")
-                .NotNull()
-                .DefaultValueByString(JasperFx.StorageConstants.DefaultTenantId);
-        }
+        // #234: single-tenant (non-conjoined) tables do NOT carry a tenant_id column, matching
+        // Marten — every document lives under the default tenant implicitly, so the whole runtime
+        // tenant_id if/then (schema column, write binder, load filter, LINQ filter, metadata query)
+        // stays off for single-tenant stores. Conjoined tenancy adds tenant_id to the primary key
+        // above. Existing single-tenant tables keep their (now-unmodeled) tenant_id column via the
+        // additive CreateDeltaAsync override (#267) — it is defaulted, so INSERTs that omit it still
+        // succeed — so this is purely additive with no destructive migration.
 
         // Declarative SQL Server RANGE partitioning (#211). The partition column must be part of the
         // table's unique (clustered) index, so a promoted member joins the primary key.

--- a/src/Polecat/Storage/SqlServerDocumentStorageDescriptorBuilder.cs
+++ b/src/Polecat/Storage/SqlServerDocumentStorageDescriptorBuilder.cs
@@ -69,26 +69,15 @@ internal static class SqlServerDocumentStorageDescriptorBuilder
             readBinders.Add(docTypeBinder);
         }
 
-        // tenant_id: pc tables always carry it. Conjoined uses the shared operations'
-        // leading tenant parameter slot (NOT a binder); single-tenant writes the session's
-        // (default) tenant id through a regular binder slot.
-        // Parity with the bespoke load path: ITenanted documents get tenant_id applied on load.
+        // tenant_id: #234 — only CONJOINED tables carry a tenant_id column. Conjoined writes the
+        // tenant through the shared operations' leading tenant parameter slot (NOT a binder) and, for
+        // ITenanted documents, reads it back through a read binder. Single-tenant tables have no
+        // tenant_id column, so there is no tenant binder at all (no write slot, no read column).
         var tenantMember = mapping.Metadata.TenantId.Member
                            ?? (typeof(Polecat.Metadata.ITenanted).IsAssignableFrom(typeof(TDoc))
                                ? typeof(TDoc).GetProperty(nameof(Polecat.Metadata.ITenanted.TenantId))
                                : null);
-        if (!isConjoined)
-        {
-            // Shared DocumentTenantIdBinder is read-only (Marten binds tenant inline);
-            // Polecat's write-capable binder sources the session's tenant id.
-            var tenantBinder = new PolecatTenantIdBinder<TDoc>(mapping.Metadata.TenantId.Name, tenantMember);
-            writeBinders.Add(tenantBinder);
-            if (tenantMember is not null)
-            {
-                readBinders.Add(tenantBinder);
-            }
-        }
-        else if (tenantMember is not null)
+        if (isConjoined && tenantMember is not null)
         {
             readBinders.Add(new DocumentTenantIdBinder<TDoc>(mapping.Metadata.TenantId.Name, tenantMember));
         }


### PR DESCRIPTION
## Problem
Every document table was created with a `tenant_id` column (and an implicit `tenant_id = @tenant_id` filter on every read/write), even for stores with no multi-tenancy configured. This diverged from Marten, which only creates `tenant_id` for **conjoined** tenancy, and imposed a per-query filter cost on single-tenant stores (#234).

## Fix — single-tenant tables have no `tenant_id`, matching Marten
Document tenancy is global (`DocumentMapping.TenancyStyle` mirrors `Events.TenancyStyle`). The whole runtime `tenant_id` if/then is now gated on conjoined tenancy:

- **Schema** (`DocumentTable`): `tenant_id` column created only for conjoined. Existing single-tenant tables keep their (now-unmodeled) `tenant_id` column via the additive `CreateDeltaAsync` override (#267) — it is defaulted, so inserts that omit it still succeed. **No destructive migration.**
- **Writes**: descriptor builder no longer adds the single-tenant tenant write/read binder; the closed-shape MERGE/UPDATE, bulk insert (all 4 modes), and delete-by-id omit `tenant_id`.
- **Reads**: closed-shape loader/load-many SQL, `FilterDocuments`, the bespoke `DocumentProvider.SelectSql`/`LoadSql` (with tenancy-aware column ordinals), batching (`Load`/`LoadMany`/`CheckExists`), and the metadata query all drop `tenant_id` for single-tenant.
- **LINQ**: the implicit tenant filter (list, scalar, aggregate, group-by, join shapes) and `BatchedQueryable`/patch WHERE predicates are conjoined-only. `AnyTenant()`/`TenantIsOneOf()` become no-ops on single-tenant stores.
- **Docs**: `storage.md` base-table example corrected (no `tenant_id`; `version` always present).

Conjoined tenancy is unchanged — `tenant_id` remains part of the composite primary key and every filter.

## Verification
Full net10 suite green. New tests: single-tenant table has no `tenant_id` column, conjoined still does, and a full single-tenant lifecycle (store / Lightweight + QueryOnly load / LINQ / metadata / delete) works without the column.

Closes #234. Part of #273.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
