### PR TITLE
feat: per-tenant event partitioning on the closed-shape append path (#273, closes #309)

### DIFF
--- a/src/Polecat.Tests/Events/closed_shape_partitioned_event_tests.cs
+++ b/src/Polecat.Tests/Events/closed_shape_partitioned_event_tests.cs
@@ -1,0 +1,189 @@
+using JasperFx;
+using JasperFx.Events;
+using Microsoft.Data.SqlClient;
+using Polecat.Tests.Harness;
+using Polecat.TestUtils;
+
+namespace Polecat.Tests.Events;
+
+/// <summary>
+///     #273 event-dialect increment 5 (closes #309): per-tenant event partitioning
+///     (UseTenantPartitionedEvents) on the closed-shape append path
+///     (Events.UseClosedShapeEventStorage). Mirrors <see cref="per_tenant_event_sequence_tests" />'s
+///     isolation guarantee but through the closed-shape operation, which draws seq_id from each
+///     tenant's own sequence via NEXT VALUE FOR and stamps the tenant_ordinal column.
+/// </summary>
+[Collection("tenant-partitioning")]
+public class closed_shape_partitioned_event_tests : IAsyncLifetime
+{
+    private const string Schema = "closed_pt";
+
+    public async Task InitializeAsync()
+    {
+        await DropSchemaTablesAsync(Schema);
+        await PartitionTestCleanup.DropEventsPartitionObjectsAsync();
+        await DropSequencesAsync(Schema);
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    private static DocumentStore CreateStore()
+    {
+        return DocumentStore.For(opts =>
+        {
+            opts.ConnectionString = ConnectionSource.ConnectionString;
+            opts.DatabaseSchemaName = Schema;
+            opts.AutoCreateSchemaObjects = AutoCreate.All;
+            opts.UseNativeJsonType = ConnectionSource.SupportsNativeJson;
+            opts.Events.TenancyStyle = TenancyStyle.Conjoined;
+            opts.EventGraph.UseTenantPartitionedEvents = true;
+            opts.Events.UseClosedShapeEventStorage = true;
+        });
+    }
+
+    [Fact]
+    public async Task per_tenant_sequences_are_isolated_and_round_trip()
+    {
+        using var store = CreateStore();
+        await store.Database.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        var redStream = Guid.NewGuid();
+        var blueStream = Guid.NewGuid();
+
+        await using (var red = store.LightweightSession(new SessionOptions { TenantId = "Red" }))
+        {
+            red.Events.StartStream(redStream,
+                new QuestStarted("Red Quest"),
+                new MembersJoined(1, "Red Town", ["RedHero"]));
+            await red.SaveChangesAsync();
+        }
+
+        await using (var blue = store.LightweightSession(new SessionOptions { TenantId = "Blue" }))
+        {
+            blue.Events.StartStream(blueStream,
+                new QuestStarted("Blue Quest"),
+                new MembersJoined(1, "Blue Town", ["BlueHero"]),
+                new MonsterSlain("Grendel", 10));
+            await blue.SaveChangesAsync();
+        }
+
+        // Distinct ordinals per tenant.
+        var partitionIds = await QueryAsync(
+            $"SELECT tenant_id, ordinal FROM [{Schema}].[pc_tenant_partitions] ORDER BY tenant_id");
+        partitionIds.Count.ShouldBe(2);
+        partitionIds.Select(r => r[1]).Distinct().Count().ShouldBe(2);
+
+        // Each tenant's seq_id comes from its own sequence, starting at 1 — overlapping across tenants.
+        (await SeqIdsForTenantAsync("Red")).ShouldBe(new long[] { 1, 2 });
+        (await SeqIdsForTenantAsync("Blue")).ShouldBe(new long[] { 1, 2, 3 });
+
+        // Round-trip is tenant-scoped.
+        await using var redQuery = store.QuerySession(new SessionOptions { TenantId = "Red" });
+        (await redQuery.Events.FetchStreamAsync(redStream)).Count.ShouldBe(2);
+        (await redQuery.Events.FetchStreamAsync(blueStream)).Count.ShouldBe(0);
+
+        await using var blueQuery = store.QuerySession(new SessionOptions { TenantId = "Blue" });
+        (await blueQuery.Events.FetchStreamAsync(blueStream)).Count.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task append_to_existing_partitioned_stream_continues_versions_and_sequence()
+    {
+        using var store = CreateStore();
+        await store.Database.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        var streamId = Guid.NewGuid();
+
+        await using (var s1 = store.LightweightSession(new SessionOptions { TenantId = "Red" }))
+        {
+            s1.Events.StartStream(streamId, new QuestStarted("Red Quest"));
+            await s1.SaveChangesAsync();
+        }
+
+        await using (var s2 = store.LightweightSession(new SessionOptions { TenantId = "Red" }))
+        {
+            s2.Events.Append(streamId, new MembersJoined(1, "Town", ["X"]), new MonsterSlain("Orc", 1));
+            await s2.SaveChangesAsync();
+        }
+
+        await using var query = store.QuerySession(new SessionOptions { TenantId = "Red" });
+        var events = await query.Events.FetchStreamAsync(streamId);
+        events.Count.ShouldBe(3);
+        events.Select(e => e.Version).ShouldBe([1, 2, 3]);
+
+        (await SeqIdsForTenantAsync("Red")).ShouldBe(new long[] { 1, 2, 3 });
+    }
+
+    // ---- helpers (mirrors per_tenant_event_sequence_tests) ----
+
+    private static async Task<long[]> SeqIdsForTenantAsync(string tenantId)
+    {
+        await using var conn = new SqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"SELECT seq_id FROM [{Schema}].[pc_events] WHERE tenant_id = @t ORDER BY seq_id";
+        cmd.Parameters.AddWithValue("@t", tenantId);
+        var list = new List<long>();
+        await using var reader = await cmd.ExecuteReaderAsync();
+        while (await reader.ReadAsync()) list.Add(reader.GetInt64(0));
+        return list.ToArray();
+    }
+
+    private static async Task<List<object[]>> QueryAsync(string sql)
+    {
+        await using var conn = new SqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = sql;
+        var rows = new List<object[]>();
+        await using var reader = await cmd.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            var values = new object[reader.FieldCount];
+            reader.GetValues(values);
+            rows.Add(values);
+        }
+
+        return rows;
+    }
+
+    private static async Task DropSchemaTablesAsync(string schema)
+    {
+        await using var conn = new SqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = """
+            DECLARE @sql nvarchar(max) = N'';
+            SELECT @sql = @sql + 'ALTER TABLE [' + s.name + '].[' + t.name + '] DROP CONSTRAINT [' + fk.name + '];'
+            FROM sys.foreign_keys fk
+            JOIN sys.tables t ON fk.parent_object_id = t.object_id
+            JOIN sys.schemas s ON t.schema_id = s.schema_id
+            WHERE s.name = @schema;
+
+            SELECT @sql = @sql + 'DROP TABLE [' + s.name + '].[' + t.name + '];'
+            FROM sys.tables t
+            JOIN sys.schemas s ON t.schema_id = s.schema_id
+            WHERE s.name = @schema;
+            EXEC sp_executesql @sql;
+            """;
+        cmd.Parameters.AddWithValue("@schema", schema);
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    private static async Task DropSequencesAsync(string schema)
+    {
+        await using var conn = new SqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = """
+            DECLARE @sql nvarchar(max) = N'';
+            SELECT @sql = @sql + 'DROP SEQUENCE [' + s.name + '].[' + sq.name + '];'
+            FROM sys.sequences sq
+            JOIN sys.schemas s ON sq.schema_id = s.schema_id
+            WHERE s.name = @schema;
+            EXEC sp_executesql @sql;
+            """;
+        cmd.Parameters.AddWithValue("@schema", schema);
+        await cmd.ExecuteNonQueryAsync();
+    }
+}

--- a/src/Polecat/Events/Storage/PolecatQuickAppendEventsOperation.cs
+++ b/src/Polecat/Events/Storage/PolecatQuickAppendEventsOperation.cs
@@ -39,10 +39,10 @@ internal enum StreamWriteMode
 ///         <see cref="IEvent.Sequence" /> in <see cref="PostprocessAsync" />.
 ///     </para>
 ///     <para>
-///         Increment 1 covers the core append shape (single/conjoined tenancy, Guid/string streams,
-///         optional correlation/causation/headers/user_name columns) plus DCB tag writes. Per-tenant
-///         event partitioning (UseTenantPartitionedEvents) is not yet supported and throws; the
-///         bespoke inline path still covers it (polecat#309).
+///         Covers the core append shape (single/conjoined tenancy, Guid/string streams, optional
+///         correlation/causation/headers/user_name columns), DCB tag writes, and per-tenant event
+///         partitioning (UseTenantPartitionedEvents — seq_id via NEXT VALUE FOR the tenant sequence
+///         plus the tenant_ordinal column, resolved by the planner).
 ///     </para>
 /// </remarks>
 internal sealed class PolecatQuickAppendEventsOperation
@@ -67,15 +67,30 @@ internal sealed class PolecatQuickAppendEventsOperation
     /// <summary>Set by the planner: INSERT a new stream row, or UPDATE the existing one's version.</summary>
     public StreamWriteMode Mode { get; set; } = StreamWriteMode.Insert;
 
+    /// <summary>
+    ///     Per-tenant partitioning (<c>UseTenantPartitionedEvents</c>): the stream tenant's compact
+    ///     partition ordinal, resolved (and provisioned) by the planner. Null when partitioning is off,
+    ///     in which case <c>seq_id</c> is the global IDENTITY column.
+    /// </summary>
+    public int? PartitionOrdinal { get; set; }
+
+    /// <summary>
+    ///     The stream tenant's per-tenant sequence name (schema-qualified) that feeds <c>seq_id</c> via
+    ///     <c>NEXT VALUE FOR</c> under per-tenant partitioning. Set alongside <see cref="PartitionOrdinal" />.
+    /// </summary>
+    public string? PartitionSequenceName { get; set; }
+
     public Type DocumentType => typeof(IEvent);
 
     public OperationRole Role() => OperationRole.Events;
 
     public void ConfigureCommand(Weasel.Core.ICommandBuilder builder, IStorageSession session)
     {
-        if (_graph.UseTenantPartitionedEvents)
-            throw new NotSupportedException(
-                "Per-tenant event partitioning is not yet supported on the closed-shape event append path.");
+        var partitioned = _graph.UseTenantPartitionedEvents;
+        if (partitioned && (PartitionSequenceName is null || PartitionOrdinal is null))
+            throw new InvalidOperationException(
+                "Per-tenant partitioning is enabled but the planner did not resolve the tenant partition " +
+                "ordinal/sequence for this append operation.");
 
         builder.Append("declare ");
         builder.Append(SeqTableVar);
@@ -110,7 +125,17 @@ internal sealed class PolecatQuickAppendEventsOperation
             ordinal++;
             builder.Append("insert into ");
             builder.Append(_graph.EventsTableName);
-            builder.Append(" (id, stream_id, version, data, type, timestamp, tenant_id, dotnet_type");
+            builder.Append(" (");
+            // Per-tenant partitioning: seq_id is drawn from the tenant's own sequence (not IDENTITY) and
+            // the row carries the tenant's physical-partition ordinal.
+            if (partitioned)
+            {
+                builder.Append("seq_id, ");
+                builder.Append(_graph.TenantPartitionManager.Column);
+                builder.Append(", ");
+            }
+
+            builder.Append("id, stream_id, version, data, type, timestamp, tenant_id, dotnet_type");
             if (options.EnableCorrelationId) builder.Append(", correlation_id");
             if (options.EnableCausationId) builder.Append(", causation_id");
             if (options.EnableHeaders) builder.Append(", headers");
@@ -118,6 +143,15 @@ internal sealed class PolecatQuickAppendEventsOperation
             builder.Append(") output inserted.seq_id into ");
             builder.Append(SeqTableVar);
             builder.Append(" values (");
+
+            if (partitioned)
+            {
+                builder.Append("next value for ");
+                builder.Append(PartitionSequenceName!);
+                builder.Append(", ");
+                Bind(builder, PartitionOrdinal!.Value, StorageColumnType.Int);
+                builder.Append(", ");
+            }
 
             Bind(builder, @event.Id, StorageColumnType.Guid);
 

--- a/src/Polecat/Internal/DocumentSessionBase.cs
+++ b/src/Polecat/Internal/DocumentSessionBase.cs
@@ -724,11 +724,16 @@ internal abstract class DocumentSessionBase : QuerySession, IDocumentSession
                 continue;
             }
 
+            // Per-tenant partitioning: resolve (and lazily provision) the stream tenant's partition
+            // ordinal + sequence once per stream before building the append op.
+            var (partitionOrdinal, partitionSequenceName) = await ResolvePartitionForClosedShapeAsync(stream, token);
+
             if (stream.ActionType == StreamActionType.Start)
             {
                 AssignEventMetadataForClosedShape(stream, 0);
                 stream.Version = stream.Events.Count;
-                ops.Add(QuickAppendEventsClosedShape(storage, isGuid, stream, Polecat.Events.Storage.StreamWriteMode.Insert));
+                ops.Add(QuickAppendEventsClosedShape(storage, isGuid, stream,
+                    Polecat.Events.Storage.StreamWriteMode.Insert, partitionOrdinal, partitionSequenceName));
             }
             else
             {
@@ -749,15 +754,12 @@ internal abstract class DocumentSessionBase : QuerySession, IDocumentSession
                 AssignEventMetadataForClosedShape(stream, currentVersion);
                 stream.Version = currentVersion + stream.Events.Count;
 
-                if (exists)
-                {
-                    stream.ExpectedVersionOnServer ??= currentVersion;
-                    ops.Add(QuickAppendEventsClosedShape(storage, isGuid, stream, Polecat.Events.Storage.StreamWriteMode.Update));
-                }
-                else
-                {
-                    ops.Add(QuickAppendEventsClosedShape(storage, isGuid, stream, Polecat.Events.Storage.StreamWriteMode.Insert));
-                }
+                var mode = exists
+                    ? Polecat.Events.Storage.StreamWriteMode.Update
+                    : Polecat.Events.Storage.StreamWriteMode.Insert;
+                if (exists) stream.ExpectedVersionOnServer ??= currentVersion;
+                ops.Add(QuickAppendEventsClosedShape(storage, isGuid, stream, mode,
+                    partitionOrdinal, partitionSequenceName));
             }
         }
 
@@ -766,13 +768,24 @@ internal abstract class DocumentSessionBase : QuerySession, IDocumentSession
         await ExecuteClosedShapeEventOperationsAsync(ops, token);
     }
 
+    private async Task<(int? ordinal, string? sequenceName)> ResolvePartitionForClosedShapeAsync(
+        StreamAction stream, CancellationToken token)
+    {
+        if (!_eventGraph.UseTenantPartitionedEvents) return (null, null);
+        var storage = await _eventGraph.TenantSequences.ResolveAsync(stream.TenantId, token);
+        return (storage.Ordinal, storage.SequenceName);
+    }
+
     private static Weasel.Storage.IStorageOperation QuickAppendEventsClosedShape(
-        object storage, bool isGuid, StreamAction stream, Polecat.Events.Storage.StreamWriteMode mode)
+        object storage, bool isGuid, StreamAction stream, Polecat.Events.Storage.StreamWriteMode mode,
+        int? partitionOrdinal, string? partitionSequenceName)
     {
         var op = (Polecat.Events.Storage.PolecatQuickAppendEventsOperation)(isGuid
             ? ((Weasel.Storage.EventStorage<Guid>)storage).QuickAppendEvents(stream)
             : ((Weasel.Storage.EventStorage<string>)storage).QuickAppendEvents(stream));
         op.Mode = mode;
+        op.PartitionOrdinal = partitionOrdinal;
+        op.PartitionSequenceName = partitionSequenceName;
         return op;
     }
 


