### PR TITLE
feat: closed-shape event append via SqlServerEventStoreDialect (#273, opt-in)

### DIFF
--- a/src/Polecat.Tests/Events/closed_shape_event_append_tests.cs
+++ b/src/Polecat.Tests/Events/closed_shape_event_append_tests.cs
@@ -1,0 +1,205 @@
+using JasperFx.Events;
+using Polecat.Exceptions;
+using Polecat.Tests.Harness;
+
+namespace Polecat.Tests.Events;
+
+/// <summary>
+///     #273 event-dialect increment 1: exercises the closed-shape event append path
+///     (Events.UseClosedShapeEventStorage) end-to-end against live SQL Server, asserting parity with
+///     the bespoke inline path for start/append/expected-version/collision/metadata/tenancy.
+/// </summary>
+[Collection("integration")]
+public class closed_shape_event_append_tests : IntegrationContext
+{
+    public closed_shape_event_append_tests(DefaultStoreFixture fixture) : base(fixture)
+    {
+    }
+
+    private async Task ConfigureClosedShape(Action<StoreOptions>? extra = null)
+    {
+        var schemaName = "closed_evt_" + Guid.NewGuid().ToString("N")[..8];
+        await StoreOptions(opts =>
+        {
+            opts.DatabaseSchemaName = schemaName;
+            opts.Events.UseClosedShapeEventStorage = true;
+            extra?.Invoke(opts);
+        });
+    }
+
+    [Fact]
+    public async Task start_stream_writes_events_and_versions_and_sequences()
+    {
+        await ConfigureClosedShape();
+        var streamId = Guid.NewGuid();
+
+        theSession.Events.StartStream(streamId,
+            new QuestStarted("Destroy the Ring"),
+            new MembersJoined(1, "Hobbiton", ["Frodo", "Sam"]),
+            new ArrivedAtLocation("Bree", 2));
+        await theSession.SaveChangesAsync();
+
+        await using var query = theStore.QuerySession();
+        var events = await query.Events.FetchStreamAsync(streamId);
+
+        events.Count.ShouldBe(3);
+        events[0].Data.ShouldBeOfType<QuestStarted>();
+        events[1].Data.ShouldBeOfType<MembersJoined>();
+        events[2].Data.ShouldBeOfType<ArrivedAtLocation>();
+
+        events[0].Version.ShouldBe(1);
+        events[1].Version.ShouldBe(2);
+        events[2].Version.ShouldBe(3);
+
+        events[0].Sequence.ShouldBeGreaterThan(0);
+        events[1].Sequence.ShouldBeGreaterThan(events[0].Sequence);
+        events[2].Sequence.ShouldBeGreaterThan(events[1].Sequence);
+    }
+
+    [Fact]
+    public async Task sequences_are_assigned_back_onto_the_in_memory_events()
+    {
+        await ConfigureClosedShape();
+        var streamId = Guid.NewGuid();
+
+        var action = theSession.Events.StartStream(streamId, new QuestStarted("A"), new MembersJoined(1, "B", ["C"]));
+        await theSession.SaveChangesAsync();
+
+        action.Events[0].Sequence.ShouldBeGreaterThan(0);
+        action.Events[1].Sequence.ShouldBe(action.Events[0].Sequence + 1);
+        action.Events[0].Version.ShouldBe(1);
+        action.Events[1].Version.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task append_to_existing_stream_continues_versions()
+    {
+        await ConfigureClosedShape();
+        var streamId = Guid.NewGuid();
+
+        theSession.Events.StartStream(streamId, new QuestStarted("Start"));
+        await theSession.SaveChangesAsync();
+
+        theSession.Events.Append(streamId, new MembersJoined(1, "Town", ["X"]), new ArrivedAtLocation("Cave", 3));
+        await theSession.SaveChangesAsync();
+
+        await using var query = theStore.QuerySession();
+        var events = await query.Events.FetchStreamAsync(streamId);
+
+        events.Count.ShouldBe(3);
+        events[0].Version.ShouldBe(1);
+        events[1].Version.ShouldBe(2);
+        events[2].Version.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task duplicate_start_stream_throws_collision()
+    {
+        await ConfigureClosedShape();
+        var streamId = Guid.NewGuid();
+
+        theSession.Events.StartStream(streamId, new QuestStarted("First"));
+        await theSession.SaveChangesAsync();
+
+        await using var second = theStore.LightweightSession();
+        second.Events.StartStream(streamId, new QuestStarted("Second"));
+
+        await Should.ThrowAsync<ExistingStreamIdCollisionException>(async () =>
+            await second.SaveChangesAsync());
+    }
+
+    [Fact]
+    public async Task expected_version_mismatch_throws()
+    {
+        await ConfigureClosedShape();
+        var streamId = Guid.NewGuid();
+
+        theSession.Events.StartStream(streamId, new QuestStarted("Start"), new MembersJoined(1, "T", ["A"]));
+        await theSession.SaveChangesAsync();
+
+        // Stream is at version 2; asserting an append that expects version 5 should fail.
+        await using var session = theStore.LightweightSession();
+        session.Events.Append(streamId, 8, new ArrivedAtLocation("X", 1));
+
+        await Should.ThrowAsync<EventStreamUnexpectedMaxEventIdException>(async () =>
+            await session.SaveChangesAsync());
+    }
+
+    [Fact]
+    public async Task correct_expected_version_appends_successfully()
+    {
+        await ConfigureClosedShape();
+        var streamId = Guid.NewGuid();
+
+        theSession.Events.StartStream(streamId, new QuestStarted("Start"), new MembersJoined(1, "T", ["A"]));
+        await theSession.SaveChangesAsync();
+
+        await using var session = theStore.LightweightSession();
+        session.Events.Append(streamId, 3, new ArrivedAtLocation("X", 1));
+        await session.SaveChangesAsync();
+
+        await using var query = theStore.QuerySession();
+        var events = await query.Events.FetchStreamAsync(streamId);
+        events.Count.ShouldBe(3);
+        events[2].Version.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task string_identified_streams()
+    {
+        await ConfigureClosedShape(opts => opts.Events.StreamIdentity = StreamIdentity.AsString);
+        var key = "quest/" + Guid.NewGuid().ToString("N")[..8];
+
+        theSession.Events.StartStream(key, new QuestStarted("Start"), new MembersJoined(1, "T", ["A"]));
+        await theSession.SaveChangesAsync();
+
+        await using var query = theStore.QuerySession();
+        var events = await query.Events.FetchStreamAsync(key);
+        events.Count.ShouldBe(2);
+        events[1].Version.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task conjoined_tenancy_isolates_streams()
+    {
+        await ConfigureClosedShape(opts => opts.Events.TenancyStyle = TenancyStyle.Conjoined);
+        var streamId = Guid.NewGuid();
+
+        await using var red = theStore.LightweightSession(new SessionOptions { TenantId = "Red" });
+        red.Events.StartStream(streamId, new QuestStarted("Red"), new MembersJoined(1, "R", ["a"]));
+        await red.SaveChangesAsync();
+
+        await using var blueQuery = theStore.QuerySession(new SessionOptions { TenantId = "Blue" });
+        (await blueQuery.Events.FetchStreamAsync(streamId)).Count.ShouldBe(0);
+
+        await using var redQuery = theStore.QuerySession(new SessionOptions { TenantId = "Red" });
+        (await redQuery.Events.FetchStreamAsync(streamId)).Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task metadata_columns_are_written()
+    {
+        await ConfigureClosedShape(opts =>
+        {
+            opts.Events.EnableCorrelationId = true;
+            opts.Events.EnableCausationId = true;
+            opts.Events.EnableHeaders = true;
+        });
+
+        var streamId = Guid.NewGuid();
+        await using var session = theStore.LightweightSession();
+        session.CorrelationId = "corr-1";
+        session.CausationId = "cause-1";
+        session.SetHeader("color", "red");
+        session.Events.StartStream(streamId, new QuestStarted("Start"));
+        await session.SaveChangesAsync();
+
+        await using var query = theStore.QuerySession();
+        var events = await query.Events.FetchStreamAsync(streamId);
+        events.Count.ShouldBe(1);
+        events[0].CorrelationId.ShouldBe("corr-1");
+        events[0].CausationId.ShouldBe("cause-1");
+        // Headers deserialize as JsonElement under STJ; compare by text like the bespoke path's tests.
+        events[0].Headers!["color"].ToString().ShouldBe("red");
+    }
+}

--- a/src/Polecat/Events/EventGraph.cs
+++ b/src/Polecat/Events/EventGraph.cs
@@ -202,6 +202,28 @@ public class EventGraph : EventRegistry, IAggregationSourceFactory<IQuerySession
         set => base.AppendMode = value;
     }
 
+    private object? _closedShapeEventStorage;
+
+    /// <summary>
+    ///     The shared closed-shape <c>Weasel.Storage.EventStorage&lt;TId&gt;</c> for this event graph
+    ///     (#273 event-dialect convergence), built once from <see cref="Storage.SqlServerEventStoreDialect" />
+    ///     and cached. Boxed as <see cref="object" /> because <c>TId</c> is fixed by
+    ///     <see cref="StreamIdentity" /> (Guid vs string) — the append planner downcasts to the concrete
+    ///     <c>EventStorage&lt;Guid&gt;</c> / <c>EventStorage&lt;string&gt;</c>. Only used when
+    ///     <see cref="EventStoreOptions.UseClosedShapeEventStorage" /> is enabled.
+    /// </summary>
+    internal object ClosedShapeEventStorage =>
+        _closedShapeEventStorage ??= BuildClosedShapeEventStorage();
+
+    private object BuildClosedShapeEventStorage()
+    {
+        var dialect = new Storage.SqlServerEventStoreDialect();
+        var serializer = Serialization.StorageSerializerAdapter.For(Serializer);
+        return StreamIdentity == StreamIdentity.AsGuid
+            ? Weasel.Storage.EventStorageBuilder.Build<Guid>(dialect, AppendMode, this, serializer)
+            : Weasel.Storage.EventStorageBuilder.Build<string>(dialect, AppendMode, this, serializer);
+    }
+
     /// <summary>
     ///     Wrap raw event data into an IEvent instance with type metadata.
     /// </summary>

--- a/src/Polecat/Events/Storage/PolecatQuickAppendEventsOperation.cs
+++ b/src/Polecat/Events/Storage/PolecatQuickAppendEventsOperation.cs
@@ -1,0 +1,208 @@
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Core.Exceptions;
+using JasperFx.Events;
+using Polecat.Exceptions;
+using Weasel.Core;
+using Weasel.Storage;
+
+namespace Polecat.Events.Storage;
+
+/// <summary>
+///     Whether the closed-shape append writes the stream row with an INSERT (new stream / start) or
+///     an UPDATE (existing stream). Decided by the append planner after its version read.
+/// </summary>
+internal enum StreamWriteMode
+{
+    Insert,
+    Update
+}
+
+/// <summary>
+///     SQL Server batched append operation for the closed-shape Quick event storage (#273
+///     event-dialect increment 1) — the dialect-supplied counterpart of Marten's Postgres
+///     <c>QuickAppendEventsOperation</c>. SQL Server has no array-parameter server function, so this
+///     emits one self-contained command per stream: the stream-row write (via the descriptor's
+///     insert/update-version closure), one <c>INSERT INTO pc_events ... OUTPUT inserted.seq_id INTO
+///     @table</c> per event, and a single trailing <c>SELECT</c> of the assigned <c>seq_id</c>s.
+/// </summary>
+/// <remarks>
+///     <para>
+///         Exactly one client result set per operation (the trailing SELECT), matching the shared
+///         batch executor's one-result-set-per-operation contract; <c>OUTPUT ... INTO</c> keeps the
+///         per-event inserts from returning their own result sets. Event <see cref="IEvent.Version" />s
+///         are pre-assigned by the planner (which reads the current stream version under
+///         <c>UPDLOCK, HOLDLOCK</c>), so this operation only writes and reads sequences back onto
+///         <see cref="IEvent.Sequence" /> in <see cref="PostprocessAsync" />.
+///     </para>
+///     <para>
+///         Increment 1 covers the core append shape (single/conjoined tenancy, Guid/string streams,
+///         optional correlation/causation/headers/user_name columns). DCB tag writes and per-tenant
+///         event partitioning are not yet supported and throw; the bespoke inline path still covers
+///         them.
+///     </para>
+/// </remarks>
+internal sealed class PolecatQuickAppendEventsOperation
+    : Weasel.Storage.IStorageOperation, IExceptionTransform
+{
+    private const string SeqTableVar = "@pc_appended_seqs";
+
+    private readonly EventGraph _graph;
+    private readonly QuickEventStorageDescriptor _descriptor;
+
+    public PolecatQuickAppendEventsOperation(EventGraph graph, QuickEventStorageDescriptor descriptor,
+        StreamAction stream)
+    {
+        _graph = graph;
+        _descriptor = descriptor;
+        Stream = stream;
+    }
+
+    public StreamAction Stream { get; }
+
+    /// <summary>Set by the planner: INSERT a new stream row, or UPDATE the existing one's version.</summary>
+    public StreamWriteMode Mode { get; set; } = StreamWriteMode.Insert;
+
+    public Type DocumentType => typeof(IEvent);
+
+    public OperationRole Role() => OperationRole.Events;
+
+    public void ConfigureCommand(Weasel.Core.ICommandBuilder builder, IStorageSession session)
+    {
+        if (_graph.UseTenantPartitionedEvents)
+            throw new NotSupportedException(
+                "Per-tenant event partitioning is not yet supported on the closed-shape event append path.");
+
+        builder.Append("declare ");
+        builder.Append(SeqTableVar);
+        builder.Append(" table (ord int identity(1,1), seq_id bigint);");
+
+        // Stream row write reuses the dialect's descriptor closures so the SQL stays in one place.
+        if (Mode == StreamWriteMode.Insert)
+            _descriptor.ConfigureInsertStreamCommand(builder, Stream);
+        else
+            _descriptor.ConfigureUpdateStreamVersionCommand(builder, Stream);
+        builder.Append(";");
+
+        var options = _graph.EventOptions;
+
+        foreach (var @event in Stream.Events)
+        {
+            if (@event.Tags is { Count: > 0 } && _graph.TagTypes.Count > 0)
+                throw new NotSupportedException(
+                    "DCB tag writes are not yet supported on the closed-shape event append path.");
+
+            builder.Append("insert into ");
+            builder.Append(_graph.EventsTableName);
+            builder.Append(" (id, stream_id, version, data, type, timestamp, tenant_id, dotnet_type");
+            if (options.EnableCorrelationId) builder.Append(", correlation_id");
+            if (options.EnableCausationId) builder.Append(", causation_id");
+            if (options.EnableHeaders) builder.Append(", headers");
+            if (options.EnableUserName) builder.Append(", user_name");
+            builder.Append(") output inserted.seq_id into ");
+            builder.Append(SeqTableVar);
+            builder.Append(" values (");
+
+            Bind(builder, @event.Id, StorageColumnType.Guid);
+
+            builder.Append(", ");
+            if (_descriptor.IsGuidStreamIdentity)
+                Bind(builder, Stream.Id, StorageColumnType.Guid);
+            else
+                Bind(builder, Stream.Key!, StorageColumnType.String);
+
+            builder.Append(", ");
+            Bind(builder, @event.Version, StorageColumnType.Long);
+
+            builder.Append(", ");
+            Bind(builder, session.Serializer.ToJson(@event.Data), StorageColumnType.Json);
+
+            builder.Append(", ");
+            Bind(builder, @event.EventTypeName, StorageColumnType.String);
+
+            builder.Append(", SYSDATETIMEOFFSET(), ");
+            Bind(builder, @event.TenantId ?? Stream.TenantId, StorageColumnType.String);
+
+            builder.Append(", ");
+            Bind(builder, @event.DotNetTypeName, StorageColumnType.String);
+
+            if (options.EnableCorrelationId)
+            {
+                builder.Append(", ");
+                Bind(builder, (object?)@event.CorrelationId ?? DBNull.Value, StorageColumnType.String);
+            }
+
+            if (options.EnableCausationId)
+            {
+                builder.Append(", ");
+                Bind(builder, (object?)@event.CausationId ?? DBNull.Value, StorageColumnType.String);
+            }
+
+            if (options.EnableHeaders)
+            {
+                builder.Append(", ");
+                object headers = @event.Headers is { Count: > 0 }
+                    ? session.Serializer.ToJson(@event.Headers)
+                    : DBNull.Value;
+                Bind(builder, headers, StorageColumnType.Json);
+            }
+
+            if (options.EnableUserName)
+            {
+                builder.Append(", ");
+                Bind(builder, (object?)@event.UserName ?? DBNull.Value, StorageColumnType.String);
+            }
+
+            builder.Append(");");
+        }
+
+        builder.Append("select seq_id from ");
+        builder.Append(SeqTableVar);
+        builder.Append(" order by ord;");
+    }
+
+    private void Bind(Weasel.Core.ICommandBuilder builder, object value, StorageColumnType type)
+    {
+        var parameter = builder.AppendParameter(value);
+        _descriptor.Dialect.SetParameterType(parameter, type);
+    }
+
+    public async Task PostprocessAsync(DbDataReader reader, IList<Exception> exceptions, CancellationToken token)
+    {
+        // Single result set (the trailing SELECT), one row per event in append order.
+        var events = Stream.Events;
+        var i = 0;
+        while (i < events.Count && await reader.ReadAsync(token).ConfigureAwait(false))
+        {
+            events[i].Sequence = await reader.GetFieldValueAsync<long>(0, token).ConfigureAwait(false);
+            i++;
+        }
+    }
+
+    /// <summary>
+    ///     Map a SQL Server primary-key violation (2627) on the stream INSERT to
+    ///     <see cref="ExistingStreamIdCollisionException" /> — the closed-shape equivalent of the
+    ///     bespoke <c>ProcessStartStreamAsync</c> catch. Only meaningful when this op inserts the
+    ///     stream row.
+    /// </summary>
+    public bool TryTransform(Exception original, out Exception? transformed)
+    {
+        if (Mode == StreamWriteMode.Insert)
+        {
+            var sql = original as Microsoft.Data.SqlClient.SqlException
+                      ?? original.InnerException as Microsoft.Data.SqlClient.SqlException;
+            if (sql is { Number: 2627 })
+            {
+                var id = Stream.Key is not null ? (object)Stream.Key : Stream.Id;
+                transformed = new ExistingStreamIdCollisionException(id);
+                return true;
+            }
+        }
+
+        transformed = null;
+        return false;
+    }
+}

--- a/src/Polecat/Events/Storage/SqlServerEventStoreDialect.cs
+++ b/src/Polecat/Events/Storage/SqlServerEventStoreDialect.cs
@@ -1,0 +1,177 @@
+using System;
+using System.Data;
+using JasperFx.Events;
+using Polecat.Exceptions;
+using Polecat.Storage;
+using Weasel.Core;
+using Weasel.Storage;
+
+namespace Polecat.Events.Storage;
+
+/// <summary>
+///     SQL Server implementation of the closed-shape event-storage dialect seam
+///     (<see cref="IEventStoreSqlDialect" />, Weasel.Storage). The SQL-Server counterpart of
+///     Marten's <c>PostgresEventStoreDialect</c> — it builds the per-append-mode descriptors that
+///     drive the shared <see cref="EventStorage{TId}" /> hierarchy. Polecat is QuickAppend-only
+///     (direct INSERTs, no stored procedures — see CLAUDE.md), so only the Quick descriptor is
+///     implemented; Rich and QuickWithServerTimestamps are not reachable and throw.
+/// </summary>
+/// <remarks>
+///     <para>
+///         Unlike the Postgres dialect, Polecat has no <c>mt_quick_append_events</c> server
+///         function: the batched append is a direct multi-statement <c>INSERT ... OUTPUT
+///         inserted.seq_id</c> supplied through <see cref="QuickEventStorageDescriptor.CreateQuickAppendEventsOperation" />
+///         (<see cref="PolecatQuickAppendEventsOperation" />). Stream-row management uses the shared
+///         <c>QuickInsertStreamOperation</c> / <c>QuickUpdateStreamVersionOperation</c> /
+///         <c>AssertStreamVersionOperation</c> via the descriptor's command-configurer closures.
+///     </para>
+///     <para>
+///         Wired behind the opt-in <see cref="EventStoreOptions.UseClosedShapeEventStorage" /> flag
+///         (#273 event-dialect increment 1); the bespoke inline append path in
+///         <c>DocumentSessionBase</c> remains the default.
+///     </para>
+/// </remarks>
+internal sealed class SqlServerEventStoreDialect : IEventStoreSqlDialect
+{
+    public RichEventStorageDescriptor BuildRichDescriptor(EventRegistry graph, IStorageSerializer serializer)
+        => throw new NotSupportedException(
+            "Polecat is QuickAppend-only; the Rich (full-mode) event append path is not supported.");
+
+    public QuickWithServerTimestampsEventStorageDescriptor BuildQuickWithServerTimestampsDescriptor(
+        EventRegistry graph, IStorageSerializer serializer)
+        => throw new NotSupportedException(
+            "Polecat is QuickAppend-only; the QuickWithServerTimestamps event append path is not supported.");
+
+    public QuickEventStorageDescriptor BuildQuickDescriptor(EventRegistry registry, IStorageSerializer serializer)
+    {
+        var graph = (EventGraph)registry;
+        var isGuid = graph.StreamIdentity == StreamIdentity.AsGuid;
+        var isConjoined = graph.TenancyStyle == TenancyStyle.Conjoined;
+        var dialect = ResolveStorageDialect(isGuid);
+        var options = graph.EventOptions;
+
+        return new QuickEventStorageDescriptor(
+            quickAppendEventsSql: $"insert into {graph.EventsTableName} ",
+            insertStreamSql: $"insert into {graph.StreamsTableName} (...) values (...)",
+            updateStreamVersionSql: $"update {graph.StreamsTableName} set version = ... where ...",
+            // Polecat is STJ/JSON-only — no binary event serialization. Data is always JSON; bdata is
+            // always null. Serialize through the session serializer at write time (see the append op);
+            // the descriptor closure below covers any shared-op path that reaches for it.
+            serializeEventData: e => serializer.ToJson(e.Data),
+            serializeEventBdata: _ => null)
+        {
+            IsGuidStreamIdentity = isGuid,
+            Dialect = dialect,
+            IsTenancyConjoined = isConjoined,
+            AssertStreamVersionSql = $"select version from {graph.StreamsTableName} where id = ",
+            HasCausationId = options.EnableCausationId,
+            HasCorrelationId = options.EnableCorrelationId,
+            HasHeaders = options.EnableHeaders,
+            HasUserName = options.EnableUserName,
+            ConfigureInsertStreamCommand = BuildInsertStreamCommandConfigurer(graph, isGuid, dialect),
+            TransformInsertStreamException = MapInsertStreamException,
+            ConfigureUpdateStreamVersionCommand = BuildUpdateStreamVersionCommandConfigurer(graph, isGuid, isConjoined, dialect),
+            // SQL Server has no array-parameter bulk function; the batched append is a direct
+            // multi-row INSERT ... OUTPUT inserted.seq_id owned by the dialect.
+            CreateQuickAppendEventsOperation = (descriptor, stream) =>
+                new PolecatQuickAppendEventsOperation(graph, descriptor, stream)
+        };
+    }
+
+    /// <summary>
+    ///     The SQL Server <see cref="IStorageDialect" /> the descriptor threads to the shared ops for
+    ///     provider parameter typing. Reuses the doc-side dialect (#273 phase D); the stream-identity
+    ///     generic only affects id typing, which the ops set explicitly anyway.
+    /// </summary>
+    private static IStorageDialect ResolveStorageDialect(bool isGuid)
+        => isGuid ? SqlServerStorageDialect<Guid>.Instance : SqlServerStorageDialect<string>.Instance;
+
+    /// <summary>
+    ///     Closure for <c>insert into {schema}.pc_streams (id, type, version, timestamp, created,
+    ///     tenant_id) values (@id, @type, @version, SYSDATETIMEOFFSET(), SYSDATETIMEOFFSET(),
+    ///     @tenant_id)</c>. Mirrors the bespoke <c>ProcessStartStreamAsync</c> insert; columns are
+    ///     named so the same statement serves both single-tenant and conjoined tables.
+    /// </summary>
+    private static Action<Weasel.Core.ICommandBuilder, StreamAction> BuildInsertStreamCommandConfigurer(
+        EventGraph graph, bool isGuid, IStorageDialect dialect)
+    {
+        var prefix = $"insert into {graph.StreamsTableName} " +
+                     "(id, type, version, timestamp, created, tenant_id) values (";
+
+        return (builder, stream) =>
+        {
+            builder.Append(prefix);
+
+            var idParam = builder.AppendParameter(isGuid ? stream.Id : (object)stream.Key!);
+            dialect.SetParameterType(idParam, isGuid ? StorageColumnType.Guid : StorageColumnType.String);
+
+            builder.Append(", ");
+            var typeParam = builder.AppendParameter((object?)stream.AggregateType?.Name ?? DBNull.Value);
+            dialect.SetParameterType(typeParam, StorageColumnType.String);
+
+            builder.Append(", ");
+            var versionParam = builder.AppendParameter(stream.Version);
+            dialect.SetParameterType(versionParam, StorageColumnType.Long);
+
+            builder.Append(", SYSDATETIMEOFFSET(), SYSDATETIMEOFFSET(), ");
+            var tenantParam = builder.AppendParameter(stream.TenantId);
+            dialect.SetParameterType(tenantParam, StorageColumnType.String);
+
+            builder.Append(")");
+        };
+    }
+
+    /// <summary>
+    ///     Closure for <c>update {schema}.pc_streams set version = @version, timestamp =
+    ///     SYSDATETIMEOFFSET() where id = @id and version = @expected [and tenant_id = @tenant]</c>.
+    ///     The <c>and version = @expected</c> guard is the shared expected-version check; Polecat's
+    ///     planner reads the current version under <c>UPDLOCK, HOLDLOCK</c> first, so the guard always
+    ///     matches, but it stays as defense-in-depth and to satisfy the shared op's Postprocess
+    ///     (0-rows → <c>EventStreamUnexpectedMaxEventIdException</c>).
+    /// </summary>
+    private static Action<Weasel.Core.ICommandBuilder, StreamAction> BuildUpdateStreamVersionCommandConfigurer(
+        EventGraph graph, bool isGuid, bool isConjoined, IStorageDialect dialect)
+    {
+        var prefix = $"update {graph.StreamsTableName} set version = ";
+
+        return (builder, stream) =>
+        {
+            builder.Append(prefix);
+            var versionParam = builder.AppendParameter(stream.Version);
+            dialect.SetParameterType(versionParam, StorageColumnType.Long);
+
+            builder.Append(", timestamp = SYSDATETIMEOFFSET() where id = ");
+            var idParam = builder.AppendParameter(isGuid ? stream.Id : (object)stream.Key!);
+            dialect.SetParameterType(idParam, isGuid ? StorageColumnType.Guid : StorageColumnType.String);
+
+            builder.Append(" and version = ");
+            var expectedParam = builder.AppendParameter(stream.ExpectedVersionOnServer!.Value);
+            dialect.SetParameterType(expectedParam, StorageColumnType.Long);
+
+            if (isConjoined)
+            {
+                builder.Append(" and tenant_id = ");
+                var tenantParam = builder.AppendParameter(stream.TenantId);
+                dialect.SetParameterType(tenantParam, StorageColumnType.String);
+            }
+        };
+    }
+
+    /// <summary>
+    ///     Maps a SQL Server primary-key violation (error 2627) on the pc_streams insert to
+    ///     <see cref="Exceptions.ExistingStreamIdCollisionException" />. Mirrors the bespoke path's
+    ///     catch in <c>ProcessStartStreamAsync</c>. Returns null for any other exception.
+    /// </summary>
+    private static Exception? MapInsertStreamException(Exception original, StreamAction stream)
+    {
+        var sql = original as Microsoft.Data.SqlClient.SqlException
+                  ?? original.InnerException as Microsoft.Data.SqlClient.SqlException;
+        if (sql is { Number: 2627 })
+        {
+            var id = stream.Key is not null ? (object)stream.Key : stream.Id;
+            return new ExistingStreamIdCollisionException(id);
+        }
+
+        return null;
+    }
+}

--- a/src/Polecat/Internal/DocumentSessionBase.cs
+++ b/src/Polecat/Internal/DocumentSessionBase.cs
@@ -474,25 +474,34 @@ internal abstract class DocumentSessionBase : QuerySession, IDocumentSession
                 }
             }
 
-            // Process event streams
-            foreach (var stream in _workTracker.Streams)
+            // Process event streams. #273: the closed-shape path routes appends through the shared
+            // Weasel.Storage.EventStorage<TId> hierarchy (SqlServerEventStoreDialect); the bespoke inline
+            // SqlCommand path remains the default.
+            if (Options.Events.UseClosedShapeEventStorage)
             {
-                // Handle AlwaysEnforceConsistency with no events — just assert version
-                if (!stream.Events.Any() && stream.AlwaysEnforceConsistency && stream.ExpectedVersionOnServer.HasValue)
+                await ProcessStreamsClosedShapeAsync(token);
+            }
+            else
+            {
+                foreach (var stream in _workTracker.Streams)
                 {
-                    await AssertStreamVersionAsync(stream, token);
-                    continue;
-                }
+                    // Handle AlwaysEnforceConsistency with no events — just assert version
+                    if (!stream.Events.Any() && stream.AlwaysEnforceConsistency && stream.ExpectedVersionOnServer.HasValue)
+                    {
+                        await AssertStreamVersionAsync(stream, token);
+                        continue;
+                    }
 
-                if (!stream.Events.Any()) continue;
+                    if (!stream.Events.Any()) continue;
 
-                if (stream.ActionType == StreamActionType.Start)
-                {
-                    await ProcessStartStreamAsync(stream, token);
-                }
-                else
-                {
-                    await ProcessAppendStreamAsync(stream, token);
+                    if (stream.ActionType == StreamActionType.Start)
+                    {
+                        await ProcessStartStreamAsync(stream, token);
+                    }
+                    else
+                    {
+                        await ProcessAppendStreamAsync(stream, token);
+                    }
                 }
             }
 
@@ -684,6 +693,195 @@ internal abstract class DocumentSessionBase : QuerySession, IDocumentSession
                     new KeyValuePair<string, object?>("event_type", @event.EventTypeName),
                     new KeyValuePair<string, object?>("tenant_id", @event.TenantId ?? TenantId));
             }
+        }
+    }
+
+    // ---- #273 closed-shape event append path (opt-in via Events.UseClosedShapeEventStorage) --------
+    // Routes appends through the shared Weasel.Storage.EventStorage<TId> hierarchy
+    // (SqlServerEventStoreDialect + PolecatQuickAppendEventsOperation) instead of the bespoke
+    // ProcessStart/ProcessAppend/AssertStreamVersion/InsertEvent methods below. Versions are assigned
+    // client-side after a locking read so inline projections see them; sequences read back in Postprocess.
+
+    private async Task ProcessStreamsClosedShapeAsync(CancellationToken token)
+    {
+        var storage = _eventGraph.ClosedShapeEventStorage;
+        var isGuid = _eventGraph.StreamIdentity == JasperFx.Events.StreamIdentity.AsGuid;
+
+        var ops = new List<Weasel.Storage.IStorageOperation>();
+
+        foreach (var stream in _workTracker.Streams)
+        {
+            if (!stream.Events.Any())
+            {
+                if (stream.AlwaysEnforceConsistency && stream.ExpectedVersionOnServer.HasValue)
+                {
+                    ops.Add(AssertStreamVersionClosedShape(storage, isGuid, stream));
+                }
+
+                continue;
+            }
+
+            if (stream.ActionType == StreamActionType.Start)
+            {
+                AssignEventMetadataForClosedShape(stream, 0);
+                stream.Version = stream.Events.Count;
+                ops.Add(QuickAppendEventsClosedShape(storage, isGuid, stream, Polecat.Events.Storage.StreamWriteMode.Insert));
+            }
+            else
+            {
+                var (currentVersion, exists, archived) = await ReadStreamStateForClosedShapeAsync(stream, token);
+
+                var streamId = isGuid ? (object)stream.Id : stream.Key!;
+                if (archived)
+                {
+                    throw new Exceptions.InvalidStreamException(streamId, "Cannot append to an archived stream.");
+                }
+
+                if (stream.ExpectedVersionOnServer.HasValue && currentVersion != stream.ExpectedVersionOnServer.Value)
+                {
+                    throw new EventStreamUnexpectedMaxEventIdException(streamId, stream.AggregateType,
+                        stream.ExpectedVersionOnServer.Value, currentVersion);
+                }
+
+                AssignEventMetadataForClosedShape(stream, currentVersion);
+                stream.Version = currentVersion + stream.Events.Count;
+
+                if (exists)
+                {
+                    stream.ExpectedVersionOnServer ??= currentVersion;
+                    ops.Add(QuickAppendEventsClosedShape(storage, isGuid, stream, Polecat.Events.Storage.StreamWriteMode.Update));
+                }
+                else
+                {
+                    ops.Add(QuickAppendEventsClosedShape(storage, isGuid, stream, Polecat.Events.Storage.StreamWriteMode.Insert));
+                }
+            }
+        }
+
+        if (ops.Count == 0) return;
+
+        await ExecuteClosedShapeEventOperationsAsync(ops, token);
+    }
+
+    private static Weasel.Storage.IStorageOperation AssertStreamVersionClosedShape(
+        object storage, bool isGuid, StreamAction stream)
+        => isGuid
+            ? ((Weasel.Storage.EventStorage<Guid>)storage).AssertStreamVersion(stream)
+            : ((Weasel.Storage.EventStorage<string>)storage).AssertStreamVersion(stream);
+
+    private static Weasel.Storage.IStorageOperation QuickAppendEventsClosedShape(
+        object storage, bool isGuid, StreamAction stream, Polecat.Events.Storage.StreamWriteMode mode)
+    {
+        var op = (Polecat.Events.Storage.PolecatQuickAppendEventsOperation)(isGuid
+            ? ((Weasel.Storage.EventStorage<Guid>)storage).QuickAppendEvents(stream)
+            : ((Weasel.Storage.EventStorage<string>)storage).QuickAppendEvents(stream));
+        op.Mode = mode;
+        return op;
+    }
+
+    private void AssignEventMetadataForClosedShape(StreamAction stream, long baseVersion)
+    {
+        var events = stream.Events;
+        for (var i = 0; i < events.Count; i++)
+        {
+            var e = events[i];
+            e.Version = baseVersion + i + 1;
+            if (e.Id == Guid.Empty) e.Id = Guid.NewGuid();
+            e.Timestamp = DateTimeOffset.UtcNow;
+            e.TenantId = stream.TenantId;
+            e.StreamId = stream.Id;
+            e.StreamKey = stream.Key;
+
+            if (CorrelationId != null && e.CorrelationId == null) e.CorrelationId = CorrelationId;
+            if (CausationId != null && e.CausationId == null) e.CausationId = CausationId;
+            if (LastModifiedBy != null && e.UserName == null) e.UserName = LastModifiedBy;
+
+            if (Headers is { Count: > 0 })
+            {
+                e.Headers ??= new Dictionary<string, object>();
+                foreach (var header in Headers)
+                {
+                    e.Headers.TryAdd(header.Key, header.Value);
+                }
+            }
+        }
+    }
+
+    private async Task<(long currentVersion, bool exists, bool archived)> ReadStreamStateForClosedShapeAsync(
+        StreamAction stream, CancellationToken token)
+    {
+        var streamId = _eventGraph.StreamIdentity == JasperFx.Events.StreamIdentity.AsGuid
+            ? (object)stream.Id
+            : stream.Key!;
+
+        await using var cmd = new SqlCommand();
+        cmd.CommandText =
+            $"SELECT version, is_archived FROM {_eventGraph.StreamsTableName} WITH (UPDLOCK, HOLDLOCK) WHERE id = @id AND tenant_id = @tenant_id;";
+        cmd.Parameters.AddWithValue("@id", streamId);
+        cmd.Parameters.AddWithValue("@tenant_id", TenantId);
+
+        await using var reader = await ExecuteReaderAsync(cmd, token);
+        if (await reader.ReadAsync(token))
+        {
+            return (reader.GetInt64(0), true, reader.GetBoolean(1));
+        }
+
+        return (0, false, false);
+    }
+
+    private async Task ExecuteClosedShapeEventOperationsAsync(
+        List<Weasel.Storage.IStorageOperation> operations, CancellationToken token)
+    {
+        await using var batch = new SqlBatch();
+        var builder = new BatchBuilder(batch);
+
+        for (var i = 0; i < operations.Count; i++)
+        {
+            if (i > 0) builder.StartNewCommand();
+            Operations.StorageOperationExecution.Configure(operations[i], builder, (Weasel.Storage.IStorageSession)this);
+        }
+
+        builder.Compile();
+
+        var exceptions = new List<Exception>();
+        try
+        {
+            await using var reader = await ExecuteReaderAsync(batch, token);
+            for (var i = 0; i < operations.Count; i++)
+            {
+                await operations[i].PostprocessAsync(reader, exceptions, token);
+                if (i < operations.Count - 1)
+                {
+                    await reader.NextResultAsync(token);
+                }
+            }
+
+            while (await reader.NextResultAsync(token))
+            {
+            }
+        }
+        catch (SqlException ex)
+        {
+            foreach (var op in operations)
+            {
+                if (op is JasperFx.Core.Exceptions.IExceptionTransform transform
+                    && transform.TryTransform(ex, out var transformed) && transformed != null)
+                {
+                    System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(transformed).Throw();
+                }
+            }
+
+            throw;
+        }
+
+        if (exceptions.Count == 1)
+        {
+            System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(exceptions[0]).Throw();
+        }
+
+        if (exceptions.Count > 0)
+        {
+            throw new AggregateException(exceptions);
         }
     }
 

