### PR TITLE
feat(#318): route event auxiliary ops through the shared Weasel.Storage seam

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -61,9 +61,9 @@
              overriding ReleaseConnectionPoolAsync (SqlConnection.ClearPool) and
              IsTransientConnectionFailure over the SQL Server/Azure SQL resource-limit error
              set. Polecat picks this up through the migrator base class — no code change. -->
-        <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.16.4" />
-        <PackageVersion Include="Weasel.SqlServer" Version="9.16.4" />
-        <PackageVersion Include="Weasel.Storage" Version="9.16.4" />
+        <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.17.0" />
+        <PackageVersion Include="Weasel.SqlServer" Version="9.17.0" />
+        <PackageVersion Include="Weasel.Storage" Version="9.17.0" />
 
         <!-- Strongly typed IDs -->
         <PackageVersion Include="StronglyTypedId" Version="1.0.0-beta08" />

--- a/src/Polecat/Events/Daemon/PolecatProjectionBatch.cs
+++ b/src/Polecat/Events/Daemon/PolecatProjectionBatch.cs
@@ -69,14 +69,13 @@ internal class PolecatProjectionBatch : IProjectionBatch<IDocumentSession, IQuer
 
     public ValueTask RecordProgress(EventRange range)
     {
-        var progressionTable = _events.ProgressionTableName;
-        var extendedTracking = _events.EnableExtendedProgressionTracking;
         var name = range.ShardName.Identity;
         var ceiling = range.SequenceCeiling;
 
+        // #318: the progression write now rides the shared Weasel.Storage.EventStorage<TId> seam
+        // (EventGraph.UpdateProgressOperation) instead of instantiating RecordProgressionOperation here.
         // Floor == 0 means the row may not exist yet, so upsert; otherwise it's already there.
-        IStorageOperation op = new RecordProgressionOperation(
-            progressionTable, name, ceiling, extendedTracking, upsert: range.SequenceFloor == 0);
+        var op = _events.UpdateProgressOperation(name, ceiling, upsert: range.SequenceFloor == 0);
 
         _progressOps.Enqueue(op);
         return ValueTask.CompletedTask;

--- a/src/Polecat/Events/EventGraph.cs
+++ b/src/Polecat/Events/EventGraph.cs
@@ -223,6 +223,31 @@ public class EventGraph : EventRegistry, IAggregationSourceFactory<IQuerySession
             : Weasel.Storage.EventStorageBuilder.Build<string>(dialect, AppendMode, this, serializer);
     }
 
+    // #318: route the event-store auxiliary operations (archive / tombstone / progression) through the
+    // shared Weasel.Storage.EventStorage<TId> seam instead of instantiating the operation classes at the
+    // call sites. TId is fixed by StreamIdentity, so downcast the boxed storage accordingly; the
+    // operations themselves are supplied by SqlServerEventStoreDialect.BuildAuxiliaryOperations.
+    private Weasel.Storage.EventStorage<Guid> GuidEventStorage
+        => (Weasel.Storage.EventStorage<Guid>)ClosedShapeEventStorage;
+
+    private Weasel.Storage.EventStorage<string> StringEventStorage
+        => (Weasel.Storage.EventStorage<string>)ClosedShapeEventStorage;
+
+    internal Weasel.Storage.IStorageOperation ArchiveStreamOperation(object streamId, string tenantId, bool archived)
+        => StreamIdentity == StreamIdentity.AsGuid
+            ? GuidEventStorage.ArchiveStream(streamId, tenantId, archived)
+            : StringEventStorage.ArchiveStream(streamId, tenantId, archived);
+
+    internal Weasel.Storage.IStorageOperation TombstoneStreamOperation(object streamId, string tenantId)
+        => StreamIdentity == StreamIdentity.AsGuid
+            ? GuidEventStorage.TombstoneStream(streamId, tenantId)
+            : StringEventStorage.TombstoneStream(streamId, tenantId);
+
+    internal Weasel.Storage.IStorageOperation UpdateProgressOperation(string shardIdentity, long sequence, bool upsert)
+        => StreamIdentity == StreamIdentity.AsGuid
+            ? GuidEventStorage.UpdateProgress(shardIdentity, sequence, upsert)
+            : StringEventStorage.UpdateProgress(shardIdentity, sequence, upsert);
+
     /// <summary>
     ///     Wrap raw event data into an IEvent instance with type metadata.
     /// </summary>

--- a/src/Polecat/Events/EventOperations.cs
+++ b/src/Polecat/Events/EventOperations.cs
@@ -478,34 +478,36 @@ internal class EventOperations : QueryEventStore, IEventOperations
         return e.InnerException is SqlException { Number: 1222 or 1205 };
     }
 
