### PR TITLE
refactor: converge bulk version-checked upsert onto the closed-shape descriptor (#273)

### DIFF
--- a/src/Polecat.Tests/BulkInsert/bulk_insert_convergence_parity.cs
+++ b/src/Polecat.Tests/BulkInsert/bulk_insert_convergence_parity.cs
@@ -81,4 +81,41 @@ public class bulk_insert_convergence_parity : IntegrationContext
         // A persisted guid_version round-trips back onto the reloaded document.
         loaded.Version.ShouldBe(doc.Version);
     }
+
+    [Fact]
+    public async Task bulk_insert_with_version_hierarchy_writes_doc_type_discriminator()
+    {
+        await StoreOptions(opts =>
+        {
+            opts.DatabaseSchemaName = "bulk_ver_hierarchy";
+            opts.Schema.For<BulkPerson>()
+                .AddSubClass<BulkEmployee>()
+                .AddSubClass<BulkContractor>();
+        });
+
+        var employee = new BulkEmployee { Id = Guid.NewGuid(), Name = "VEmp", Department = "Eng" };
+
+        // Expected version 0 → the row is absent → WHEN NOT MATCHED → INSERT.
+        await theStore.Advanced.BulkInsertWithVersionAsync(new[] { (employee, 0L) });
+
+        await using var query = theStore.QuerySession();
+        var loaded = await query.LoadAsync<BulkPerson>(employee.Id);
+        loaded.ShouldBeOfType<BulkEmployee>();
+        ((BulkEmployee)loaded).Department.ShouldBe("Eng");
+    }
+
+    [Fact]
+    public async Task bulk_insert_with_version_optimistic_writes_guid_version()
+    {
+        await StoreOptions(opts => opts.DatabaseSchemaName = "bulk_ver_optimistic");
+
+        var doc = new VersionedDoc { Id = Guid.NewGuid(), Name = "VOpt" };
+        await theStore.Advanced.BulkInsertWithVersionAsync(new[] { (doc, 0L) });
+
+        await using var query = theStore.QuerySession();
+        var loaded = await query.LoadAsync<VersionedDoc>(doc.Id);
+        loaded.ShouldNotBeNull();
+        // guid_version is now written (bound via the version binder's session-free bulk value).
+        loaded.Version.ShouldNotBe(Guid.Empty);
+    }
 }

--- a/src/Polecat/AdvancedOperations.cs
+++ b/src/Polecat/AdvancedOperations.cs
@@ -245,18 +245,19 @@ public class AdvancedOperations
 
         var provider = _store.GetProvider(typeof(T));
         var mapping = provider.Mapping;
-        var serializer = _store.Options.Serializer;
 
         var ensurer = _store.ResolveTableEnsurer(tenantId);
         await ensurer.EnsureTableAsync(provider, token);
 
