### PR TITLE
release: 4.9.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>4.8.0</Version>
+        <Version>4.9.0</Version>
         <LangVersion>latest</LangVersion>
         <Authors>Jeremy D. Miller</Authors>
         <PackageIcon>logo.png</PackageIcon>


### PR DESCRIPTION
Cuts **4.9.0** (from 4.8.0). Version bump in `Directory.Build.props`; publish via `workflow_dispatch` on `publish.yml` once CI is green.

## Highlights — #273 closed-shape storage convergence (doc-side complete)
- **#313** batched `Load`/`LoadMany` → closed-shape read path
- **#314** versionless bulk insert → closed-shape write ops
- **#316** bulk version-checked upsert → closed-shape descriptor
- **#317** set-based delete/undelete → closed-shape operation fragments

Every document write path now flows through the shared `Weasel.Storage` runtime — **no `DocumentMapping`-driven document write SQL remains**. Follow-up for the event-auxiliary ops tracked in #318; tracking issue #273 closed.

## Notable behavior changes
- Bulk inserts now correctly write `doc_type` (hierarchy), `guid_version` (optimistic concurrency), and the range-partition column — previously silently omitted.
- `BulkInsertMode.InsertsOnly` duplicates now throw `DocumentAlreadyExistsException` (Marten + single-doc `Store` parity) instead of a raw `SqlException`.

## Dependencies
- Weasel 9.16.0 → **9.16.2**; JasperFx 2.24.0 → **2.24.1** (#315).

🤖 Generated with [Claude Code](https://claude.com/claude-code)