### PR TITLE
feat: JasperFx 2.33 + surface assembly-reuse warning (#345) + MultiStreamProjection stepthrough (#346)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -26,9 +26,14 @@
              local restart seam (IProjectionDaemon.HighWaterLastPolledAt / IsHighWaterStale /
              RestartHighWaterAgentAsync; DaemonSettings.HighWaterStalenessThreshold; ShardAction.Faulted/
              Restarted). Foundation for the Phase 2 high-water health check (polecat#341). Also carries
-             the jasperfx#540 faulted-start teardown that first shipped in 2.32.0. -->
-        <PackageVersion Include="JasperFx" Version="2.32.0" />
-        <PackageVersion Include="JasperFx.Events" Version="2.32.0" />
+             the jasperfx#540 faulted-start teardown that first shipped in 2.32.0.
+             JasperFx 2.33.0: (a) jasperfx#543 — JasperFxOptions.ApplicationAssemblyReuseWarning, the
+             GH-3521 application-assembly-reuse detection Polecat surfaces once at startup (#345); and
+             (b) the JasperFx.Events instrumented-fold surface (ISteppableAggregation,
+             JasperFxAggregationProjectionBase.Stepping, EnrichEventsAsync) that Polecat's
+             MultiStreamProjection stepthrough parity builds on (#346). -->
+        <PackageVersion Include="JasperFx" Version="2.33.0" />
+        <PackageVersion Include="JasperFx.Events" Version="2.33.0" />
         <!-- Pin the sibling JasperFx packages for parity with Marten 9's matrix
              even though Polecat doesn't currently reference them directly —
              keeps the lockstep matrix coherent when transitive resolution
@@ -36,7 +41,7 @@
              RuntimeCompiler 5.x line is the active continuation of the 4.x
              lineage; do not pin against the parallel stale 2.0.x series. -->
         <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.32.0" />
+        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.33.0" />
         <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
@@ -81,7 +86,7 @@
         <PackageVersion Include="StronglyTypedId" Version="1.0.0-beta08" />
 
         <!-- Source generators (matched to JasperFx.Events above) -->
-        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.32.0" />
+        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.33.0" />
 
         <!-- Build automation -->
         <PackageVersion Include="Nuke.Common" Version="9.0.4" />

--- a/src/Polecat.Tests/Events/application_assembly_reuse_warning_tests.cs
+++ b/src/Polecat.Tests/Events/application_assembly_reuse_warning_tests.cs
@@ -1,0 +1,121 @@
+using System.Reflection;
+using JasperFx;
+using Microsoft.Extensions.Logging;
+using Polecat.Internal;
+
+namespace Polecat.Tests.Events;
+
+// #345: Polecat surfaces JasperFx's GH-3521 application-assembly-reuse warning
+// (JasperFxOptions.ApplicationAssemblyReuseWarning, jasperfx#543). JasperFx only *detects*
+// the condition — the warning is non-null only when a later host in the process adopts an
+// earlier host's process-pinned application assembly that differs from its own registration
+// assembly. Consumers surface it; Polecat does so once at startup from PolecatActivator, the
+// always-on hosted service.
+//
+// Because the warning derives from JasperFx's process-static RememberedApplicationAssembly,
+// these tests exercise the two integration seams in isolation rather than through the real
+// (order-dependent) assembly-resolution path.
+public class application_assembly_reuse_warning_tests
+{
+    // JasperFxOptions.ApplicationAssemblyReuseWarning has an internal setter (owned by the
+    // JasperFx assembly), so a test sets it via reflection to simulate a detected reuse.
+    private static JasperFxOptions WithReuseWarning(string message)
+    {
+        var options = new JasperFxOptions();
+        typeof(JasperFxOptions)
+            .GetProperty(nameof(JasperFxOptions.ApplicationAssemblyReuseWarning),
+                BindingFlags.Public | BindingFlags.Instance)!
+            .SetValue(options, message);
+        return options;
+    }
+
+    [Fact]
+    public void read_jasperfx_options_buffers_the_reuse_warning()
+    {
+        var storeOptions = new StoreOptions();
+
+        storeOptions.ReadJasperFxOptions(WithReuseWarning("assembly reuse detected"));
+
+        storeOptions.ApplicationAssemblyReuseWarning.ShouldBe("assembly reuse detected");
+    }
+
+    [Fact]
+    public void first_non_null_warning_is_not_clobbered_by_a_later_null()
+    {
+        // Both the primary (AddPolecat) and ancillary (AddPolecatStore<T>) paths call
+        // ReadJasperFxOptions; ??= keeps the first non-null value.
+        var storeOptions = new StoreOptions();
+
+        storeOptions.ReadJasperFxOptions(WithReuseWarning("first warning"));
+        storeOptions.ReadJasperFxOptions(new JasperFxOptions()); // ApplicationAssemblyReuseWarning == null
+
+        storeOptions.ApplicationAssemblyReuseWarning.ShouldBe("first warning");
+    }
+
+    [Fact]
+    public void no_warning_when_jasperfx_did_not_detect_reuse()
+    {
+        var storeOptions = new StoreOptions();
+
+        storeOptions.ReadJasperFxOptions(new JasperFxOptions());
+
+        storeOptions.ApplicationAssemblyReuseWarning.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task activator_logs_the_buffered_warning_once_at_startup()
+    {
+        var store = DocumentStore.For(opts =>
+        {
+            opts.ConnectionString = ConnectionSource.ConnectionString;
+            opts.DatabaseSchemaName = "assembly_reuse_warning";
+            // ShouldApplyChangesOnStartup stays false and no InitialData is registered, so
+            // StartAsync only reaches the warning-logging branch — no database interaction.
+            opts.ApplicationAssemblyReuseWarning = "adopted assembly 'A' but registered from 'B'";
+        });
+
+        var logger = new CapturingLogger<PolecatActivator>();
+        var activator = new PolecatActivator(store, logger);
+
+        await activator.StartAsync(CancellationToken.None);
+
+        var warning = logger.Entries.ShouldHaveSingleItem();
+        warning.Level.ShouldBe(LogLevel.Warning);
+        warning.Message.ShouldContain("adopted assembly 'A' but registered from 'B'");
+    }
+
+    [Fact]
+    public async Task activator_logs_nothing_when_there_is_no_warning()
+    {
+        var store = DocumentStore.For(opts =>
+        {
+            opts.ConnectionString = ConnectionSource.ConnectionString;
+            opts.DatabaseSchemaName = "assembly_reuse_no_warning";
+        });
+
+        var logger = new CapturingLogger<PolecatActivator>();
+        var activator = new PolecatActivator(store, logger);
+
+        await activator.StartAsync(CancellationToken.None);
+
+        logger.Entries.ShouldBeEmpty();
+    }
+
+    private sealed class CapturingLogger<T> : ILogger<T>
+    {
+        public List<(LogLevel Level, string Message)> Entries { get; } = new();
+
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter)
+            => Entries.Add((logLevel, formatter(state, exception)));
+
+        private sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new();
+            public void Dispose() { }
+        }
+    }
+}

--- a/src/Polecat.Tests/Projections/multi_stream_projection_stepthrough_tests.cs
+++ b/src/Polecat.Tests/Projections/multi_stream_projection_stepthrough_tests.cs
@@ -1,0 +1,193 @@
+using System.Text.Json;
+using JasperFx.Descriptors;
+using JasperFx.Events;
+using JasperFx.Events.Grouping;
+using JasperFx.Events.Projections;
+using Polecat.Projections;
+using Polecat.Tests.Harness;
+
+namespace Polecat.Tests.Projections;
+
+// #346: MultiStreamProjection stepthrough parity. IEventStore.RunMultiStreamProjectionAsync drives a
+// registered aggregation projection's REAL execution path — slice → group → EnrichEventsAsync → evolve
+// — over a fixed in-memory event list, fanning out across every aggregate identity the projection
+// touches and returning one timeline per identity. The fold lives in JasperFx.Events; Polecat delegates
+// through ISteppableAggregation.
+public class multi_stream_projection_stepthrough_tests : OneOffConfigurationsContext
+{
+    private static readonly JsonSerializerOptions s_camelCase = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+
+    private static EventRecord Record<T>(string streamId, string typeName, T data, long sequence, long version)
+        => new(
+            EventId: Guid.NewGuid(),
+            Sequence: sequence,
+            StreamVersion: version,
+            StreamId: streamId,
+            EventTypeName: typeName,
+            Data: JsonSerializer.SerializeToElement(data, s_camelCase),
+            Metadata: null,
+            Timestamp: DateTimeOffset.UtcNow,
+            TenantId: "*DEFAULT*",
+            Tags: null!);
+
+    private async Task<DocumentStore> StoreWith(ProjectionSourceRegistration register)
+    {
+        ConfigureStore(opts => register(opts));
+        await theDatabase.ApplyAllConfiguredChangesToDatabaseAsync();
+        return theStore;
+    }
+
+    private delegate void ProjectionSourceRegistration(StoreOptions opts);
+
+    [Fact]
+    public async Task multi_stream_replay_produces_one_timeline_per_identity()
+    {
+        var store = await StoreWith(opts =>
+            opts.Projections.Add(new CustomerSummaryProjection(), ProjectionLifecycle.Inline));
+
+        var alice = Guid.NewGuid();
+        var bob = Guid.NewGuid();
+
+        // Events span multiple physical streams and two customer identities — exactly the multi-stream
+        // fan-out the daemon slicer performs.
+        var events = new List<EventRecord>
+        {
+            Record(Guid.NewGuid().ToString(), "customer_created", new CustomerCreated(alice, "Alice"), 1, 1),
+            Record(Guid.NewGuid().ToString(), "customer_created", new CustomerCreated(bob, "Bob"), 2, 1),
+            Record(Guid.NewGuid().ToString(), "order_placed", new OrderPlaced(alice, 100m), 3, 1),
+            Record(Guid.NewGuid().ToString(), "order_placed", new OrderPlaced(bob, 200m), 4, 1),
+            Record(Guid.NewGuid().ToString(), "order_placed", new OrderPlaced(bob, 150m), 5, 1),
+            Record(Guid.NewGuid().ToString(), "payment_received", new PaymentReceived(alice, 40m), 6, 1),
+        };
+
+        IEventStore es = store;
+        var result = await es.RunMultiStreamProjectionAsync(nameof(CustomerSummary), events, CancellationToken.None);
+
+        result.ProjectionName.ShouldBe(nameof(CustomerSummary));
+        result.AggregatesByIdentity.Count.ShouldBe(2);
+
+        var aliceTimeline = result.AggregatesByIdentity[alice.ToString()];
+        var aliceFinal = aliceTimeline.FinalState!.Value;
+        aliceFinal.GetProperty("name").GetString().ShouldBe("Alice");
+        aliceFinal.GetProperty("orderCount").GetInt32().ShouldBe(1);
+        aliceFinal.GetProperty("totalSpent").GetDecimal().ShouldBe(100m);
+        aliceFinal.GetProperty("totalPaid").GetDecimal().ShouldBe(40m);
+
+        var bobFinal = result.AggregatesByIdentity[bob.ToString()].FinalState!.Value;
+        bobFinal.GetProperty("name").GetString().ShouldBe("Bob");
+        bobFinal.GetProperty("orderCount").GetInt32().ShouldBe(2);
+        bobFinal.GetProperty("totalSpent").GetDecimal().ShouldBe(350m);
+    }
+
+    [Fact]
+    public async Task multi_stream_timeline_captures_per_event_before_after_steps()
+    {
+        var store = await StoreWith(opts =>
+            opts.Projections.Add(new CustomerSummaryProjection(), ProjectionLifecycle.Inline));
+
+        var alice = Guid.NewGuid();
+        var events = new List<EventRecord>
+        {
+            Record(Guid.NewGuid().ToString(), "customer_created", new CustomerCreated(alice, "Alice"), 1, 1),
+            Record(Guid.NewGuid().ToString(), "order_placed", new OrderPlaced(alice, 100m), 2, 1),
+        };
+
+        IEventStore es = store;
+        var result = await es.RunMultiStreamProjectionAsync(nameof(CustomerSummary), events, CancellationToken.None);
+
+        var steps = result.AggregatesByIdentity[alice.ToString()].Steps;
+        steps.Count.ShouldBe(2);
+        steps[0].Error.ShouldBeNull();
+        // Create step: no state before, state after
+        steps[0].Before.ShouldBeNull();
+        steps[0].After!.Value.GetProperty("name").GetString().ShouldBe("Alice");
+        // Apply step: order count goes 0 -> 1
+        steps[1].Before!.Value.GetProperty("orderCount").GetInt32().ShouldBe(0);
+        steps[1].After!.Value.GetProperty("orderCount").GetInt32().ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task single_stream_replay_produces_exactly_one_timeline()
+    {
+        var store = await StoreWith(opts =>
+            opts.Projections.Add<SingleStreamProjection<QuestParty, Guid>>(ProjectionLifecycle.Inline));
+
+        var streamId = Guid.NewGuid();
+        var events = new List<EventRecord>
+        {
+            Record(streamId.ToString(), "quest_started", new QuestStarted("replay"), 1, 1),
+            Record(streamId.ToString(), "members_joined", new MembersJoined(1, "Town", new[] { "Pippin" }), 2, 2),
+        };
+
+        IEventStore es = store;
+        var result = await es.RunMultiStreamProjectionAsync(nameof(QuestParty), events, CancellationToken.None);
+
+        result.AggregatesByIdentity.Count.ShouldBe(1);
+        var final = result.AggregatesByIdentity[streamId.ToString()].FinalState!.Value;
+        final.GetProperty("name").GetString().ShouldBe("replay");
+    }
+
+    [Fact]
+    public async Task enrich_events_async_runs_through_the_real_path_per_group()
+    {
+        var projection = new EnrichingCustomerSummaryProjection();
+        var store = await StoreWith(opts => opts.Projections.Add(projection, ProjectionLifecycle.Inline));
+
+        var alice = Guid.NewGuid();
+        var bob = Guid.NewGuid();
+        var events = new List<EventRecord>
+        {
+            Record(Guid.NewGuid().ToString(), "customer_created", new CustomerCreated(alice, "Alice"), 1, 1),
+            Record(Guid.NewGuid().ToString(), "customer_created", new CustomerCreated(bob, "Bob"), 2, 1),
+        };
+
+        IEventStore es = store;
+        await es.RunMultiStreamProjectionAsync(nameof(EnrichingCustomerSummary), events, CancellationToken.None);
+
+        // The user override ran through the real fold — invoked once per sliced GROUP (the daemon's
+        // per-group enrichment contract), not per event and not per identity. Both identities' slices
+        // land in one group here, so a single enrich call covers them: 1 (not 2 events, not 2 ids).
+        projection.EnrichCalls.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task unknown_projection_throws_argument_exception()
+    {
+        var store = await StoreWith(opts =>
+            opts.Projections.Add(new CustomerSummaryProjection(), ProjectionLifecycle.Inline));
+
+        IEventStore es = store;
+        await Should.ThrowAsync<ArgumentException>(() =>
+            es.RunMultiStreamProjectionAsync("does_not_exist", new List<EventRecord>(), CancellationToken.None));
+    }
+}
+
+// Multi-stream projection whose user EnrichEventsAsync override is expected to run through the real
+// fold once per sliced group, proving parity with the async daemon's enrichment path.
+public partial class EnrichingCustomerSummary
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+}
+
+public partial class EnrichingCustomerSummaryProjection : MultiStreamProjection<EnrichingCustomerSummary, Guid>
+{
+    public int EnrichCalls;
+
+    public EnrichingCustomerSummaryProjection()
+    {
+        Identity<CustomerCreated>(e => e.CustomerId);
+    }
+
+    public static EnrichingCustomerSummary Create(CustomerCreated e) => new() { Name = e.Name };
+
+    public override Task EnrichEventsAsync(SliceGroup<EnrichingCustomerSummary, Guid> group,
+        IQuerySession querySession, CancellationToken cancellation)
+    {
+        Interlocked.Increment(ref EnrichCalls);
+        return Task.CompletedTask;
+    }
+}

--- a/src/Polecat/DocumentStore.ProjectionReplay.cs
+++ b/src/Polecat/DocumentStore.ProjectionReplay.cs
@@ -4,6 +4,7 @@ using System.Reflection;
 using System.Text.Json;
 using JasperFx.Descriptors;
 using JasperFx.Events;
+using JasperFx.Events.Aggregation;
 using JasperFx.Events.Projections;
 using Polecat.Events;
 
@@ -164,6 +165,70 @@ public partial class DocumentStore
             : JsonSerializer.SerializeToElement(typedFinal, stateType);
 
         return new ProjectionTimelineRaw(rawSteps, finalJson);
+    }
+
+    /// <summary>
+    ///     #346: MultiStreamProjection stepthrough parity. Replays a fixed event list through a
+    ///     registered aggregation projection's <em>real</em> execution path — slice → group →
+    ///     <c>EnrichEventsAsync</c> → evolve — fanning the events out across every aggregate identity
+    ///     the projection touches and returning one timeline per identity. Single-stream projections
+    ///     produce exactly one. Stateless; nothing is persisted.
+    ///
+    ///     The fold itself lives in JasperFx.Events on <c>JasperFxAggregationProjectionBase</c> (which
+    ///     every Polecat single/multi-stream projection derives from) and is reached through
+    ///     <see cref="ISteppableAggregation{TQuerySession}" />, so this is a thin adapter: resolve the
+    ///     projection by name, convert the wire events, open a read-only query session, and delegate.
+    /// </summary>
+    [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
+        Justification = "Calls ToDomainEvent (annotated [RequiresUnreferencedCode]) and STJ over the store serializer output. The explicit interface impl can't propagate the requirement because IEventStore.RunMultiStreamProjectionAsync doesn't declare it (tracked with the sibling replay methods above).")]
+    [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+        Justification = "ToDomainEvent + JsonSerializer.Deserialize<JsonElement> use STJ runtime code generation. Diagnostic IEventStore surface — same rationale as RunProjectionAsync / RunProjectionByNameAsync above.")]
+    async Task<MultiAggregateProjectionResult> IEventStore.RunMultiStreamProjectionAsync(
+        string projectionName, IReadOnlyList<EventRecord> events, CancellationToken ct)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(projectionName);
+        ArgumentNullException.ThrowIfNull(events);
+
+        if (!Options.Projections.TryFindProjection(projectionName, out var source))
+        {
+            throw new ArgumentException(
+                $"Unknown projection '{projectionName}'. Register the projection on StoreOptions.Projections before replaying.",
+                nameof(projectionName));
+        }
+
+        // Only aggregation (single- or multi-stream) projections carry the instrumented fold. The
+        // projection source returned by TryFindProjection is the JasperFxAggregationProjectionBase
+        // instance itself, so for an aggregation projection it casts straight to ISteppableAggregation.
+        if (source is not ISteppableAggregation<IQuerySession> steppable)
+        {
+            throw new NotSupportedException(
+                $"Projection '{projectionName}' is not an aggregation (single- or multi-stream) projection and cannot be stepped through.");
+        }
+
+        // Convert wire events to domain events, keeping a reference-keyed map back to each originating
+        // EventRecord for the fold's toRecord delegate (the fold hands back the same IEvent instances).
+        // Unregistered event types are skipped, matching the single-aggregate replay path above.
+        var recordByEvent = new Dictionary<IEvent, EventRecord>(ReferenceEqualityComparer.Instance);
+        var domainEvents = new List<IEvent>(events.Count);
+        foreach (var record in events)
+        {
+            var domainEvent = ToDomainEvent(record);
+            if (domainEvent is null) continue;
+            recordByEvent[domainEvent] = record;
+            domainEvents.Add(domainEvent);
+        }
+
+        await using var session = QuerySession();
+
+        // serialize: use the store's own serializer so captured snapshots match what the store would
+        // persist (per the ISteppableAggregation contract), then parse to a JsonElement.
+        return await steppable.BuildTimelinesAsync(
+            domainEvents,
+            session,
+            state => state is null ? null : JsonSerializer.Deserialize<JsonElement>(Options.Serializer.ToJson(state)),
+            e => recordByEvent[e],
+            observer: null,
+            ct).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/src/Polecat/Internal/PolecatActivator.cs
+++ b/src/Polecat/Internal/PolecatActivator.cs
@@ -1,22 +1,35 @@
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Polecat.Internal;
 
 /// <summary>
-///     Hosted service that applies database schema changes on startup.
-///     Registered by ApplyAllDatabaseChangesOnStartup().
+///     Always-on hosted service (registered unconditionally by <c>AddPolecat</c>, #219) that surfaces the
+///     #345 application-assembly-reuse warning, applies database schema changes when
+///     <c>ApplyAllDatabaseChangesOnStartup()</c> opted in, and runs InitialData seeders on startup.
 /// </summary>
 internal class PolecatActivator : IHostedService
 {
     private readonly IDocumentStore _store;
+    private readonly ILogger<PolecatActivator> _logger;
 
-    public PolecatActivator(IDocumentStore store)
+    public PolecatActivator(IDocumentStore store, ILogger<PolecatActivator>? logger = null)
     {
         _store = store;
+        _logger = logger ?? NullLogger<PolecatActivator>.Instance;
     }
 
     public async Task StartAsync(CancellationToken cancellationToken)
     {
+        // #345: surface JasperFx's GH-3521 application-assembly-reuse warning (jasperfx#543) once, early,
+        // so it is logged even if the schema migration below later throws. JasperFx only detects the
+        // condition — consumers surface it, and Polecat has no other always-on emit point.
+        if (_store.Options.ApplicationAssemblyReuseWarning is { } reuseWarning)
+        {
+            _logger.LogWarning("{Warning}", reuseWarning);
+        }
+
         if (_store.Options.ShouldApplyChangesOnStartup)
         {
             var documentStore = (DocumentStore)_store;

--- a/src/Polecat/PolecatServiceCollectionExtensions.cs
+++ b/src/Polecat/PolecatServiceCollectionExtensions.cs
@@ -119,8 +119,10 @@ public static class PolecatServiceCollectionExtensions
         services.AddScoped(sp => sp.GetRequiredService<ISessionFactory>().QuerySession());
 
         // #219: register the activator unconditionally so InitialData seeders run on host startup
-        // even without ApplyAllDatabaseChangesOnStartup. StartAsync is a no-op when there is no
-        // InitialData and ShouldApplyChangesOnStartup is false, so this is safe for every app.
+        // even without ApplyAllDatabaseChangesOnStartup. #345: it is also Polecat's always-on emit
+        // point for the JasperFx application-assembly-reuse warning. StartAsync only logs that warning
+        // (when present) and is otherwise a no-op when there is no InitialData and
+        // ShouldApplyChangesOnStartup is false, so this is safe for every app.
         PolecatConfigurationExpression.EnsureActivatorIsRegistered(services);
 
         return new PolecatConfigurationExpression(services);

--- a/src/Polecat/StoreOptions.cs
+++ b/src/Polecat/StoreOptions.cs
@@ -99,6 +99,15 @@ public class StoreOptions
     ///     (<c>AddPolecatStore&lt;T&gt;</c>) registration paths. Mirrors Marten's
     ///     <c>StoreOptions.ReadJasperFxOptions</c>.
     /// </summary>
+    /// <summary>
+    ///     #345: buffered copy of <see cref="JasperFxOptions.ApplicationAssemblyReuseWarning" /> (jasperfx#543 /
+    ///     GH-3521). Non-null only when this host adopted an earlier host's process-pinned application
+    ///     assembly that differs from its own registration assembly — the quiet, order-dependent failure
+    ///     mode in a multi-host test process. <see cref="Internal.PolecatActivator" /> logs it once at
+    ///     startup. JasperFx only detects the condition; consumers surface it.
+    /// </summary>
+    internal string? ApplicationAssemblyReuseWarning { get; set; }
+
     internal void ReadJasperFxOptions(JasperFxOptions? options)
     {
         if (options == null) return;
@@ -111,6 +120,11 @@ public class StoreOptions
         {
             Events.EnableExtendedProgressionTracking = true;
         }
+
+        // #345: buffer JasperFx's GH-3521 application-assembly-reuse warning so PolecatActivator can
+        // log it once at startup. ??= so the first non-null value (primary or ancillary path) wins and
+        // a later null never clobbers it.
+        ApplicationAssemblyReuseWarning ??= options.ApplicationAssemblyReuseWarning;
     }
 
     /// <summary>


### PR DESCRIPTION
Bumps JasperFx.* to 2.33.0 and lands the two features that release unblocks — closes #345 and #346.

## 1. Bump JasperFx.* `2.32.0 → 2.33.0`

`Directory.Packages.props`: JasperFx, JasperFx.Events, and both SourceGenerators. Weasel (9.18.0) and RuntimeCompiler (5.0.0) are unaffected — 2.33 doesn't force them forward. Verified runtime-clean: **113/113** projection+aggregation tests pass on the bump alone.

## 2. #345 — surface JasperFx's application-assembly-reuse warning at startup

JasperFx 2.33 (jasperfx#543 / GH-3521) *detects* when a later host in a process adopts an earlier host's process-pinned application assembly that differs from its own registration assembly — a quiet, order-dependent failure mode in multi-host test processes. JasperFx only detects; consumers surface it.

- `StoreOptions.ReadJasperFxOptions` buffers `JasperFxOptions.ApplicationAssemblyReuseWarning` (`??=`, so the first non-null value across the primary + ancillary registration paths wins).
- `PolecatActivator` — **already** registered unconditionally by `AddPolecat` (#219), so it's Polecat's always-on emit point — gains an `ILogger` and logs the warning once, early in `StartAsync` (before schema migration, so it surfaces even if migration throws). The optional logger keeps direct `new PolecatActivator(store)` test call sites compiling.

The issue's "wrinkle" (PolecatActivator being conditional) turned out to be stale — it's been unconditional since #219 — so option (a) was the clean path, mirroring Marten's always-on-activator-with-logger structure. (Marten had not yet surfaced this specific warning as of the referenced checkout; Polecat implements it here, as Wolverine does for Wolverine hosts.)

## 3. #346 — MultiStreamProjection stepthrough parity (instrumented fold)

Implements `IEventStore.RunMultiStreamProjectionAsync` (new in JasperFx.Events 2.33, default-throwing) on `DocumentStore`. Replays a fixed in-memory event list through a registered aggregation projection's **real** execution path — slice → group → `EnrichEventsAsync` → evolve — fanning out across every aggregate identity the projection touches, one timeline per identity (single-stream → exactly one). Stateless.

The fold lives entirely in JasperFx.Events on `JasperFxAggregationProjectionBase` (which every Polecat single/multi-stream projection derives from) and is reached through `ISteppableAggregation<IQuerySession>`, so this is a **thin adapter**: resolve by name → cast to the steppable surface → convert wire `EventRecord`s to domain `IEvent`s (reusing `ToDomainEvent`, keeping a reference-keyed map for the fold's `toRecord` delegate) → open a read-only `QuerySession` → delegate to `BuildTimelinesAsync`. Slicing/grouping/enrichment/per-event dispatch are **fully delegated** — Polecat reimplements none of it.

Marten hadn't consumed this JasperFx.Events surface as of the referenced checkout, so there's no Marten body to copy; Polecat implements directly against the shared 2.33 contract (and is effectively the first implementor).

## Verification

- Library + tests build clean on net9 + net10.
- **#345**: 5 new tests (both seams in isolation — the warning is process-static, so end-to-end assertions would be order-dependent); 27 activator-consumer tests still green.
- **#346**: 5 new tests — multi-stream fan-out (timeline per identity + correct folded state), per-event before/after capture, single-stream → one timeline, user `EnrichEventsAsync` override runs through the real path **once per group** (the per-group enrichment contract — a nice confirmation that 1 call, not 2, is correct), unknown-projection `ArgumentException`. 25/25 replay+multistream regression green.
- CI (fresh DB, net9, default+edge) is the real referee for the schema/runtime surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)