### PR TITLE
feat(#336): re-point ITenanted at JasperFx.MultiTenancy.ITenanted

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,8 +22,8 @@
              IEventDatabase.QueryDeadLetterEventsAsync (dead-letter row drill-in), DeadLetterEvent.TenantId,
              and the tenant-aware daemon surface. Polecat implements the dead-letter row query + per-tenant
              FetchDeadLetterCountsAsync below. -->
-        <PackageVersion Include="JasperFx" Version="2.29.0" />
-        <PackageVersion Include="JasperFx.Events" Version="2.29.0" />
+        <PackageVersion Include="JasperFx" Version="2.30.0" />
+        <PackageVersion Include="JasperFx.Events" Version="2.30.0" />
         <!-- Pin the sibling JasperFx packages for parity with Marten 9's matrix
              even though Polecat doesn't currently reference them directly —
              keeps the lockstep matrix coherent when transitive resolution
@@ -31,7 +31,7 @@
              RuntimeCompiler 5.x line is the active continuation of the 4.x
              lineage; do not pin against the parallel stale 2.0.x series. -->
         <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.29.0" />
+        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.30.0" />
         <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
@@ -69,7 +69,7 @@
         <PackageVersion Include="StronglyTypedId" Version="1.0.0-beta08" />
 
         <!-- Source generators (matched to JasperFx.Events above) -->
-        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.29.0" />
+        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.30.0" />
 
         <!-- Build automation -->
         <PackageVersion Include="Nuke.Common" Version="9.0.4" />

--- a/src/Polecat/Metadata/ITenanted.cs
+++ b/src/Polecat/Metadata/ITenanted.cs
@@ -5,12 +5,12 @@ namespace Polecat.Metadata;
 /// <summary>
 ///     Implement this interface on a document type to automatically have
 ///     the TenantId set from the session on save and from the tenant_id
-///     column on load. Inherits the <see cref="IHasTenantId.TenantId"/>
-///     contract from the canonical <see cref="JasperFx.MultiTenancy"/>
-///     marker — Polecat-side framework code accepting <c>IHasTenantId</c>
-///     accepts any <c>ITenanted</c> document type. Per the dedup audit
-///     row JasperFx/jasperfx#224 (multi-tenancy slice).
+///     column on load. Derives from the shared
+///     <see cref="JasperFx.MultiTenancy.ITenanted"/> marker (jasperfx#531)
+///     so the same marker drives conjoined behavior across Marten,
+///     Polecat, and Wolverine — framework code accepting
+///     <c>IHasTenantId</c> accepts any <c>ITenanted</c> document type.
 /// </summary>
-public interface ITenanted : IHasTenantId
+public interface ITenanted : JasperFx.MultiTenancy.ITenanted
 {
 }


### PR DESCRIPTION
Closes #336. Follow-up to JasperFx/jasperfx#531, part of the Wolverine conjoined EF Core multi-tenancy epic (JasperFx/wolverine#3465).

- Bumps JasperFx, JasperFx.Events, JasperFx.SourceGenerator, and JasperFx.Events.SourceGenerator to **2.30.0**
- `Polecat.Metadata.ITenanted` now derives from the shared `JasperFx.MultiTenancy.ITenanted` marker instead of declaring `: IHasTenantId` directly — non-breaking for existing documents, and any Polecat `ITenanted` document now also satisfies the cross-tool marker

🤖 Generated with [Claude Code](https://claude.com/claude-code)