### PR TITLE
refactor: converge batched Load/LoadMany onto the closed-shape read path (#273)

### DIFF
--- a/src/Polecat.Tests/Batching/batch_load_parity.cs
+++ b/src/Polecat.Tests/Batching/batch_load_parity.cs
@@ -1,0 +1,159 @@
+using JasperFx;
+using Polecat.Tests.Harness;
+
+namespace Polecat.Tests.Batching;
+
+// Hierarchy types local to the batched-load parity tests (#273 doc-side convergence).
+public abstract class BatchPerson
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+}
+
+public class BatchEmployee : BatchPerson
+{
+    public string Department { get; set; } = string.Empty;
+}
+
+public class BatchContractor : BatchPerson
+{
+    public string Agency { get; set; } = string.Empty;
+}
+
+/// <summary>
+///     Broadened parity coverage for the batched Load/LoadMany read path after it was retired
+///     onto the closed-shape QueryOnly storage + selector (#273 doc-side convergence). Exercises
+///     the risk areas the shared read path must still honor: optimistic-concurrency + numeric
+///     revision version sync, the soft-delete filter, the conjoined tenant filter (#234), and
+///     hierarchy (subclass doc_type discrimination).
+/// </summary>
+[Collection("integration")]
+public class batch_load_parity : IntegrationContext
+{
+    public batch_load_parity(DefaultStoreFixture fixture) : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task batch_load_populates_guid_version()
+    {
+        var doc = new VersionedDoc { Id = Guid.NewGuid(), Name = "Optimistic" };
+        theSession.Store(doc);
+        await theSession.SaveChangesAsync();
+        var savedVersion = doc.Version;
+        savedVersion.ShouldNotBe(Guid.Empty);
+
+        await using var query = theStore.QuerySession();
+        var batch = query.CreateBatchQuery();
+        var loaded = batch.Load<VersionedDoc>(doc.Id);
+        await batch.Execute();
+
+        var result = await loaded;
+        result.ShouldNotBeNull();
+        result.Version.ShouldBe(savedVersion);
+    }
+
+    [Fact]
+    public async Task batch_load_populates_numeric_revision()
+    {
+        var doc = new RevisionedDoc { Id = Guid.NewGuid(), Name = "Revisioned" };
+        theSession.Store(doc);
+        await theSession.SaveChangesAsync();
+
+        await using var query = theStore.QuerySession();
+        var batch = query.CreateBatchQuery();
+        var loaded = batch.Load<RevisionedDoc>(doc.Id);
+        var loadedMany = batch.LoadMany<RevisionedDoc>(doc.Id);
+        await batch.Execute();
+
+        (await loaded).ShouldNotBeNull();
+        (await loaded)!.Version.ShouldBe(1);
+        (await loadedMany).Single().Version.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task batch_load_respects_soft_delete_filter()
+    {
+        var live = new SoftDeletedDoc { Id = Guid.NewGuid(), Name = "Live" };
+        var gone = new SoftDeletedDoc { Id = Guid.NewGuid(), Name = "Gone" };
+        theSession.Store(live, gone);
+        await theSession.SaveChangesAsync();
+
+        theSession.Delete(gone); // soft delete
+        await theSession.SaveChangesAsync();
+
+        await using var query = theStore.QuerySession();
+        var batch = query.CreateBatchQuery();
+        var loadLive = batch.Load<SoftDeletedDoc>(live.Id);
+        var loadGone = batch.Load<SoftDeletedDoc>(gone.Id);
+        var loadMany = batch.LoadMany<SoftDeletedDoc>(live.Id, gone.Id);
+        await batch.Execute();
+
+        (await loadLive).ShouldNotBeNull();
+        (await loadGone).ShouldBeNull();
+        (await loadMany).Select(d => d.Id).ShouldBe(new[] { live.Id });
+    }
+
+    [Fact]
+    public async Task batch_load_respects_conjoined_tenant_filter()
+    {
+        await StoreOptions(opts =>
+        {
+            opts.DatabaseSchemaName = "batch_conjoined";
+            opts.Events.TenancyStyle = TenancyStyle.Conjoined;
+        });
+
+        var id = Guid.NewGuid();
+        theSession.ForTenant("tenant-a").Store(new TenantScopedDoc { Id = id, Name = "A" });
+        theSession.ForTenant("tenant-b").Store(new TenantScopedDoc { Id = id, Name = "B" });
+        await theSession.SaveChangesAsync();
+
+        await using var query = theStore.QuerySession(new SessionOptions { TenantId = "tenant-a" });
+        var batch = query.CreateBatchQuery();
+        var loadOne = batch.Load<TenantScopedDoc>(id);
+        var loadMany = batch.LoadMany<TenantScopedDoc>(id);
+        await batch.Execute();
+
+        (await loadOne).ShouldNotBeNull();
+        (await loadOne)!.Name.ShouldBe("A");
+        (await loadMany).Single().Name.ShouldBe("A");
+    }
+
+    [Fact]
+    public async Task batch_load_discriminates_subclasses_by_doc_type()
+    {
+        await StoreOptions(opts =>
+        {
+            opts.DatabaseSchemaName = "batch_hierarchy";
+            opts.Schema.For<BatchPerson>()
+                .AddSubClass<BatchEmployee>()
+                .AddSubClass<BatchContractor>();
+        });
+
+        var employee = new BatchEmployee { Id = Guid.NewGuid(), Name = "Emp", Department = "Eng" };
+        var contractor = new BatchContractor { Id = Guid.NewGuid(), Name = "Con", Agency = "Acme" };
+        theSession.Store<BatchPerson>(employee, contractor);
+        await theSession.SaveChangesAsync();
+
+        await using var query = theStore.QuerySession();
+        var batch = query.CreateBatchQuery();
+        var asBase = batch.Load<BatchPerson>(employee.Id);
+        var asEmployee = batch.Load<BatchEmployee>(employee.Id);
+        var wrongSubclass = batch.Load<BatchEmployee>(contractor.Id); // contractor row, filtered by doc_type
+        var manyEmployees = batch.LoadMany<BatchEmployee>(employee.Id, contractor.Id);
+        await batch.Execute();
+
+        (await asBase).ShouldBeOfType<BatchEmployee>();
+        (await asEmployee).ShouldNotBeNull();
+        (await asEmployee)!.Department.ShouldBe("Eng");
+        (await wrongSubclass).ShouldBeNull();
+        (await manyEmployees).Select(e => e.Id).ShouldBe(new[] { employee.Id });
+    }
+}
+
+/// <summary>Conjoined-tenancy target for the batch tenant-filter test.</summary>
+public class TenantScopedDoc
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+}