-        // Pre-process. The id-assignment and metadata sync mirrors the
-        // versionless path; the only extra piece is carrying the expected
-        // version forward into the batched MERGE.
-        var rows = new List<(object Id, string Json, string DotNetType, long ExpectedVersion)>(documents.Count);
-        foreach (var (doc, expectedVersion) in documents)
+        // #273 doc-side convergence: source the version-checked MERGE's full column set from the
+        // closed-shape descriptor's write binders (doc_type, guid_version, partition, soft-delete)
+        // instead of the bespoke hardcoded id/data/version/dotnet_type[/tenant_id] subset.
+        var storage = (Storage.ClosedShape.IPolecatBulkVersionCheckStorage<T>)
+            _store.Options.Providers.ClosedShapeGraph.StorageFor<T>().QueryOnly;
+
+        // Pre-process: assign ids + sync ITenanted before the operations serialize each document.
+        foreach (var (doc, _) in documents)
         {
-            // #273: route id generation through the shared Weasel.Core.Identity strategy (see above).
             if (provider.SequenceSource is not null)
             {
                 mapping.AssignIdIfMissing(doc, provider.SequenceSource);
@@ -266,39 +267,37 @@ public class AdvancedOperations
             {
                 tenanted.TenantId = tenantId;
             }
-
-            var id = mapping.GetId(doc);
-            var json = serializer.ToJson(doc);
-            rows.Add((id, json, mapping.DotNetTypeName, expectedVersion));
         }
 
         var connFactory = _store.Options.Tenancy!.GetConnectionFactory(tenantId);
 
         await _resilience.ExecuteAsync(static async (state, ct) =>
         {
-            var (factory, allRows, size, docMapping, tenant) = state;
+            var (factory, docs, size, docStorage, tenant) = state;
             await using var conn = factory.Create();
             await conn.OpenAsync(ct);
 
-            for (var offset = 0; offset < allRows.Count; offset += size)
+            for (var offset = 0; offset < docs.Count; offset += size)
             {
-                var batch = allRows.Skip(offset).Take(size).ToList();
-                await using var cmd = conn.CreateCommand();
-                BuildVersionCheckedBatchCommand(cmd, batch, docMapping, tenant);
+                var chunk = docs.Skip(offset).Take(size).ToList();
+                await using var batch = new SqlBatch(conn);
+                var builder = new BatchBuilder(batch);
 
-                // Read the OUTPUTed inserted.id stream to discover which rows
-                // the MERGE actually touched. Any incoming id missing from
-                // the output set is a version-mismatch (the WHEN MATCHED AND
-                // ... predicate failed and the row was neither updated nor
-                // inserted). One ConcurrencyException per batch, thrown for
-                // the first missing id we find — matches the per-row pattern
-                // in UpdateOperation / UpsertOperation rather than the
-                // aggregate pattern.
-                //
-                // Each MERGE-OUTPUT in the batched command produces its own
-                // result set; iterate all of them via NextResultAsync.
+                for (var i = 0; i < chunk.Count; i++)
+                {
+                    if (i > 0) builder.StartNewCommand();
+                    docStorage.ConfigureVersionCheckedUpsert(
+                        builder, chunk[i].Document, chunk[i].ExpectedVersion, tenant);
+                }
+
+                builder.Compile();
+
+                // Each MERGE's OUTPUT inserted.id is its own result set. A row absent from the
+                // combined stream was neither updated (version mismatch) nor inserted — a
+                // concurrency violation, surfaced for the first missing id (per-row pattern,
+                // matching UpdateOperation / UpsertOperation).
                 var touched = new HashSet<object>();
-                await using (var reader = await cmd.ExecuteReaderAsync(ct))
+                await using (var reader = await batch.ExecuteReaderAsync(ct))
                 {
                     do
                     {
@@ -309,71 +308,16 @@ public class AdvancedOperations
                     } while (await reader.NextResultAsync(ct));
                 }
 
-                foreach (var row in batch)
+                foreach (var (doc, _) in chunk)
                 {
-                    if (!touched.Contains(row.Id))
+                    var rawId = docStorage.BulkRawId(doc);
+                    if (!touched.Contains(rawId))
                     {
-                        throw new ConcurrencyException(typeof(T), row.Id);
+                        throw new ConcurrencyException(typeof(T), rawId);
                     }
                 }
             }
-        }, (connFactory, rows, batchSize, mapping, tenantId), token);
-    }
-
-    private static void BuildVersionCheckedBatchCommand(
-        SqlCommand cmd,
-        List<(object Id, string Json, string DotNetType, long ExpectedVersion)> batch,
-        Storage.DocumentMapping mapping,
-        string tenantId)
-    {
-        var sb = new StringBuilder();
-        var paramIndex = 0;
-
-        foreach (var (id, json, dotnetType, expectedVersion) in batch)
-        {
-            // #234: tenant_id column exists only on conjoined tables.
-            var conjoined = mapping.TenancyStyle == TenancyStyle.Conjoined;
-            var pId = $"@p{paramIndex++}";
-            var pData = $"@p{paramIndex++}";
-            var pType = $"@p{paramIndex++}";
-            var pTenant = conjoined ? $"@p{paramIndex++}" : null;
-            var pExpected = $"@p{paramIndex++}";
-
-            var usingTenant = conjoined ? $", {pTenant} AS tenant_id" : "";
-            var onTenant = conjoined ? " AND target.tenant_id = source.tenant_id" : "";
-            var insertTenantCol = conjoined ? ", tenant_id" : "";
-            var insertTenantVal = conjoined ? $", {pTenant}" : "";
-
-            // MERGE pattern from the polecat#48 audit body. The expected_version
-            // is part of the USING projection rather than a free-standing
-            // parameter so SQL Server's optimizer can see it as a column on the
-            // source rowset (matters when this is extended to set-based MERGEs).
-            sb.AppendLine(
-                $"MERGE INTO {mapping.QualifiedTableName} WITH (HOLDLOCK) AS target");
-            sb.AppendLine(
-                $"USING (SELECT {pId} AS id{usingTenant}, {pExpected} AS expected_version) AS source");
-            sb.AppendLine(
-                $"    ON target.id = source.id{onTenant}");
-            sb.AppendLine("WHEN MATCHED AND target.version = source.expected_version THEN");
-            sb.AppendLine(
-                $"    UPDATE SET data = {pData}, version = target.version + 1,");
-            sb.AppendLine(
-                $"        last_modified = SYSDATETIMEOFFSET(), dotnet_type = {pType}");
-            sb.AppendLine("WHEN NOT MATCHED THEN");
-            sb.AppendLine(
-                $"    INSERT (id, data, version, last_modified, created_at, dotnet_type{insertTenantCol})");
-            sb.AppendLine(
-                $"    VALUES ({pId}, {pData}, 1, SYSDATETIMEOFFSET(), SYSDATETIMEOFFSET(), {pType}{insertTenantVal})");
-            sb.AppendLine("OUTPUT inserted.id;");
-
-            cmd.Parameters.AddWithValue(pId, id);
-            cmd.Parameters.AddWithValue(pData, json);
-            cmd.Parameters.AddWithValue(pType, dotnetType);
-            if (conjoined) cmd.Parameters.AddWithValue(pTenant!, tenantId);
-            cmd.Parameters.AddWithValue(pExpected, expectedVersion);
-        }
-
-        cmd.CommandText = sb.ToString();
+        }, (connFactory, documents, batchSize, storage, tenantId), token);
     }
 
     public Task ResetHiloSequenceFloor<T>(long floor)

