### PR TITLE
feat(#344): native SQL Server 2025 JSON indexes + covering computed-column indexes

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -80,6 +80,12 @@ const config: UserConfig<DefaultTheme.Config> = {
             { text: 'Storing Documents', link: '/documents/storing' },
             { text: 'Deleting Documents', link: '/documents/deletes' },
             {
+              text: 'Indexing Documents', link: '/documents/indexing/', collapsed: true, items: [
+                { text: 'Computed Indexes', link: '/documents/indexing/computed-indexes' },
+                { text: 'JSON Indexes', link: '/documents/indexing/json-indexes' },
+              ]
+            },
+            {
               text: 'Querying Documents', link: '/documents/querying/', collapsed: true, items: [
                 { text: 'Loading Documents by Id', link: '/documents/querying/byid' },
                 { text: 'Querying Documents with LINQ', link: '/documents/querying/linq/' },

--- a/docs/documents/indexing/computed-indexes.md
+++ b/docs/documents/indexing/computed-indexes.md
@@ -61,6 +61,41 @@ opts.Schema.For<User>().UniqueIndex(x => x.Email);
 
 Attempting to store two documents with the same email will throw a SQL Server unique constraint violation.
 
+## Covering Indexes (INCLUDE Columns)
+
+A query that filters on one property but also *selects* others can still pay for a lookup back into the
+table to fetch the extra columns. You can avoid that by carrying those extra members in the index as
+non-key **`INCLUDE`** columns, so SQL Server satisfies the whole query from the index alone. Pass the
+`include:` argument — a single member or an anonymous type, just like the key expression:
+
+```cs
+opts.Schema.For<User>().Index(x => x.UserName, include: x => new { x.FirstName, x.LastName });
+```
+
+Each include member gets its own persisted computed column, and the index gains an `INCLUDE` clause:
+
+```sql
+ALTER TABLE [myschema].[pc_doc_user]
+    ADD [cc_firstname] AS CAST(JSON_VALUE(data, '$.firstName') AS varchar(250)) PERSISTED;
+ALTER TABLE [myschema].[pc_doc_user]
+    ADD [cc_lastname] AS CAST(JSON_VALUE(data, '$.lastName') AS varchar(250)) PERSISTED;
+
+CREATE NONCLUSTERED INDEX [ix_pc_doc_user_username]
+    ON [myschema].[pc_doc_user] ([cc_username]) INCLUDE ([cc_firstname], [cc_lastname]);
+```
+
+This maps to the `IncludeColumns` property on `DocumentIndex` (named after Marten/Weasel's
+`IndexDefinition.IncludeColumns`), which you can also set directly in the `configure` action if you
+prefer to work in raw JSON paths:
+
+```cs
+opts.Schema.For<User>().Index(x => x.UserName, idx => idx.IncludeColumns = ["$.firstName", "$.lastName"]);
+```
+
+`UniqueIndex(...)` accepts the same `include:` argument. Include columns are always stored with default
+casing (they are payload, not keys), and covering indexes work on both native `json` and `nvarchar(max)`
+storage.
+
 ## Customizing an Index
 
 The `Index()` and `UniqueIndex()` methods accept an optional `Action<DocumentIndex>` to customize the index:

--- a/docs/documents/indexing/index.md
+++ b/docs/documents/indexing/index.md
@@ -1,0 +1,21 @@
+# Indexing Documents
+
+::: warning
+Polecat owns the indexes on its own tables, so any custom index needs to be declared through Polecat
+itself. An index created out of band may be dropped the next time Polecat reconciles the schema.
+:::
+
+Like Marten, Polecat gives you several ways to speed up document queries — all of which trade slightly
+slower inserts for faster reads. Polecat supports:
+
+* [Computed indexes](/documents/indexing/computed-indexes) — persisted computed columns backed by
+  `JSON_VALUE`, with standard nonclustered indexes. Supports composite keys, uniqueness, case
+  transformations, filtered (partial) indexes, per-tenant scoping, and covering `INCLUDE` columns.
+* [JSON indexes](/documents/indexing/json-indexes) — native SQL Server 2025 `CREATE JSON INDEX` over the
+  `data` column, covering many JSON paths with one index (the SQL Server counterpart to Marten's
+  `GinIndexJsonData`).
+
+Indexes can be declared with the fluent `Schema.For<T>()` API or, for computed indexes, with `[Index]` /
+`[UniqueIndex]` attributes on the document type itself. As in Marten, the choice between keeping
+persistence concerns off your document types (fluent API) and colocating them for traceability
+(attributes) is yours — both are supported and can be combined on the same type.

--- a/docs/documents/indexing/json-indexes.md
+++ b/docs/documents/indexing/json-indexes.md
@@ -1,0 +1,114 @@
+# JSON Indexes
+
+Polecat can create a native SQL Server 2025 **`CREATE JSON INDEX`** over a document's `data` column —
+the SQL Server counterpart to Marten's `GinIndexJsonData()` GIN index on the JSONB column.
+
+Unlike a [computed index](/documents/indexing/computed-indexes), which materializes one persisted
+computed column per path, a **single** JSON index covers **many** JSON paths at once and accelerates a
+wide range of ad-hoc predicates against the document body — `JSON_VALUE` equality (including the
+`JSON_VALUE(data, '$.x' RETURNING type)` form used on native `json` storage), `JSON_PATH_EXISTS`, and
+`JSON_CONTAINS` — with no per-path computed columns.
+
+::: warning
+Native JSON indexes require the native `json` column type, so they are only available when
+`UseNativeJsonType = true` (the default) against **SQL Server 2025**. `CREATE JSON INDEX` is invalid
+against `nvarchar(max)` storage, so Polecat throws a clear `InvalidOperationException` if you configure
+one on a store that isn't using the native `json` type — use a [computed index](/documents/indexing/computed-indexes)
+there instead. JSON indexes are a preview, on-prem SQL Server 2025 feature.
+:::
+
+## Indexing Specific Paths
+
+Use `JsonIndex(...)` in `Schema.For<T>()`, passing a single member or an anonymous type for the paths
+you want covered:
+
+```cs
+var store = DocumentStore.For(opts =>
+{
+    opts.ConnectionString = "...";
+
+    // Index two paths with one JSON index
+    opts.Schema.For<User>().JsonIndex(x => new { x.UserName, x.Department });
+});
+```
+
+This produces one JSON index over both paths:
+
+```sql
+SET QUOTED_IDENTIFIER ON;
+CREATE JSON INDEX [jidx_pc_doc_user] ON [myschema].[pc_doc_user] (data)
+    FOR ('$.userName', '$.department');
+```
+
+SQL Server can then use the index for queries against either path:
+
+```cs
+var users = await session.Query<User>()
+    .Where(x => x.Department == "Engineering")
+    .ToListAsync();
+```
+
+## Indexing the Whole Document
+
+Omit the expression to index the entire JSON body (no `FOR` clause) — the direct analog of Marten's
+`GinIndexJsonData()`:
+
+```cs
+opts.Schema.For<User>().JsonIndex();
+```
+
+```sql
+SET QUOTED_IDENTIFIER ON;
+CREATE JSON INDEX [jidx_pc_doc_user] ON [myschema].[pc_doc_user] (data);
+```
+
+## Optimizing for Array Search
+
+When you query *inside* a JSON array property (for example `JSON_CONTAINS` over a list), set
+`OptimizeForArraySearch` to emit `WITH (OPTIMIZE_FOR_ARRAY_SEARCH = ON)`:
+
+```cs
+opts.Schema.For<User>().JsonIndex(x => x.Roles, idx => idx.OptimizeForArraySearch = true);
+```
+
+```sql
+SET QUOTED_IDENTIFIER ON;
+CREATE JSON INDEX [jidx_pc_doc_user] ON [myschema].[pc_doc_user] (data)
+    FOR ('$.roles') WITH (OPTIMIZE_FOR_ARRAY_SEARCH = ON);
+```
+
+## Customizing a JSON Index
+
+The `JsonIndex()` methods accept an optional `Action<JsonIndex>` to customize the index:
+
+```cs
+opts.Schema.For<User>().JsonIndex(x => x.UserName, idx =>
+{
+    // Override the auto-derived index name (default: jidx_<table>)
+    idx.IndexName = "jidx_user_custom";
+
+    // Tune for array searches
+    idx.OptimizeForArraySearch = true;
+
+    // Set a FILLFACTOR (1–100)
+    idx.FillFactor = 80;
+});
+```
+
+## Constraints
+
+Native JSON indexes carry a number of SQL Server restrictions, all documented on the `JsonIndex` type:
+
+* Native `json` storage only (`UseNativeJsonType = true`).
+* The table's clustered primary key must be ≤ 128 bytes. Polecat's single-tenant `id` primary key
+  satisfies this, but **per-tenant tables whose primary key prepends a `varchar` `tenant_id` can exceed
+  the limit**, in which case SQL Server rejects the index.
+* Only **one** JSON index is allowed per `json` column, so a table has at most one JSON index. Polecat
+  keys idempotency on the table, so re-applying the schema never creates a duplicate.
+* Indexed paths may not overlap (e.g. `$.a` and `$.a.b`).
+* No `UNIQUE`, filtered (`WHERE`), `INCLUDE`, range/`ORDER BY`, or `LIKE` / `IS NULL` support — use a
+  [computed index](/documents/indexing/computed-indexes) for any of those.
+
+JSON indexes are therefore **additive** to computed-column indexes, not a replacement: reach for a JSON
+index to accelerate many ad-hoc paths at once, and a computed index when you need uniqueness, filtering,
+covering columns, ordering, or portable `nvarchar(max)` storage.

--- a/src/Polecat.Tests/Storage/covering_index_tests.cs
+++ b/src/Polecat.Tests/Storage/covering_index_tests.cs
@@ -1,0 +1,95 @@
+using Polecat.Linq;
+using Polecat.Storage;
+using Polecat.Tests.Harness;
+
+namespace Polecat.Tests.Storage;
+
+/// <summary>
+/// Covering computed-column indexes: Index(key, include: ...) carries the include members as non-key
+/// INCLUDE columns so a query can be satisfied from the index alone (no key lookup). Each include
+/// path gets its own persisted computed column. Works on any SQL Server (it's a standard nonclustered
+/// index over computed columns), so these run on both native-json and nvarchar storage.
+/// </summary>
+public class covering_index_tests : OneOffConfigurationsContext
+{
+    public class Doc
+    {
+        public Guid Id { get; set; }
+        public string ServiceName { get; set; } = string.Empty;
+        public DateTimeOffset BucketEnd { get; set; }
+        public int Count { get; set; }
+    }
+
+    private const string Table = "pc_doc_doc";
+    private const string IndexName = "ix_pc_doc_doc_servicename";
+    private string Schema => GetType().Name.ToLowerInvariant();
+
+    [Fact]
+    public void ddl_creates_include_columns_and_include_clause()
+    {
+        var mapping = new DocumentMapping(typeof(Doc), new StoreOptions { DatabaseSchemaName = "s" });
+        var index = new DocumentIndex(["$.serviceName"]) { IncludeColumns = ["$.bucketEnd", "$.count"] };
+
+        var ddl = index.ToDdlStatements(mapping);
+        var joined = string.Join("\n", ddl);
+
+        // computed columns for the key and both include paths
+        joined.ShouldContain("[cc_servicename] AS");
+        joined.ShouldContain("[cc_bucketend] AS");
+        joined.ShouldContain("[cc_count] AS");
+        // INCLUDE clause over the include columns
+        ddl[^1].ShouldContain("([cc_servicename]) INCLUDE ([cc_bucketend], [cc_count])");
+    }
+
+    [Fact]
+    public async Task covering_index_marks_only_the_include_paths_as_included()
+    {
+        ConfigureStore(opts =>
+            opts.Schema.For<Doc>().Index(x => x.ServiceName, include: x => new { x.BucketEnd, x.Count }));
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Store(new Doc { Id = Guid.NewGuid(), ServiceName = "svc", BucketEnd = DateTimeOffset.UtcNow, Count = 3 });
+            await session.SaveChangesAsync();
+        }
+
+        await using var conn = await OpenConnectionAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"""
+            SELECT c.name, ic.is_included_column
+            FROM sys.indexes i
+            JOIN sys.index_columns ic ON i.object_id = ic.object_id AND i.index_id = ic.index_id
+            JOIN sys.columns c ON ic.object_id = c.object_id AND ic.column_id = c.column_id
+            WHERE i.name = '{IndexName}' AND i.object_id = OBJECT_ID('[{Schema}].[{Table}]');
+            """;
+
+        var included = new Dictionary<string, bool>();
+        await using (var reader = await cmd.ExecuteReaderAsync())
+        {
+            while (await reader.ReadAsync()) included[reader.GetString(0)] = reader.GetBoolean(1);
+        }
+
+        included["cc_servicename"].ShouldBeFalse(); // key column
+        included["cc_bucketend"].ShouldBeTrue();    // included
+        included["cc_count"].ShouldBeTrue();        // included
+    }
+
+    [Fact]
+    public async Task covering_index_still_returns_correct_rows()
+    {
+        ConfigureStore(opts =>
+            opts.Schema.For<Doc>().Index(x => x.ServiceName, include: x => x.Count));
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Store(new Doc { Id = Guid.NewGuid(), ServiceName = "svc-A", Count = 1 });
+            session.Store(new Doc { Id = Guid.NewGuid(), ServiceName = "svc-A", Count = 2 });
+            session.Store(new Doc { Id = Guid.NewGuid(), ServiceName = "svc-B", Count = 3 });
+            await session.SaveChangesAsync();
+        }
+
+        await using var session2 = theStore.QuerySession();
+        var rows = await session2.Query<Doc>().Where(x => x.ServiceName == "svc-A").ToListAsync();
+        rows.Count.ShouldBe(2);
+    }
+}

--- a/src/Polecat.Tests/Storage/json_index_tests.cs
+++ b/src/Polecat.Tests/Storage/json_index_tests.cs
@@ -1,0 +1,163 @@
+using Polecat.Linq;
+using Polecat.Storage;
+using Polecat.TestUtils;
+using Polecat.Tests.Harness;
+
+namespace Polecat.Tests.Storage;
+
+/// <summary>
+/// Native SQL Server 2025 JSON indexes (CREATE JSON INDEX) over the json `data` column — one index
+/// covering multiple JSON paths, gated on UseNativeJsonType.
+/// </summary>
+public class json_index_tests : OneOffConfigurationsContext
+{
+    public class Doc
+    {
+        public Guid Id { get; set; }
+        public string ServiceName { get; set; } = string.Empty;
+        public DateTimeOffset BucketEnd { get; set; }
+        public List<string> Tags { get; set; } = new();
+    }
+
+    private const string Table = "pc_doc_doc";
+    private string Schema => GetType().Name.ToLowerInvariant();
+
+    // ---- unit: DDL generation (no DB) -----------------------------------------------------------
+
+    [Fact]
+    public void ddl_for_multiple_paths()
+    {
+        var mapping = new DocumentMapping(typeof(Doc), new StoreOptions { DatabaseSchemaName = "s" });
+        var ddl = new JsonIndex(["$.serviceName", "$.bucketEnd"]).ToDdlStatements(mapping);
+
+        ddl[0].ShouldContain(
+            "CREATE JSON INDEX [jidx_pc_doc_doc] ON [s].[pc_doc_doc] (data) FOR ('$.serviceName', '$.bucketEnd')");
+        ddl[0].ShouldContain("SET QUOTED_IDENTIFIER ON");
+    }
+
+    [Fact]
+    public void ddl_for_whole_document_omits_the_for_clause()
+    {
+        var mapping = new DocumentMapping(typeof(Doc), new StoreOptions { DatabaseSchemaName = "s" });
+        var ddl = new JsonIndex([]).ToDdlStatements(mapping);
+
+        ddl[0].ShouldContain("CREATE JSON INDEX [jidx_pc_doc_doc] ON [s].[pc_doc_doc] (data);");
+        ddl[0].ShouldNotContain("FOR (");
+    }
+
+    [Fact]
+    public void ddl_with_options()
+    {
+        var mapping = new DocumentMapping(typeof(Doc), new StoreOptions { DatabaseSchemaName = "s" });
+        var ddl = new JsonIndex(["$.tags"]) { OptimizeForArraySearch = true, FillFactor = 80 }
+            .ToDdlStatements(mapping);
+
+        ddl[0].ShouldContain("WITH (OPTIMIZE_FOR_ARRAY_SEARCH = ON, FILLFACTOR = 80)");
+    }
+
+    [Fact]
+    public void ddl_throws_without_native_json()
+    {
+        var mapping = new DocumentMapping(typeof(Doc),
+            new StoreOptions { DatabaseSchemaName = "s", UseNativeJsonType = false });
+
+        Should.Throw<InvalidOperationException>(() => new JsonIndex([]).ToDdlStatements(mapping))
+            .Message.ShouldContain("native json");
+    }
+
+    // ---- integration: actually create the index (native json only) ------------------------------
+
+    [RequiresNativeJsonFact(true)]
+    public async Task creates_a_json_index_covering_the_given_paths()
+    {
+        ConfigureStore(opts =>
+            opts.Schema.For<Doc>().JsonIndex(x => new { x.ServiceName, x.BucketEnd }));
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Store(new Doc { Id = Guid.NewGuid(), ServiceName = "svc", BucketEnd = DateTimeOffset.UtcNow });
+            await session.SaveChangesAsync();
+        }
+
+        (await JsonIndexCountAsync()).ShouldBe(1);
+    }
+
+    [RequiresNativeJsonFact(true)]
+    public async Task whole_document_json_index_is_created()
+    {
+        ConfigureStore(opts => opts.Schema.For<Doc>().JsonIndex());
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Store(new Doc { Id = Guid.NewGuid(), ServiceName = "svc" });
+            await session.SaveChangesAsync();
+        }
+
+        (await JsonIndexCountAsync()).ShouldBe(1);
+    }
+
+    [RequiresNativeJsonFact(true)]
+    public async Task optimize_for_array_search_is_applied()
+    {
+        ConfigureStore(opts =>
+            opts.Schema.For<Doc>().JsonIndex(x => x.Tags, idx => idx.OptimizeForArraySearch = true));
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Store(new Doc { Id = Guid.NewGuid(), Tags = new List<string> { "a", "b" } });
+            await session.SaveChangesAsync();
+        }
+
+        await using var conn = await OpenConnectionAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"""
+            SELECT ji.optimize_for_array_search
+            FROM sys.json_indexes ji
+            WHERE ji.object_id = OBJECT_ID('[{Schema}].[{Table}]');
+            """;
+        (await cmd.ExecuteScalarAsync()).ShouldBe(true);
+    }
+
+    [RequiresNativeJsonFact(true)]
+    public async Task queries_return_correct_rows_with_a_json_index_present()
+    {
+        ConfigureStore(opts => opts.Schema.For<Doc>().JsonIndex(x => x.ServiceName));
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Store(new Doc { Id = Guid.NewGuid(), ServiceName = "svc-A" });
+            session.Store(new Doc { Id = Guid.NewGuid(), ServiceName = "svc-A" });
+            session.Store(new Doc { Id = Guid.NewGuid(), ServiceName = "svc-B" });
+            await session.SaveChangesAsync();
+        }
+
+        await using var session2 = theStore.QuerySession();
+        var a = await session2.Query<Doc>().Where(x => x.ServiceName == "svc-A").ToListAsync();
+        a.Count.ShouldBe(2);
+    }
+
+    [RequiresNativeJsonFact(true)]
+    public async Task re_ensuring_is_idempotent()
+    {
+        ConfigureStore(opts => opts.Schema.For<Doc>().JsonIndex(x => x.ServiceName));
+
+        for (var i = 0; i < 2; i++)
+        {
+            await using var session = theStore.LightweightSession();
+            session.Store(new Doc { Id = Guid.NewGuid(), ServiceName = $"svc-{i}" });
+            await session.SaveChangesAsync();
+        }
+
+        (await JsonIndexCountAsync()).ShouldBe(1); // still exactly one, no duplicate-create error
+    }
+
+    private async Task<int> JsonIndexCountAsync()
+    {
+        await using var conn = await OpenConnectionAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"""
+            SELECT COUNT(*) FROM sys.json_indexes WHERE object_id = OBJECT_ID('[{Schema}].[{Table}]');
+            """;
+        return (int)(await cmd.ExecuteScalarAsync())!;
+    }
+}