--- a/src/Polecat/Internal/Batching/BatchedQuery.cs
+++ b/src/Polecat/Internal/Batching/BatchedQuery.cs
@@ -41,24 +41,10 @@ internal class BatchedQuery : IBatchedQuery
     public Task<T?> Load<T>(long id) where T : class => AddLoad<T>(id);
 
     public Task<IReadOnlyList<T>> LoadMany<T>(params Guid[] ids) where T : class
-    {
-        var provider = _providers.GetProvider<T>();
-        _involvedProviders.Add(provider);
-        var item = new LoadManyBatchQueryItem<T>(ids.Cast<object>().ToArray(), provider,
-            _session.Serializer, _session.TenantId);
-        _items.Add(item);
-        return item.Result;
-    }
+        => AddLoadMany<T>(ids.Cast<object>().ToArray());
 
     public Task<IReadOnlyList<T>> LoadMany<T>(params string[] ids) where T : class
-    {
-        var provider = _providers.GetProvider<T>();
-        _involvedProviders.Add(provider);
-        var item = new LoadManyBatchQueryItem<T>(ids.Cast<object>().ToArray(), provider,
-            _session.Serializer, _session.TenantId);
-        _items.Add(item);
-        return item.Result;
-    }
+        => AddLoadMany<T>(ids.Cast<object>().ToArray());
 
     public IBatchedQueryable<T> Query<T>() where T : class
     {
@@ -153,10 +139,24 @@ internal class BatchedQuery : IBatchedQuery
 
     private Task<T?> AddLoad<T>(object id) where T : class
     {
-        var provider = _providers.GetProvider<T>();
-        _involvedProviders.Add(provider);
-        var item = new LoadBatchQueryItem<T>(id, provider, _session.Serializer, _session.TenantId);
+        // Track the bespoke provider so the shared table gets ensured; compose the read via the
+        // closed-shape QueryOnly storage (#273 doc-side convergence).
+        _involvedProviders.Add(_providers.GetProvider<T>());
+        var storage = ClosedShapeLoadStorageFor<T>();
+        var item = new LoadBatchQueryItem<T>(id, storage, _session, _session.TenantId);
         _items.Add(item);
         return item.Result;
     }
+
+    private Task<IReadOnlyList<T>> AddLoadMany<T>(object[] ids) where T : class
+    {
+        _involvedProviders.Add(_providers.GetProvider<T>());
+        var storage = ClosedShapeLoadStorageFor<T>();
+        var item = new LoadManyBatchQueryItem<T>(ids, storage, _session, _session.TenantId);
+        _items.Add(item);
+        return item.Result;
+    }
+
+    private Storage.ClosedShape.IPolecatBatchLoadStorage<T> ClosedShapeLoadStorageFor<T>() where T : class
+        => (Storage.ClosedShape.IPolecatBatchLoadStorage<T>)_providers.ClosedShapeGraph.StorageFor<T>().QueryOnly;
 }

