### PR TITLE
feat(#341): high-water health check autoRestart + heartbeat primary signal

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,9 +21,14 @@
              Events.EnableExtendedProgressionTracking, mirroring Marten PR #4741; and (b) jasperfx#453 —
              IEventDatabase.QueryDeadLetterEventsAsync (dead-letter row drill-in), DeadLetterEvent.TenantId,
              and the tenant-aware daemon surface. Polecat implements the dead-letter row query + per-tenant
-             FetchDeadLetterCountsAsync below. -->
-        <PackageVersion Include="JasperFx" Version="2.30.0" />
-        <PackageVersion Include="JasperFx.Events" Version="2.30.0" />
+             FetchDeadLetterCountsAsync below.
+             JasperFx 2.32.0: jasperfx#539 — HighWaterAgent liveness heartbeat, staleness surface, and
+             local restart seam (IProjectionDaemon.HighWaterLastPolledAt / IsHighWaterStale /
+             RestartHighWaterAgentAsync; DaemonSettings.HighWaterStalenessThreshold; ShardAction.Faulted/
+             Restarted). Foundation for the Phase 2 high-water health check (polecat#341). Also carries
+             the jasperfx#540 faulted-start teardown that first shipped in 2.32.0. -->
+        <PackageVersion Include="JasperFx" Version="2.32.0" />
+        <PackageVersion Include="JasperFx.Events" Version="2.32.0" />
         <!-- Pin the sibling JasperFx packages for parity with Marten 9's matrix
              even though Polecat doesn't currently reference them directly —
              keeps the lockstep matrix coherent when transitive resolution
@@ -31,7 +36,7 @@
              RuntimeCompiler 5.x line is the active continuation of the 4.x
              lineage; do not pin against the parallel stale 2.0.x series. -->
         <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.30.0" />
+        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.32.0" />
         <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
@@ -75,7 +80,7 @@
         <PackageVersion Include="StronglyTypedId" Version="1.0.0-beta08" />
 
         <!-- Source generators (matched to JasperFx.Events above) -->
-        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.30.0" />
+        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.32.0" />
 
         <!-- Build automation -->
         <PackageVersion Include="Nuke.Common" Version="9.0.4" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -52,6 +52,7 @@
         <PackageVersion Include="Alba" Version="8.5.2" />
         <PackageVersion Include="coverlet.collector" Version="6.0.4" />
         <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+        <PackageVersion Include="NSubstitute" Version="5.3.0" />
         <PackageVersion Include="Shouldly" Version="4.3.0" />
         <PackageVersion Include="xunit" Version="2.9.3" />
         <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.4" />

--- a/src/Polecat.AspNetCore.Testing/HighWaterHealthCheckTests.cs
+++ b/src/Polecat.AspNetCore.Testing/HighWaterHealthCheckTests.cs
@@ -4,6 +4,7 @@ using JasperFx.Events.Projections;
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
+using NSubstitute;
 using Polecat;
 using Polecat.Events.Daemon;
 using Polecat.Projections;
@@ -96,9 +97,19 @@ public class HighWaterHealthCheckTests: IAsyncLifetime
         return _store;
     }
 
-    private HighWaterHealthCheck buildCheck(TimeSpan? staleThreshold = null, long minimumGap = 1) =>
-        new(_store!, new HighWaterHealthCheckSettings(staleThreshold ?? TimeSpan.FromSeconds(30), minimumGap),
-            _timeProvider, _tracker);
+    private HighWaterHealthCheck buildCheck(TimeSpan? staleThreshold = null, long minimumGap = 1,
+        bool autoRestart = false, IProjectionCoordinator? coordinator = null)
+    {
+        var services = new ServiceCollection();
+        if (coordinator != null)
+        {
+            services.AddSingleton(coordinator);
+        }
+
+        return new(_store!,
+            new HighWaterHealthCheckSettings(staleThreshold ?? TimeSpan.FromSeconds(30), minimumGap, autoRestart),
+            _timeProvider, _tracker, services.BuildServiceProvider());
+    }
 
     private async Task appendEventsAsync(int count)
     {
@@ -121,6 +132,26 @@ public class HighWaterHealthCheckTests: IAsyncLifetime
             WHEN NOT MATCHED THEN INSERT (name, last_seq_id, last_updated)
                 VALUES (s.name, s.last_seq_id, SYSDATETIMEOFFSET());
             """;
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    // Seeds the HighWaterMark row's liveness heartbeat (jasperfx#539). Requires
+    // EnableExtendedProgressionTracking so the `heartbeat` column exists.
+    private async Task seedHighWaterHeartbeatAsync(long sequence, DateTimeOffset heartbeat)
+    {
+        await using var conn = new SqlConnection(ConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"""
+            MERGE [{_schemaName}].[pc_event_progression] AS t
+            USING (SELECT 'HighWaterMark' AS name, CAST({sequence} AS bigint) AS last_seq_id,
+                   CAST(@hb AS datetimeoffset) AS heartbeat) AS s
+            ON t.name = s.name
+            WHEN MATCHED THEN UPDATE SET last_seq_id = s.last_seq_id, heartbeat = s.heartbeat
+            WHEN NOT MATCHED THEN INSERT (name, last_seq_id, last_updated, heartbeat)
+                VALUES (s.name, s.last_seq_id, SYSDATETIMEOFFSET(), s.heartbeat);
+            """;
+        cmd.Parameters.Add(new SqlParameter("@hb", heartbeat));
         await cmd.ExecuteNonQueryAsync();
     }
 
@@ -261,6 +292,127 @@ public class HighWaterHealthCheckTests: IAsyncLifetime
         var result = await check.CheckHealthAsync(new HealthCheckContext());
 
         result.Status.ShouldBe(HealthStatus.Healthy);
+    }
+
+    // ---- heartbeat primary signal (polecat#341) ------------------------------------------
+
+    [Fact]
+    public async Task healthy_when_heartbeat_is_fresh_even_though_mark_is_behind()
+    {
+        // ExtendedProgression on -> the heartbeat is the primary signal. A fresh heartbeat means the
+        // agent is cycling, so a mark sitting behind the latest event is NOT unhealthy (unlike the gap
+        // heuristic, which would trip here).
+        configure(opts =>
+        {
+            opts.Projections.Add<HwFakeProjection>(ProjectionLifecycle.Async);
+            opts.DaemonSettings.AsyncMode = DaemonMode.Solo;
+            opts.Events.EnableExtendedProgressionTracking = true;
+        });
+        await _store!.Database.ApplyAllConfiguredChangesToDatabaseAsync();
+        await appendEventsAsync(20);
+        await seedHighWaterHeartbeatAsync(1, _now.AddSeconds(-5)); // mark stuck at 1, heartbeat only 5s old
+
+        var result = await buildCheck(TimeSpan.FromSeconds(30)).CheckHealthAsync(new HealthCheckContext());
+
+        result.Status.ShouldBe(HealthStatus.Healthy);
+    }
+
+    [Fact]
+    public async Task unhealthy_when_heartbeat_is_stale_even_though_mark_is_caught_up()
+    {
+        // A stale heartbeat means the loop stopped cycling. This trips even when the mark is fully caught
+        // up (gap == 0) — the case the gap heuristic is blind to.
+        configure(opts =>
+        {
+            opts.Projections.Add<HwFakeProjection>(ProjectionLifecycle.Async);
+            opts.DaemonSettings.AsyncMode = DaemonMode.Solo;
+            opts.Events.EnableExtendedProgressionTracking = true;
+        });
+        await _store!.Database.ApplyAllConfiguredChangesToDatabaseAsync();
+        await appendEventsAsync(20);
+        var highest = await _store.Database.FetchHighestEventSequenceNumber(CancellationToken.None);
+        await seedHighWaterHeartbeatAsync(highest, _now.AddSeconds(-90)); // caught up, heartbeat 90s old
+
+        var result = await buildCheck(TimeSpan.FromSeconds(30)).CheckHealthAsync(new HealthCheckContext());
+
+        result.Status.ShouldBe(HealthStatus.Unhealthy);
+    }
+
+    // ---- autoRestart remediation (polecat#341) -------------------------------------------
+
+    [Fact]
+    public async Task autorestart_triggers_a_restart_once_and_still_reports_unhealthy()
+    {
+        configure(opts =>
+        {
+            opts.Projections.Add<HwFakeProjection>(ProjectionLifecycle.Async);
+            opts.DaemonSettings.AsyncMode = DaemonMode.Solo;
+            opts.Events.EnableExtendedProgressionTracking = true;
+        });
+        await _store!.Database.ApplyAllConfiguredChangesToDatabaseAsync();
+        await appendEventsAsync(20);
+        var highest = await _store.Database.FetchHighestEventSequenceNumber(CancellationToken.None);
+        await seedHighWaterHeartbeatAsync(highest, _now.AddSeconds(-90));
+
+        var daemon = Substitute.For<IProjectionDaemon>();
+        var coordinator = new FakeCoordinator(daemon);
+
+        var check = buildCheck(TimeSpan.FromSeconds(30), autoRestart: true, coordinator: coordinator);
+
+        // First stale cycle: restart the loop, still report Unhealthy so an alert fires.
+        (await check.CheckHealthAsync(new HealthCheckContext())).Status.ShouldBe(HealthStatus.Unhealthy);
+        await daemon.Received(1).RestartHighWaterAgentAsync(Arg.Any<CancellationToken>());
+
+        // Second cycle inside the same staleness window: still Unhealthy, but NOT restarted again (capped).
+        (await check.CheckHealthAsync(new HealthCheckContext())).Status.ShouldBe(HealthStatus.Unhealthy);
+        await daemon.Received(1).RestartHighWaterAgentAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task without_autorestart_no_restart_is_attempted()
+    {
+        configure(opts =>
+        {
+            opts.Projections.Add<HwFakeProjection>(ProjectionLifecycle.Async);
+            opts.DaemonSettings.AsyncMode = DaemonMode.Solo;
+            opts.Events.EnableExtendedProgressionTracking = true;
+        });
+        await _store!.Database.ApplyAllConfiguredChangesToDatabaseAsync();
+        await appendEventsAsync(20);
+        var highest = await _store.Database.FetchHighestEventSequenceNumber(CancellationToken.None);
+        await seedHighWaterHeartbeatAsync(highest, _now.AddSeconds(-90));
+
+        var daemon = Substitute.For<IProjectionDaemon>();
+        var coordinator = new FakeCoordinator(daemon);
+
+        var result = await buildCheck(TimeSpan.FromSeconds(30), coordinator: coordinator)
+            .CheckHealthAsync(new HealthCheckContext());
+
+        result.Status.ShouldBe(HealthStatus.Unhealthy);
+        await daemon.DidNotReceive().RestartHighWaterAgentAsync(Arg.Any<CancellationToken>());
+    }
+
+    // Minimal IProjectionCoordinator that hands back a single daemon — avoids mocking a ValueTask-returning
+    // member (CA2012) while letting the daemon itself stay an NSubstitute for Received(...) assertions.
+    private sealed class FakeCoordinator: IProjectionCoordinator
+    {
+        private readonly IProjectionDaemon _daemon;
+
+        public FakeCoordinator(IProjectionDaemon daemon) => _daemon = daemon;
+
+        public IProjectionDaemon DaemonForMainDatabase() => _daemon;
+
+        public ValueTask<IProjectionDaemon> DaemonForDatabase(string databaseIdentifier) => new(_daemon);
+
+        public ValueTask<IReadOnlyList<IProjectionDaemon>> AllDaemonsAsync() => new(new[] { _daemon });
+
+        public Task PauseAsync() => Task.CompletedTask;
+
+        public Task ResumeAsync() => Task.CompletedTask;
+
+        public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
     }
 
     private sealed class MutableTimeProvider: TimeProvider

--- a/src/Polecat.AspNetCore.Testing/Polecat.AspNetCore.Testing.csproj
+++ b/src/Polecat.AspNetCore.Testing/Polecat.AspNetCore.Testing.csproj
@@ -9,6 +9,7 @@
     <ItemGroup>
         <PackageReference Include="Alba" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="NSubstitute" />
         <PackageReference Include="Shouldly" />
         <PackageReference Include="xunit" />
         <PackageReference Include="xunit.runner.visualstudio">

--- a/src/Polecat.AspNetCore/Daemon/HighWaterHealthCheckExtensions.cs
+++ b/src/Polecat.AspNetCore/Daemon/HighWaterHealthCheckExtensions.cs
@@ -15,47 +15,64 @@ namespace Polecat.Events.Daemon;
 ///     Health check that detects a stalled or dead high-water agent — the failure mode in
 ///     marten#4961 where the async daemon's high-water agent dies, the mark freezes, projections
 ///     catch up to the frozen value, and any lag-based check reports Healthy. This check instead
-///     compares the high-water mark against the actual highest event sequence and reports
-///     Unhealthy only when the mark stops advancing while events keep accumulating past it.
+///     detects that the high-water agent has stopped and, optionally, restarts it.
 ///     <para>
 ///         This is the Polecat parity implementation of Marten's <c>AddMartenHighWaterHealthCheck</c>
-///         (marten#4982 / polecat#339). Polecat has no async-daemon lag health check to be blind to,
-///         but the high-water liveness signal is valuable on its own.
+///         (marten#4982 / polecat#339, Phase 2 marten#4986 / polecat#341). Two staleness signals,
+///         best first:
+///         <list type="number">
+///             <item>
+///                 <b>Heartbeat age (primary).</b> When ExtendedProgression is enabled, the
+///                 high-water agent stamps a liveness heartbeat on the <c>HighWaterMark</c>
+///                 progression row on every completed poll cycle (JasperFx/jasperfx#539). Its age
+///                 is a direct signal that the loop is <em>cycling</em>, independent of whether the
+///                 mark <em>advances</em> — so a quiet store with no new events never trips it.
+///             </item>
+///             <item>
+///                 <b>Sequence gap (fallback).</b> When ExtendedProgression is off, no heartbeat is
+///                 persisted, so the check falls back to the original heuristic: the mark sitting
+///                 unchanged while later events pile up past it.
+///             </item>
+///         </list>
 ///     </para>
 /// </summary>
 public static class HighWaterHealthCheckExtensions
 {
     /// <summary>
     ///     Adds a health check that reports <see cref="HealthCheckResult.Unhealthy" /> when the
-    ///     high-water mark has stopped advancing for at least <paramref name="staleThreshold" />
-    ///     while later events remain unprocessed — a strong signal that the high-water agent has
-    ///     died or wedged (marten#4961).
-    ///     <para>
-    ///         Built on the sequence-gap heuristic so it ships without an upstream dependency. A
-    ///         non-zero gap is normal transiently (the detector holds the mark inside a "safe
-    ///         harbor" behind in-flight/gapped sequences), so the check trips only on a
-    ///         <em>sustained non-advance</em>, never on a single snapshot. The reading is
-    ///         store-global database state, so it is correct on any node regardless of which one
-    ///         runs the agent — it fails only when <em>no</em> node is advancing the mark.
-    ///     </para>
+    ///     high-water agent has stopped for at least <paramref name="staleThreshold" /> — via its
+    ///     liveness heartbeat where available, otherwise via the sequence-gap heuristic
+    ///     (marten#4961 / polecat#341).
     /// </summary>
     /// <param name="builder"><see cref="IHealthChecksBuilder" /></param>
     /// <param name="staleThreshold">
-    ///     How long the high-water mark may sit unchanged while behind the latest event sequence
-    ///     before the store is considered unhealthy. Defaults to 30 seconds.
+    ///     How long the high-water agent may go without a heartbeat (or, on the fallback path, how
+    ///     long the mark may sit unchanged while behind the latest event sequence) before the store
+    ///     is considered unhealthy. Defaults to 30 seconds.
     /// </param>
     /// <param name="minimumGap">
-    ///     The gap (highest event sequence minus high-water mark) that is treated as "caught up"
-    ///     and never trips the check, absorbing the normal safe-harbor lag. Defaults to 1.
+    ///     Fallback path only: the gap (highest event sequence minus high-water mark) that is
+    ///     treated as "caught up" and never trips the check, absorbing the normal safe-harbor lag.
+    ///     Defaults to 1.
+    /// </param>
+    /// <param name="autoRestart">
+    ///     When <c>true</c>, an Unhealthy result also asks the local projection coordinator to
+    ///     restart the high-water agent's poll loop for the affected database
+    ///     (<see cref="IProjectionDaemon.RestartHighWaterAgentAsync" />). The restart never advances
+    ///     the mark and is capped to once per <paramref name="staleThreshold" /> window per database
+    ///     to avoid churn; the cycle is still reported <b>Unhealthy</b> so an alert fires. Defaults
+    ///     to <c>false</c> (detection only). Intended for single-writer (Solo) or leader nodes —
+    ///     the process running the health check must be the one hosting the daemon.
     /// </param>
     public static IHealthChecksBuilder AddPolecatHighWaterHealthCheck(
         this IHealthChecksBuilder builder,
         TimeSpan? staleThreshold = null,
-        long minimumGap = 1
+        long minimumGap = 1,
+        bool autoRestart = false
     )
     {
         builder.Services.AddSingleton(new HighWaterHealthCheckSettings(
-            staleThreshold ?? TimeSpan.FromSeconds(30), minimumGap));
+            staleThreshold ?? TimeSpan.FromSeconds(30), minimumGap, autoRestart));
         builder.Services.TryAddSingleton(TimeProvider.System);
         builder.Services.TryAddSingleton<HighWaterStateTracker>();
         return builder.AddCheck<HighWaterHealthCheck>(
@@ -67,17 +84,20 @@ public static class HighWaterHealthCheckExtensions
     /// <summary>
     ///     DI-injected settings for <see cref="HighWaterHealthCheck" />.
     /// </summary>
-    public record HighWaterHealthCheckSettings(TimeSpan StaleThreshold, long MinimumGap);
+    public record HighWaterHealthCheckSettings(TimeSpan StaleThreshold, long MinimumGap, bool AutoRestart = false);
 
     /// <summary>
-    ///     Tracks, per database, when the high-water mark was first observed to be behind the
-    ///     latest event sequence and what value it held then, so a <em>sustained</em> non-advance
-    ///     can be distinguished from a transient safe-harbor gap across health check invocations.
+    ///     Tracks, per database, the fallback gap heuristic's "first observed a stuck mark" reading
+    ///     and (when <c>autoRestart</c> is on) the last auto-restart moment, so a <em>sustained</em>
+    ///     non-advance can be distinguished from a transient safe-harbor gap and restarts can be
+    ///     capped to once per staleness window across health check invocations.
     /// </summary>
     public class HighWaterStateTracker
     {
         public ConcurrentDictionary<string, (DateTimeOffset FirstObservedAt, long HighWaterMark)> Readings { get; } =
             new();
+
+        public ConcurrentDictionary<string, DateTimeOffset> Restarts { get; } = new();
     }
 
     /// <summary>
@@ -91,16 +111,20 @@ public static class HighWaterHealthCheckExtensions
         private readonly TimeProvider _timeProvider;
         private readonly TimeSpan _staleThreshold;
         private readonly long _minimumGap;
+        private readonly bool _autoRestart;
         private readonly HighWaterStateTracker _tracker;
+        private readonly IServiceProvider _services;
 
         public HighWaterHealthCheck(IDocumentStore store, HighWaterHealthCheckSettings settings,
-            TimeProvider timeProvider, HighWaterStateTracker tracker)
+            TimeProvider timeProvider, HighWaterStateTracker tracker, IServiceProvider services)
         {
             _store = store;
             _timeProvider = timeProvider;
             _staleThreshold = settings.StaleThreshold;
             _minimumGap = settings.MinimumGap;
+            _autoRestart = settings.AutoRestart;
             _tracker = tracker;
+            _services = services;
         }
 
         public async Task<HealthCheckResult> CheckHealthAsync(
@@ -161,40 +185,109 @@ public static class HighWaterHealthCheckExtensions
             // No HighWaterMark progression row yet -> the daemon has not started here. Nothing to assert.
             if (highWater is null)
             {
-                _tracker.Readings.TryRemove(database.Identifier, out _);
+                clearTracking(database.Identifier);
                 return HealthCheckResult.Healthy("Healthy");
             }
 
+            var now = _timeProvider.GetUtcNow();
+
+            // Phase 2 (polecat#341) primary signal: the liveness heartbeat (jasperfx#539). Present only
+            // when ExtendedProgression is enabled. Heartbeat age proves the poll loop is *cycling*
+            // independent of whether the mark *advances*, so a quiet store never trips it — a strictly
+            // better signal than the gap heuristic. Use it whenever it is available.
+            if (highWater.LastHeartbeat is { } lastHeartbeat)
+            {
+                // The gap tracker is only for the fallback path; keep it clear while on the heartbeat path.
+                _tracker.Readings.TryRemove(database.Identifier, out _);
+
+                var age = now - lastHeartbeat;
+                if (age < _staleThreshold)
+                {
+                    _tracker.Restarts.TryRemove(database.Identifier, out _);
+                    return HealthCheckResult.Healthy("Healthy");
+                }
+
+                var restartNote = await tryAutoRestartAsync(database.Identifier, now, token).ConfigureAwait(false);
+                return HealthCheckResult.Unhealthy(
+                    $"Unhealthy: the high-water agent for database '{database.Identifier}' last reported a liveness heartbeat {age.TotalSeconds:F0}s ago (at {lastHeartbeat:O}), exceeding the {_staleThreshold} staleness threshold. Its poll loop has stopped cycling (see JasperFx/jasperfx#539 / marten#4961).{restartNote}");
+            }
+
+            // Fallback (ExtendedProgression off): the sequence-gap heuristic. A non-zero gap is normal
+            // transiently (the detector holds the mark inside a "safe harbor" behind in-flight/gapped
+            // sequences), so this trips only on a sustained non-advance while events pile up past the mark.
             var highest = await database.FetchHighestEventSequenceNumber(token).ConfigureAwait(false);
             var gap = highest - highWater.Sequence;
-            var now = _timeProvider.GetUtcNow();
 
             // Caught up (within the normal safe-harbor gap). Clear any stalled-mark tracking.
             if (gap <= _minimumGap)
             {
-                _tracker.Readings.TryRemove(database.Identifier, out _);
+                clearTracking(database.Identifier);
                 return HealthCheckResult.Healthy("Healthy");
             }
 
-            // A gap exists. That is normal transiently; it is only a problem when the mark is NOT
-            // advancing while events keep piling up beyond it. Track the first time we saw a gap at
-            // this mark value; if the mark moves, reset the clock; if it stays put past the
-            // threshold, the high-water agent has almost certainly died or wedged.
+            // Track the first time we saw a gap at this mark value; if the mark moves, reset the clock; if
+            // it stays put past the threshold, the high-water agent has almost certainly died or wedged.
             var reading = _tracker.Readings.GetOrAdd(database.Identifier, _ => (now, highWater.Sequence));
 
             if (reading.HighWaterMark != highWater.Sequence)
             {
                 _tracker.Readings[database.Identifier] = (now, highWater.Sequence);
+                _tracker.Restarts.TryRemove(database.Identifier, out _);
                 return HealthCheckResult.Healthy("Healthy");
             }
 
             if (now - reading.FirstObservedAt >= _staleThreshold)
             {
+                var restartNote = await tryAutoRestartAsync(database.Identifier, now, token).ConfigureAwait(false);
                 return HealthCheckResult.Unhealthy(
-                    $"Unhealthy: the high-water mark for database '{database.Identifier}' has been stuck at {highWater.Sequence} with {gap} later event(s) unprocessed (highest sequence {highest}) for at least {_staleThreshold}. The high-water agent may have stopped (see marten#4961).");
+                    $"Unhealthy: the high-water mark for database '{database.Identifier}' has been stuck at {highWater.Sequence} with {gap} later event(s) unprocessed (highest sequence {highest}) for at least {_staleThreshold}. The high-water agent may have stopped (see marten#4961).{restartNote}");
             }
 
             return HealthCheckResult.Healthy("Healthy");
+        }
+
+        private void clearTracking(string databaseIdentifier)
+        {
+            _tracker.Readings.TryRemove(databaseIdentifier, out _);
+            _tracker.Restarts.TryRemove(databaseIdentifier, out _);
+        }
+
+        // polecat#341 item 1: opt-in remediation. Ask the local coordinator's daemon to restart the
+        // high-water poll loop for this database — loop only, never advancing the mark. Best-effort and
+        // capped to once per staleness window so the (faster) health-check cadence can't thrash a loop
+        // that legitimately needs longer to re-establish. The cycle is still reported Unhealthy by the
+        // caller so an alert fires regardless.
+        private async Task<string> tryAutoRestartAsync(string databaseIdentifier, DateTimeOffset now,
+            CancellationToken token)
+        {
+            if (!_autoRestart)
+            {
+                return string.Empty;
+            }
+
+            if (_tracker.Restarts.TryGetValue(databaseIdentifier, out var lastRestart) &&
+                now - lastRestart < _staleThreshold)
+            {
+                return " An auto-restart was already attempted within the current staleness window.";
+            }
+
+            var coordinator = _services.GetService<IProjectionCoordinator>();
+            if (coordinator is null)
+            {
+                return " (autoRestart is enabled but no IProjectionCoordinator is registered to restart the agent.)";
+            }
+
+            try
+            {
+                var daemon = await coordinator.DaemonForDatabase(databaseIdentifier).ConfigureAwait(false);
+                await daemon.RestartHighWaterAgentAsync(token).ConfigureAwait(false);
+                _tracker.Restarts[databaseIdentifier] = now;
+                return " An auto-restart of the high-water agent was triggered (the mark was NOT advanced).";
+            }
+            catch (Exception e)
+            {
+                return $" An auto-restart of the high-water agent was attempted but failed: {e.Message}.";
+            }
         }
     }
 }


### PR DESCRIPTION
Closes #341. Follow-up to #339 (issue) / #340 (detection). Parity with JasperFx/marten#4986.

> **Stacked on #342** (the JasperFx 2.32.0 bump). Base is `upgrade/jasperfx-2.32.0`; it will retarget to `main` once #342 merges. The heartbeat surface (`ShardState.LastHeartbeat`, `IProjectionDaemon.RestartHighWaterAgentAsync`) ships in JasperFx **2.32.0** (jasperfx#539).

## 1. Opt-in `autoRestart` remediation

`AddPolecatHighWaterHealthCheck(TimeSpan? staleThreshold = null, long minimumGap = 1, bool autoRestart = false)`.

When `autoRestart` is on and the check is Unhealthy, it asks the local `IProjectionCoordinator`'s daemon to `RestartHighWaterAgentAsync` for the affected database — **loop only, the mark is never advanced** — capped to **once per staleness window** per database to avoid churn. The cycle is still reported **Unhealthy** so an alert fires. Best-effort: no coordinator registered / restart throws → still Unhealthy, with a note. Intended for Solo / leader nodes (the health-check process must host the daemon).

## 2. Phase 2 — heartbeat is now the primary signal

When `EnableExtendedProgressionTracking` is on, the high-water agent stamps a liveness heartbeat on the `HighWaterMark` progression row every completed poll cycle (jasperfx#539). The check reads it from `AllProjectionProgress` and treats **heartbeat age** as the primary staleness signal:

- Fresh heartbeat → **Healthy**, even if the mark sits behind the latest event (a case the gap heuristic falsely trips).
- Stale heartbeat → **Unhealthy**, even when fully caught up, gap 0 (a case the gap heuristic is **blind** to — the exact marten#4961 failure).

The sequence-gap heuristic is retained as the **ExtendedProgression-off fallback**, unchanged.

## Tests
`Polecat.AspNetCore.Testing/HighWaterHealthCheckTests` — 11 pass against SQL Server: the 7 existing gap-heuristic tests plus fresh-heartbeat-healthy, stale-heartbeat-unhealthy-while-caught-up, autoRestart-restarts-once-still-unhealthy, and no-autoRestart-no-restart. Adds NSubstitute (test-only) for the daemon spy, matching Marten's setup.

## Related
- Parity: JasperFx/marten#4986. Foundation: JasperFx/jasperfx#539 (2.32.0). Origin: marten#4961.