--- a/src/Polecat/Storage/ClosedShape/PolecatDocumentStorage.cs
+++ b/src/Polecat/Storage/ClosedShape/PolecatDocumentStorage.cs
@@ -84,11 +84,35 @@ internal interface IPolecatBatchLoadStorage<TDoc> where TDoc : notnull
     ISelector<TDoc> BuildLoadSelector(IStorageSession session);
 }
 
+/// <summary>
+///     Session-free bulk version-checked upsert seam (#273 doc-side convergence). Sources the
+///     full write-column set from the closed-shape descriptor's write binders — including
+///     <c>doc_type</c>, <c>guid_version</c>, the partition column and soft-delete defaults that
+///     the bespoke <c>BuildVersionCheckedBatchCommand</c> silently omitted — while keeping the
+///     bulk-specific strict version guard (<c>WHEN MATCHED AND version = expected</c>).
+/// </summary>
+internal interface IPolecatBulkVersionCheckStorage<TDoc> where TDoc : notnull
+{
+    /// <summary>
+    ///     Appends one <c>MERGE … OUTPUT inserted.id</c> for the document + its expected version
+    ///     (positional params), session-free. A row absent from the OUTPUT stream is a version
+    ///     mismatch (neither updated nor inserted).
+    /// </summary>
+    void ConfigureVersionCheckedUpsert(Weasel.SqlServer.ICommandBuilder builder, TDoc document,
+        long expectedVersion, string tenantId);
+
+    /// <summary>The raw id value as it appears in the <c>OUTPUT inserted.id</c> stream.</summary>
+    object BulkRawId(TDoc document);
+}
+
 internal abstract class PolecatDocumentStorage<TDoc, TId>
-    : IDocumentStorage<TDoc, TId>, IPolecatObjectStorage<TDoc>, IPolecatBatchLoadStorage<TDoc>
+    : IDocumentStorage<TDoc, TId>, IPolecatObjectStorage<TDoc>, IPolecatBatchLoadStorage<TDoc>,
+        IPolecatBulkVersionCheckStorage<TDoc>
     where TDoc : notnull
     where TId : notnull
 {
+    private string? _bulkVersionCheckedSql;
+
     protected readonly DocumentMapping _mapping;
     protected readonly DocumentStorageDescriptor<TDoc, TId> _descriptor;
     private readonly string _loaderSql;
@@ -346,6 +370,113 @@ internal abstract class PolecatDocumentStorage<TDoc, TId>
     }
 
     public ISelector<TDoc> BuildLoadSelector(IStorageSession session) => (ISelector<TDoc>)BuildSelector(session);