--- a/src/Polecat/Internal/Batching/LoadBatchQueryItem.cs
+++ b/src/Polecat/Internal/Batching/LoadBatchQueryItem.cs
@@ -1,58 +1,42 @@
 using System.Data.Common;
-using System.Diagnostics.CodeAnalysis;
-using Polecat.Metadata;
-using Polecat.Serialization;
+using Polecat.Storage.ClosedShape;
 using Weasel.SqlServer;
+using Weasel.Storage;
 
 namespace Polecat.Internal.Batching;
 
-[UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
-    Justification = "Class-level: deserializes a loaded document row via ISerializer.FromJson. T is preserved by IBatch.Load<T>() registration on the caller side per the AOT publishing guide.")]
-[UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
-    Justification = "Class-level: ISerializer.FromJson is annotated RDC. AOT consumers supply a source-generator-backed impl.")]
+/// <summary>
+///     Batched single-document load. Composes the closed-shape whole-document SELECT
+///     (#273 doc-side convergence) into the shared <c>SqlBatch</c> command via the QueryOnly
+///     storage and materializes the row through the closed-shape selector — the same read
+///     path as <c>session.Query&lt;T&gt;()</c>.
+/// </summary>
 internal class LoadBatchQueryItem<T> : IBatchQueryItem where T : class
 {
     private readonly TaskCompletionSource<T?> _tcs = new();
     private readonly object _id;
-    private readonly DocumentProvider _provider;
-    private readonly ISerializer _serializer;
+    private readonly IPolecatBatchLoadStorage<T> _storage;
+    private readonly IStorageSession _session;
     private readonly string _tenantId;
 
-    public LoadBatchQueryItem(object id, DocumentProvider provider, ISerializer serializer, string tenantId)
+    public LoadBatchQueryItem(object id, IPolecatBatchLoadStorage<T> storage, IStorageSession session, string tenantId)
     {
         _id = id;
-        _provider = provider;
-        _serializer = serializer;
+        _storage = storage;
+        _session = session;
         _tenantId = tenantId;
     }
 
     public Task<T?> Result => _tcs.Task;
 
-    public void WriteSql(ICommandBuilder builder)
-    {
-        var softDeleteFilter = _provider.Mapping.DeleteStyle == DeleteStyle.SoftDelete
-            ? " AND is_deleted = 0"
-            : "";
-
-        builder.Append($"{_provider.SelectSql} WHERE id = ");
-        builder.AppendParameter(_id);
-        if (_provider.Mapping.TenancyStyle == TenancyStyle.Conjoined) // #234
-        {
-            builder.Append(" AND tenant_id = ");
-            builder.AppendParameter(_tenantId);
-        }
-
-        builder.Append(softDeleteFilter);
-        builder.Append(";\n");
-    }
+    public void WriteSql(ICommandBuilder builder) => _storage.WriteLoadByIdSql(builder, _id, _tenantId);
 
     public async Task ReadResultSetAsync(DbDataReader reader, CancellationToken token)
     {
         if (await reader.ReadAsync(token))
         {
-            var json = reader.GetString(1); // data column
-            var doc = _serializer.FromJson<T>(json);
-            QuerySession.SyncVersionProperties(doc, reader, _provider);
+            var selector = _storage.BuildLoadSelector(_session);
+            var doc = await selector.ResolveAsync(reader, token);
             _tcs.SetResult(doc);
         }
         else

--- a/src/Polecat/Internal/Batching/LoadManyBatchQueryItem.cs
+++ b/src/Polecat/Internal/Batching/LoadManyBatchQueryItem.cs
@@ -1,72 +1,43 @@
 using System.Data.Common;
-using System.Diagnostics.CodeAnalysis;
-using Polecat.Metadata;
-using Polecat.Serialization;
+using Polecat.Storage.ClosedShape;
 using Weasel.SqlServer;
+using Weasel.Storage;
 
 namespace Polecat.Internal.Batching;
 
-[UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
-    Justification = "Class-level: deserializes loaded document rows via ISerializer.FromJson. T is preserved by IBatch.LoadMany<T>() registration on the caller side per the AOT publishing guide.")]
-[UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
-    Justification = "Class-level: ISerializer.FromJson is annotated RDC. AOT consumers supply a source-generator-backed impl.")]
+/// <summary>
+///     Batched multi-document load. Composes the closed-shape whole-document SELECT
+///     (#273 doc-side convergence) into the shared <c>SqlBatch</c> command via the QueryOnly
+///     storage and materializes rows through the closed-shape selector.
+/// </summary>
 internal class LoadManyBatchQueryItem<T> : IBatchQueryItem where T : class
 {
     private readonly TaskCompletionSource<IReadOnlyList<T>> _tcs = new();
     private readonly object[] _ids;
-    private readonly DocumentProvider _provider;
-    private readonly ISerializer _serializer;
+    private readonly IPolecatBatchLoadStorage<T> _storage;
+    private readonly IStorageSession _session;
     private readonly string _tenantId;
 
-    public LoadManyBatchQueryItem(object[] ids, DocumentProvider provider, ISerializer serializer, string tenantId)
+    public LoadManyBatchQueryItem(object[] ids, IPolecatBatchLoadStorage<T> storage, IStorageSession session,
+        string tenantId)
     {
         _ids = ids;
-        _provider = provider;
-        _serializer = serializer;
+        _storage = storage;
+        _session = session;
         _tenantId = tenantId;
     }
 
     public Task<IReadOnlyList<T>> Result => _tcs.Task;
 
-    public void WriteSql(ICommandBuilder builder)
-    {
-        if (_ids.Length == 0)
-        {
-            builder.Append($"{_provider.SelectSql} WHERE 1 = 0;\n");
-            return;
-        }
-
-        var softDeleteFilter = _provider.Mapping.DeleteStyle == DeleteStyle.SoftDelete
-            ? " AND is_deleted = 0"
-            : "";
-
-        builder.Append($"{_provider.SelectSql} WHERE id IN (");
-        for (var i = 0; i < _ids.Length; i++)
-        {
-            if (i > 0) builder.Append(", ");
-            builder.AppendParameter(_ids[i]);
-        }
-
-        builder.Append(")");
-        if (_provider.Mapping.TenancyStyle == TenancyStyle.Conjoined) // #234
-        {
-            builder.Append(" AND tenant_id = ");
-            builder.AppendParameter(_tenantId);
-        }
-
-        builder.Append(softDeleteFilter);
-        builder.Append(";\n");
-    }
+    public void WriteSql(ICommandBuilder builder) => _storage.WriteLoadManySql(builder, _ids, _tenantId);
 
     public async Task ReadResultSetAsync(DbDataReader reader, CancellationToken token)
     {
+        var selector = _storage.BuildLoadSelector(_session);
         var results = new List<T>();
         while (await reader.ReadAsync(token))
         {
-            var json = reader.GetString(1); // data column
-            var doc = _serializer.FromJson<T>(json);
-            QuerySession.SyncVersionProperties(doc, reader, _provider);
-            results.Add(doc);
+            results.Add(await selector.ResolveAsync(reader, token));
         }
 
         _tcs.SetResult(results);

--- a/src/Polecat/Internal/DocumentProvider.cs
+++ b/src/Polecat/Internal/DocumentProvider.cs
@@ -34,66 +34,8 @@ internal class DocumentProvider
 
     public string QualifiedTableName => Mapping.QualifiedTableName;
 
-    // #234: tenant_id is present only on conjoined tables. When absent, every trailing column
-    // ordinal shifts down by one, so the read-side ordinals below are computed off tenancy.
-    private bool IsConjoined => Mapping.TenancyStyle == TenancyStyle.Conjoined;
-
-    public string SelectSql
-    {
-        get
-        {
-            var baseCols = "id, data, version, last_modified, created_at, dotnet_type";
-            if (IsConjoined)
-            {
-                baseCols += ", tenant_id";
-            }
-
-            if (Mapping.UseOptimisticConcurrency)
-            {
-                baseCols += ", guid_version";
-            }
-
-            if (Mapping.IsHierarchy())
-            {
-                baseCols += ", doc_type";
-            }
-
-            return $"SELECT {baseCols} FROM {Mapping.QualifiedTableName}";
-        }
-    }
-
-    /// <summary>
-    ///     Column index of guid_version in SelectSql (valid only under optimistic concurrency).
-    ///     Base columns id[0]..dotnet_type[5], then tenant_id[6] only when conjoined.
-    /// </summary>
-    public int GuidVersionColumnIndex => 6 + (IsConjoined ? 1 : 0);
-
-    /// <summary>
-    ///     Column index of doc_type in SelectSql, or -1 if not a hierarchy.
-    /// </summary>
-    public int DocTypeColumnIndex
-    {
-        get
-        {
-            if (!Mapping.IsHierarchy()) return -1;
-            return 6 + (IsConjoined ? 1 : 0) + (Mapping.UseOptimisticConcurrency ? 1 : 0);
-        }
-    }
-
-    public string LoadSql
-    {
-        get
-        {
-            var softDeleteFilter = Mapping.DeleteStyle == DeleteStyle.SoftDelete
-                ? " AND is_deleted = 0"
-                : "";
-            var tenantFilter = IsConjoined ? " AND tenant_id = @tenant_id" : "";
-            return $"{SelectSql} WHERE id = @id{tenantFilter}{softDeleteFilter};";
-        }
-    }
-
-    // #273 E2e: the per-document write/delete operation factories are retired — every write
-    // and delete now flows through the closed-shape storage layer (Storage/ClosedShape).
-    // What remains here is the read-side SQL the batching items still compose (SelectSql /
-    // LoadSql / DocTypeColumnIndex) and the sequence plumbing.
+    // #273: the per-document write/delete operation factories (E2e) and the read-side SQL the
+    // batching items used to compose (doc-side convergence) are both retired — every write,
+    // delete, and load now flows through the closed-shape storage layer (Storage/ClosedShape).
+    // What remains here is the table-mapping handle and the sequence plumbing.
 }

--- a/src/Polecat/Internal/QuerySession.cs
+++ b/src/Polecat/Internal/QuerySession.cs
@@ -352,31 +352,6 @@ internal partial class QuerySession : IQuerySession
         return polecatProvider.BuildSql(queryable.Expression, TenantId);
     }
 
