### PR TITLE
feat(#326): verify + document the blue/green projection side-effect gate

### DIFF
--- a/docs/events/projections/async-daemon.md
+++ b/docs/events/projections/async-daemon.md
@@ -153,6 +153,94 @@ Async listeners are **suppressed during projection rebuilds**. A full replay re-
 so firing post-commit side effects for each historical batch is almost never what you want.
 :::
 
+## Blue/Green Deployments with Projection Versioning
+
+Every projection carries a `Version` (default `1`). The version is baked into the shard's
+progression identity, so different versions of the same projection track their progress
+independently:
+
+```cs
+public class TripProjection : SingleStreamProjection<Trip, Guid>
+{
+    public TripProjection()
+    {
+        // Bump the version when you change the projection's logic or shape
+        Version = 3;
+    }
+}
+```
+
+| Projection | `Version` | Progression identity (`pc_event_progression.name`) |
+|------------|-----------|-----------------------------------------------------|
+| `Trip`     | `1`       | `Trips:All`                                         |
+| `Trip`     | `2`       | `Trips:V2:All`                                       |
+| `Trip`     | `3`       | `Trips:V3:All`                                       |
+
+Because each version has its own progression row, you can stand up a new version alongside
+the old one and let it rebuild from zero while the old version keeps serving reads — a
+blue/green deployment.
+
+### Gating Side Effects Behind the Prior Version
+
+The catch with a blue/green rebuild is [side effects](side-effects.md). If your projection
+publishes messages or emits other side effects from `RaiseSideEffects()`, a new version
+replaying the full event history from zero would **re-fire every side effect** for events the
+previous version already processed — duplicate emails, duplicate messages, and so on.
+
+Opt into the **side-effect gate** to prevent that:
+
+```cs
+public class TripProjection : SingleStreamProjection<Trip, Guid>
+{
+    public TripProjection()
+    {
+        Version = 3;
+
+        // Suppress side effects for events the prior version already processed
+        Options.GateSideEffectsBehindPriorVersion = true;
+    }
+}
+```
+
+When the daemon starts a gated shard whose own progression is **behind** the highest prior
+version's persisted mark `N`, it:
+
+1. Replays the new version from its current position up to `N` in **Rebuild mode**, with side
+   effects **suppressed** (the projected documents are still built — only the side effects are
+   gated).
+2. Hands off to **Continuous** execution from `N`, where side effects fire normally.
+
+The net effect: side effects fire exactly once, only for events past `N` — the events the
+previous version never saw.
+
+### Semantics and Edge Cases
+
+- **Trigger is "own progress `< prior mark`".** The gate keys off the new version's own
+  persisted progression, so an interrupted warm-up **resumes suppressed** rather than
+  re-emitting. Restarting the daemon after a crash mid-warm-up picks up from the recorded
+  position with side effects still gated.
+- **Failed warm-up pauses the shard.** If the suppressed replay throws (e.g. a poison event
+  under a pausing error policy), the shard is left **paused** with the exception attached, no
+  continuous execution starts, and no side effects fire. Restarting the daemon resumes the
+  warm-up from its persisted progress.
+- **`Version == 1` and the flag-off case are inert.** The gate is skipped entirely unless
+  `Version > 1` **and** `GateSideEffectsBehindPriorVersion` is set — a v1 projection behaves
+  exactly as it always has.
+- **`SubscribeFromPresent` is incompatible.** A shard that subscribes from "present" ignores
+  persisted progression, so the gate cannot reason about a prior mark. The gate is skipped and
+  a warning is logged; use versioning-with-gate _or_ subscribe-from-present, not both.
+- **Overlap window.** The prior mark `N` is snapshotted when the new version starts. If the
+  **old** version is still running and advances past `N` while the new version warms up, the
+  events in `(N, old_final]` can be processed by both versions — an accepted duplicate window.
+  Stop the old version (or accept the small overlap) when you need exactly-once across the
+  cutover.
+
+::: tip
+The gate suppresses **side effects**, not the projection write itself — the new version's
+documents are fully rebuilt over the entire history. Only `RaiseSideEffects()` output
+(published messages, emitted events, etc.) is held back during the warm-up.
+:::
+
 ## Error Handling
 
 The daemon uses Polly resilience pipelines for error handling. See [Resiliency Policies](/configuration/retries) for configuration.

--- a/docs/events/projections/side-effects.md
+++ b/docs/events/projections/side-effects.md
@@ -2,7 +2,10 @@
 
 ::: tip
 By default, side effects only fire during _continuous_ asynchronous projection execution.
-They do not run during projection rebuilds. Inline projections can opt in via
+They do not run during projection rebuilds, and they do not run during the _warm-up phase_
+of a new projection version that opts into the
+[blue/green side-effect gate](async-daemon.md#blue-green-deployments-with-projection-versioning).
+Inline projections can opt in via
 [`EnableSideEffectsOnInlineProjections`](#side-effects-in-inline-projections).
 :::
 
@@ -114,6 +117,21 @@ messages to a database table inside the same transaction) and "best-effort" patt
 A first-class [Wolverine](https://wolverinefx.net) integration is on the roadmap that will
 plug Wolverine's outbox in via `IntegrateWithWolverine()`, mirroring the existing
 Marten/Wolverine bridge.
+
+### When Messages Do and Do Not Fire
+
+Published messages (and every other `RaiseSideEffects()` side effect) fire only when the
+daemon is processing _new_ events in **continuous** execution. They are suppressed:
+
+- during a projection **rebuild** (`RebuildProjectionAsync`), and
+- during the **blue/green warm-up phase** of a new projection version that opts into
+  `GateSideEffectsBehindPriorVersion` — while the new version replays the history the prior
+  version already processed, side effects stay suppressed, and only start firing once the
+  new version catches up to the prior version's progression mark and switches to continuous
+  execution.
+
+See [Blue/Green Deployments with Projection Versioning](async-daemon.md#blue-green-deployments-with-projection-versioning)
+for the versioning mechanics.
 
 ## Side Effects in Inline Projections
 

--- a/src/Polecat.Tests/Daemon/bluegreen_gate_flag_flow_tests.cs
+++ b/src/Polecat.Tests/Daemon/bluegreen_gate_flag_flow_tests.cs
@@ -1,0 +1,153 @@
+using JasperFx.Events;
+using JasperFx.Events.Projections;
+using Polecat.Events.Aggregation;
+using Polecat.Projections;
+using Polecat.Tests.Harness;
+
+namespace Polecat.Tests.Daemon;
+
+/// <summary>
+///     #326 (jasperfx#480), work item 2: verify the blue/green side-effect gate
+///     (<c>GateSideEffectsBehindPriorVersion</c>) flows through Polecat's projection registration
+///     surface all the way to the async shard the daemon reads. The daemon skips the gate unless
+///     <c>shard.Options.GateSideEffectsBehindPriorVersion</c> is set AND <c>shard.Name.Version &gt; 1</c>
+///     (see JasperFxAsyncDaemon warm-up), so both must survive registration + shard construction. Each
+///     async shard is built as <c>new AsyncShard(projection.Options, ..., ShardName.Compose(Name, "All",
+///     null, projection.Version))</c>, so this asserts the flag + version reach the shard for each
+///     directly-registered Polecat projection kind. Note aggregation projections name their shard after
+///     the aggregate type, event projections after the projection type.
+/// </summary>
+public partial class bluegreen_gate_flag_flow_tests : OneOffConfigurationsContext
+{
+    private AsyncShard<IDocumentSession, IQuerySession> V2ShardFor(string identityContains)
+    {
+        var all = theStore.Options.Projections.AllShards();
+        var match = all.SingleOrDefault(s => s.Name.Identity.Contains(identityContains) && s.Name.Version == 2);
+        if (match == null)
+        {
+            throw new Exception($"No V2 shard matching '{identityContains}'. Available: " +
+                                string.Join(" | ", all.Select(s => $"{s.Name.Identity}(v{s.Name.Version})")));
+        }
+        return match;
+    }
+
+    [Fact]
+    public void gate_flows_through_single_stream_projection()
+    {
+        ConfigureStore(opts =>
+        {
+            var projection = new GatedSingleStream { Version = 2 };
+            projection.Options.GateSideEffectsBehindPriorVersion = true;
+            opts.Projections.Add(projection, ProjectionLifecycle.Async);
+        });
+
+        var shard = V2ShardFor("GatedAggregate");
+        shard.Options.GateSideEffectsBehindPriorVersion.ShouldBeTrue();
+        shard.Name.Version.ShouldBe(2u);
+    }
+
+    [Fact]
+    public void gate_flows_through_multi_stream_projection()
+    {
+        ConfigureStore(opts =>
+        {
+            var projection = new GatedMultiStream { Version = 2 };
+            projection.Options.GateSideEffectsBehindPriorVersion = true;
+            opts.Projections.Add(projection, ProjectionLifecycle.Async);
+        });
+
+        var shard = V2ShardFor("GatedMultiAggregate");
+        shard.Options.GateSideEffectsBehindPriorVersion.ShouldBeTrue();
+        shard.Name.Version.ShouldBe(2u);
+    }
+
+    [Fact]
+    public void gate_flows_through_event_projection()
+    {
+        ConfigureStore(opts =>
+        {
+            var projection = new GatedEventProjection { Version = 2 };
+            projection.Options.GateSideEffectsBehindPriorVersion = true;
+            opts.Projections.Add(projection, ProjectionLifecycle.Async);
+        });
+
+        var shard = V2ShardFor("GatedEventProjection");
+        shard.Options.GateSideEffectsBehindPriorVersion.ShouldBeTrue();
+        shard.Name.Version.ShouldBe(2u);
+    }
+
+    // The composite wrapper re-hosts child projections in ordered stages. A composite produces a single
+    // v0-versioned parent shard (its children are internal stages, not separately-versioned shards), so
+    // the per-child gate is not a top-level shard concern — but the wrapper must not strip the child's
+    // AsyncOptions during assembly. Assert the child instance keeps its gate + version after composite
+    // registration.
+    [Fact]
+    public void composite_assembly_preserves_child_gate()
+    {
+        var child = new GatedSingleStream { Version = 2 };
+        child.Options.GateSideEffectsBehindPriorVersion = true;
+
+        ConfigureStore(opts =>
+        {
+            opts.Projections.CompositeProjectionFor("GatedComposite", composite => composite.Add(child));
+        });
+
+        child.Options.GateSideEffectsBehindPriorVersion.ShouldBeTrue();
+        child.Version.ShouldBe(2u);
+    }
+
+    // The daemon skips the gate for Version <= 1, so a v1 projection with the flag set must still
+    // produce a v1 shard (the gate is inert, by design — this documents the skip condition).
+    [Fact]
+    public void version_one_projection_is_not_gated_even_with_flag_set()
+    {
+        ConfigureStore(opts =>
+        {
+            var projection = new GatedSingleStream(); // Version defaults to 1
+            projection.Options.GateSideEffectsBehindPriorVersion = true;
+            opts.Projections.Add(projection, ProjectionLifecycle.Async);
+        });
+
+        var shard = theStore.Options.Projections.AllShards()
+            .Single(s => s.Name.Identity.Contains("GatedAggregate"));
+        shard.Name.Version.ShouldBe(1u);
+    }
+
+    public record GateStarted(string Name);
+
+    public partial class GatedAggregate
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; } = "";
+
+        public void Apply(GateStarted e) => Name = e.Name;
+    }
+
+    public partial class GatedMultiAggregate
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; } = "";
+    }
+
+    public partial class GatedSingleStream : SingleStreamProjection<GatedAggregate, Guid>
+    {
+    }
+
+    public partial class GatedMultiStream : MultiStreamProjection<GatedMultiAggregate, Guid>
+    {
+        public GatedMultiStream()
+        {
+            Identity<GateStarted>(_ => Guid.NewGuid());
+        }
+
+        public void Apply(GateStarted e, GatedMultiAggregate agg) => agg.Name = e.Name;
+    }
+
+    public partial class GatedEventProjection : EventProjection
+    {
+        public void Project(GateStarted e, IDocumentSession ops)
+        {
+            // No-op projection body; this test only cares about registration/shard flow.
+        }
+    }
+}