+
+    // ---- bulk version-checked upsert seam (#273 doc-side convergence) ----
+
+    /// <summary>Client-side write binders that drive the versioned bulk column set. The numeric
+    /// revision binder (column <c>version</c>) is excluded — this path owns that column via the
+    /// version guard/increment.</summary>
+    private IEnumerable<IDocumentMetadataBinder<TDoc>> BulkClientBinders
+        => _descriptor.ClientSideWriteBinders.Where(b => b.ColumnName != "version");
+
+    private string BulkVersionCheckedSql()
+    {
+        if (_bulkVersionCheckedSql is not null) return _bulkVersionCheckedSql;
+
+        var table = _mapping.QualifiedTableName;
+        var conjoined = _descriptor.IsConjoined;
+        var clientCols = BulkClientBinders.Select(b => b.ColumnName).ToArray();
+        var serverBinders = _descriptor.WriteBinders.Where(b => b.IsServerSide && b.ColumnName != "version").ToArray();
+
+        // USING tuple = parameter order: [tenant_id,] id, data, expected_version, {client cols}.
+        var usingCols = new List<string>();
+        if (conjoined) usingCols.Add("tenant_id");
+        usingCols.Add("id");
+        usingCols.Add("data");
+        usingCols.Add("expected_version");
+        usingCols.AddRange(clientCols);
+
+        var usingValues = string.Join(", ", usingCols.Select(_ => "?"));
+        var sourceCols = string.Join(", ", usingCols);
+        var on = conjoined ? "t.id = s.id AND t.tenant_id = s.tenant_id" : "t.id = s.id";
+
+        // UPDATE (matched AND version == expected): data, version+1, client cols, server literals.
+        var setList = new List<string> { "data = s.data", "version = t.version + 1" };
+        setList.AddRange(clientCols.Select(c => $"{c} = s.{c}"));
+        setList.AddRange(serverBinders.Select(b => $"{b.ColumnName} = {b.ValueSql}"));
+
+        // INSERT (not matched): id, data, version=1, created_at, {client cols}, {server literals}[, tenant].
+        var insertCols = new List<string> { "id", "data", "version", "created_at" };
+        var insertVals = new List<string> { "s.id", "s.data", "1", "SYSDATETIMEOFFSET()" };
+        foreach (var c in clientCols)
+        {
+            insertCols.Add(c);
+            insertVals.Add($"s.{c}");
+        }
+
+        foreach (var b in serverBinders)
+        {
+            insertCols.Add(b.ColumnName);
+            insertVals.Add(b.ValueSql);
+        }
+
+        if (conjoined)
+        {
+            insertCols.Add("tenant_id");
+            insertVals.Add("s.tenant_id");
+        }
+
+        _bulkVersionCheckedSql =
+            $"MERGE {table} WITH (HOLDLOCK) AS t " +
+            $"USING (VALUES ({usingValues})) AS s ({sourceCols}) ON {on} " +
+            $"WHEN MATCHED AND t.version = s.expected_version THEN UPDATE SET {string.Join(", ", setList)} " +
+            $"WHEN NOT MATCHED THEN INSERT ({string.Join(", ", insertCols)}) VALUES ({string.Join(", ", insertVals)}) " +
+            $"OUTPUT inserted.id;";
+        return _bulkVersionCheckedSql;
+    }
+
+    public void ConfigureVersionCheckedUpsert(Weasel.SqlServer.ICommandBuilder builder, TDoc document,
+        long expectedVersion, string tenantId)
+    {
+        var parameters = builder.AppendWithParameters(BulkVersionCheckedSql(), '?');
+        var slot = 0;
+
+        if (_descriptor.IsConjoined)
+        {
+            parameters[slot].Value = tenantId;
+            _descriptor.Dialect.SetParameterType(parameters[slot], StorageColumnType.String);
+            slot++;
+        }
+
+        parameters[slot].Value = _descriptor.Identification.ToRawSqlValue(Identity(document));
+        _descriptor.Dialect.SetIdParameterType(parameters[slot], _descriptor.Identification.RawSqlType);
+        slot++;
+
+        _descriptor.Serializer.WriteToParameter(parameters[slot], document);
+        slot++;
+
+        parameters[slot].Value = expectedVersion;
+        _descriptor.Dialect.SetParameterType(parameters[slot], StorageColumnType.Long);
+        slot++;
+
+        foreach (var binder in BulkClientBinders)
+        {
+            var bulk = binder.GetBulkValue(document);
+            if (bulk.Value is null)
+            {
+                parameters[slot].Value = DBNull.Value;
+            }
+            else
+            {
+                parameters[slot].Value = bulk.Value;
+                _descriptor.Dialect.SetParameterType(parameters[slot], bulk.Type);
+            }
+
+            slot++;
+        }
+    }
+
+    public object BulkRawId(TDoc document) => _descriptor.Identification.ToRawSqlValue(Identity(document));
 
     // ---- session bookkeeping ----
 