-    /// <summary>
-    ///     Syncs version/revision properties from the DB columns to the document object.
-    ///     SelectSql column layout: id[0], data[1], version[2], last_modified[3], created_at[4], dotnet_type[5], tenant_id[6], guid_version[7]?
-    /// </summary>
-    internal static void SyncVersionProperties<T>(T doc, DbDataReader reader, DocumentProvider provider) where T : class
-    {
-        if (provider.Mapping.UseNumericRevisions)
-        {
-            var version = reader.GetInt64(2); // version column
-            if (doc is ILongVersioned longVersioned)
-            {
-                longVersioned.Version = version;
-            }
-            else if (doc is IRevisioned revisioned)
-            {
-                revisioned.Version = (int)version;
-            }
-        }
-
-        if (provider.Mapping.UseOptimisticConcurrency && doc is IVersioned versioned)
-        {
-            versioned.Version = reader.GetGuid(provider.GuidVersionColumnIndex); // guid_version column
-        }
-    }
-
     public virtual async ValueTask DisposeAsync()
     {
         await _lifetime.DisposeAsync();

--- a/src/Polecat/Storage/ClosedShape/PolecatDocumentStorage.cs
+++ b/src/Polecat/Storage/ClosedShape/PolecatDocumentStorage.cs
@@ -65,7 +65,27 @@ internal interface IPolecatObjectStorage<TDoc> : IPolecatObjectWriteStorage wher
     IDeletion DeletionForObjectId(object id, string tenantId);
 }
 
