### PR TITLE
Persist extended-progression telemetry incl. running_on_node (marten#5001)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -27,8 +27,8 @@
              RestartHighWaterAgentAsync; DaemonSettings.HighWaterStalenessThreshold; ShardAction.Faulted/
              Restarted). Foundation for the Phase 2 high-water health check (polecat#341). Also carries
              the jasperfx#540 faulted-start teardown that first shipped in 2.32.0. -->
-        <PackageVersion Include="JasperFx" Version="2.32.0" />
-        <PackageVersion Include="JasperFx.Events" Version="2.32.0" />
+        <PackageVersion Include="JasperFx" Version="2.33.1" />
+        <PackageVersion Include="JasperFx.Events" Version="2.33.1" />
         <!-- Pin the sibling JasperFx packages for parity with Marten 9's matrix
              even though Polecat doesn't currently reference them directly —
              keeps the lockstep matrix coherent when transitive resolution
@@ -36,7 +36,7 @@
              RuntimeCompiler 5.x line is the active continuation of the 4.x
              lineage; do not pin against the parallel stale 2.0.x series. -->
         <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.32.0" />
+        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.33.1" />
         <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
@@ -81,7 +81,7 @@
         <PackageVersion Include="StronglyTypedId" Version="1.0.0-beta08" />
 
         <!-- Source generators (matched to JasperFx.Events above) -->
-        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.32.0" />
+        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.33.1" />
 
         <!-- Build automation -->
         <PackageVersion Include="Nuke.Common" Version="9.0.4" />

--- a/src/Polecat.Tests/Daemon/write_projection_progress_extended_tests.cs
+++ b/src/Polecat.Tests/Daemon/write_projection_progress_extended_tests.cs
@@ -1,0 +1,85 @@
+using System;
+using JasperFx.Events;
+using JasperFx.Events.Projections;
+using Microsoft.Data.SqlClient;
+using Polecat.Internal.Operations;
+using Polecat.Tests.Harness;
+using Weasel.SqlServer;
+
+namespace Polecat.Tests.Daemon;
+
+/// <summary>
+///     marten#5001 / CritterWatch#750: PolecatDatabase.WriteExtendedProgressionAsync persists the async
+///     daemon's extended telemetry (heartbeat / agent_status / pause_reason / running_on_node) that the
+///     shared ExtendedProgressionWriter drives. Mirrors Marten's telemetry-only
+///     mt_mark_event_progression_extended: it decorates an EXISTING progression row's extended columns and
+///     never touches last_seq_id (no "clobber") and never INSERTs.
+/// </summary>
+public class write_projection_progress_extended_tests : OneOffConfigurationsContext
+{
+    [Fact]
+    public async Task writes_extended_telemetry_including_running_on_node()
+    {
+        ConfigureStore(opts => opts.Events.EnableExtendedProgressionTracking = true);
+        await theDatabase.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        var shardName = new ShardName("ExtendedWrite");
+        // Establish the progression row + last_seq_id (owned by the batch-commit path).
+        await RecordProgressAsync(shardName, ceiling: 42, upsert: true, extended: true);
+
+        // A heartbeat/transition publication carrying a DIFFERENT sequence than the committed row.
+        var state = new ShardState(shardName.Identity, 999)
+        {
+            AgentStatus = "Running",
+            LastHeartbeat = DateTimeOffset.UtcNow,
+            RunningOnNode = 5
+        };
+
+        await theDatabase.WriteExtendedProgressionAsync(state, CancellationToken.None);
+
+        var progress = await theDatabase.AllProjectionProgress();
+        var row = progress.Single(x => x.ShardName == shardName.Identity);
+
+        row.AgentStatus.ShouldBe("Running");
+        row.LastHeartbeat.ShouldNotBeNull();
+        row.RunningOnNode.ShouldBe(5);
+
+        // Telemetry-only: last_seq_id stays the committed 42, NOT the ShardState's 999.
+        row.Sequence.ShouldBe(42);
+    }
+
+    [Fact]
+    public async Task is_a_no_op_when_no_progression_row_exists_yet()
+    {
+        ConfigureStore(opts => opts.Events.EnableExtendedProgressionTracking = true);
+        await theDatabase.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        var shardName = new ShardName("NeverCommitted");
+        var state = new ShardState(shardName.Identity, 7) { AgentStatus = "Running", RunningOnNode = 3 };
+
+        // No row exists yet — the zero-row UPDATE must not throw and must not create a row.
+        await theDatabase.WriteExtendedProgressionAsync(state, CancellationToken.None);
+
+        var progress = await theDatabase.AllProjectionProgress();
+        progress.ShouldNotContain(x => x.ShardName == shardName.Identity);
+    }
+
+    private async Task RecordProgressAsync(ShardName shardName, long ceiling, bool upsert, bool extended)
+    {
+        var op = new RecordProgressionOperation(
+            theDatabase.Events.ProgressionTableName,
+            shardName.Identity,
+            ceiling,
+            extended,
+            upsert);
+
+        await using var conn = new SqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        await using var batch = new SqlBatch(conn);
+        var builder = new BatchBuilder(batch);
+        op.ConfigureCommand(builder);
+        builder.Compile();
+        await using var reader = await batch.ExecuteReaderAsync(CancellationToken.None);
+        await op.PostprocessAsync(reader, new List<Exception>(), CancellationToken.None);
+    }
+}

--- a/src/Polecat/Storage/PolecatDatabase.cs
+++ b/src/Polecat/Storage/PolecatDatabase.cs
@@ -174,6 +174,43 @@ public class PolecatDatabase : DatabaseBase<SqlConnection>, IEventDatabase, IPro
         }, (_connectionString, _events.ProgressionTableName, shardIdentity), token);
     }
 
