### PR TITLE
Tenant-scoped event/tag explorer reads (#353)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -27,8 +27,8 @@
              RestartHighWaterAgentAsync; DaemonSettings.HighWaterStalenessThreshold; ShardAction.Faulted/
              Restarted). Foundation for the Phase 2 high-water health check (polecat#341). Also carries
              the jasperfx#540 faulted-start teardown that first shipped in 2.32.0. -->
-        <PackageVersion Include="JasperFx" Version="2.33.1" />
-        <PackageVersion Include="JasperFx.Events" Version="2.33.1" />
+        <PackageVersion Include="JasperFx" Version="2.34.0" />
+        <PackageVersion Include="JasperFx.Events" Version="2.34.0" />
         <!-- Pin the sibling JasperFx packages for parity with Marten 9's matrix
              even though Polecat doesn't currently reference them directly —
              keeps the lockstep matrix coherent when transitive resolution
@@ -36,7 +36,7 @@
              RuntimeCompiler 5.x line is the active continuation of the 4.x
              lineage; do not pin against the parallel stale 2.0.x series. -->
         <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.33.1" />
+        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.34.0" />
         <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
@@ -81,7 +81,7 @@
         <PackageVersion Include="StronglyTypedId" Version="1.0.0-beta08" />
 
         <!-- Source generators (matched to JasperFx.Events above) -->
-        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.33.1" />
+        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.34.0" />
 
         <!-- Build automation -->
         <PackageVersion Include="Nuke.Common" Version="9.0.4" />

--- a/src/Polecat.Tests/Diagnostics/tenant_scoped_explorer_reads_tests.cs
+++ b/src/Polecat.Tests/Diagnostics/tenant_scoped_explorer_reads_tests.cs
@@ -1,0 +1,117 @@
+using JasperFx.Descriptors;
+using JasperFx.Events;
+using JasperFx.Events.Aggregation;
+using JasperFx.Events.Tags;
+using Polecat.Tests.Events;
+using Polecat.Tests.Harness;
+
+namespace Polecat.Tests.ExplorerApi;
+
+/// <summary>
+///     #353 / jasperfx#555 — the second pair of explorer read paths jasperfx#503 left untenanted, now
+///     tenant-scoped for a conjoined store: the DCB tag query (QueryByTagsAsync) and the event/metadata
+///     query (EventQuery.TenantId). On a conjoined store the same tag value / the same event can exist
+///     under two tenants, so an untenanted query reads an ambiguous cross-tenant union; these overloads
+///     isolate each tenant's slice via a tenant_id predicate.
+/// </summary>
+public class tenant_scoped_explorer_reads_tests : OneOffConfigurationsContext
+{
+    private const string RedTenant = "Red";
+    private const string BlueTenant = "Blue";
+
+    private void ConfigureConjoinedStoreWithTags()
+    {
+        ConfigureStore(opts =>
+        {
+            opts.Events.TenancyStyle = TenancyStyle.Conjoined;
+            opts.Events.RegisterTagType<StudentId>("student")
+                .ForAggregate<StudentCourseEnrollment>();
+            opts.Events.RegisterTagType<CourseId>("course")
+                .ForAggregate<StudentCourseEnrollment>();
+        });
+    }
+
+    [Fact]
+    public async Task query_by_tags_is_isolated_per_tenant_on_conjoined_store()
+    {
+        ConfigureConjoinedStoreWithTags();
+        await theDatabase.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        // The SAME tag values are attached to an event under each tenant — the exact cross-tenant
+        // ambiguity #353 closes for the DCB tag query.
+        var studentId = new StudentId(Guid.NewGuid());
+        var courseId = new CourseId(Guid.NewGuid());
+
+        var redStream = Guid.NewGuid();
+        var blueStream = Guid.NewGuid();
+
+        await using (var red = theStore.LightweightSession(new SessionOptions { TenantId = RedTenant }))
+        {
+            var e = red.Events.BuildEvent(new StudentEnrolled("Alice", "Math"));
+            e.WithTag(studentId, courseId);
+            red.Events.Append(redStream, e);
+            await red.SaveChangesAsync();
+        }
+
+        await using (var blue = theStore.LightweightSession(new SessionOptions { TenantId = BlueTenant }))
+        {
+            var e = blue.Events.BuildEvent(new StudentEnrolled("Bob", "Science"));
+            e.WithTag(studentId, courseId);
+            blue.Events.Append(blueStream, e);
+            await blue.SaveChangesAsync();
+        }
+
+        var explorer = (IEventStore)theStore;
+        var tags = new Dictionary<string, string> { ["StudentId"] = studentId.Value.ToString() };
+
+        var redEvents = new List<EventRecord>();
+        await foreach (var e in explorer.QueryByTagsAsync(tags, RedTenant, CancellationToken.None))
+            redEvents.Add(e);
+
+        var blueEvents = new List<EventRecord>();
+        await foreach (var e in explorer.QueryByTagsAsync(tags, BlueTenant, CancellationToken.None))
+            blueEvents.Add(e);
+
+        redEvents.Count.ShouldBe(1);
+        redEvents.ShouldAllBe(e => e.TenantId == RedTenant);
+        redEvents[0].StreamId.ShouldBe(redStream.ToString());
+
+        blueEvents.Count.ShouldBe(1);
+        blueEvents.ShouldAllBe(e => e.TenantId == BlueTenant);
+        blueEvents[0].StreamId.ShouldBe(blueStream.ToString());
+    }
+
+    [Fact]
+    public async Task query_events_honours_event_query_tenant_id_on_conjoined_store()
+    {
+        ConfigureConjoinedStoreWithTags();
+        await theDatabase.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        await using (var red = theStore.LightweightSession(new SessionOptions { TenantId = RedTenant }))
+        {
+            red.Events.StartStream<StudentCourseEnrollment>(Guid.NewGuid(), new StudentEnrolled("Alice", "Math"));
+            red.Events.StartStream<StudentCourseEnrollment>(Guid.NewGuid(), new StudentEnrolled("Amy", "Math"));
+            await red.SaveChangesAsync();
+        }
+
+        await using (var blue = theStore.LightweightSession(new SessionOptions { TenantId = BlueTenant }))
+        {
+            blue.Events.StartStream<StudentCourseEnrollment>(Guid.NewGuid(), new StudentEnrolled("Bob", "Science"));
+            await blue.SaveChangesAsync();
+        }
+
+        // EventQuery.TenantId scopes the read-store query. TenantIsOneOf overrides the implicit
+        // session-tenant filter, so a default read store isolates whichever tenant the query names.
+        var readStore = ((IEventStore)theStore).OpenReadOnlyEventStore();
+
+        var redPage = await readStore.QueryEventsAsync(
+            new EventQuery { TenantId = RedTenant, PageSize = 100 }, CancellationToken.None);
+        redPage.TotalCount.ShouldBe(2);
+        redPage.Events.ShouldAllBe(e => e.TenantId == RedTenant);
+
+        var bluePage = await readStore.QueryEventsAsync(
+            new EventQuery { TenantId = BlueTenant, PageSize = 100 }, CancellationToken.None);
+        bluePage.TotalCount.ShouldBe(1);
+        bluePage.Events.ShouldAllBe(e => e.TenantId == BlueTenant);
+    }
+}

--- a/src/Polecat/DocumentStore.EventStoreExplorer.cs
+++ b/src/Polecat/DocumentStore.EventStoreExplorer.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
+using System.Text;
 using System.Text.Json;
 using JasperFx.Descriptors;
 using JasperFx.Events;
@@ -150,6 +151,97 @@ public partial class DocumentStore
         throw new NotSupportedException(
             "DCB tag-set queries are not yet supported on Polecat. " +
             "Tracked at https://github.com/JasperFx/polecat/issues — see the CritterWatch master plan for the DCB roadmap.");
+    }
+
+    /// <summary>
+    ///     #353 / jasperfx#555 — tenant-scoped DCB tag query, companion to the jasperfx#503 stream reads.
+    ///     On a conjoined multi-tenant store the same tag value can be attached to events living under two
+    ///     tenants, so an untenanted query reads an ambiguous cross-tenant union. This overload isolates a
+    ///     single tenant with an <c>e.tenant_id</c> predicate on pc_events, AND-combining a <c>seq_id</c>
+    ///     sub-select per requested tag (matching the Marten companion's shape).
+    ///     <para>
+    ///     Scope here is the conjoined single-database <c>tenant_id</c>-predicate path only. A null
+    ///     <paramref name="tenantId"/> delegates to the tenant-less overload — still a NotSupportedException,
+    ///     because store-global DCB tag queries are a separate, pre-existing Polecat gap. Database-per-tenant
+    ///     explorer scoping is likewise a pre-existing Polecat gap (the stream-read explorer methods don't
+    ///     open a per-database session either); when that lands, this method grows the same
+    ///     FindOrCreateDatabase branch its Marten counterpart already uses.
+    ///     </para>
+    /// </summary>
+    async IAsyncEnumerable<EventRecord> IEventStore.QueryByTagsAsync(
+        IReadOnlyDictionary<string, string> tags,
+        string? tenantId,
+        [EnumeratorCancellation] CancellationToken ct)
+    {
+        if (tenantId == null)
+        {
+            // Store-global tag query is not yet supported on Polecat — defer to the tenant-less overload,
+            // which throws NotSupportedException as soon as this iterator is enumerated.
+            await foreach (var e in ((IEventStore)this).QueryByTagsAsync(tags, ct).ConfigureAwait(false))
+            {
+                yield return e;
+            }
+
+            yield break;
+        }
+
+        ArgumentNullException.ThrowIfNull(tags);
+        if (tags.Count == 0) yield break;
+
+        var schema = Events.DatabaseSchemaName;
+        var options = Events.EventOptions;
+        var registered = Events.TagTypes;
+
+        // #148: run through a QuerySession so the command is covered by Options.ResiliencePipeline (Polly),
+        // like the rest of the explorer read path. The e.tenant_id predicate below — not the session's own
+        // tenant — does the scoping, matching how the other explorer reads run raw SQL over every tenant.
+        await using var session = (Internal.QuerySession)QuerySession();
+        await using var cmd = new SqlCommand();
+
+        var sb = new StringBuilder();
+        sb.Append(
+            $"SELECT {PcEventsRowReader.ComposeSelectColumnsWithAlias(options, "e")} FROM {Events.EventsTableName} e WHERE ");
+
+        var idx = 0;
+        foreach (var (tagName, tagValue) in tags)
+        {
+            var registration = registered.FirstOrDefault(r =>
+                string.Equals(r.TagType.Name, tagName, StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(r.TableSuffix, tagName, StringComparison.OrdinalIgnoreCase));
+            if (registration == null)
+            {
+                throw new ArgumentException(
+                    $"Tag type '{tagName}' is not registered on this event store. Registered tag types: {string.Join(", ", registered.Select(t => t.TagType.Name))}",
+                    nameof(tags));
+            }
+
+            if (idx > 0) sb.Append(" AND ");
+
+            // A seq_id sub-select per tag, AND-combined: the event must carry every requested tag. The tag
+            // value arrives as a string from the explorer, so it's compared case-insensitively via nvarchar —
+            // matching whatever native type (uniqueidentifier, etc.) the tag's value column stores.
+            sb.Append(
+                $"e.seq_id IN (SELECT seq_id FROM [{schema}].[pc_event_tag_{registration.TableSuffix}] WHERE LOWER(CONVERT(nvarchar(4000), value)) = LOWER(@tag_value_{idx}))");
+            cmd.Parameters.AddWithValue($"@tag_value_{idx}", tagValue);
+            idx++;
+        }
+
+        sb.Append(" AND e.tenant_id = @tenant_id ORDER BY e.seq_id");
+        cmd.Parameters.AddWithValue("@tenant_id", tenantId);
+        cmd.CommandText = sb.ToString();
+
+        var ctx = new EventHydrationContext(
+            Events,
+            Options.Serializer,
+            streamId: string.Empty,
+            defaultTenantId: tenantId);
+        var slots = MetadataSlots.Compute(options);
+
+        await using var reader = await session.ExecuteReaderAsync(cmd, ct);
+        while (await reader.ReadAsync(ct))
+        {
+            yield return PcEventsRowReader.ReadEventRecord(reader, ctx, slots);
+        }
     }
 
     Task<DcbProjectedState?> IEventStore.GetProjectedStateForTagsAsync(

--- a/src/Polecat/Events/Internal/PcEventsRowReader.cs
+++ b/src/Polecat/Events/Internal/PcEventsRowReader.cs
@@ -83,6 +83,25 @@ internal static class PcEventsRowReader
     }
 
     /// <summary>
+    ///     <see cref="ComposeSelectColumns"/> with every column qualified by the supplied table
+    ///     <paramref name="alias"/>. Needed by any read that JOINs pc_events against another table
+    ///     (e.g. the DCB tag query joining pc_event_tag_*, which shares the <c>seq_id</c> /
+    ///     <c>tenant_id</c> column names), where a bare column list would be ambiguous. The column
+    ///     ORDER is identical to <see cref="ComposeSelectColumns"/> so <see cref="ReadEventRecord"/>
+    ///     and the IEvent readers keep reading by the same ordinals.
+    /// </summary>
+    internal static string ComposeSelectColumnsWithAlias(EventStoreOptions options, string alias)
+    {
+        var sb = new StringBuilder(
+            $"{alias}.seq_id, {alias}.id, {alias}.stream_id, {alias}.version, {alias}.data, {alias}.type, {alias}.timestamp, {alias}.tenant_id, {alias}.dotnet_type, {alias}.is_archived");
+        if (options.EnableCorrelationId) sb.Append($", {alias}.correlation_id");
+        if (options.EnableCausationId) sb.Append($", {alias}.causation_id");
+        if (options.EnableHeaders) sb.Append($", {alias}.headers");
+        if (options.EnableUserName) sb.Append($", {alias}.user_name");
+        return sb.ToString();
+    }
+
+    /// <summary>
     ///     Read the row the reader is positioned on into a fully-hydrated
     ///     <see cref="IEvent"/>, assuming the active store uses
     ///     <see cref="StreamIdentity.AsGuid"/>. Caller selects between this

--- a/src/Polecat/Events/QueryEventStore.cs
+++ b/src/Polecat/Events/QueryEventStore.cs
@@ -58,6 +58,16 @@ internal class QueryEventStore : IQueryEventStore, IReadOnlyEventStore
     {
         IQueryable<IEvent> queryable = QueryAllRawEvents();
 
+        // #353 / jasperfx#555 — honour the tenant scope the Event Explorer sets. On a conjoined
+        // multi-tenant store the same event can exist under two tenants, so the Explorer sets
+        // EventQuery.TenantId to isolate one; TenantIsOneOf overrides the implicit session-tenant filter
+        // the event LINQ provider adds for conjoined stores. A null TenantId is left untouched, preserving
+        // the pre-existing per-session-tenant paging contract.
+        if (query.TenantId != null)
+        {
+            queryable = queryable.TenantIsOneOf(query.TenantId);
+        }
+
         if (query.EventTypeName != null)
         {
             queryable = queryable.Where(e => e.EventTypeName == query.EventTypeName);


### PR DESCRIPTION
Closes #353. Companion to JasperFx/marten#5021.

Bumps `JasperFx` / `JasperFx.Events` 2.33.1 → **2.34.0** to consume **jasperfx#555** (the two remaining tenant-scoped explorer read paths jasperfx#503 left untenanted), then implements them for a conjoined Polecat store.

On a conjoined store the same tag value / the same event can exist under two tenants, so an untenanted query reads an ambiguous cross-tenant union — the class of bug jasperfx#503 fixed for the stream reads.

## Scope (conjoined `tenant_id`-predicate path)

- **`QueryByTagsAsync(tags, tenantId, ct)`** override in `DocumentStore.EventStoreExplorer.cs` (previously the tenant-less overload was a `NotSupportedException` stub). The conjoined path AND-combines a `seq_id` sub-select per requested tag over `pc_events` and bounds the scan with an `e.tenant_id` predicate. The tag value arrives as a string, so it's compared case-insensitively via `nvarchar` to match whatever native type (`uniqueidentifier`, etc.) the tag column stores.
  - **null tenant** → delegates to the tenant-less overload (still `NotSupportedException` — store-global DCB tag queries are a separate Polecat gap).
  - **database-per-tenant** explorer scoping is a pre-existing Polecat gap (the stream-read explorer methods don't open a per-database session either) — called out in code as the follow-up its Marten counterpart already handles.
- **`EventQuery.TenantId`** honoured in `QueryEventStore.QueryEventsAsync`: a set tenant scopes the read with `TenantIsOneOf` (overriding the implicit session-tenant filter the event LINQ provider adds); a **null** tenant is left untouched, preserving the pre-existing per-session-tenant paging contract.
- **`PcEventsRowReader.ComposeSelectColumnsWithAlias`**: alias-qualified column list (identical ORDER to `ComposeSelectColumns`) so the tag query's JOIN — where `seq_id` / `tenant_id` column names are shared with `pc_event_tag_*` — is unambiguous while `ReadEventRecord` keeps reading by the same ordinals.

## Tests

Same tag / same event under two tenants on a conjoined store reads each tenant's slice in isolation. Local run (SQL Server 2025): new tests 2/2, existing explorer 12/12, metadata-filter 15/15, conjoined-DCB 13/13 — all green.

## Companion

- Abstraction: jasperfx#555 (shipped in JasperFx.Events 2.34.0)
- Marten parity: JasperFx/marten#5021
- Consumer: CritterWatch #798 §4

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JQ9NHbg31EWJmrQK9EN6i8