### PR TITLE
chore: bump Weasel 9.16.2 -> 9.16.4

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -53,10 +53,17 @@
         <!-- Weasel 9.8.0/9.9.0 introduce Weasel.Storage: the dialect-neutral closed-shape
              storage contracts extracted from Marten (marten#4821/#4830, weasel#329/#331) —
              IStorageSession / IStorageDatabase / IStorageSerializer / IDocumentStorage /
-             IStorageDialect. This is the shared runtime Polecat retargets onto for #273. -->
-        <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.16.2" />
-        <PackageVersion Include="Weasel.SqlServer" Version="9.16.2" />
-        <PackageVersion Include="Weasel.Storage" Version="9.16.2" />
+             IStorageDialect. This is the shared runtime Polecat retargets onto for #273.
+             Weasel 9.16.3: AdvisoryLock.TryAttainLockAsync treats a disposed data source as
+             terminal (Postgres-only; no Polecat surface).
+             Weasel 9.16.4: weasel#356 — db-apply bounds its connection usage across many
+             databases and retries transient connection failures, with SqlServerMigrator now
+             overriding ReleaseConnectionPoolAsync (SqlConnection.ClearPool) and
+             IsTransientConnectionFailure over the SQL Server/Azure SQL resource-limit error
+             set. Polecat picks this up through the migrator base class — no code change. -->
+        <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.16.4" />
+        <PackageVersion Include="Weasel.SqlServer" Version="9.16.4" />
+        <PackageVersion Include="Weasel.Storage" Version="9.16.4" />
 
         <!-- Strongly typed IDs -->
         <PackageVersion Include="StronglyTypedId" Version="1.0.0-beta08" />


### PR DESCRIPTION
Version-only bump. One file changed.

## Nothing was gated on this

Checked rather than assumed. The only Weasel-gated item in the tracker is #318, and its blocker is unchanged at 9.16.4:

- `EventStorage<TId>` still exposes exactly the six append/stream-lifecycle seams (`AppendEvent`, `QuickAppendEventWithVersion`, `QuickAppendEvents`, `InsertStream`, `UpdateStreamVersion`, `AssertStreamVersion`) — no archive/tombstone/progression.
- `IEventStoreSqlDialect` is untouched.
- The **only** file changed across `Weasel.Storage` + `Weasel.SqlServer` between 9.16.2 and 9.16.4 is `SqlServerMigrator.cs`.

(#318's seam design is separately [documented as not holding up](https://github.com/JasperFx/polecat/issues/318#issuecomment-5002893274), so it stays parked regardless of version.)

The one genuinely blocked item, #324, is **JasperFx-gated, not Weasel-gated** — it needs a release carrying `ReadProjectionProgressAsync`, and the latest `JasperFx.Events` (2.27.0) doesn't have it yet.

## What Polecat actually gets

**9.16.3** — `AdvisoryLock.TryAttainLockAsync` treats a disposed data source as terminal. Postgres-only; no Polecat surface.

**9.16.4** — weasel#356: `db-apply` bounds its connection usage across many databases and retries transient connection failures. `SqlServerMigrator` now overrides:

- `ReleaseConnectionPoolAsync` → `SqlConnection.ClearPool`
- `IsTransientConnectionFailure` → narrow over the SQL Server / Azure SQL resource-limit error set (`10928`, `10929`, `17809`, `40197`, `40501`, `40613`, `49918-49920`), deliberately excluding `-2` and the transport-drop codes so a half-applied migration is never silently re-run.

Polecat inherits both through the migrator base class — **no code change needed**. A real improvement for multi-database `db-apply`; just not one that unblocks anything.

## Verification

- All Weasel packages resolve to 9.16.4, including transitive `Weasel.Core`.
- Build clean, 0 errors.
- Full suite on net10 against the rebased state: **1452 passed, 0 failed, 3 skipped** — identical to main's baseline, as a version-only bump should be.

🤖 Generated with [Claude Code](https://claude.com/claude-code)