--- a/src/Polecat/Internal/DocumentProviderRegistry.cs
+++ b/src/Polecat/Internal/DocumentProviderRegistry.cs
@@ -122,6 +122,16 @@ internal class DocumentProviderRegistry
                 }
             }
 
+            // Apply JSON indexes
+            var jsonIndexesField = exprType.GetField("JsonIndexes", BindingFlags.NonPublic | BindingFlags.Instance);
+            if (jsonIndexesField?.GetValue(expr) is IEnumerable<Storage.JsonIndex> jsonIndexes)
+            {
+                foreach (var jsonIndex in jsonIndexes)
+                {
+                    mapping.JsonIndexes.Add(jsonIndex);
+                }
+            }
+
             // Apply foreign keys
             var fkField = exprType.GetField("ForeignKeys", BindingFlags.NonPublic | BindingFlags.Instance);
             if (fkField?.GetValue(expr) is IEnumerable<Storage.DocumentForeignKey> foreignKeys)

--- a/src/Polecat/Internal/DocumentTableEnsurer.cs
+++ b/src/Polecat/Internal/DocumentTableEnsurer.cs
@@ -120,6 +120,17 @@ internal class DocumentTableEnsurer
                 }
             }
 
+            // Native SQL Server 2025 JSON indexes (CREATE JSON INDEX) on the json data column.
+            foreach (var jsonIndex in provider.Mapping.JsonIndexes)
+            {
+                foreach (var statement in jsonIndex.ToDdlStatements(provider.Mapping))
+                {
+                    await using var jsonIndexCmd = conn.CreateCommand();
+                    jsonIndexCmd.CommandText = statement;
+                    await jsonIndexCmd.ExecuteNonQueryAsync(token);
+                }
+            }
+
             _ensured.TryAdd(docType, true);
         }
         finally

