### PR TITLE
feat(#324): implement IEventDatabase.ReadProjectionProgressAsync

### DIFF
--- a/src/Polecat.Tests/Daemon/projection_progression_tests.cs
+++ b/src/Polecat.Tests/Daemon/projection_progression_tests.cs
@@ -96,6 +96,52 @@ public class projection_progression_tests : IntegrationContext
         progress.ShouldBe(0);
     }
 
+    // #324 (jasperfx#435): the targeted single-cell read.
+    [Fact]
+    public async Task read_single_progression_row()
+    {
+        var shardName = new ShardName("ReadOne");
+        await RecordProgressAsync(shardName, ceiling: 42, upsert: true);
+
+        var row = await theStore.Database.ReadProjectionProgressAsync(shardName.Identity, null, default);
+
+        row.ShouldNotBeNull();
+        row!.ProjectionName.ShouldBe(shardName.Identity);
+        row.TenantId.ShouldBeNull();
+        row.Sequence.ShouldBe(42);
+        // The default store has no extended progression tracking, so these columns don't exist / aren't read.
+        row.AgentStatus.ShouldBeNull();
+        row.LastHeartbeat.ShouldBeNull();
+    }
+
+    // A missing (projection, tenant) pair is the meaningful "not observed yet" answer: null, never 0.
+    [Fact]
+    public async Task read_returns_null_for_unknown_projection()
+    {
+        var row = await theStore.Database.ReadProjectionProgressAsync("NoSuchProjection:All", null, default);
+        row.ShouldBeNull();
+    }
+
+    // A non-null tenantId composes the trailing ":{tenant}" segment onto the identity, matching the
+    // ShardName grammar the daemon writes (range.ShardName.Identity).
+    [Fact]
+    public async Task read_composes_the_tenant_suffix()
+    {
+        var tenantShard = ShardName.Compose("TenantRead", "All", "Red");
+        tenantShard.Identity.ShouldBe("TenantRead:All:Red");
+        await RecordProgressAsync(tenantShard, ceiling: 7, upsert: true);
+
+        var row = await theStore.Database.ReadProjectionProgressAsync("TenantRead:All", "Red", default);
+        row.ShouldNotBeNull();
+        row!.ProjectionName.ShouldBe("TenantRead:All");
+        row.TenantId.ShouldBe("Red");
+        row.Sequence.ShouldBe(7);
+
+        // The store-global lookup (null tenant) must NOT match the tenant-suffixed row.
+        var global = await theStore.Database.ReadProjectionProgressAsync("TenantRead:All", null, default);
+        global.ShouldBeNull();
+    }
+
     private async Task RecordProgressAsync(ShardName shardName, long ceiling, bool upsert)
     {
         var events = theStore.Database.Events;

--- a/src/Polecat.Tests/Daemon/read_projection_progress_extended_tests.cs
+++ b/src/Polecat.Tests/Daemon/read_projection_progress_extended_tests.cs
@@ -1,0 +1,57 @@
+using JasperFx.Events.Projections;
+using Microsoft.Data.SqlClient;
+using Polecat.Internal.Operations;
+using Polecat.Tests.Harness;
+using Weasel.SqlServer;
+
+namespace Polecat.Tests.Daemon;
+
+/// <summary>
+///     #324 (jasperfx#435): the extended-tracking branch of
+///     <c>ReadProjectionProgressAsync</c>. Under <c>EnableExtendedProgressionTracking</c> the
+///     progression table gains the <c>heartbeat</c> + <c>agent_status</c> columns; the targeted read
+///     surfaces them as <c>ProjectionProgressRow.LastHeartbeat</c> / <c>.AgentStatus</c>. This confirms
+///     issue 324's open question — those two fields ARE available from <c>pc_event_progression</c> (once
+///     extended tracking is on), so the record does not need trimming on the JasperFx side.
+/// </summary>
+public class read_projection_progress_extended_tests : OneOffConfigurationsContext
+{
+    [Fact]
+    public async Task reads_heartbeat_when_extended_tracking_is_enabled()
+    {
+        ConfigureStore(opts => opts.Events.EnableExtendedProgressionTracking = true);
+        await theDatabase.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        var shardName = new ShardName("ExtendedRead");
+        // RecordProgressionOperation stamps heartbeat = SYSDATETIMEOFFSET() under extended tracking.
+        await RecordProgressAsync(shardName, ceiling: 99, upsert: true, extended: true);
+
+        var row = await theDatabase.ReadProjectionProgressAsync(shardName.Identity, null, default);
+
+        row.ShouldNotBeNull();
+        row!.Sequence.ShouldBe(99);
+        row.LastHeartbeat.ShouldNotBeNull();
+        // agent_status is written by the daemon's heartbeat path, not by the plain progression write,
+        // so it stays null here — the read must tolerate a null column, which is the point.
+        row.AgentStatus.ShouldBeNull();
+    }
+
+    private async Task RecordProgressAsync(ShardName shardName, long ceiling, bool upsert, bool extended)
+    {
+        var op = new RecordProgressionOperation(
+            theDatabase.Events.ProgressionTableName,
+            shardName.Identity,
+            ceiling,
+            extended,
+            upsert);
+
+        await using var conn = new SqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        await using var batch = new SqlBatch(conn);
+        var builder = new BatchBuilder(batch);
+        op.ConfigureCommand(builder);
+        builder.Compile();
+        await using var reader = await batch.ExecuteReaderAsync(CancellationToken.None);
+        await op.PostprocessAsync(reader, new List<Exception>(), CancellationToken.None);
+    }
+}

--- a/src/Polecat/Storage/PolecatDatabase.cs
+++ b/src/Polecat/Storage/PolecatDatabase.cs
@@ -218,6 +218,56 @@ public class PolecatDatabase : DatabaseBase<SqlConnection>, IEventDatabase, IPro
         }, (_connectionString, _events), token);
     }
 
