### PR TITLE
Implement tenant-scoped ReadStreamAsync / GetRecentStreamsAsync explorer overrides

### DIFF
--- a/src/Polecat.Tests/Diagnostics/event_store_explorer_tenant_isolation_tests.cs
+++ b/src/Polecat.Tests/Diagnostics/event_store_explorer_tenant_isolation_tests.cs
@@ -1,0 +1,104 @@
+using JasperFx;
+using JasperFx.Descriptors;
+using JasperFx.Events;
+using Polecat.Tests.Harness;
+
+namespace Polecat.Tests.ExplorerApi;
+
+/// <summary>
+///     #782 / jasperfx#503 — on a conjoined multi-tenant Polecat store the same stream id can
+///     live under two tenants. The tenant-less explorer read returns an ambiguous union of both;
+///     the tenant-scoped <c>IEventStore.ReadStreamAsync(streamId, tenantId, ct)</c> /
+///     <c>GetRecentStreamsAsync(count, tenantId, ct)</c> overloads must isolate each tenant's
+///     slice via a <c>tenant_id</c> predicate.
+/// </summary>
+public class event_store_explorer_tenant_isolation_tests
+{
+    private const string Schema = "explorer_tenant_iso";
+
+    private static DocumentStore CreateStore()
+    {
+        return DocumentStore.For(opts =>
+        {
+            opts.ConnectionString = ConnectionSource.ConnectionString;
+            opts.DatabaseSchemaName = Schema;
+            opts.AutoCreateSchemaObjects = AutoCreate.All;
+            opts.UseNativeJsonType = ConnectionSource.SupportsNativeJson;
+            opts.Events.TenancyStyle = TenancyStyle.Conjoined;
+        });
+    }
+
+    [Fact]
+    public async Task read_stream_is_isolated_per_tenant_on_conjoined_store()
+    {
+        using var store = CreateStore();
+        await store.Database.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        // Same stream id under two tenants — the exact cross-tenant ambiguity #782 closes.
+        var streamId = Guid.NewGuid();
+
+        await using (var a = store.LightweightSession(new SessionOptions { TenantId = "tenant-a" }))
+        {
+            a.Events.StartStream(streamId, new QuestStarted("Alice-1"), new QuestStarted("Alice-2"));
+            await a.SaveChangesAsync();
+        }
+
+        await using (var b = store.LightweightSession(new SessionOptions { TenantId = "tenant-b" }))
+        {
+            b.Events.StartStream(streamId, new QuestStarted("Bob-1"));
+            await b.SaveChangesAsync();
+        }
+
+        IEventStore explorer = store;
+
+        var tenantA = new List<EventRecord>();
+        await foreach (var e in explorer.ReadStreamAsync(streamId.ToString(), "tenant-a", CancellationToken.None))
+            tenantA.Add(e);
+
+        var tenantB = new List<EventRecord>();
+        await foreach (var e in explorer.ReadStreamAsync(streamId.ToString(), "tenant-b", CancellationToken.None))
+            tenantB.Add(e);
+
+        tenantA.Count.ShouldBe(2);
+        tenantB.Count.ShouldBe(1);
+
+        // The tenant-less overload is unchanged: it still reads across every tenant, so it sees
+        // the union — the ambiguity the tenant-scoped read exists to resolve.
+        var union = new List<EventRecord>();
+        await foreach (var e in explorer.ReadStreamAsync(streamId.ToString(), CancellationToken.None))
+            union.Add(e);
+        union.Count.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task recent_streams_is_isolated_per_tenant_on_conjoined_store()
+    {
+        using var store = CreateStore();
+        await store.Database.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        var streamA = Guid.NewGuid();
+        var streamB = Guid.NewGuid();
+
+        await using (var a = store.LightweightSession(new SessionOptions { TenantId = "tenant-a" }))
+        {
+            a.Events.StartStream(streamA, new QuestStarted("Alice"));
+            await a.SaveChangesAsync();
+        }
+
+        await using (var b = store.LightweightSession(new SessionOptions { TenantId = "tenant-b" }))
+        {
+            b.Events.StartStream(streamB, new QuestStarted("Bob"));
+            await b.SaveChangesAsync();
+        }
+
+        IEventStore explorer = store;
+
+        var tenantA = await explorer.GetRecentStreamsAsync(100, "tenant-a", CancellationToken.None);
+        tenantA.ShouldContain(s => s.StreamId == streamA.ToString());
+        tenantA.ShouldNotContain(s => s.StreamId == streamB.ToString());
+
+        var tenantB = await explorer.GetRecentStreamsAsync(100, "tenant-b", CancellationToken.None);
+        tenantB.ShouldContain(s => s.StreamId == streamB.ToString());
+        tenantB.ShouldNotContain(s => s.StreamId == streamA.ToString());
+    }
+}

--- a/src/Polecat/DocumentStore.EventStoreExplorer.cs
+++ b/src/Polecat/DocumentStore.EventStoreExplorer.cs
@@ -26,8 +26,17 @@ namespace Polecat;
     Justification = "Class-level: RehydrateAtVersionByNameAsync uses MethodInfo.MakeGenericMethod with the resolved aggregate type — runtime code generation. AOT consumers should prefer the strong-typed RehydrateAtVersionAsync<T> overload (covered by the AOT publishing guide).")]
 public partial class DocumentStore
 {
+    Task<IReadOnlyList<StreamSummary>> IEventStore.GetRecentStreamsAsync(int count, CancellationToken ct)
+        => ((IEventStore)this).GetRecentStreamsAsync(count, null, ct);
+
+    // #782 / jasperfx#503 — tenant-scoped recent-streams listing. On a conjoined multi-tenant
+    // Polecat store the pc_streams rows carry a tenant_id column, so a non-null tenantId bounds
+    // the listing with a tenant_id predicate. Null preserves the store-global listing across
+    // every tenant (today's behaviour). Database-per-tenant scoping (StaticMultiple /
+    // DynamicMultiple) is a separate, broader gap — the tenant-less explorer reads themselves do
+    // not yet resolve per-database — so it is not attempted here.
     async Task<IReadOnlyList<StreamSummary>> IEventStore.GetRecentStreamsAsync(
-        int count, CancellationToken ct)
+        int count, string? tenantId, CancellationToken ct)
     {
         if (count <= 0) return Array.Empty<StreamSummary>();
 
@@ -40,12 +49,14 @@ public partial class DocumentStore
         // #57: share the column projection + row read with FetchStreamStateAsync
         // and GetStreamMetadataAsync via PcStreamsRowReader so all three sites
         // stay aligned when pc_streams' shape evolves.
+        var tenantFilter = tenantId == null ? "" : "WHERE tenant_id = @tenant_id\n            ";
         cmd.CommandText = $"""
             SELECT TOP (@count) {PcStreamsRowReader.SelectColumns}
             FROM {Events.StreamsTableName}
-            ORDER BY timestamp DESC;
+            {tenantFilter}ORDER BY timestamp DESC;
             """;
         cmd.Parameters.AddWithValue("@count", count);
+        if (tenantId != null) cmd.Parameters.AddWithValue("@tenant_id", tenantId);
 
         await using var reader = await session.ExecuteReaderAsync(cmd, ct);
         while (await reader.ReadAsync(ct))
@@ -56,8 +67,16 @@ public partial class DocumentStore
         return results;
     }
 