+    // marten#5001 / CritterWatch#750: persist the async daemon's extended telemetry (heartbeat,
+    // agent_status, pause_reason, running_on_node) that the shared ExtendedProgressionWriter drives
+    // through IEventDatabase.WriteExtendedProgressionAsync (the default is a no-op). Mirrors Marten's
+    // mt_mark_event_progression_extended: TELEMETRY-ONLY — decorate an EXISTING progression row's
+    // extended columns and nothing else. It must never INSERT and never touch last_seq_id/last_updated,
+    // because the progression row (name/last_seq_id/last_updated) is owned by the projection batch
+    // commit: a pre-emptive insert here would race the batch's own insert into a duplicate-key failure,
+    // and updating last_seq_id on a throttled heartbeat would roll committed progress backwards (the
+    // "clobber" defect). If no row exists yet, the zero-row UPDATE simply skips until the first commit
+    // creates it. running_on_node stays NULL until a distribution layer stamps AssignedNodeNumber onto
+    // the published ShardState (Wolverine-managed distribution), which the writer carries into RunningOnNode.
+    public async Task WriteExtendedProgressionAsync(ShardState state, CancellationToken token = default)
+    {
+        await _resilience.ExecuteAsync(static async (s, ct) =>
+        {
+            var (connectionString, progressionTable, shardState) = s;
+            await using var conn = new SqlConnection(connectionString);
+            await conn.OpenAsync(ct);
+
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = $"""
+                UPDATE {progressionTable}
+                SET heartbeat = @heartbeat,
+                    agent_status = @status,
+                    pause_reason = @reason,
+                    running_on_node = @node
+                WHERE name = @name;
+                """;
+            cmd.Parameters.AddWithValue("@name", shardState.ShardName);
+            cmd.Parameters.AddWithValue("@heartbeat", (object?)shardState.LastHeartbeat ?? DBNull.Value);
+            cmd.Parameters.AddWithValue("@status", (object?)shardState.AgentStatus ?? DBNull.Value);
+            cmd.Parameters.AddWithValue("@reason", (object?)shardState.PauseReason ?? DBNull.Value);
+            cmd.Parameters.AddWithValue("@node", (object?)shardState.RunningOnNode ?? DBNull.Value);
+            await cmd.ExecuteNonQueryAsync(ct);
+        }, (_connectionString, _events.ProgressionTableName, state), token);
+    }
+
     public async Task<IReadOnlyList<ShardState>> AllProjectionProgress(CancellationToken token = default)
     {
         return await _resilience.ExecuteAsync(static async (state, ct) =>


### PR DESCRIPTION
The Polecat side of [JasperFx/marten#5001](https://github.com/JasperFx/marten/issues/5001).

## What

`PolecatDatabase` overrides `IEventDatabase.WriteExtendedProgressionAsync` (the default is a no-op) to persist the async daemon's extended telemetry — `heartbeat`, `agent_status`, `pause_reason`, `running_on_node` — which the shared `ExtendedProgressionWriter` drives. Polecat previously only wrote `heartbeat` via the normal `RecordProgressionOperation`; `agent_status`/`running_on_node` never landed.

Mirrors Marten's telemetry-only `mt_mark_event_progression_extended`: a pure `UPDATE` of the extended columns on an **existing** progression row that **never INSERTs and never touches `last_seq_id`/`last_updated`**. The progression row (name/last_seq_id/last_updated) is owned by the projection batch commit, so a pre-emptive insert here would race the batch's own insert, and moving `last_seq_id` on a throttled heartbeat would roll committed progress backwards (the "clobber" defect). A zero-row `UPDATE` simply skips until the first commit creates the row.

`running_on_node` is populated once a distribution layer stamps `AssignedNodeNumber` onto the published `ShardState` (Wolverine-managed distribution), which JasperFx **2.33.1**'s `ShardStateTracker` rides through the writer. Pin bumped `2.32.0 → 2.33.1`.

## Tests

`write_projection_progress_extended_tests`: writes the extended telemetry incl. `running_on_node`, asserts `last_seq_id` is **not** clobbered (telemetry-only), and that a missing row is a clean no-op.

> Note: these are DB-backed (SQL Server) and validate on CI. Locally they could not run — an amd64 SQL Server under arm64 emulation exceeds the harness's 5s connect timeout (`error 258`), which reproduces on the pre-existing `read_projection_progress_extended_tests` too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)