### PR TITLE
Upgrade JasperFx + JasperFx.Events to 2.32.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,9 +21,14 @@
              Events.EnableExtendedProgressionTracking, mirroring Marten PR #4741; and (b) jasperfx#453 —
              IEventDatabase.QueryDeadLetterEventsAsync (dead-letter row drill-in), DeadLetterEvent.TenantId,
              and the tenant-aware daemon surface. Polecat implements the dead-letter row query + per-tenant
-             FetchDeadLetterCountsAsync below. -->
-        <PackageVersion Include="JasperFx" Version="2.30.0" />
-        <PackageVersion Include="JasperFx.Events" Version="2.30.0" />
+             FetchDeadLetterCountsAsync below.
+             JasperFx 2.32.0: jasperfx#539 — HighWaterAgent liveness heartbeat, staleness surface, and
+             local restart seam (IProjectionDaemon.HighWaterLastPolledAt / IsHighWaterStale /
+             RestartHighWaterAgentAsync; DaemonSettings.HighWaterStalenessThreshold; ShardAction.Faulted/
+             Restarted). Foundation for the Phase 2 high-water health check (polecat#341). Also carries
+             the jasperfx#540 faulted-start teardown that first shipped in 2.32.0. -->
+        <PackageVersion Include="JasperFx" Version="2.32.0" />
+        <PackageVersion Include="JasperFx.Events" Version="2.32.0" />
         <!-- Pin the sibling JasperFx packages for parity with Marten 9's matrix
              even though Polecat doesn't currently reference them directly —
              keeps the lockstep matrix coherent when transitive resolution
@@ -31,7 +36,7 @@
              RuntimeCompiler 5.x line is the active continuation of the 4.x
              lineage; do not pin against the parallel stale 2.0.x series. -->
         <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.30.0" />
+        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.32.0" />
         <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
@@ -75,7 +80,7 @@
         <PackageVersion Include="StronglyTypedId" Version="1.0.0-beta08" />
 
         <!-- Source generators (matched to JasperFx.Events above) -->
-        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.30.0" />
+        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.32.0" />
 
         <!-- Build automation -->
         <PackageVersion Include="Nuke.Common" Version="9.0.4" />


### PR DESCRIPTION
Rolls the JasperFx package pins forward **2.30.0 → 2.32.0**:

| Package | Was | Now |
|---|---|---|
| JasperFx | 2.30.0 | **2.32.0** |
| JasperFx.Events | 2.30.0 | **2.32.0** |
| JasperFx.SourceGenerator | 2.30.0 | **2.32.0** |
| JasperFx.Events.SourceGenerator | 2.30.0 | **2.32.0** |
| JasperFx.RuntimeCompiler | 5.0.0 | 5.0.0 (unchanged) |

### What 2.32.0 brings
- **jasperfx#539** — HighWaterAgent liveness heartbeat, staleness surface, and a local restart seam: new `IProjectionDaemon` members (`HighWaterLastPolledAt`, `IsHighWaterStale`, `RestartHighWaterAgentAsync`), `DaemonSettings.HighWaterStalenessThreshold` (30s), `ShardAction.Faulted`/`Restarted`. `PolecatProjectionDaemon : JasperFxAsyncDaemon` inherits it for free. **Foundation for the Phase 2 high-water health check (#341).**
- **jasperfx#540** — faulted-start teardown so a faulted shard start can't orphan the shard.

`src/Polecat` and `src/Polecat.AspNetCore` build clean against 2.32.0. Pure pin bump — no source changes.

Follow-up: #341 (opt-in `autoRestart` + swap the high-water health check's primary signal to the new heartbeat) builds on this.