+    IAsyncEnumerable<EventRecord> IEventStore.ReadStreamAsync(string streamId, CancellationToken ct)
+        => ((IEventStore)this).ReadStreamAsync(streamId, null, ct);
+
+    // #782 / jasperfx#503 — tenant-scoped stream read. On a conjoined multi-tenant Polecat
+    // store the same stream id can exist under two tenants; the tenant-less overload reads
+    // across every tenant and returns their ambiguous union. A non-null tenantId filters the
+    // read to that tenant's rows via a tenant_id predicate. Null preserves the store-global
+    // read. (See the GetRecentStreamsAsync note on the database-per-tenant boundary.)
     async IAsyncEnumerable<EventRecord> IEventStore.ReadStreamAsync(
-        string streamId, [EnumeratorCancellation] CancellationToken ct)
+        string streamId, string? tenantId, [EnumeratorCancellation] CancellationToken ct)
     {
         ArgumentException.ThrowIfNullOrEmpty(streamId);
 
@@ -79,13 +98,15 @@ public partial class DocumentStore
         // (dotnet_type, is_archived, correlation_id, causation_id) per the
         // polecat#57 Q2 design note — wire cost is negligible against the
         // readability of one canonical projection.
+        var tenantFilter = tenantId == null ? "" : "AND tenant_id = @tenant_id\n            ";
         cmd.CommandText = $"""
             SELECT {PcEventsRowReader.ComposeSelectColumns(Events.EventOptions)}
             FROM {Events.EventsTableName}
             WHERE stream_id = @stream_id
-            ORDER BY version;
+            {tenantFilter}ORDER BY version;
             """;
         cmd.Parameters.AddWithValue("@stream_id", resolvedStreamId);
+        if (tenantId != null) cmd.Parameters.AddWithValue("@tenant_id", tenantId);
 
         var ctx = new EventHydrationContext(
             Events,


### PR DESCRIPTION
Fixes #351 (conjoined half).

Polecat's `IEventStore` explorer surface implemented **none** of the jasperfx#503 tenant-scoped read overloads — they fell through to the throwing interface default on a non-null tenant. This adds the two stream reads:

- `ReadStreamAsync(string streamId, string? tenantId, CancellationToken ct)`
- `GetRecentStreamsAsync(int count, string? tenantId, CancellationToken ct)`

### Approach
`pc_streams` / `pc_events` carry a `tenant_id` column, so the conjoined case is a `WHERE tenant_id = @tenant_id` predicate on the same `QuerySession()` the tenant-less reads use. A null tenant delegates to the tenant-less overload (byte-identical to today); the tenant-less overloads become thin delegators.

### Why
On a conjoined multi-tenant store the same stream id can exist under two tenants, so the tenant-less read returns an ambiguous cross-tenant union. These overloads isolate a single tenant's slice.

### Tests
A new `Polecat.Tests` isolation test (`event_store_explorer_tenant_isolation_tests`) covers read-stream + recent-streams under two tenants on a conjoined store.

> ⚠️ **Local test execution was infra-blocked**: on my machine the SQL Server test container timed out on schema DDL under concurrent load — this fails *all* existing Polecat explorer tests at `DefaultStoreFixture.InitializeAsync`, not just these, so it's environmental, not the change. The change builds clean, and the **identical approach is green in the companion Marten PR** (JasperFx/marten#5020, 16/16 explorer tests). Please let CI validate.

### Scope note
Database-per-tenant explorer scoping remains a separate, broader gap (the tenant-less reads open a default `QuerySession()` and don't resolve per-database). `GetStreamMetadataAsync` / `GetProjectionStatusesAsync` tenant overloads should follow the same shape.

### Consumer
CritterWatch's Event Store Explorer — JasperFx/CritterWatch#782. Companions: marten#5020, jasperfx#555.

🤖 Generated with [Claude Code](https://claude.com/claude-code)