### PR TITLE
Add high-water staleness health check (parity with marten#4982)

### DIFF
--- a/src/Polecat.AspNetCore.Testing/HighWaterHealthCheckTests.cs
+++ b/src/Polecat.AspNetCore.Testing/HighWaterHealthCheckTests.cs
@@ -1,0 +1,283 @@
+using JasperFx;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Projections;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Polecat;
+using Polecat.Events.Daemon;
+using Polecat.Projections;
+using Polecat.Storage;
+using Polecat.TestUtils;
+using Shouldly;
+using Xunit;
+using static Polecat.Events.Daemon.HighWaterHealthCheckExtensions;
+
+namespace Polecat.AspNetCore.Testing;
+
+public record HwFakeEvent();
+
+public partial class HwFakeStream
+{
+    public Guid Id { get; set; }
+}
+
+public partial class HwFakeProjection: SingleStreamProjection<HwFakeStream, Guid>
+{
+    public static HwFakeStream Create(JasperFx.Events.IEvent<HwFakeEvent> e) =>
+        new() { Id = e.StreamId };
+
+    public void Apply(HwFakeEvent @event, HwFakeStream projection) { }
+}
+
+/// <summary>
+///     Polecat parity for Marten's HighWaterHealthCheckTests (marten#4982 / polecat#339).
+///     Self-contained DB harness: builds a DocumentStore against the SQL Server test instance,
+///     seeds the high-water mark directly, and drives the check with a controllable clock.
+///     Run one TFM at a time — DB-backed tests collide on the shared database.
+/// </summary>
+public class HighWaterHealthCheckTests: IAsyncLifetime
+{
+    private static readonly string ConnectionString = ConnectionSource.ConnectionString;
+
+    private readonly string _schemaName;
+    private readonly MutableTimeProvider _timeProvider;
+    private readonly DateTimeOffset _now = DateTimeOffset.UtcNow;
+    private readonly HighWaterStateTracker _tracker = new();
+    private DocumentStore? _store;
+
+    public HighWaterHealthCheckTests()
+    {
+        _schemaName = "hw_health_" + Guid.NewGuid().ToString("N")[..8];
+        _timeProvider = new MutableTimeProvider(_now);
+    }
+
+    public async Task InitializeAsync()
+    {
+        // Drop the schema for a clean slate.
+        await using var conn = new SqlConnection(ConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"""
+            IF SCHEMA_ID('{_schemaName}') IS NOT NULL
+            BEGIN
+                DECLARE @sql NVARCHAR(MAX) = '';
+                SELECT @sql += 'DROP TABLE IF EXISTS ' + QUOTENAME(s.name) + '.' + QUOTENAME(t.name) + ';' + CHAR(13)
+                FROM sys.tables t
+                JOIN sys.schemas s ON t.schema_id = s.schema_id
+                WHERE s.name = '{_schemaName}';
+                EXEC sp_executesql @sql;
+            END
+            """;
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_store != null)
+        {
+            await _store.DisposeAsync();
+        }
+    }
+
+    private DocumentStore configure(Action<StoreOptions> configure)
+    {
+        var options = new StoreOptions
+        {
+            ConnectionString = ConnectionString,
+            AutoCreateSchemaObjects = AutoCreate.All,
+            DatabaseSchemaName = _schemaName,
+            UseNativeJsonType = ConnectionSource.SupportsNativeJson
+        };
+
+        configure(options);
+
+        _store = new DocumentStore(options);
+        return _store;
+    }
+
+    private HighWaterHealthCheck buildCheck(TimeSpan? staleThreshold = null, long minimumGap = 1) =>
+        new(_store!, new HighWaterHealthCheckSettings(staleThreshold ?? TimeSpan.FromSeconds(30), minimumGap),
+            _timeProvider, _tracker);
+
+    private async Task appendEventsAsync(int count)
+    {
+        await using var session = _store!.LightweightSession();
+        var events = Enumerable.Range(0, count).Select(_ => new HwFakeEvent()).Cast<object>().ToArray();
+        session.Events.StartStream(Guid.NewGuid(), events);
+        await session.SaveChangesAsync();
+    }
+
+    private async Task seedHighWaterMarkAsync(long sequence)
+    {
+        await using var conn = new SqlConnection(ConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"""
+            MERGE [{_schemaName}].[pc_event_progression] AS t
+            USING (SELECT 'HighWaterMark' AS name, CAST({sequence} AS bigint) AS last_seq_id) AS s
+            ON t.name = s.name
+            WHEN MATCHED THEN UPDATE SET last_seq_id = s.last_seq_id
+            WHEN NOT MATCHED THEN INSERT (name, last_seq_id, last_updated)
+                VALUES (s.name, s.last_seq_id, SYSDATETIMEOFFSET());
+            """;
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    // ---- registration --------------------------------------------------------------------
+
+    [Fact]
+    public void registers_settings_timeprovider_tracker_and_check()
+    {
+        var builder = new FakeHealthCheckBuilderStub();
+        builder.AddPolecatHighWaterHealthCheck(TimeSpan.FromSeconds(30));
+
+        builder.Services.ShouldContain(x => x.ServiceType == typeof(HighWaterHealthCheckSettings));
+        builder.Services.ShouldContain(x => x.ServiceType == typeof(TimeProvider));
+        builder.Services.ShouldContain(x => x.ServiceType == typeof(HighWaterStateTracker));
+
+        var provider = builder.Services.BuildServiceProvider();
+        provider.GetServices<HealthCheckRegistration>()
+            .ShouldContain(reg => reg.Name == nameof(HighWaterHealthCheck));
+    }
+
+    // ---- gating --------------------------------------------------------------------------
+
+    [Fact]
+    public async Task healthy_when_no_async_projections_even_if_events_pile_up()
+    {
+        // No async projection registered -> the high-water agent runs nowhere, so a stuck mark
+        // is legitimate. The gate short-circuits before any database read.
+        configure(_ => { });
+        await appendEventsAsync(20);
+
+        var result = await buildCheck().CheckHealthAsync(new HealthCheckContext());
+
+        result.Status.ShouldBe(HealthStatus.Healthy);
+    }
+
+    [Fact]
+    public async Task healthy_when_daemon_mode_is_disabled_even_if_mark_is_stuck()
+    {
+        configure(opts =>
+        {
+            opts.Projections.Add<HwFakeProjection>(ProjectionLifecycle.Async);
+            opts.DaemonSettings.AsyncMode = DaemonMode.Disabled;
+        });
+        await _store!.Database.ApplyAllConfiguredChangesToDatabaseAsync();
+        await appendEventsAsync(20);
+        await seedHighWaterMarkAsync(1);
+
+        var result = await buildCheck().CheckHealthAsync(new HealthCheckContext());
+
+        result.Status.ShouldBe(HealthStatus.Healthy);
+    }
+
+    // ---- signal --------------------------------------------------------------------------
+
+    [Fact]
+    public async Task healthy_when_mark_is_caught_up()
+    {
+        configure(opts =>
+        {
+            opts.Projections.Add<HwFakeProjection>(ProjectionLifecycle.Async);
+            opts.DaemonSettings.AsyncMode = DaemonMode.Solo;
+        });
+        await _store!.Database.ApplyAllConfiguredChangesToDatabaseAsync();
+        await appendEventsAsync(20);
+        var highest = await _store.Database.FetchHighestEventSequenceNumber(CancellationToken.None);
+        await seedHighWaterMarkAsync(highest);
+
+        var result = await buildCheck().CheckHealthAsync(new HealthCheckContext());
+
+        result.Status.ShouldBe(HealthStatus.Healthy);
+    }
+
+    [Fact]
+    public async Task healthy_within_grace_window_when_mark_first_seen_behind()
+    {
+        configure(opts =>
+        {
+            opts.Projections.Add<HwFakeProjection>(ProjectionLifecycle.Async);
+            opts.DaemonSettings.AsyncMode = DaemonMode.Solo;
+        });
+        await _store!.Database.ApplyAllConfiguredChangesToDatabaseAsync();
+        await appendEventsAsync(20);
+        await seedHighWaterMarkAsync(1);
+
+        // First observation of the gap only starts the clock; not yet stale.
+        var result = await buildCheck().CheckHealthAsync(new HealthCheckContext());
+
+        result.Status.ShouldBe(HealthStatus.Healthy);
+    }
+
+    [Fact]
+    public async Task unhealthy_when_mark_stuck_behind_past_threshold()
+    {
+        configure(opts =>
+        {
+            opts.Projections.Add<HwFakeProjection>(ProjectionLifecycle.Async);
+            opts.DaemonSettings.AsyncMode = DaemonMode.Solo;
+        });
+        await _store!.Database.ApplyAllConfiguredChangesToDatabaseAsync();
+        await appendEventsAsync(20);
+        await seedHighWaterMarkAsync(1);
+
+        var check = buildCheck(TimeSpan.FromSeconds(30));
+
+        // First check records the stalled mark at _now.
+        (await check.CheckHealthAsync(new HealthCheckContext())).Status.ShouldBe(HealthStatus.Healthy);
+
+        // Advance the clock past the threshold with the mark still stuck.
+        _timeProvider.Now = _now.AddSeconds(60);
+
+        var result = await check.CheckHealthAsync(new HealthCheckContext());
+
+        result.Status.ShouldBe(HealthStatus.Unhealthy);
+    }
+
+    [Fact]
+    public async Task healthy_when_mark_advances_before_threshold()
+    {
+        configure(opts =>
+        {
+            opts.Projections.Add<HwFakeProjection>(ProjectionLifecycle.Async);
+            opts.DaemonSettings.AsyncMode = DaemonMode.Solo;
+        });
+        await _store!.Database.ApplyAllConfiguredChangesToDatabaseAsync();
+        await appendEventsAsync(20);
+        await seedHighWaterMarkAsync(1);
+
+        var check = buildCheck(TimeSpan.FromSeconds(30));
+
+        // First check: gap observed, clock starts.
+        (await check.CheckHealthAsync(new HealthCheckContext())).Status.ShouldBe(HealthStatus.Healthy);
+
+        // The mark advances (agent alive) and time moves forward past the threshold.
+        await seedHighWaterMarkAsync(10);
+        _timeProvider.Now = _now.AddSeconds(60);
+
+        // The advance resets the clock, so it must not be reported stale.
+        var result = await check.CheckHealthAsync(new HealthCheckContext());
+
+        result.Status.ShouldBe(HealthStatus.Healthy);
+    }
+
+    private sealed class MutableTimeProvider: TimeProvider
+    {
+        public MutableTimeProvider(DateTimeOffset now) => Now = now;
+        public DateTimeOffset Now { get; set; }
+        public override DateTimeOffset GetUtcNow() => Now;
+    }
+
+    private sealed class FakeHealthCheckBuilderStub: IHealthChecksBuilder
+    {
+        public IServiceCollection Services { get; } = new ServiceCollection();
+
+        public IHealthChecksBuilder Add(HealthCheckRegistration registration)
+        {
+            Services.AddSingleton(registration);
+            return this;
+        }
+    }
+}

--- a/src/Polecat.AspNetCore/Daemon/HighWaterHealthCheckExtensions.cs
+++ b/src/Polecat.AspNetCore/Daemon/HighWaterHealthCheckExtensions.cs
@@ -1,0 +1,200 @@
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Events;
+using JasperFx.Events.Daemon;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Polecat.Events.Daemon;
+
+/// <summary>
+///     Health check that detects a stalled or dead high-water agent — the failure mode in
+///     marten#4961 where the async daemon's high-water agent dies, the mark freezes, projections
+///     catch up to the frozen value, and any lag-based check reports Healthy. This check instead
+///     compares the high-water mark against the actual highest event sequence and reports
+///     Unhealthy only when the mark stops advancing while events keep accumulating past it.
+///     <para>
+///         This is the Polecat parity implementation of Marten's <c>AddMartenHighWaterHealthCheck</c>
+///         (marten#4982 / polecat#339). Polecat has no async-daemon lag health check to be blind to,
+///         but the high-water liveness signal is valuable on its own.
+///     </para>
+/// </summary>
+public static class HighWaterHealthCheckExtensions
+{
+    /// <summary>
+    ///     Adds a health check that reports <see cref="HealthCheckResult.Unhealthy" /> when the
+    ///     high-water mark has stopped advancing for at least <paramref name="staleThreshold" />
+    ///     while later events remain unprocessed — a strong signal that the high-water agent has
+    ///     died or wedged (marten#4961).
+    ///     <para>
+    ///         Built on the sequence-gap heuristic so it ships without an upstream dependency. A
+    ///         non-zero gap is normal transiently (the detector holds the mark inside a "safe
+    ///         harbor" behind in-flight/gapped sequences), so the check trips only on a
+    ///         <em>sustained non-advance</em>, never on a single snapshot. The reading is
+    ///         store-global database state, so it is correct on any node regardless of which one
+    ///         runs the agent — it fails only when <em>no</em> node is advancing the mark.
+    ///     </para>
+    /// </summary>
+    /// <param name="builder"><see cref="IHealthChecksBuilder" /></param>
+    /// <param name="staleThreshold">
+    ///     How long the high-water mark may sit unchanged while behind the latest event sequence
+    ///     before the store is considered unhealthy. Defaults to 30 seconds.
+    /// </param>
+    /// <param name="minimumGap">
+    ///     The gap (highest event sequence minus high-water mark) that is treated as "caught up"
+    ///     and never trips the check, absorbing the normal safe-harbor lag. Defaults to 1.
+    /// </param>
+    public static IHealthChecksBuilder AddPolecatHighWaterHealthCheck(
+        this IHealthChecksBuilder builder,
+        TimeSpan? staleThreshold = null,
+        long minimumGap = 1
+    )
+    {
+        builder.Services.AddSingleton(new HighWaterHealthCheckSettings(
+            staleThreshold ?? TimeSpan.FromSeconds(30), minimumGap));
+        builder.Services.TryAddSingleton(TimeProvider.System);
+        builder.Services.TryAddSingleton<HighWaterStateTracker>();
+        return builder.AddCheck<HighWaterHealthCheck>(
+            nameof(HighWaterHealthCheck),
+            tags: new[] { "Polecat", "AsyncDaemon", "HighWater" }
+        );
+    }
+
+    /// <summary>
+    ///     DI-injected settings for <see cref="HighWaterHealthCheck" />.
+    /// </summary>
+    public record HighWaterHealthCheckSettings(TimeSpan StaleThreshold, long MinimumGap);
+
+    /// <summary>
+    ///     Tracks, per database, when the high-water mark was first observed to be behind the
+    ///     latest event sequence and what value it held then, so a <em>sustained</em> non-advance
+    ///     can be distinguished from a transient safe-harbor gap across health check invocations.
+    /// </summary>
+    public class HighWaterStateTracker
+    {
+        public ConcurrentDictionary<string, (DateTimeOffset FirstObservedAt, long HighWaterMark)> Readings { get; } =
+            new();
+    }
+
+    /// <summary>
+    ///     Health check implementation.
+    /// </summary>
+    public class HighWaterHealthCheck: IHealthCheck
+    {
+        private const string HighWaterMarkShard = "HighWaterMark";
+
+        private readonly IDocumentStore _store;
+        private readonly TimeProvider _timeProvider;
+        private readonly TimeSpan _staleThreshold;
+        private readonly long _minimumGap;
+        private readonly HighWaterStateTracker _tracker;
+
+        public HighWaterHealthCheck(IDocumentStore store, HighWaterHealthCheckSettings settings,
+            TimeProvider timeProvider, HighWaterStateTracker tracker)
+        {
+            _store = store;
+            _timeProvider = timeProvider;
+            _staleThreshold = settings.StaleThreshold;
+            _minimumGap = settings.MinimumGap;
+            _tracker = tracker;
+        }
+
+        public async Task<HealthCheckResult> CheckHealthAsync(
+            HealthCheckContext context,
+            CancellationToken cancellationToken = default
+        )
+        {
+            try
+            {
+                var options = _store.Options;
+
+                // Gate: the high-water mark is only expected to advance when this store is actually
+                // responsible for running the async daemon. Otherwise a frozen mark is legitimate
+                // and asserting on it would be a false positive.
+
+                // No async projections or subscriptions -> no high-water agent runs anywhere.
+                if (!options.Projections.HasAnyAsyncProjections())
+                {
+                    return HealthCheckResult.Healthy("No async projections or subscriptions are registered");
+                }
+
+                // Disabled / ExternallyManaged -> this store hosts no daemon, so it must not assert
+                // that some local agent is advancing the mark.
+                var asyncMode = options.DaemonSettings.AsyncMode;
+                if (asyncMode is not (DaemonMode.Solo or DaemonMode.HotCold))
+                {
+                    return HealthCheckResult.Healthy(
+                        $"Async daemon mode is {asyncMode}; high-water is not advanced by this store");
+                }
+
+                // Store-agnostic database enumeration (no Marten-style store.Storage in Polecat).
+                var databases = _store is IEventStore eventStore
+                    ? await eventStore.AllDatabases().ConfigureAwait(false)
+                    : Array.Empty<IEventDatabase>();
+
+                foreach (var database in databases)
+                {
+                    var result = await checkDatabaseAsync(database, cancellationToken).ConfigureAwait(false);
+                    if (result.Status != HealthStatus.Healthy)
+                    {
+                        return result;
+                    }
+                }
+
+                return HealthCheckResult.Healthy("Healthy");
+            }
+            catch (Exception ex)
+            {
+                return HealthCheckResult.Unhealthy($"Unhealthy: {ex.Message}", ex);
+            }
+        }
+
+        private async Task<HealthCheckResult> checkDatabaseAsync(IEventDatabase database, CancellationToken token)
+        {
+            var allProgress = await database.AllProjectionProgress(token).ConfigureAwait(false);
+            var highWater = allProgress.FirstOrDefault(x => string.Equals(HighWaterMarkShard, x.ShardName));
+
+            // No HighWaterMark progression row yet -> the daemon has not started here. Nothing to assert.
+            if (highWater is null)
+            {
+                _tracker.Readings.TryRemove(database.Identifier, out _);
+                return HealthCheckResult.Healthy("Healthy");
+            }
+
+            var highest = await database.FetchHighestEventSequenceNumber(token).ConfigureAwait(false);
+            var gap = highest - highWater.Sequence;
+            var now = _timeProvider.GetUtcNow();
+
+            // Caught up (within the normal safe-harbor gap). Clear any stalled-mark tracking.
+            if (gap <= _minimumGap)
+            {
+                _tracker.Readings.TryRemove(database.Identifier, out _);
+                return HealthCheckResult.Healthy("Healthy");
+            }
+
+            // A gap exists. That is normal transiently; it is only a problem when the mark is NOT
+            // advancing while events keep piling up beyond it. Track the first time we saw a gap at
+            // this mark value; if the mark moves, reset the clock; if it stays put past the
+            // threshold, the high-water agent has almost certainly died or wedged.
+            var reading = _tracker.Readings.GetOrAdd(database.Identifier, _ => (now, highWater.Sequence));
+
+            if (reading.HighWaterMark != highWater.Sequence)
+            {
+                _tracker.Readings[database.Identifier] = (now, highWater.Sequence);
+                return HealthCheckResult.Healthy("Healthy");
+            }
+
+            if (now - reading.FirstObservedAt >= _staleThreshold)
+            {
+                return HealthCheckResult.Unhealthy(
+                    $"Unhealthy: the high-water mark for database '{database.Identifier}' has been stuck at {highWater.Sequence} with {gap} later event(s) unprocessed (highest sequence {highest}) for at least {_staleThreshold}. The high-water agent may have stopped (see marten#4961).");
+            }
+
+            return HealthCheckResult.Healthy("Healthy");
+        }
+    }
+}


### PR DESCRIPTION
Closes #339.

Polecat has no health check of any kind today. This adds `AddPolecatHighWaterHealthCheck`, the Polecat parity of Marten's `AddMartenHighWaterHealthCheck` (marten#4982, itself a follow-up to marten#4961 — a dead/stalled high-water agent).

## Why

Any lag-based async-daemon health check measures each projection's lag *against* the `HighWaterMark`. When the high-water agent itself dies, the mark freezes, projections catch up to that frozen value, lag drops to zero, and the check reports **Healthy** — the exact inverse of what's wanted.

`AddPolecatHighWaterHealthCheck` instead compares the high-water mark against the actual highest event sequence and reports **Unhealthy** only when the mark *stops advancing* while events keep piling up past it. A non-zero gap is normal transiently (the detector holds the mark inside a "safe harbor" behind in-flight/gapped sequences), so it trips only on a **sustained non-advance** tracked across invocations — never on a single snapshot. The reading is store-global database state, so it is correct on any node regardless of which one runs the agent; it fails only when *no* node is advancing the mark.

## Gating (avoids false positives)

Evaluated per database, Healthy/not-applicable unless all hold:
- `Options.Projections.HasAnyAsyncProjections()` — at least one async projection or subscription;
- `Options.DaemonSettings.AsyncMode ∈ {Solo, HotCold}` — `Disabled` / `ExternallyManaged` skip;
- no `HighWaterMark` progression row yet ⇒ daemon not started here ⇒ nothing to assert.

## Notes

- Lives in `Polecat.AspNetCore`, **AOT-clean** (0 IL warnings under the project's `WarningsAsErrors`). Uses the HealthChecks abstractions already bundled by the `Microsoft.AspNetCore.App` framework reference — **no new package reference** needed.
- Databases enumerated store-agnostically via `IEventStore.AllDatabases()`; per-database progress via `IEventDatabase.AllProjectionProgress` and `FetchHighestEventSequenceNumber`.
- This is Phase 0 (the sequence-gap heuristic), matching marten#4982's merged implementation. When JasperFx/jasperfx#539 ships the high-water heartbeat, the primary signal can swap to it with the gap heuristic kept as the `ExtendedProgression`-off fallback.

## Tests

Mirror Marten's merged `HighWaterHealthCheckTests`: registration; gate cases (no async projections; `Disabled`); caught-up; within-grace-window; stuck-past-threshold → Unhealthy; advances-before-threshold → Healthy. Self-contained DB harness (builds a `DocumentStore`, seeds the mark, drives the check with a controllable `TimeProvider`).

⚠️ **Local test verification:** the DI-only registration test passes locally. The six DB-backed tests could **not** be run on my machine — the Docker SQL Server 2025 image (emulated amd64 on arm64) cannot complete Weasel's schema-migration introspection within the command timeout / available memory. This is an environment limit, **not** specific to these tests: the existing `Polecat.Tests/Daemon/async_daemon_tests` fail identically on this host. The DB tests mirror the merged, green Marten suite one-to-one and use the same store-build / `ApplyAllConfiguredChangesToDatabaseAsync` / append / `AllProjectionProgress` / `FetchHighestEventSequenceNumber` pattern proven by those existing daemon tests, so they should pass on CI (native SQL Server). Please confirm via CI.

## Related
- Reference implementation: JasperFx/marten#4982 (merged as marten#4984).
- Foundation for Phase 2: JasperFx/jasperfx#539. Origin: marten#4961.

🤖 Generated with [Claude Code](https://claude.com/claude-code)