--- a/src/Polecat/Storage/DocumentIndex.cs
+++ b/src/Polecat/Storage/DocumentIndex.cs
@@ -56,6 +56,17 @@ public class DocumentIndex
     public Dictionary<string, string> SqlTypeByPath { get; } = new();
 
     /// <summary>
+    ///     JSON paths whose values are carried in the index as non-key <c>INCLUDE</c> columns (a
+    ///     covering index). Mirrors Marten/Weasel's <see cref="!:IndexDefinition.IncludeColumns" />.
+    ///     Each entry is a JSON path (e.g. "$.bucketEnd"); it gets its own persisted computed column.
+    ///     Including the columns a query also selects lets SQL Server satisfy the query from the index
+    ///     alone, avoiding a key lookup back into the table. Include columns are always Default casing
+    ///     (they are payload, not keys). Set directly, or via the type-safe <c>include:</c> parameter
+    ///     on <c>Schema.For&lt;T&gt;().Index(...)</c>.
+    /// </summary>
+    public string[] IncludeColumns { get; set; } = [];
+
+    /// <summary>
     ///     Sort order for the index columns.
     /// </summary>
     public SortOrder SortOrder { get; set; } = SortOrder.Ascending;
@@ -165,12 +176,25 @@ public class DocumentIndex
 
         var statements = new List<string>();
 
