### PR TITLE
fix: closed-shape AssertStreamVersion parity for not-found + expected 0 (#273)

### DIFF
--- a/src/Polecat.Tests/Events/closed_shape_event_append_tests.cs
+++ b/src/Polecat.Tests/Events/closed_shape_event_append_tests.cs
@@ -177,6 +177,57 @@ public class closed_shape_event_append_tests : IntegrationContext
     }
 
     [Fact]
+    public async Task always_enforce_consistency_not_found_expected_zero_succeeds()
+    {
+        await ConfigureClosedShape();
+        var streamId = Guid.NewGuid();
+
+        // FetchForWriting on a non-existent stream yields ExpectedVersionOnServer == 0; with
+        // AlwaysEnforceConsistency and no events, 0 == 0 (missing) must NOT throw.
+        await using var session = theStore.LightweightSession();
+        var stream = await session.Events.FetchForWriting<QuestAggregate>(streamId);
+        stream.AlwaysEnforceConsistency = true;
+
+        await session.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task always_enforce_consistency_throws_when_version_changed()
+    {
+        await ConfigureClosedShape();
+        var streamId = Guid.NewGuid();
+
+        theSession.Events.StartStream(streamId, new QuestStarted("Ring Quest"), new MembersJoined(1, "Shire", ["Frodo"]));
+        await theSession.SaveChangesAsync();
+
+        await using var session2 = theStore.LightweightSession();
+        var stream = await session2.Events.FetchForWriting<QuestAggregate>(streamId);
+        stream.AlwaysEnforceConsistency = true;
+
+        await using var session3 = theStore.LightweightSession();
+        session3.Events.Append(streamId, new MonsterSlain("Balrog", 100));
+        await session3.SaveChangesAsync();
+
+        await Should.ThrowAsync<EventStreamUnexpectedMaxEventIdException>(session2.SaveChangesAsync());
+    }
+
+    [Fact]
+    public async Task always_enforce_consistency_succeeds_when_version_unchanged()
+    {
+        await ConfigureClosedShape();
+        var streamId = Guid.NewGuid();
+
+        theSession.Events.StartStream(streamId, new QuestStarted("Ring Quest"), new MembersJoined(1, "Shire", ["Frodo"]));
+        await theSession.SaveChangesAsync();
+
+        await using var session2 = theStore.LightweightSession();
+        var stream = await session2.Events.FetchForWriting<QuestAggregate>(streamId);
+        stream.AlwaysEnforceConsistency = true;
+
+        await session2.SaveChangesAsync();
+    }
+
+    [Fact]
     public async Task metadata_columns_are_written()
     {
         await ConfigureClosedShape(opts =>

--- a/src/Polecat/Internal/DocumentSessionBase.cs
+++ b/src/Polecat/Internal/DocumentSessionBase.cs
@@ -715,7 +715,10 @@ internal abstract class DocumentSessionBase : QuerySession, IDocumentSession
             {
                 if (stream.AlwaysEnforceConsistency && stream.ExpectedVersionOnServer.HasValue)
                 {
-                    ops.Add(AssertStreamVersionClosedShape(storage, isGuid, stream));
+                    // Reuse the bespoke assert: unlike the shared AssertStreamVersionOperation (which
+                    // throws on any missing stream), Polecat treats a not-found stream with expected
+                    // version 0 as consistent (0 == 0), matching FetchForWriting on a new stream.
+                    await AssertStreamVersionAsync(stream, token);
                 }
 
                 continue;
@@ -762,12 +765,6 @@ internal abstract class DocumentSessionBase : QuerySession, IDocumentSession
 
         await ExecuteClosedShapeEventOperationsAsync(ops, token);
     }
-
-    private static Weasel.Storage.IStorageOperation AssertStreamVersionClosedShape(
-        object storage, bool isGuid, StreamAction stream)
-        => isGuid
-            ? ((Weasel.Storage.EventStorage<Guid>)storage).AssertStreamVersion(stream)
-            : ((Weasel.Storage.EventStorage<string>)storage).AssertStreamVersion(stream);
 
     private static Weasel.Storage.IStorageOperation QuickAppendEventsClosedShape(
         object storage, bool isGuid, StreamAction stream, Polecat.Events.Storage.StreamWriteMode mode)


### PR DESCRIPTION
## Summary
Follow-up to #306. Forcing `Events.UseClosedShapeEventStorage` on across the **entire** `Events` test suite (299 tests) surfaced exactly **one** parity gap, fixed here.

## The gap
A zero-event `AlwaysEnforceConsistency` stream that **doesn't exist** with `ExpectedVersionOnServer == 0` — the shape `FetchForWriting<T>` produces for a brand-new stream — must be treated as consistent (`0 == 0`). The shared `Weasel.Storage.AssertStreamVersionOperation` throws on *any* missing stream, so the closed-shape path incorrectly raised `EventStreamUnexpectedMaxEventIdException`.

## Fix
Route the zero-event consistency case through the bespoke `AssertStreamVersionAsync`, which already models Polecat's semantics:
- not-found + expected `0` → OK
- not-found + expected `!= 0` → throw
- found + mismatch → throw

Drops the now-unused shared-op helper.

## Tests
- 3 new closed-shape assert-version tests (not-found-expected-0 succeeds, version-changed throws, version-unchanged succeeds) — `closed_shape_event_append_tests` now 12 green.
- Bespoke `always_enforce_consistency_tests` unchanged (6 green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)