### PR TITLE
release: 4.8.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>4.7.1</Version>
+        <Version>4.8.0</Version>
         <LangVersion>latest</LangVersion>
         <Authors>Jeremy D. Miller</Authors>
         <PackageIcon>logo.png</PackageIcon>


### PR DESCRIPTION
Cuts **4.8.0** (from 4.7.1).

## Included
- **#301** — Weasel / Weasel.SqlServer / Weasel.Storage / Weasel.EntityFrameworkCore → **9.16.0**. 9.16.0 relocated the closed-shape event-storage bases (`IEventStoreSqlDialect` + descriptors) into Weasel.Storage, unblocking the SQL Server event dialect (next #273 item).
- **#296** — strongly-typed id documents store the id column as the **inner** primitive type (`uniqueidentifier`/`int`/`bigint`) instead of `varchar(250)`, with an in-place migration for legacy tables. Fixes `InvalidCastException` on Lightweight/IdentityMap reads of wrapper-id docs.
- **#234** — single-tenant document tables no longer create a `tenant_id` column (Marten parity); the implicit per-query tenant filter is conjoined-only. Existing single-tenant tables keep their defaulted column via the additive schema diff — no destructive migration.

Version bumped in `Directory.Build.props`. After merge + green CI, publish is dispatched via `publish.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)