+    // #324 (jasperfx#435 / jasperfx#518): targeted per-cell progression read. The JasperFx.Events
+    // default throws NotSupportedException — null is the meaningful "no row yet" answer, so a store
+    // that has not implemented this must not report a live cell as absent. This override reads the
+    // single (projection, tenant) row from pc_event_progression.
+    //
+    // The progression row is keyed by ShardName.Identity (the daemon writes range.ShardName.Identity;
+    // see PolecatProjectionBatch.RecordProgress). Tenant is always the trailing ":{tenant}" segment of
+    // the identity grammar (ShardName ctor), and a null/default tenant carries no suffix — matching the
+    // abstraction's "null tenantId => store-global on a non-tenanted store, or the default-tenant row
+    // on a tenanted store". So the lookup key is projectionName as-is when tenantId is null, or
+    // "{projectionName}:{tenantId}" otherwise. heartbeat + agent_status are only present under
+    // EnableExtendedProgressionTracking; without it, AgentStatus/LastHeartbeat come back null.
+    public async ValueTask<ProjectionProgressRow?> ReadProjectionProgressAsync(
+        string projectionName, string? tenantId, CancellationToken token)
+    {
+        var name = string.IsNullOrEmpty(tenantId) ? projectionName : $"{projectionName}:{tenantId}";
+
+        return await _resilience.ExecuteAsync(static async (state, ct) =>
+        {
+            var (connectionString, events, projName, tenant, lookupName) = state;
+
+            await using var conn = new SqlConnection(connectionString);
+            await conn.OpenAsync(ct);
+
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = events.EnableExtendedProgressionTracking
+                ? $"SELECT last_seq_id, heartbeat, agent_status FROM {events.ProgressionTableName} WHERE name = @name;"
+                : $"SELECT last_seq_id FROM {events.ProgressionTableName} WHERE name = @name;";
+            cmd.Parameters.AddWithValue("@name", lookupName);
+
+            await using var reader = await cmd.ExecuteReaderAsync(ct);
+            if (!await reader.ReadAsync(ct))
+            {
+                // No row for this (projection, tenant) pair yet — the meaningful "not observed" answer.
+                return (ProjectionProgressRow?)null;
+            }
+
+            var seq = reader.GetInt64(0);
+            DateTimeOffset? heartbeat = null;
+            string? agentStatus = null;
+            if (events.EnableExtendedProgressionTracking)
+            {
+                if (!reader.IsDBNull(1)) heartbeat = reader.GetDateTimeOffset(1);
+                if (!reader.IsDBNull(2)) agentStatus = reader.GetString(2);
+            }
+
+            return new ProjectionProgressRow(projName, tenant, seq, agentStatus, heartbeat);
+        }, (_connectionString, _events, projectionName, tenantId, name), token);
+    }
+
     public async Task<long> FetchHighestEventSequenceNumber(CancellationToken token)
     {
         return await _resilience.ExecuteAsync(static async (state, ct) =>


### PR DESCRIPTION
Closes #324.

Overrides the JasperFx.Events default (which throws `NotSupportedException`) on `PolecatDatabase` to read a single `(projection, tenant)` progression row directly from `pc_event_progression` — the targeted counterpart to `AllProjectionProgress`, for CritterWatch's per-cell ~1Hz polling loop.

## Semantics
- **Lookup key** mirrors the `ShardName.Identity` grammar the daemon writes (`range.ShardName.Identity`): `projectionName` as-is when `tenantId` is null, or `{projectionName}:{tenantId}` otherwise. Tenant is always the trailing `:{tenant}` segment; a null/default tenant carries no suffix — matching the abstraction's *"null tenantId ⇒ store-global on a non-tenanted store, or the default-tenant row on a tenanted store."*
- Returns **`null` when no row exists** (the meaningful "not observed yet" answer), never a synthesized zero row.
- Runs through `Options.ResiliencePipeline` like the other `IEventDatabase` reads.

## Resolves issue 324's open question
`heartbeat` + `agent_status` **are** available from `pc_event_progression` under `EnableExtendedProgressionTracking`, so `ProjectionProgressRow` needs no trimming on the JasperFx side. Without extended tracking those columns don't exist and come back null — the read tolerates both shapes.

## Tests
Exercise the production write path (`RecordProgressionOperation`):
- single-row read (sequence + echoed projection/tenant)
- `null` for an unknown projection
- tenant-suffix composition, and that a null-tenant lookup does **not** match a tenant-suffixed row
- the extended-tracking `heartbeat` column populated

All green locally (net10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)