--- a/src/Polecat/StoreOptions.cs
+++ b/src/Polecat/StoreOptions.cs
@@ -403,6 +403,18 @@ public class EventStoreOptions : IEventStoreInstrumentation
     public bool EnableSideEffectsOnInlineProjections { get; set; }
 
     /// <summary>
+    ///     Opt into the closed-shape event append path (#273 event-dialect convergence): route event
+    ///     appends through the shared <c>Weasel.Storage.EventStorage&lt;TId&gt;</c> hierarchy driven by
+    ///     <c>SqlServerEventStoreDialect</c>, instead of the bespoke inline <c>SqlCommand</c> path in
+    ///     <c>DocumentSessionBase</c>. <b>Off by default</b> while the closed-shape path is being brought
+    ///     to full parity; increment 1 covers single/conjoined tenancy, Guid/string streams, and the
+    ///     optional correlation/causation/headers/user_name columns. DCB tag writes and per-tenant event
+    ///     partitioning are not yet supported on this path and fall back is not automatic — leave this off
+    ///     when using those features.
+    /// </summary>
+    public bool UseClosedShapeEventStorage { get; set; }
+
+    /// <summary>
     ///     Opt into extended columns on the event progression table for CritterWatch alerting.
     ///     Adds nullable heartbeat, agent_status, pause_reason, running_on_node,
     ///     warning_behind_threshold, and critical_behind_threshold columns. This is the