--- a/src/Polecat.Tests/Daemon/bluegreen_side_effect_gate_tests.cs
+++ b/src/Polecat.Tests/Daemon/bluegreen_side_effect_gate_tests.cs
@@ -1,0 +1,177 @@
+using JasperFx;
+using JasperFx.Events;
+using JasperFx.Events.Projections;
+using Microsoft.Data.SqlClient;
+using Polecat.Events.Aggregation;
+using Polecat.Linq;
+using Polecat.Projections;
+using Polecat.TestUtils;
+
+namespace Polecat.Tests.Daemon;
+
+/// <summary>
+///     #326 (jasperfx#480) — the headline blue/green scenario (CritterWatch#77). When a new projection
+///     version opts into <c>GateSideEffectsBehindPriorVersion</c> and starts behind the prior version's
+///     persisted progression mark <c>N</c>, the daemon replays to <c>N</c> in Rebuild mode with side
+///     effects SUPPRESSED, then hands off to Continuous from <c>N</c> — so message side effects fire
+///     only for events the previous version never processed.
+///
+///     This drives the shared JasperFxAsyncDaemon warm-up against real SQL Server through Polecat's
+///     PolecatProjectionBatch → IMessageOutbox message-publication path.
+/// </summary>
+public partial class bluegreen_side_effect_gate_tests : IAsyncLifetime
+{
+    private const string Schema = "bluegreen_gate";
+
+    public async Task InitializeAsync() => await DropSchemaTablesAsync(Schema);
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    private static DocumentStore CreateStore(uint version, GateOutbox outbox, bool gate)
+    {
+        return DocumentStore.For(opts =>
+        {
+            opts.ConnectionString = ConnectionSource.ConnectionString;
+            opts.DatabaseSchemaName = Schema;
+            opts.AutoCreateSchemaObjects = AutoCreate.All;
+            opts.UseNativeJsonType = ConnectionSource.SupportsNativeJson;
+            opts.Events.MessageOutbox = outbox;
+
+            var projection = new GateSnapProjection { Version = version };
+            projection.Options.GateSideEffectsBehindPriorVersion = gate;
+            opts.Projections.Add(projection, ProjectionLifecycle.Async);
+        });
+    }
+
+    // Append K single-event streams, returning their labels in order.
+    private static async Task<List<string>> AppendStreamsAsync(DocumentStore store, string prefix, int count)
+    {
+        var labels = new List<string>();
+        for (var i = 0; i < count; i++)
+        {
+            var label = $"{prefix}-{i}";
+            labels.Add(label);
+            await using var session = store.LightweightSession();
+            session.Events.StartStream(Guid.NewGuid(), new GateStarted(label));
+            await session.SaveChangesAsync();
+        }
+
+        return labels;
+    }
+
+    [Fact]
+    public async Task new_version_suppresses_side_effects_for_events_the_prior_version_already_processed()
+    {
+        // --- V2: run to N with side effects firing normally ---
+        var v2Outbox = new GateOutbox();
+        using (var v2 = CreateStore(version: 2, v2Outbox, gate: false))
+        {
+            await v2.Database.ApplyAllConfiguredChangesToDatabaseAsync();
+            var priorLabels = await AppendStreamsAsync(v2, "prior", 3);
+
+            await v2.WaitForProjectionAsync();
+
+            // V2 processed all 3 prior streams and fired their side effects.
+            v2Outbox.Labels.OrderBy(x => x).ShouldBe(priorLabels.OrderBy(x => x));
+        }
+
+        // --- V3: gate on. Append M new events, then start. The warm-up replays [0..N] suppressed,
+        //     then continuous fires only for the new events. ---
+        var v3Outbox = new GateOutbox();
+        using (var v3 = CreateStore(version: 3, v3Outbox, gate: true))
+        {
+            var newLabels = await AppendStreamsAsync(v3, "new", 2);
+
+            await v3.WaitForProjectionAsync();
+
+            // Headline assertion: V3 fired side effects ONLY for the 2 new events — the 3 prior events
+            // were replayed with side effects suppressed during the blue/green warm-up.
+            v3Outbox.Labels.OrderBy(x => x).ShouldBe(newLabels.OrderBy(x => x));
+            foreach (var prior in new[] { "prior-0", "prior-1", "prior-2" })
+            {
+                v3Outbox.Labels.ShouldNotContain(prior);
+            }
+
+            // And V3's projected state is correct over the FULL history (all 5 aggregates exist).
+            await using var query = v3.QuerySession();
+            var all = await query.Query<GateSnap>().ToListAsync();
+            all.Count.ShouldBe(5);
+        }
+    }
+
+    private static async Task DropSchemaTablesAsync(string schema)
+    {
+        await using var conn = new SqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = """
+            DECLARE @sql nvarchar(max) = N'';
+            SELECT @sql = @sql + 'ALTER TABLE [' + s.name + '].[' + t.name + '] DROP CONSTRAINT [' + fk.name + '];'
+            FROM sys.foreign_keys fk
+            JOIN sys.tables t ON fk.parent_object_id = t.object_id
+            JOIN sys.schemas s ON t.schema_id = s.schema_id
+            WHERE s.name = @schema;
+
+            SELECT @sql = @sql + 'DROP TABLE [' + s.name + '].[' + t.name + '];'
+            FROM sys.tables t
+            JOIN sys.schemas s ON t.schema_id = s.schema_id
+            WHERE s.name = @schema;
+            EXEC sp_executesql @sql;
+            """;
+        cmd.Parameters.AddWithValue("@schema", schema);
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    public record GateStarted(string Label);
+
+    public record GateNotice(string Label);
+
+    public partial class GateSnap
+    {
+        public Guid Id { get; set; }
+        public string Label { get; set; } = "";
+
+        public void Apply(GateStarted e) => Label = e.Label;
+    }
+
+    public partial class GateSnapProjection : SingleStreamProjection<GateSnap, Guid>
+    {
+        public override ValueTask RaiseSideEffects(IDocumentSession session, IEventSlice<GateSnap> slice)
+        {
+            if (slice.Snapshot is not null)
+            {
+                slice.PublishMessage(new GateNotice(slice.Snapshot.Label));
+            }
+
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    // Captures every message published through the async daemon's IMessageOutbox path.
+    private sealed class GateOutbox : IMessageOutbox
+    {
+        private readonly GateBatch _batch = new();
+        public List<string> Labels => _batch.Labels;
+
+        public ValueTask<IMessageBatch> CreateBatch(IDocumentSession session) =>
+            new(_batch);
+
+        private sealed class GateBatch : IMessageBatch
+        {
+            public List<string> Labels { get; } = new();
+
+            public ValueTask PublishAsync<T>(T message, string tenantId)
+            {
+                if (message is GateNotice notice)
+                {
+                    lock (Labels) Labels.Add(notice.Label);
+                }
+
+                return ValueTask.CompletedTask;
+            }
+
+            public Task BeforeCommitAsync(CancellationToken token) => Task.CompletedTask;
+            public Task AfterCommitAsync(CancellationToken token) => Task.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
Closes #326. Adopts `GateSideEffectsBehindPriorVersion` (jasperfx#480 / CritterWatch#77) for Polecat.

The warm-up mechanism itself is inherited from the shared `JasperFxAsyncDaemon` — Polecat's projections carry the flag through `ProjectionBase`, and message side effects route through the shared `AggregationRunner` → `PolecatProjectionBatch.PublishMessageAsync`. **No production code change was required**; this PR verifies the behavior against real SQL Server and documents it.

## Work items

**(2) Flag flows through Polecat's registration surface** — `bluegreen_gate_flag_flow_tests`
Confirms `GateSideEffectsBehindPriorVersion` + `Version` reach the async shard the daemon reads (`shard.Options` / `shard.Name.Version`) for single-stream, multi-stream, and event projections; that the composite wrapper does not strip a child's `AsyncOptions`; and that a v1 projection stays un-gated (the documented skip condition).

**(4) Headline scenario** — `bluegreen_side_effect_gate_tests`
Drives the real warm-up against SQL Server through `PolecatProjectionBatch → IMessageOutbox`:
- V2 runs to `N` firing side effects normally
- V3 (gate on) replays `[0..N]` with side effects **suppressed**, then fires side effects **only** for the new events `(N, N+M]`
- V3's projected state is correct over the full history

Stable across repeated local runs.

**(7) Documentation**
- `side-effects.md`: side effects are now documented as suppressed during the blue/green warm-up (with cross-link).
- `async-daemon.md`: new **Blue/Green Deployments with Projection Versioning** section — `Version`, versioned progression identities (`Trips:V2:All` vs `Trips:V3:All`), warm-up mechanics, resume-after-interruption, failed-warm-up-pauses-the-shard, `SubscribeFromPresent` incompatibility, and the overlap window.

## Notes for reviewers
- Aggregation projections name their shard after the **aggregate** type; event projections after the **projection** type (reflected in the tests).
- Composite projections produce a single **v0-versioned parent shard**, so the per-child gate is carried into composite execution rather than surfacing as a separately-versioned top-level shard.
- Scenarios 2–7 in the issue's test plan (resume-after-interruption, failure-path, multi-tenancy, etc.) exercise shared-runtime behavior that is unit-tested upstream in JasperFx.Events; this PR covers the Polecat-specific flow-through + the headline suppression scenario end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)