### PR TITLE
chore: bump Weasel 9.16.0 → 9.16.2 (+ JasperFx 2.24.1)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,8 +22,8 @@
              IEventDatabase.QueryDeadLetterEventsAsync (dead-letter row drill-in), DeadLetterEvent.TenantId,
              and the tenant-aware daemon surface. Polecat implements the dead-letter row query + per-tenant
              FetchDeadLetterCountsAsync below. -->
-        <PackageVersion Include="JasperFx" Version="2.24.0" />
-        <PackageVersion Include="JasperFx.Events" Version="2.24.0" />
+        <PackageVersion Include="JasperFx" Version="2.24.1" />
+        <PackageVersion Include="JasperFx.Events" Version="2.24.1" />
         <!-- Pin the sibling JasperFx packages for parity with Marten 9's matrix
              even though Polecat doesn't currently reference them directly —
              keeps the lockstep matrix coherent when transitive resolution
@@ -54,9 +54,9 @@
              storage contracts extracted from Marten (marten#4821/#4830, weasel#329/#331) —
              IStorageSession / IStorageDatabase / IStorageSerializer / IDocumentStorage /
              IStorageDialect. This is the shared runtime Polecat retargets onto for #273. -->
-        <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.16.0" />
-        <PackageVersion Include="Weasel.SqlServer" Version="9.16.0" />
-        <PackageVersion Include="Weasel.Storage" Version="9.16.0" />
+        <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.16.2" />
+        <PackageVersion Include="Weasel.SqlServer" Version="9.16.2" />
+        <PackageVersion Include="Weasel.Storage" Version="9.16.2" />
 
         <!-- Strongly typed IDs -->
         <PackageVersion Include="StronglyTypedId" Version="1.0.0-beta08" />


### PR DESCRIPTION
Bumps the three Weasel packages (`Weasel.SqlServer`, `Weasel.Storage`, `Weasel.EntityFrameworkCore`) 9.16.0 → **9.16.2**.

Weasel 9.16.2 transitively requires `JasperFx >= 2.24.1` (via `Weasel.Core`), so `JasperFx` + `JasperFx.Events` move 2.24.0 → **2.24.1** in lockstep to keep the matrix coherent and avoid an `NU1605` downgrade. `JasperFx.RuntimeCompiler` stays on its separate 5.x line.

Restore + build clean; targeted CRUD / bulk-insert / event-append smoke tests green locally. Full suite via CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)