### PR DESCRIPTION
## Summary
First increment of the polecat#273 marquee item — the **SQL Server event-store dialect** — converging Polecat's bespoke inline event-append code onto the shared `Weasel.Storage.EventStorage<TId>` closed-shape hierarchy (the SQL-Server analogue of Marten's `PostgresEventStoreDialect`).

Everything is behind the new opt-in flag **`Events.UseClosedShapeEventStorage` (default `false`)** — the bespoke inline `SqlCommand` path in `DocumentSessionBase` remains the default and is untouched.

## What's here
- **`SqlServerEventStoreDialect : IEventStoreSqlDialect`** — Quick descriptor implemented (Polecat is QuickAppend-only; Rich / QuickWithServerTimestamps throw `NotSupportedException`). Supplies the pc_streams INSERT / UPDATE-version command closures, `AssertStreamVersionSql`, metadata flags, reuses the doc-side `SqlServerStorageDialect<TId>` for parameter typing, and maps SQL Server error 2627 → `ExistingStreamIdCollisionException`.
- **`PolecatQuickAppendEventsOperation`** — the dialect-supplied batched append. SQL Server has no `mt_quick_append_events` array-parameter server function, so it emits one **self-contained command per stream**: `declare @table` + the stream INSERT/UPDATE (via the descriptor closures) + one `INSERT … OUTPUT inserted.seq_id INTO @table` per event + a single trailing `SELECT`. This yields **exactly one client result set**, matching the shared batch executor's one-result-set-per-operation contract. `seq_id`s are read back onto `IEvent.Sequence` in `PostprocessAsync`.
- **`EventGraph.ClosedShapeEventStorage`** — lazily builds/caches the `EventStorage<Guid|string>` from the dialect via `EventStorageBuilder`.
- **`DocumentSessionBase` planner** (flag-gated) — a locking `SELECT version, is_archived … WITH (UPDLOCK, HOLDLOCK)` assigns versions client-side (so inline projections see them), guards archived / expected-version, then queues `storage.QuickAppendEvents` (+ `storage.AssertStreamVersion` for zero-event `AlwaysEnforceConsistency`), executed through the existing shared-op `SqlBatch` machinery.

## Key decisions
- **`seq_id` stays IDENTITY** — no schema change. The batched op reads it back via `OUTPUT`, which works with IDENTITY. (A future increment may switch to a SQL Server `SEQUENCE` to unlock the shared per-event `QuickAppendEventWithVersion` op via `NEXT VALUE FOR`.)
- Blind appends need the current version; the planner does the eager `UPDLOCK` read (Marten does this server-side in its function — SQL Server has no equivalent).

## Scope / not yet on this path
Under the flag, **DCB tag writes** and **per-tenant event partitioning** (`UseTenantPartitionedEvents`) throw `NotSupportedException` — the bespoke path still covers them. These + retiring the bespoke methods + flipping the default are follow-up increments.

## Tests
- `closed_shape_event_append_tests` — 9 new integration tests green on live SQL Server 2025: start-stream, versions, sequence read-back (DB + in-memory), append-to-existing, duplicate-start collision, expected-version mismatch/success, string-identified streams, conjoined-tenancy isolation, metadata columns.
- 59 existing bespoke event tests unchanged (flag default off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)