-internal abstract class PolecatDocumentStorage<TDoc, TId> : IDocumentStorage<TDoc, TId>, IPolecatObjectStorage<TDoc>
+/// <summary>
+///     Read-side seam for the batched-query load items (#273 doc-side convergence): composes the
+///     closed-shape whole-document SELECT with positional parameters into a shared
+///     <c>SqlBatch</c> command, and materializes rows through the closed-shape QueryOnly selector.
+///     This retires the bespoke <c>DocumentProvider.SelectSql</c>/<c>LoadSql</c> +
+///     <c>FromJson</c>/<c>SyncVersionProperties</c> load path from <c>Internal/Batching</c>.
+/// </summary>
+internal interface IPolecatBatchLoadStorage<TDoc> where TDoc : notnull
+{
+    /// <summary>Appends <c>SELECT … FROM … WHERE id = @p [AND tenant] [AND soft-delete]</c> (no trailing <c>;</c>).</summary>
+    void WriteLoadByIdSql(Weasel.SqlServer.ICommandBuilder builder, object id, string tenantId);
+
+    /// <summary>Appends <c>SELECT … FROM … WHERE id IN (…) [AND tenant] [AND soft-delete]</c> (no trailing <c>;</c>).</summary>
+    void WriteLoadManySql(Weasel.SqlServer.ICommandBuilder builder, IReadOnlyList<object> ids, string tenantId);
+
+    /// <summary>The closed-shape QueryOnly selector whose ordinals match the composed SELECT.</summary>
+    ISelector<TDoc> BuildLoadSelector(IStorageSession session);
+}
+
+internal abstract class PolecatDocumentStorage<TDoc, TId>
+    : IDocumentStorage<TDoc, TId>, IPolecatObjectStorage<TDoc>, IPolecatBatchLoadStorage<TDoc>
     where TDoc : notnull
     where TId : notnull
 {
@@ -73,6 +93,7 @@ internal abstract class PolecatDocumentStorage<TDoc, TId> : IDocumentStorage<TDo
     protected readonly DocumentStorageDescriptor<TDoc, TId> _descriptor;
     private readonly string _loaderSql;
     private readonly string _loadManySql;
+    private readonly string _selectPrefixSql;
     private readonly string[] _selectFields;
     private readonly IOperationFragment _deleteFragment;
     private readonly IOperationFragment _hardDeleteFragment;
@@ -96,6 +117,7 @@ internal abstract class PolecatDocumentStorage<TDoc, TId> : IDocumentStorage<TDo
         _selectFields = readColumns.ToArray();
 
         var select = $"SELECT {string.Join(", ", _selectFields)} FROM {_mapping.QualifiedTableName}";
+        _selectPrefixSql = select;
         // #234: only conjoined tables carry a tenant_id column, so single-tenant loads omit the
         // tenant predicate entirely (the harmless @tenant_id parameter the dialect still binds is
         // simply unreferenced by the SQL).
@@ -274,6 +296,56 @@ internal abstract class PolecatDocumentStorage<TDoc, TId> : IDocumentStorage<TDo
         CancellationToken token)
         => ClosedShapeProjectionLoader<TDoc, TId>.LoadManyAsync(
             BuildLoadManyCommand(ids, tenantId), _descriptor, _descriptor.Serializer, database, token);