+    // #318: archive / un-archive / tombstone now flow through the shared Weasel.Storage.EventStorage<TId>
+    // seam (EventGraph.*Operation) rather than instantiating the operation classes here.
     public void ArchiveStream(Guid streamId)
     {
-        _workTracker.Add(new SetStreamArchivedOperation(_events, streamId, _tenantId, archived: true));
+        _workTracker.Add(_events.ArchiveStreamOperation(streamId, _tenantId, archived: true));
     }
 
     public void ArchiveStream(string streamKey)
     {
-        _workTracker.Add(new SetStreamArchivedOperation(_events, streamKey, _tenantId, archived: true));
+        _workTracker.Add(_events.ArchiveStreamOperation(streamKey, _tenantId, archived: true));
     }
 
     public void UnArchiveStream(Guid streamId)
     {
-        _workTracker.Add(new SetStreamArchivedOperation(_events, streamId, _tenantId, archived: false));
+        _workTracker.Add(_events.ArchiveStreamOperation(streamId, _tenantId, archived: false));
     }
 
     public void UnArchiveStream(string streamKey)
     {
-        _workTracker.Add(new SetStreamArchivedOperation(_events, streamKey, _tenantId, archived: false));
+        _workTracker.Add(_events.ArchiveStreamOperation(streamKey, _tenantId, archived: false));
     }
 
     public void TombstoneStream(Guid streamId)
     {
-        _workTracker.Add(new TombstoneStreamOperation(_events, streamId, _tenantId));
+        _workTracker.Add(_events.TombstoneStreamOperation(streamId, _tenantId));
     }
 
     public void TombstoneStream(string streamKey)
     {
-        _workTracker.Add(new TombstoneStreamOperation(_events, streamKey, _tenantId));
+        _workTracker.Add(_events.TombstoneStreamOperation(streamKey, _tenantId));
     }
 
     public void OverwriteEvent(IEvent @event)

--- a/src/Polecat/Events/Storage/SqlServerEventStoreDialect.cs
+++ b/src/Polecat/Events/Storage/SqlServerEventStoreDialect.cs
@@ -2,6 +2,7 @@ using System;
 using System.Data;
 using JasperFx.Events;
 using Polecat.Exceptions;
+using Polecat.Internal.Operations;
 using Polecat.Storage;
 using Weasel.Core;
 using Weasel.Storage;
@@ -71,6 +72,29 @@ internal sealed class SqlServerEventStoreDialect : IEventStoreSqlDialect
             CreateQuickAppendEventsOperation = (descriptor, stream) =>
                 new PolecatQuickAppendEventsOperation(graph, descriptor, stream)
         };
+    }
+
+    /// <summary>
+    ///     #318: the SQL Server dialect of the shared auxiliary-operation seam
+    ///     (<see cref="EventAuxiliaryOperations" />, Weasel.Storage 9.17.0). Vends the archive/un-archive,
+    ///     tombstone, and progression-upsert operations that ride alongside the append/stream lifecycle.
+    ///     The operation classes hold the SQL Server SQL (SYSDATETIMEOFFSET(), MERGE); the shared
+    ///     <see cref="EventStorage{TId}" /> exposes them through ArchiveStream / TombstoneStream /
+    ///     UpdateProgress so the call sites no longer instantiate the operations directly.
+    /// </summary>
+    public EventAuxiliaryOperations? BuildAuxiliaryOperations(EventRegistry registry)
+    {
+        var graph = (EventGraph)registry;
+
+        return new EventAuxiliaryOperations(
+            ArchiveStream: (streamId, tenantId, archived) =>
+                new SetStreamArchivedOperation(graph, streamId, tenantId, archived),
+            TombstoneStream: (streamId, tenantId) =>
+                new TombstoneStreamOperation(graph, streamId, tenantId),
+            UpdateProgress: (shardIdentity, sequence, upsert) =>
+                new RecordProgressionOperation(
+                    graph.ProgressionTableName, shardIdentity, sequence,
+                    graph.EnableExtendedProgressionTracking, upsert));
     }
 
     /// <summary>


### PR DESCRIPTION
Closes #318. Finishes the closed-shape convergence: the last hand-written event-store SQL — **archive / un-archive**, **tombstone**, and **projection-progression** writes — now rides the shared `Weasel.Storage.Events` seam instead of being instantiated at the call sites.

Depends on the upstream Weasel seam (JasperFx/weasel#360, shipped in **9.17.0**).

## Changes
- **Bump** Weasel family 9.16.4 → **9.17.0**.
- `SqlServerEventStoreDialect.BuildAuxiliaryOperations` implements the SQL Server dialect of the new seam, vending the operation factories. The operation classes still hold the SQL Server SQL (`SYSDATETIMEOFFSET()`, `MERGE`).
- `EventGraph` exposes `ArchiveStreamOperation` / `TombstoneStreamOperation` / `UpdateProgressOperation`, which downcast the boxed `EventStorage<TId>` and call `ArchiveStream` / `TombstoneStream` / `UpdateProgress`.
- `EventOperations` (archive/un-archive/tombstone) and `PolecatProjectionBatch` (progression) route through those helpers. No call site instantiates `SetStreamArchivedOperation` / `TombstoneStreamOperation` / `RecordProgressionOperation` directly anymore.

## Why it's clean
The operations already implemented `Weasel.Storage.IStorageOperation` (via `Polecat.Internal.IStorageOperation`), and both `WorkTracker.Add` and the batch's progress queue already speak that currency — so the seam result is enqueued **directly, no adapter needed**.

## Out of scope
`AssertDcbConsistencyOperation` stays store-local (DCB tag-table `EXISTS` check), per issue #318's non-goals.

## Verification
Existing event-store suite is the safety net — archive/tombstone/progression, async daemon, per-tenant rebuild, and partitioned-archive tests all green locally (net10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)