### PR TITLE
ci: drop deleted Polecat.CodeGeneration from publish pack step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,7 +49,6 @@ jobs:
           fi
           dotnet pack src/Polecat/Polecat.csproj -c Release --no-build -o ./artifacts $VERSION_ARG
           dotnet pack src/Polecat.AspNetCore/Polecat.AspNetCore.csproj -c Release --no-build -o ./artifacts $VERSION_ARG
-          dotnet pack src/Polecat.CodeGeneration/Polecat.CodeGeneration.csproj -c Release --no-build -o ./artifacts $VERSION_ARG
           dotnet pack src/Polecat.EntityFrameworkCore/Polecat.EntityFrameworkCore.csproj -c Release --no-build -o ./artifacts $VERSION_ARG
 
       - name: Push to NuGet


### PR DESCRIPTION
The 4.8.0 publish run failed at **Pack** with `MSB1009: Project file does not exist — src/Polecat.CodeGeneration/Polecat.CodeGeneration.csproj`. That project was deleted in #273 Phase 0 (#274) but `publish.yml` still packed it. The step exits on first error (`bash -e`), so it died before the Push step — **nothing was published**.

Removes the stale pack line. The remaining packages (Polecat, Polecat.AspNetCore, Polecat.EntityFrameworkCore) are unaffected; `solution build` already excludes the deleted project.

After merge, re-dispatch `publish.yml -f version=4.8.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)