+
+    // ---- batched-query read seam (#273 doc-side convergence) ----
+
+    public void WriteLoadByIdSql(Weasel.SqlServer.ICommandBuilder builder, object id, string tenantId)
+    {
+        builder.Append(_selectPrefixSql);
+        builder.Append(" WHERE id = ");
+        builder.AppendParameter(id);
+        AppendBatchLoadFilters(builder, tenantId);
+    }
+
+    public void WriteLoadManySql(Weasel.SqlServer.ICommandBuilder builder, IReadOnlyList<object> ids, string tenantId)
+    {
+        builder.Append(_selectPrefixSql);
+        if (ids.Count == 0)
+        {
+            builder.Append(" WHERE 1 = 0");
+            return;
+        }
+
+        builder.Append(" WHERE id IN (");
+        for (var i = 0; i < ids.Count; i++)
+        {
+            if (i > 0) builder.Append(", ");
+            builder.AppendParameter(ids[i]);
+        }
+
+        builder.Append(")");
+        AppendBatchLoadFilters(builder, tenantId);
+    }
+
+    /// <summary>
+    ///     Appends the conjoined tenant predicate (#234 — conjoined tables only) and the
+    ///     soft-delete predicate, with positional parameters, mirroring the closed-shape
+    ///     loader SQL. <see cref="SubClassPolecatStorage{T,TRoot,TId}" /> reuses these filters
+    ///     by delegating to the whole write methods above before appending its <c>doc_type</c>
+    ///     discriminator.
+    /// </summary>
+    private void AppendBatchLoadFilters(Weasel.SqlServer.ICommandBuilder builder, string tenantId)
+    {
+        if (_mapping.TenancyStyle == TenancyStyle.Conjoined)
+        {
+            builder.Append(" AND tenant_id = ");
+            builder.AppendParameter(tenantId);
+        }
+
+        builder.Append(SoftDeleteFilterSql());
+    }
+
+    public ISelector<TDoc> BuildLoadSelector(IStorageSession session) => (ISelector<TDoc>)BuildSelector(session);
 
     // ---- session bookkeeping ----
 

