### PR TITLE
fix: IEventStore.Subject identifies the store, not the database (#320)

### DIFF
--- a/src/Polecat.Tests/Documents/DocumentStoreTests.cs
+++ b/src/Polecat.Tests/Documents/DocumentStoreTests.cs
@@ -125,6 +125,44 @@ public class DocumentStoreTests
         store.Options.StoreName.ShouldBe(nameof(IInvoiceStore));
         ((IEventStore)store).Identity.Name.ShouldBe("iinvoicestore");
     }
+
+    // polecat#320: IEventStore.Subject identifies the store, not the database backing it.
+    [Fact]
+    public void event_store_subject_defaults_to_polecat_main()
+    {
+        using var store = DocumentStore.For(ConnectionSource.ConnectionString);
+        ((IEventStore)store).Subject.ShouldBe(new Uri("polecat://main"));
+    }
+
+    [Fact]
+    public void event_store_subject_varies_by_store_name()
+    {
+        using var store = DocumentStore.For(opts =>
+        {
+            opts.ConnectionString = ConnectionSource.ConnectionString;
+            opts.StoreName = "Invoicing";
+        });
+
+        ((IEventStore)store).Subject.ShouldBe(new Uri("polecat://invoicing"));
+    }
+
+    // The actual regression: a primary store and an ancillary store sharing ONE database (schemas
+    // apart) must still report distinct Subjects, or monitoring tools bucket their shard states and
+    // high-water marks together.
+    [Fact]
+    public void stores_sharing_a_database_have_distinct_subjects()
+    {
+        using var primary = DocumentStore.For(ConnectionSource.ConnectionString);
+
+        var services = new ServiceCollection();
+        services.AddPolecatStore<IInvoiceStore>(opts => opts.ConnectionString = ConnectionSource.ConnectionString);
+        using var provider = services.BuildServiceProvider();
+        var ancillary = provider.GetRequiredService<IInvoiceStore>();
+
+        ((IEventStore)primary).Subject.ShouldBe(new Uri("polecat://main"));
+        ((IEventStore)ancillary).Subject.ShouldBe(new Uri("polecat://iinvoicestore"));
+        ((IEventStore)primary).Subject.ShouldNotBe(((IEventStore)ancillary).Subject);
+    }
 }
 
 public interface IInvoiceStore : IDocumentStore;

--- a/src/Polecat/DocumentStore.EventStore.cs
+++ b/src/Polecat/DocumentStore.EventStore.cs
@@ -91,7 +91,13 @@ public partial class DocumentStore : IEventStore<IDocumentSession, IQuerySession
         }
     }
 
-    Uri IEventStore.Subject => Database.DatabaseUri;
+    // polecat#320: Subject identifies the *store*, not the database backing it. Returning the database
+    // URI collapsed a primary store and an ancillary store on the same database (the default layout —
+    // schemas apart, one DB) onto an identical Subject, so monitoring tools keying per-store state by
+    // Subject (CritterWatch's EventProgressionPoller) merged their shard states and clobbered each
+    // other's high-water marks. Mirrors Marten's `marten://main` / `marten://{storename}`. The database
+    // identity keeps its own surfaces (Database.DatabaseUri, IEventDatabase.Identifier).
+    Uri IEventStore.Subject => new("polecat://" + Options.StoreName.ToLowerInvariant());
 
     // Store-agnostic accessor for every IEventDatabase backing this store (jasperfx#387).
     // Monitoring/tooling (e.g. CritterWatch) resolves IEventStore from DI and enumerates the


### PR DESCRIPTION
Closes #320.

## Problem

`IEventStore.Subject` returned `Database.DatabaseUri`, identifying the *database* rather than the *store*. A host with a primary store plus an ancillary `AddPolecatStore<T>()` on the **same database** — the default CritterWatch layout, schemas apart and one DB — reported an identical Subject for every store:

```
Polecat.DocumentStore                                   subject=sqlserver://localhost/cw_db
Polecat.DynamicStores.ICritterWatchStoreImplementation  subject=sqlserver://localhost/cw_db
```

Monitoring tools key per-store state by `Subject` (CritterWatch's `EventProgressionPoller` buckets shard states and high-water marks per `store.Subject`), so primary and ancillary shard states merged into one bucket and their HWMs clobbered each other.

## Fix

Return `polecat://main` / `polecat://{storename.ToLowerInvariant()}`, mirroring Marten's `marten://main` / `marten://{storename}` (`SecondaryStoreConfig.cs:91`). Ancillary stores already get a distinct logical `StoreName` (polecat#207) — `Subject` just wasn't using it. This matches the neighbouring `IEventStore.Identity`, which already derives from `StoreName`.

The database identity keeps its own surfaces (`Database.DatabaseUri`, `IEventDatabase.Identifier`), so nothing needed the DB-shaped Subject — confirmed by grepping every `Subject`/`SubjectUri` consumer.

## Tests

Three tests added next to the existing polecat#207 identity tests, including the actual regression — two stores sharing one database must report distinct Subjects. **All three fail without the production change and pass with it** (verified by stashing the fix).

Full suite green on net10: **1451 passed, 0 failed, 3 skipped**.

## Note on scope

`IDocumentStoreUsageSource.Subject` (`DocumentStore.DocumentStoreUsage.cs:13`) has the same database-shaped value and arguably the same collapse on the document side. Marten passes its store-identity Subject there too. Left alone here to keep this PR scoped to the reported issue — happy to follow up if you want doc-side parity as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)