-        // Add persisted computed columns for each JSON path
+        // Add persisted computed columns for each key JSON path
         foreach (var path in JsonPaths)
         {
             var colName = ColumnNameForPath(path, Casing);
             var sqlType = ResolveSqlType(path, mapping.ResolveClrMemberType(path));
             var castedExpr = ComputedColumnExpression(path, sqlType, Casing, UsesNativeJson(mapping));
+
+            statements.Add($"""
+                IF COL_LENGTH('{schema}.{table}', '{colName}') IS NULL
+                    ALTER TABLE {qualifiedTable} ADD [{colName}] AS {castedExpr} PERSISTED;
+                """);
+        }
+
+        // Add persisted computed columns for each INCLUDE (covering) path — always Default casing.
+        foreach (var path in IncludeColumns)
+        {
+            var colName = ColumnNameForPath(path, IndexCasing.Default);
+            var sqlType = ResolveSqlType(path, mapping.ResolveClrMemberType(path));
+            var castedExpr = ComputedColumnExpression(path, sqlType, IndexCasing.Default, UsesNativeJson(mapping));
 
             statements.Add($"""
                 IF COL_LENGTH('{schema}.{table}', '{colName}') IS NULL
@@ -193,12 +217,16 @@ public class DocumentIndex
         }
 
         var columnList = string.Join(", ", indexColumns);
+        var include = IncludeColumns.Length > 0
+            ? " INCLUDE (" + string.Join(", ",
+                IncludeColumns.Select(p => $"[{ColumnNameForPath(p, IndexCasing.Default)}]")) + ")"
+            : "";
         var where = !string.IsNullOrEmpty(Predicate) ? $" WHERE {Predicate}" : "";
 
         statements.Add($"""
             IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = '{name}'
                            AND object_id = OBJECT_ID('{qualifiedTable}'))
-                CREATE {unique}NONCLUSTERED INDEX [{name}] ON {qualifiedTable} ({columnList}){where};
+                CREATE {unique}NONCLUSTERED INDEX [{name}] ON {qualifiedTable} ({columnList}){include}{where};
             """);
 
         return statements.ToArray();

--- a/src/Polecat/Storage/DocumentMapping.cs
+++ b/src/Polecat/Storage/DocumentMapping.cs
@@ -217,6 +217,12 @@ internal class DocumentMapping
     public List<DocumentIndex> Indexes { get; } = new();
 
     /// <summary>
+    ///     Native SQL Server 2025 JSON indexes (<c>CREATE JSON INDEX</c>) configured for this document
+    ///     type. The SQL Server analog of Marten's whole-body <c>GinIndexJsonData</c>.
+    /// </summary>
+    public List<JsonIndex> JsonIndexes { get; } = new();
+
+    /// <summary>
     ///     #243: document metadata configuration (opt-in columns + member mappings), populated from
     ///     metadata attributes and the <c>Schema.For&lt;T&gt;().Metadata(...)</c> DSL.
     /// </summary>

--- a/src/Polecat/Storage/DocumentMappingExpression.cs
+++ b/src/Polecat/Storage/DocumentMappingExpression.cs
@@ -14,6 +14,7 @@ public class DocumentMappingExpression<T>
     internal readonly Type DocumentType = typeof(T);
     internal readonly List<(Type SubClass, string? Alias)> SubClasses = new();
     internal readonly List<DocumentIndex> Indexes = new();
+    internal readonly List<JsonIndex> JsonIndexes = new();
     internal readonly List<DocumentForeignKey> ForeignKeys = new();
     internal DocumentPartitioning? Partitioning;
     internal readonly Metadata.DocumentMetadataConfig MetadataConfig = new();
@@ -65,29 +66,67 @@ public class DocumentMappingExpression<T>
     }
 
     /// <summary>
-    ///     Add a computed index on one or more document properties.
-    ///     Properties are extracted via JSON_VALUE from the data column.
+    ///     Add a computed index on one or more document properties, mirroring Marten's
+    ///     <c>Schema.For&lt;T&gt;().Index(...)</c>. Properties are extracted via JSON_VALUE from the
+    ///     data column into persisted computed columns. Pass <paramref name="include" /> (a member or
+    ///     anonymous type) to carry those members as non-key <c>INCLUDE</c> columns for a covering
+    ///     index that avoids key lookups — the type-safe equivalent of setting
+    ///     <see cref="DocumentIndex.IncludeColumns" /> inside <paramref name="configure" />.
     /// </summary>
     public DocumentMappingExpression<T> Index(Expression<Func<T, object?>> expression,
-        Action<DocumentIndex>? configure = null)
+        Action<DocumentIndex>? configure = null, Expression<Func<T, object?>>? include = null)
     {
         var paths = DocumentIndex.ResolveJsonPaths(expression);
         var index = new DocumentIndex(paths);
+        if (include != null) index.IncludeColumns = DocumentIndex.ResolveJsonPaths(include);
         configure?.Invoke(index);
         Indexes.Add(index);
         return this;
     }
 
     /// <summary>
-    ///     Add a unique index on one or more document properties.
+    ///     Add a unique index on one or more document properties, mirroring Marten's
+    ///     <c>Schema.For&lt;T&gt;().UniqueIndex(...)</c>. Pass <paramref name="include" /> to carry
+    ///     extra members as non-key <c>INCLUDE</c> columns (covering index).
     /// </summary>
     public DocumentMappingExpression<T> UniqueIndex(Expression<Func<T, object?>> expression,
-        Action<DocumentIndex>? configure = null)
+        Action<DocumentIndex>? configure = null, Expression<Func<T, object?>>? include = null)
     {
         var paths = DocumentIndex.ResolveJsonPaths(expression);
         var index = new DocumentIndex(paths) { IsUnique = true };
+        if (include != null) index.IncludeColumns = DocumentIndex.ResolveJsonPaths(include);
         configure?.Invoke(index);
         Indexes.Add(index);
+        return this;
+    }
+
+    /// <summary>
+    ///     Add a native SQL Server 2025 JSON index (<c>CREATE JSON INDEX</c>) over one or more JSON
+    ///     paths in the document. A single JSON index covers all the given paths and accelerates
+    ///     <c>JSON_VALUE</c> (=, including the <c>RETURNING</c> form) / <c>JSON_PATH_EXISTS</c> /
+    ///     <c>JSON_CONTAINS</c> predicates without per-path computed columns. Requires
+    ///     <c>UseNativeJsonType = true</c>. See <see cref="JsonIndex" /> for the constraints.
+    /// </summary>
+    public DocumentMappingExpression<T> JsonIndex(Expression<Func<T, object?>> expression,
+        Action<JsonIndex>? configure = null)
+    {
+        var paths = Storage.JsonIndex.ResolveJsonPaths(expression);
+        var index = new JsonIndex(paths);
+        configure?.Invoke(index);
+        JsonIndexes.Add(index);
+        return this;
+    }
+
+    /// <summary>
+    ///     Add a native JSON index over the entire JSON document (no <c>FOR</c> path filter) — the
+    ///     SQL Server counterpart to Marten's <c>GinIndexJsonData</c>. Requires
+    ///     <c>UseNativeJsonType = true</c>.
+    /// </summary>
+    public DocumentMappingExpression<T> JsonIndex(Action<JsonIndex>? configure = null)
+    {
+        var index = new JsonIndex([]);
+        configure?.Invoke(index);
+        JsonIndexes.Add(index);
         return this;
     }
 

--- a/src/Polecat/Storage/JsonIndex.cs
+++ b/src/Polecat/Storage/JsonIndex.cs
@@ -1,0 +1,104 @@
+using System.Linq.Expressions;
+
+namespace Polecat.Storage;
+
+/// <summary>
+///     A native SQL Server 2025 JSON index (<c>CREATE JSON INDEX</c>) over a document's native
+///     <c>json</c> <c>data</c> column. Unlike a computed-column <see cref="DocumentIndex" />, a single
+///     JSON index can cover many JSON paths and accelerates <c>JSON_VALUE</c> (equality, including the
+///     <c>RETURNING</c> form), <c>JSON_PATH_EXISTS</c>, and <c>JSON_CONTAINS</c> predicates without any
+///     per-path computed columns.
+///
+///     Requirements (enforced / documented):
+///     - The <c>data</c> column must be the native <c>json</c> type — i.e. <c>UseNativeJsonType = true</c>
+///       (SQL Server 2025+). A computed-column <see cref="DocumentIndex" /> is the portable alternative.
+///     - The table needs a clustered primary key whose key is ≤128 bytes. Polecat's single-tenant
+///       <c>id</c> PK satisfies this; per-tenant tables (whose PK prepends a <c>varchar</c> tenant_id)
+///       can exceed the limit, in which case SQL Server rejects the index.
+///     - Only one JSON index can exist per <c>json</c> column, so a table has at most one JSON index.
+///     - Indexed paths can't overlap (e.g. <c>$.a</c> and <c>$.a.b</c>).
+///     - Does not support UNIQUE, filtered (WHERE), INCLUDE, ORDER BY/range seeks, or LIKE/IS NULL —
+///       use a computed-column <see cref="DocumentIndex" /> for those.
+/// </summary>
+public class JsonIndex
+{
+    public JsonIndex(string[] jsonPaths, string? indexName = null)
+    {
+        JsonPaths = jsonPaths;
+        IndexName = indexName;
+    }
+
+    /// <summary>
+    ///     The JSON paths to index (e.g. "$.serviceName", "$.address.city"). When empty, the entire
+    ///     JSON document is indexed (the <c>FOR</c> clause is omitted).
+    /// </summary>
+    public string[] JsonPaths { get; }
+
+    /// <summary>
+    ///     Optional explicit index name. Auto-derived from the table name when null.
+    /// </summary>
+    public string? IndexName { get; set; }
+
+    /// <summary>
+    ///     Maps to <c>WITH (OPTIMIZE_FOR_ARRAY_SEARCH = ON)</c> — tunes the index for searching inside
+    ///     JSON arrays (e.g. <c>JSON_CONTAINS</c> over an array property).
+    /// </summary>
+    public bool OptimizeForArraySearch { get; set; }
+
+    /// <summary>
+    ///     Optional <c>WITH (FILLFACTOR = n)</c>, 1–100.
+    /// </summary>
+    public int? FillFactor { get; set; }
+
+    /// <summary>
+    ///     Derives the index name. One JSON index per table, so the table name alone is unique.
+    /// </summary>
+    internal string GetIndexName(string tableName) => IndexName ?? $"jidx_{tableName}";
+
+    /// <summary>
+    ///     Generates the <c>CREATE JSON INDEX</c> DDL. Throws when the store isn't using the native
+    ///     json column type, since the statement is invalid against <c>nvarchar(max)</c> storage.
+    /// </summary>
+    internal string[] ToDdlStatements(DocumentMapping mapping)
+    {
+        if (mapping.JsonColumnType != "json")
+        {
+            throw new InvalidOperationException(
+                $"A JSON index on '{mapping.DocumentType.Name}' requires the native json column type. " +
+                "Set UseNativeJsonType = true (SQL Server 2025+), or use a computed-column Index(...) instead.");
+        }
+
+        var schema = mapping.DatabaseSchemaName;
+        var table = mapping.TableName;
+        var qualifiedTable = $"[{schema}].[{table}]";
+        var name = GetIndexName(table);
+
+        var forClause = JsonPaths.Length > 0
+            ? " FOR (" + string.Join(", ", JsonPaths.Select(p => $"'{p}'")) + ")"
+            : "";
+
+        var withOptions = new List<string>();
+        if (OptimizeForArraySearch) withOptions.Add("OPTIMIZE_FOR_ARRAY_SEARCH = ON");
+        if (FillFactor.HasValue) withOptions.Add($"FILLFACTOR = {FillFactor.Value}");
+        var withClause = withOptions.Count > 0 ? " WITH (" + string.Join(", ", withOptions) + ")" : "";
+
+        // CREATE JSON INDEX requires SET QUOTED_IDENTIFIER ON; set it explicitly so the statement is
+        // robust regardless of the caller's session options. Only one JSON index per json column is
+        // allowed, so existence is keyed on the table, not the index name.
+        return
+        [
+            $"""
+             SET QUOTED_IDENTIFIER ON;
+             IF NOT EXISTS (SELECT 1 FROM sys.json_indexes WHERE object_id = OBJECT_ID('{qualifiedTable}'))
+                 CREATE JSON INDEX [{name}] ON {qualifiedTable} (data){forClause}{withClause};
+             """
+        ];
+    }
+
+    /// <summary>
+    ///     Resolves a lambda to the JSON paths to index — a single (possibly nested) member or an
+    ///     anonymous type combining several. Reuses <see cref="DocumentIndex.ResolveJsonPaths{T}" />.
+    /// </summary>
+    internal static string[] ResolveJsonPaths<T>(Expression<Func<T, object?>> expression)
+        => DocumentIndex.ResolveJsonPaths(expression);
+}


### PR DESCRIPTION
Closes #344.

Re-applies the two index features that were stranded on `feat/json-index` — [PR #229](https://github.com/JasperFx/polecat/pull/229) (native JSON indexes) and #230 (covering INCLUDE indexes). Those PRs were merged only into their stacked base branch and never retargeted to `main`, so the branch fell ~a month behind the #273 closed-shape convergence and can no longer be merged wholesale. This is a clean re-application onto today's `main`.

Both features are **additive** and hook into index seams that survived the convergence unchanged. The one drift handled: main's `ComputedColumnExpression` gained a 4th `useReturning` arg (#236), so the covering-index computed-column DDL is adapted to pass `UsesNativeJson(mapping)`.

## JSON indexes (#229)

Native SQL Server 2025 `CREATE JSON INDEX` over the json `data` column via `.JsonIndex(...)`:

```csharp
.JsonIndex(x => new { x.ServiceName, x.BucketEnd })   // FOR ('$.serviceName', '$.bucketEnd')
.JsonIndex()                                          // whole-document index
.JsonIndex(x => x.Tags, idx => idx.OptimizeForArraySearch = true)
```

One JSON index covers **many** JSON paths and accelerates `JSON_VALUE` (=, including the `RETURNING` form from #217/#236), `JSON_PATH_EXISTS`, and `JSON_CONTAINS` — with no per-path computed columns. This is additive to computed-column indexes, not a replacement.

- **Gated on `UseNativeJsonType = true`.** `CREATE JSON INDEX` is invalid against `nvarchar(max)`, so `JsonIndex.ToDdlStatements` throws a clear `InvalidOperationException` otherwise (fail-fast).
- DDL sets `QUOTED_IDENTIFIER ON` (required by `CREATE JSON INDEX`) and is idempotent — one JSON index per json column, existence keyed on the table.
- Flows through the same expression → `DocumentProviderRegistry` → `DocumentMapping` → `DocumentTableEnsurer` path as computed-column indexes.

**Constraints (documented on `JsonIndex`):** native json only · clustered PK key ≤128 bytes (fine for single-tenant `id` PKs; per-tenant tables whose PK prepends a `varchar` tenant_id can exceed it → SQL rejects the index) · one per table · no overlapping paths · no UNIQUE / filtered / INCLUDE / range / LIKE / IS NULL — use a computed-column `Index(...)` for those. Preview, on-prem SQL Server 2025 only.

## Covering computed-column indexes (#230)

`Index(...)` / `UniqueIndex(...)` can carry extra members as non-key `INCLUDE` columns so a query is satisfied from the index alone (no key lookup back into the table). Each include path gets its own persisted computed column; works on **both** native json and `nvarchar(max)`.

## Fluent interface — aligned to Marten

Per the request to mirror Marten usage:

- `.Index(x => x.Foo, configure)` / `.UniqueIndex(...)` keep their exact Marten signatures.
- Covering includes are exposed as **`DocumentIndex.IncludeColumns`** — the same property name as Weasel's `IndexDefinition.IncludeColumns` that Marten uses — settable in the `configure` action, plus a type-safe `include:` expression parameter as a Polecat convenience:

  ```csharp
  .Index(x => x.ServiceName, include: x => new { x.BucketEnd, x.Count })   // type-safe
  .Index(x => x.ServiceName, idx => idx.IncludeColumns = ["$.bucketEnd"])   // Marten-style
  ```
- The whole-document `.JsonIndex()` is the SQL Server counterpart to Marten's `GinIndexJsonData` (cross-referenced in the XML docs).

## Verification

- **12/12** index tests (`json_index_tests` + `covering_index_tests`) green on net10 against SQL Server 2025 (0 skipped).
- **168/168** Storage suite green on net10 — the `Index`/`UniqueIndex` signature change (optional `include:` param) is source-compatible.
- Native-json integration tests gate on `[RequiresNativeJsonFact(true)]`, so they skip (rather than fail) on SQL Server 2022; the DDL-generation unit tests always run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)