--- a/src/Polecat/Storage/ClosedShape/SubClassPolecatStorage.cs
+++ b/src/Polecat/Storage/ClosedShape/SubClassPolecatStorage.cs
@@ -15,7 +15,8 @@ namespace Polecat.Storage.ClosedShape;
 ///     Marten's semantics). One wrapper instance exists per closed-shape flavor, wrapping the
 ///     parent provider's corresponding flavor.
 /// </summary>
-internal sealed class SubClassPolecatStorage<T, TRoot, TId> : IDocumentStorage<T, TId>, IPolecatObjectStorage<T>
+internal sealed class SubClassPolecatStorage<T, TRoot, TId>
+    : IDocumentStorage<T, TId>, IPolecatObjectStorage<T>, IPolecatBatchLoadStorage<T>
     where T : notnull, TRoot
     where TRoot : notnull
     where TId : notnull
@@ -178,6 +179,33 @@ internal sealed class SubClassPolecatStorage<T, TRoot, TId> : IDocumentStorage<T
     public Task TruncateDocumentStorageAsync(IStorageDatabase database, CancellationToken ct = default)
         => database.RunSqlAsync(
             $"DELETE FROM {_mapping.QualifiedTableName} WHERE doc_type = '{_alias.Replace("'", "''")}'", ct);
+
+    // ---- batched-query read seam (#273 doc-side convergence) ----
+    // Delegate the SELECT + id/tenant/soft-delete filters to the root storage, then constrain
+    // to this subclass with a doc_type discriminator so the casting selector cannot see a row
+    // of a sibling subclass.
+
+    private IPolecatBatchLoadStorage<TRoot> BatchParent => (IPolecatBatchLoadStorage<TRoot>)_parent;
+
+    public void WriteLoadByIdSql(Weasel.SqlServer.ICommandBuilder builder, object id, string tenantId)
+    {
+        BatchParent.WriteLoadByIdSql(builder, id, tenantId);
+        AppendDocTypeFilter(builder);
+    }
+
+    public void WriteLoadManySql(Weasel.SqlServer.ICommandBuilder builder, IReadOnlyList<object> ids, string tenantId)
+    {
+        BatchParent.WriteLoadManySql(builder, ids, tenantId);
+        AppendDocTypeFilter(builder);
+    }
+
+    private void AppendDocTypeFilter(Weasel.SqlServer.ICommandBuilder builder)
+    {
+        builder.Append(" AND doc_type = ");
+        builder.AppendParameter(_alias);
+    }
+
+    public ISelector<T> BuildLoadSelector(IStorageSession session) => (ISelector<T>)BuildSelector(session);
 
     // ---- IPolecatObjectStorage bridge ----
 


### PR DESCRIPTION
## What & why

Increment 7 of the [#273 doc-side convergence handoff](https://github.com/JasperFx/polecat/issues/273): retire the bespoke `DocumentProvider.SelectSql`/`LoadSql` + `FromJson`/`SyncVersionProperties` load path from `Internal/Batching`.

Batched `Load`/`LoadMany` now compose the closed-shape whole-document `SELECT` via the **QueryOnly** storage and materialize rows through the shared closed-shape `ISelector<TDoc>` — the exact read path `session.Query<T>()` already uses. This makes the batched read a dialect of the shared runtime rather than a parallel hand-written SQL/materialization path.

## Changes

- **New `IPolecatBatchLoadStorage<TDoc>` seam** on `PolecatDocumentStorage`: exposes the `SELECT <fields> FROM <table>` prefix + the id / conjoined-tenant (#234) / soft-delete filters (positional params into the shared `SqlBatch` command), plus the QueryOnly selector. Ordinals are guaranteed to match because both the column list and the selector come from the same QueryOnly flavor.
- **`SubClassPolecatStorage`** delegates SQL to the root and appends a `doc_type` discriminator, so batched `Load<Subclass>` no longer force-casts a sibling-subclass row (previously the bespoke path selected by id only).
- **Dead code removed**: `DocumentProvider.SelectSql`/`LoadSql`/`DocTypeColumnIndex`/`GuidVersionColumnIndex` and `QuerySession.SyncVersionProperties`.
- **Broadened parity tests** (`batch_load_parity.cs`): guid-version + numeric-revision sync, soft-delete filter, conjoined tenant isolation, hierarchy subclass discrimination.

## Verification

Full suite **1444 passed / 0 failed / 3 skipped** (net10, single-framework). Batching suite 16/16.

Remaining #273 Polecat-local work after this: bulk-insert convergence (`AdvancedOperations.cs`) as a standalone follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)