### PR DESCRIPTION
## Summary
Fifth increment of the #273 closed-shape event-append convergence — and the **last feature gap**. Adds support for `Events.UseTenantPartitionedEvents` on the closed-shape path, so `PolecatQuickAppendEventsOperation` no longer throws for partitioned stores. **Closes #309.**

## Implementation
- The op gains `PartitionOrdinal` / `PartitionSequenceName`, set by the planner. When partitioning is on, the `pc_events` INSERT prepends `seq_id, tenant_ordinal` and draws `seq_id` from the tenant's own sequence via `NEXT VALUE FOR` (instead of the global IDENTITY). `OUTPUT inserted.seq_id` still returns the assigned value, so the trailing-`SELECT` read-back and the DCB tag ordinal lookup carry over unchanged.
- The planner resolves (and lazily provisions) each stream tenant's partition ordinal + sequence once per stream via `EventGraph.TenantSequences.ResolveAsync` before building the op. `pc_streams` is not partitioned, so the stream-row closures are unchanged.

## Tests
New `closed_shape_partitioned_event_tests` (in the serialized `tenant-partitioning` collection):
- per-tenant sequence isolation (each tenant's `seq_id` starts at 1, overlapping across tenants) + tenant-scoped round-trip
- append-to-existing partitioned stream continues versions and per-tenant sequence

The bespoke partitioning suite (`per_tenant_event_sequence_tests`, `per_tenant_rebuild_tests`) is unchanged — 10 green together.

## Status
With this in, the closed-shape event append path is at feature parity with the bespoke inline path (single/conjoined tenancy, Guid/string streams, metadata columns, DCB tags, per-tenant partitioning, inline projections, optimistic concurrency, archived guards). Next: flip the default + retire the bespoke inline methods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)