--- a/src/Polecat/Storage/ClosedShape/SubClassPolecatStorage.cs
+++ b/src/Polecat/Storage/ClosedShape/SubClassPolecatStorage.cs
@@ -16,7 +16,8 @@ namespace Polecat.Storage.ClosedShape;
 ///     parent provider's corresponding flavor.
 /// </summary>
 internal sealed class SubClassPolecatStorage<T, TRoot, TId>
-    : IDocumentStorage<T, TId>, IPolecatObjectStorage<T>, IPolecatBatchLoadStorage<T>
+    : IDocumentStorage<T, TId>, IPolecatObjectStorage<T>, IPolecatBatchLoadStorage<T>,
+        IPolecatBulkVersionCheckStorage<T>
     where T : notnull, TRoot
     where TRoot : notnull
     where TId : notnull
@@ -206,6 +207,17 @@ internal sealed class SubClassPolecatStorage<T, TRoot, TId>
     }
 
     public ISelector<T> BuildLoadSelector(IStorageSession session) => (ISelector<T>)BuildSelector(session);
+
+    // The root storage owns the descriptor + write binders (incl. the doc_type binder, whose
+    // GetBulkValue resolves the alias from the document's runtime type), so bulk version-checked
+    // upserts for a subclass delegate straight through with the subclass instance.
+    public void ConfigureVersionCheckedUpsert(Weasel.SqlServer.ICommandBuilder builder, T document,
+        long expectedVersion, string tenantId)
+        => ((IPolecatBulkVersionCheckStorage<TRoot>)_parent)
+            .ConfigureVersionCheckedUpsert(builder, document, expectedVersion, tenantId);
+
+    public object BulkRawId(T document)
+        => ((IPolecatBulkVersionCheckStorage<TRoot>)_parent).BulkRawId(document);
 
     // ---- IPolecatObjectStorage bridge ----
 


### PR DESCRIPTION
## What & why

Completes the [#273 doc-side convergence](https://github.com/JasperFx/polecat/issues/273). `BulkInsertWithVersionAsync` was the **last hand-written, `DocumentMapping`-driven write SQL** in the codebase (`BuildVersionCheckedBatchCommand`). It now sources the version-checked MERGE's full column set from the closed-shape descriptor's write binders (session-free, via `GetBulkValue`).

Like the versionless path (#314), the bespoke builder hardcoded `id, data, version, dotnet_type[, tenant_id]` and **silently omitted** columns the descriptor writes:

| Gap | Before | After |
|-----|--------|-------|
| Hierarchy `doc_type` | not written → version-checked bulk insert of a subclass couldn't load as its subclass | written → loads correctly |
| Optimistic `guid_version` | not written | written via the version binder's bulk value |
| Range-partition column / soft-delete defaults | not written | written, like single-doc `Store` |

## Design

New `IPolecatBulkVersionCheckStorage<T>` seam on the closed-shape storage builds one `MERGE … WHEN MATCHED AND version = expected … OUTPUT inserted.id` per document from the descriptor binders, keeping the **bulk-specific strict version guard**. That guard (caller-supplied `long` expected vs. the numeric `version` column, for any type regardless of its configured concurrency mode) genuinely doesn't map onto the per-type descriptor SQL — so it stays a bulk-owned statement, but its *column set* is now the single source of truth. `SubClassPolecatStorage` delegates to the root (whose `doc_type` binder resolves the alias from the document's runtime type). Concurrency detection (OUTPUT touched-set → `ConcurrencyException`) is unchanged.

Execution stays on bulk insert's own `ResiliencePipeline`-wrapped connection; binding is session-free (`GetBulkValue` + `descriptor.Serializer`/`Identification`/`Dialect`).

## Result

**Every** Polecat document write path — single-doc `Store`, projections, versionless bulk, and version-checked bulk — now flows through the closed-shape descriptor. No hand-written write SQL remains.

## Verification

New parity tests prove the `doc_type` + `guid_version` fixes on the version-check path (both fail against the pre-convergence builder). Full suite **1448 passed / 0 failed / 3 skipped** (net10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)