### PR TITLE
feat(#355): StreamPaged<T> — paged JSON envelope in one round trip (marten#5014 parity)

### DIFF
--- a/docs/documents/aspnetcore.md
+++ b/docs/documents/aspnetcore.md
@@ -20,6 +20,7 @@ that dispatch any `IResult` return value), Polecat.AspNetCore ships three typed 
 | --- | --- | --- | --- |
 | `StreamOne<T>` | `IQueryable<T>` — document query | Single `T` | yes |
 | `StreamMany<T>` | `IQueryable<T>` — document query | JSON array `T[]` | no (empty array = 200) |
+| `StreamPaged<T>` | `IQueryable<T>` + page number/size | Paged JSON envelope | no (empty page = 200) |
 | `StreamAggregate<T>` | `IQuerySession` + stream id — event-sourced | Single `T` | yes |
 
 Each type implements both `IResult` (so ASP.NET dispatches it via `ExecuteAsync`) and
@@ -46,6 +47,48 @@ app.MapGet("/issues/open",
 
 Returns `200 application/json` with a JSON array body. An empty result set yields `[]`,
 not a 404.
+
+### StreamPaged — one page of documents plus paging metadata
+
+```csharp
+app.MapGet("/issues/paged/{pageNumber:int}/{pageSize:int}",
+    (int pageNumber, int pageSize, IQuerySession session) =>
+        new StreamPaged<Issue>(
+            session.Query<Issue>().OrderBy(x => x.Number), pageNumber, pageSize));
+```
+
+Streams a single page of documents **plus** paging metadata as one JSON envelope in a
+**single database round trip** — the total row count rides along on every row via
+`COUNT(*) OVER()`, so there is no separate `COUNT` query. Raw persisted document JSON is
+streamed straight into `items` with no deserialize/reserialize:
+
+```json
+{"pageNumber":3,"pageSize":25,"totalItemCount":1207,"pageCount":49,
+ "hasNextPage":true,"hasPreviousPage":true,"items":[...]}
+```
+
+The envelope key names and shape are byte-for-byte identical to Marten's `StreamPaged`, so
+clients are interchangeable across the two stores. Include an `OrderBy` on the query for a
+stable page order (SQL Server requires an `ORDER BY` for `OFFSET/FETCH` paging).
+
+`pageNumber` is 1-based; both `pageNumber` and `pageSize` must be `>= 1` (otherwise an
+`ArgumentOutOfRangeException` is thrown). An empty match — or paging past the end of the set
+— yields `totalItemCount: 0`, `pageCount: 0`, `items: []`.
+
+::: warning
+Paging **past the end of a non-empty set** (e.g. 10 items, page 5 of size 3 → `OFFSET 12`)
+returns zero rows, so the window-function total is lost and the envelope reports
+`totalItemCount: 0` even though items exist. This matches `PagedList`/Marten behavior; page
+within range to get an accurate total.
+:::
+
+The same one-round-trip envelope is available off any Polecat `IQueryable<T>` without ASP.NET
+Core via `StreamPagedJsonArray`:
+
+```csharp
+await session.Query<Issue>().OrderBy(x => x.Number)
+    .StreamPagedJsonArray(pageNumber, pageSize, destinationStream);
+```
 
 ### StreamAggregate — event-sourced aggregate (latest)
 
@@ -119,8 +162,8 @@ app.MapPost("/issues",
 ```
 
 ::: tip
-`StreamOne<T>` streams the raw persisted document JSON straight through (no
-deserialize/reserialize). `StreamMany<T>` and `StreamAggregate<T>` materialize via the
-regular query/projection path and serialize through `System.Text.Json`. All of them
-eliminate the endpoint boilerplate (null-check, status code, content type, OpenAPI metadata).
+`StreamOne<T>` and `StreamPaged<T>` stream the raw persisted document JSON straight through
+(no deserialize/reserialize). `StreamMany<T>` and `StreamAggregate<T>` materialize via the
+regular query/projection path and serialize through `System.Text.Json`. All of them eliminate
+the endpoint boilerplate (null-check, status code, content type, OpenAPI metadata).
 :::

--- a/src/Polecat.AspNetCore.Testing/Program.cs
+++ b/src/Polecat.AspNetCore.Testing/Program.cs
@@ -33,6 +33,12 @@ app.MapGet("/api/issues/{id:guid}", async (Guid id, IQuerySession session) =>
 app.MapGet("/api/issues", async (IQuerySession session) =>
     new StreamMany<StreamingIssue>(session.Query<StreamingIssue>()));
 
+// StreamPaged endpoint — returns one page of documents plus paging metadata in one round trip
+app.MapGet("/api/issues/paged/{pageNumber:int}/{pageSize:int}",
+    (int pageNumber, int pageSize, IQuerySession session) =>
+        new StreamPaged<StreamingIssue>(
+            session.Query<StreamingIssue>().OrderBy(x => x.Number), pageNumber, pageSize));
+
 // StreamAggregate endpoint — returns latest aggregate state or 404
 app.MapGet("/api/aggregates/{id:guid}", async (Guid id, IQuerySession session) =>
     new StreamAggregate<StreamingQuestParty>(session, id));
@@ -57,6 +63,9 @@ namespace Polecat.AspNetCore.Testing
         public Guid Id { get; set; }
         public string Title { get; set; } = "";
         public bool IsOpen { get; set; } = true;
+
+        // Stable ordering key for paged streaming endpoints.
+        public int Number { get; set; }
     }
 
     // Aggregate type for StreamAggregate tests

--- a/src/Polecat.AspNetCore.Testing/stream_paged_tests.cs
+++ b/src/Polecat.AspNetCore.Testing/stream_paged_tests.cs
@@ -1,0 +1,102 @@
+using System.Text.Json;
+using Alba;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Xunit;
+
+namespace Polecat.AspNetCore.Testing;
+
+/// <summary>
+///     Alba HTTP coverage for the <c>StreamPaged&lt;T&gt;</c> minimal-API result over
+///     <c>/api/issues/paged/{pageNumber}/{pageSize}</c> (marten#5014 parity, polecat#355).
+///     Each scenario asserts 200, application/json, and the deserialized envelope shape.
+/// </summary>
+public class stream_paged_tests : IAsyncLifetime
+{
+    private IAlbaHost _host = null!;
+
+    public async Task InitializeAsync()
+    {
+        _host = await AlbaHost.For<Program>();
+
+        var store = (DocumentStore)_host.Services.GetRequiredService<IDocumentStore>();
+        await store.Database.ApplyAllConfiguredChangesToDatabaseAsync();
+        await store.Advanced.CleanAllDocumentsAsync();
+
+        await using var session = store.LightweightSession();
+        for (var i = 0; i < 10; i++)
+        {
+            session.Store(new StreamingIssue { Id = Guid.NewGuid(), Title = $"Issue {i}", Number = i });
+        }
+
+        await session.SaveChangesAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _host.DisposeAsync();
+    }
+
+    private async Task<JsonElement> GetPageAsync(int pageNumber, int pageSize)
+    {
+        var result = await _host.Scenario(s =>
+        {
+            s.Get.Url($"/api/issues/paged/{pageNumber}/{pageSize}");
+            s.StatusCodeShouldBe(200);
+            s.ContentTypeShouldBe("application/json");
+        });
+
+        return JsonDocument.Parse(result.ReadAsText()).RootElement.Clone();
+    }
+
+    private static int[] ItemNumbers(JsonElement envelope) =>
+        envelope.GetProperty("items").EnumerateArray()
+            .Select(x => x.GetProperty("number").GetInt32())
+            .ToArray();
+
+    [Fact]
+    public async Task first_page()
+    {
+        var envelope = await GetPageAsync(1, 3);
+
+        envelope.GetProperty("pageNumber").GetInt32().ShouldBe(1);
+        envelope.GetProperty("pageSize").GetInt32().ShouldBe(3);
+        envelope.GetProperty("totalItemCount").GetInt32().ShouldBe(10);
+        envelope.GetProperty("pageCount").GetInt32().ShouldBe(4);
+        envelope.GetProperty("hasNextPage").GetBoolean().ShouldBeTrue();
+        envelope.GetProperty("hasPreviousPage").GetBoolean().ShouldBeFalse();
+        ItemNumbers(envelope).ShouldBe([0, 1, 2]);
+    }
+
+    [Fact]
+    public async Task middle_page()
+    {
+        var envelope = await GetPageAsync(2, 3);
+
+        envelope.GetProperty("hasNextPage").GetBoolean().ShouldBeTrue();
+        envelope.GetProperty("hasPreviousPage").GetBoolean().ShouldBeTrue();
+        ItemNumbers(envelope).ShouldBe([3, 4, 5]);
+    }
+
+    [Fact]
+    public async Task last_partial_page()
+    {
+        var envelope = await GetPageAsync(4, 3);
+
+        envelope.GetProperty("hasNextPage").GetBoolean().ShouldBeFalse();
+        envelope.GetProperty("hasPreviousPage").GetBoolean().ShouldBeTrue();
+        ItemNumbers(envelope).ShouldBe([9]);
+    }
+
+    [Fact]
+    public async Task single_page()
+    {
+        var envelope = await GetPageAsync(1, 25);
+
+        envelope.GetProperty("totalItemCount").GetInt32().ShouldBe(10);
+        envelope.GetProperty("pageCount").GetInt32().ShouldBe(1);
+        envelope.GetProperty("hasNextPage").GetBoolean().ShouldBeFalse();
+        envelope.GetProperty("hasPreviousPage").GetBoolean().ShouldBeFalse();
+        envelope.GetProperty("items").GetArrayLength().ShouldBe(10);
+    }
+}

--- a/src/Polecat.AspNetCore/StreamPaged.cs
+++ b/src/Polecat.AspNetCore/StreamPaged.cs
@@ -1,0 +1,88 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Metadata;
+using Polecat.Linq;
+
+namespace Polecat.AspNetCore;
+
+/// <summary>
+/// Minimal-API endpoint return value that streams a single page of Polecat documents plus
+/// paging metadata as one JSON envelope directly to the HTTP response, in a single database
+/// round trip.
+/// <para>
+/// The envelope shape is byte-for-byte identical to Marten's <c>StreamPaged</c> so clients
+/// are interchangeable:
+/// <code>
+/// {"pageNumber":3,"pageSize":25,"totalItemCount":1207,"pageCount":49,
+///  "hasNextPage":true,"hasPreviousPage":true,"items":[...]}
+/// </code>
+/// The <c>items</c> array carries raw persisted document JSON — no deserialize/reserialize.
+/// </para>
+/// <para>
+/// Unlike <see cref="StreamOne{T}"/>, this type never returns 404: an empty page yields a
+/// well-formed envelope with <c>totalItemCount: 0</c>, <c>pageCount: 0</c> and <c>items: []</c>.
+/// </para>
+/// </summary>
+/// <typeparam name="T">The document type contained in the page.</typeparam>
+public sealed class StreamPaged<T> : IResult, IEndpointMetadataProvider
+{
+    private readonly IQueryable<T> _queryable;
+    private readonly int _pageNumber;
+    private readonly int _pageSize;
+
+    /// <summary>
+    /// Create a <see cref="StreamPaged{T}"/> over a Polecat <see cref="IQueryable{T}"/>.
+    /// Include an <c>OrderBy</c> on the queryable for a stable page order.
+    /// </summary>
+    /// <param name="queryable">The (optionally filtered/ordered) query to page.</param>
+    /// <param name="pageNumber">1-based page number. Must be &gt;= 1.</param>
+    /// <param name="pageSize">Page size. Must be &gt;= 1.</param>
+    public StreamPaged(IQueryable<T> queryable, int pageNumber, int pageSize)
+    {
+        _queryable = queryable ?? throw new ArgumentNullException(nameof(queryable));
+        _pageNumber = pageNumber;
+        _pageSize = pageSize;
+    }
+
+    /// <summary>
+    /// Status code written with the response. Defaults to 200.
+    /// </summary>
+    public int OnFoundStatus { get; init; } = StatusCodes.Status200OK;
+
+    /// <summary>
+    /// Response content type. Defaults to <c>application/json</c>.
+    /// </summary>
+    public string ContentType { get; init; } = "application/json";
+
+    /// <inheritdoc />
+    [UnconditionalSuppressMessage("Trimming", "IL2046",
+        Justification = "IResult.ExecuteAsync is not RUC-annotated; the contract lives on this override.")]
+    [UnconditionalSuppressMessage("AOT", "IL3051",
+        Justification = "IResult.ExecuteAsync is not RDC-annotated; the contract lives on this override.")]
+    [RequiresDynamicCode("StreamPaged<T>.ExecuteAsync routes through the Polecat LINQ provider, which closes generic handler types over T via MakeGenericType.")]
+    [RequiresUnreferencedCode("StreamPaged<T>.ExecuteAsync routes through the Polecat LINQ provider, which reflects over T. AOT consumers must preserve T's members through DynamicallyAccessedMembers or source generation.")]
+    public async Task ExecuteAsync(HttpContext httpContext)
+    {
+        ArgumentNullException.ThrowIfNull(httpContext);
+
+        httpContext.Response.StatusCode = OnFoundStatus;
+        httpContext.Response.ContentType = ContentType;
+
+        await _queryable.StreamPagedJsonArray(_pageNumber, _pageSize, httpContext.Response.Body,
+            httpContext.RequestAborted);
+    }
+
+    /// <summary>
+    /// Populates endpoint metadata so OpenAPI advertises a <c>200</c> JSON response.
+    /// No 404 is advertised because an empty page is a valid response.
+    /// </summary>
+    public static void PopulateMetadata(MethodInfo method, EndpointBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.Metadata.Add(new ProducesResponseTypeMetadata(
+            StatusCodes.Status200OK, typeof(object), ["application/json"]));
+    }
+}

--- a/src/Polecat.Tests/Linq/stream_paged_tests.cs
+++ b/src/Polecat.Tests/Linq/stream_paged_tests.cs
@@ -1,0 +1,176 @@
+using System.Text.Json;
+using Polecat.Linq;
+using Polecat.Tests.Harness;
+
+namespace Polecat.Tests.Linq;
+
+/// <summary>
+///     Unit-level coverage for <see cref="JsonQueryExtensions.StreamPagedJsonArray{T}"/> — the
+///     paged JSON envelope streamed in one round trip (marten#5014 parity, polecat#355). Each test
+///     isolates its own document set behind a unique color filter so the running-total window
+///     (COUNT(*) OVER()) counts only that set on the shared integration schema.
+/// </summary>
+[Collection("integration")]
+public class stream_paged_tests : IntegrationContext
+{
+    public stream_paged_tests(DefaultStoreFixture fixture) : base(fixture)
+    {
+    }
+
+    private async Task<string> SeedTargetsAsync(int count)
+    {
+        var color = $"Paged_{Guid.NewGuid():N}";
+        for (var i = 0; i < count; i++)
+        {
+            theSession.Store(new Target { Id = Guid.NewGuid(), Color = color, Number = i });
+        }
+
+        await theSession.SaveChangesAsync();
+        return color;
+    }
+
+    private async Task<JsonDocument> StreamPageAsync(string color, int pageNumber, int pageSize)
+    {
+        await using var query = theStore.QuerySession();
+        using var stream = new MemoryStream();
+        await query.Query<Target>()
+            .Where(t => t.Color == color)
+            .OrderBy(t => t.Number)
+            .StreamPagedJsonArray(pageNumber, pageSize, stream);
+
+        stream.Position = 0;
+        return await JsonDocument.ParseAsync(stream);
+    }
+
+    private static int[] ItemNumbers(JsonDocument doc) =>
+        doc.RootElement.GetProperty("items").EnumerateArray()
+            .Select(x => x.GetProperty("number").GetInt32())
+            .ToArray();
+
+    [Fact]
+    public async Task stream_paged_json_array_first_page()
+    {
+        var color = await SeedTargetsAsync(10);
+
+        using var doc = await StreamPageAsync(color, 1, 3);
+        var root = doc.RootElement;
+
+        root.GetProperty("pageNumber").GetInt32().ShouldBe(1);
+        root.GetProperty("pageSize").GetInt32().ShouldBe(3);
+        root.GetProperty("totalItemCount").GetInt32().ShouldBe(10);
+        root.GetProperty("pageCount").GetInt32().ShouldBe(4);
+        root.GetProperty("hasNextPage").GetBoolean().ShouldBeTrue();
+        root.GetProperty("hasPreviousPage").GetBoolean().ShouldBeFalse();
+        ItemNumbers(doc).ShouldBe([0, 1, 2]);
+    }
+
+    [Fact]
+    public async Task stream_paged_json_array_middle_page()
+    {
+        var color = await SeedTargetsAsync(10);
+
+        using var doc = await StreamPageAsync(color, 2, 3);
+        var root = doc.RootElement;
+
+        root.GetProperty("hasNextPage").GetBoolean().ShouldBeTrue();
+        root.GetProperty("hasPreviousPage").GetBoolean().ShouldBeTrue();
+        ItemNumbers(doc).ShouldBe([3, 4, 5]);
+    }
+
+    [Fact]
+    public async Task stream_paged_json_array_last_partial_page()
+    {
+        var color = await SeedTargetsAsync(10);
+
+        using var doc = await StreamPageAsync(color, 4, 3);
+        var root = doc.RootElement;
+
+        root.GetProperty("totalItemCount").GetInt32().ShouldBe(10);
+        root.GetProperty("pageCount").GetInt32().ShouldBe(4);
+        root.GetProperty("hasNextPage").GetBoolean().ShouldBeFalse();
+        root.GetProperty("hasPreviousPage").GetBoolean().ShouldBeTrue();
+        ItemNumbers(doc).ShouldBe([9]);
+    }
+
+    [Fact]
+    public async Task stream_paged_json_array_single_page()
+    {
+        var color = await SeedTargetsAsync(5);
+
+        using var doc = await StreamPageAsync(color, 1, 25);
+        var root = doc.RootElement;
+
+        root.GetProperty("totalItemCount").GetInt32().ShouldBe(5);
+        root.GetProperty("pageCount").GetInt32().ShouldBe(1);
+        root.GetProperty("hasNextPage").GetBoolean().ShouldBeFalse();
+        root.GetProperty("hasPreviousPage").GetBoolean().ShouldBeFalse();
+        root.GetProperty("items").GetArrayLength().ShouldBe(5);
+    }
+
+    [Fact]
+    public async Task stream_paged_json_array_no_hits()
+    {
+        var color = $"NeverExists_{Guid.NewGuid():N}";
+
+        using var doc = await StreamPageAsync(color, 1, 10);
+        var root = doc.RootElement;
+
+        root.GetProperty("totalItemCount").GetInt32().ShouldBe(0);
+        root.GetProperty("pageCount").GetInt32().ShouldBe(0);
+        root.GetProperty("hasNextPage").GetBoolean().ShouldBeFalse();
+        root.GetProperty("hasPreviousPage").GetBoolean().ShouldBeFalse();
+        root.GetProperty("items").GetArrayLength().ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task stream_paged_json_array_no_hits_beyond_first_page_has_previous_page()
+    {
+        var color = $"NeverExists_{Guid.NewGuid():N}";
+
+        // page > 1 on an empty set: total 0 but hasPreviousPage stays true (pins the empty-branch semantics)
+        using var doc = await StreamPageAsync(color, 2, 10);
+        var root = doc.RootElement;
+
+        root.GetProperty("totalItemCount").GetInt32().ShouldBe(0);
+        root.GetProperty("pageCount").GetInt32().ShouldBe(0);
+        root.GetProperty("hasNextPage").GetBoolean().ShouldBeFalse();
+        root.GetProperty("hasPreviousPage").GetBoolean().ShouldBeTrue();
+        root.GetProperty("items").GetArrayLength().ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task stream_paged_json_array_throws_for_page_number_below_one()
+    {
+        await using var query = theStore.QuerySession();
+        using var stream = new MemoryStream();
+
+        await Should.ThrowAsync<ArgumentOutOfRangeException>(async () =>
+            await query.Query<Target>().OrderBy(t => t.Number).StreamPagedJsonArray(0, 10, stream));
+    }
+
+    [Fact]
+    public async Task stream_paged_json_array_throws_for_page_size_below_one()
+    {
+        await using var query = theStore.QuerySession();
+        using var stream = new MemoryStream();
+
+        await Should.ThrowAsync<ArgumentOutOfRangeException>(async () =>
+            await query.Query<Target>().OrderBy(t => t.Number).StreamPagedJsonArray(1, 0, stream));
+    }
+
+    [Fact]
+    public async Task stream_paged_json_array_past_end_of_non_empty_set_reports_zero_total()
+    {
+        // 10 items, request page 5 of pageSize 3 → OFFSET 12 → zero rows. The window-function total
+        // is lost, so the envelope reports totalItemCount 0 even though items exist. Same quirk as
+        // PagedList / Marten — pin it so we don't diverge without a coordinated decision.
+        var color = await SeedTargetsAsync(10);
+
+        using var doc = await StreamPageAsync(color, 5, 3);
+        var root = doc.RootElement;
+
+        root.GetProperty("totalItemCount").GetInt32().ShouldBe(0);
+        root.GetProperty("pageCount").GetInt32().ShouldBe(0);
+        root.GetProperty("items").GetArrayLength().ShouldBe(0);
+    }
+}

--- a/src/Polecat/Linq/JsonQueryExtensions.cs
+++ b/src/Polecat/Linq/JsonQueryExtensions.cs
@@ -46,4 +46,34 @@ public static class JsonQueryExtensions
         var result = await provider.ExecuteJsonFirstWithVersionAsync(queryable.Expression, token);
         return result is { } r ? new DocumentJsonWithVersion(r.Json, r.Version) : null;
     }
+
+    /// <summary>
+    ///     Streams a single page of documents plus paging metadata as one JSON envelope
+    ///     directly to <paramref name="destination"/> in a single database round trip.
+    ///     The envelope shape is
+    ///     <c>{"pageNumber":..,"pageSize":..,"totalItemCount":..,"pageCount":..,"hasNextPage":..,
+    ///     "hasPreviousPage":..,"items":[..]}</c> — byte-for-byte identical to Marten's
+    ///     <c>StreamPagedJsonArray</c> so clients are interchangeable. Raw persisted JSON is
+    ///     streamed straight into <c>items</c> without deserialize/reserialize.
+    /// </summary>
+    /// <param name="queryable">A Polecat <see cref="IQueryable{T}"/>. Include an <c>OrderBy</c> for a stable page order.</param>
+    /// <param name="pageNumber">1-based page number. Must be &gt;= 1.</param>
+    /// <param name="pageSize">Page size. Must be &gt;= 1.</param>
+    /// <param name="destination">The stream the JSON envelope is written to.</param>
+    /// <param name="token">Cancellation token.</param>
+    /// <exception cref="ArgumentOutOfRangeException">If <paramref name="pageNumber"/> or <paramref name="pageSize"/> is below 1.</exception>
+    public static async Task StreamPagedJsonArray<T>(
+        this IQueryable<T> queryable, int pageNumber, int pageSize, Stream destination,
+        CancellationToken token = default)
+    {
+        ArgumentNullException.ThrowIfNull(destination);
+
+        if (queryable.Provider is not PolecatLinqQueryProvider provider)
+        {
+            throw new InvalidOperationException(
+                "StreamPagedJsonArray can only be used with Polecat IQueryable instances.");
+        }
+
+        await provider.StreamPagedJsonArrayAsync(queryable.Expression, pageNumber, pageSize, destination, token);
+    }
 }

--- a/src/Polecat/Linq/PolecatLinqQueryProvider.cs
+++ b/src/Polecat/Linq/PolecatLinqQueryProvider.cs
@@ -237,6 +237,103 @@ internal class PolecatLinqQueryProvider : IPolecatAsyncQueryProvider
         return (json, version);
     }
 
+    /// <summary>
+    ///     Streams a single page of raw document JSON plus paging metadata as one JSON envelope
+    ///     (<c>{"pageNumber":..,"pageSize":..,"totalItemCount":..,"pageCount":..,"hasNextPage":..,
+    ///     "hasPreviousPage":..,"items":[..]}</c>) directly to <paramref name="destination"/> in a
+    ///     single database round trip. The total row count rides along on every row via
+    ///     <c>COUNT(*) OVER()</c> so no second COUNT query is needed. Raw <c>data</c> column JSON is
+    ///     written straight through — no deserialize/reserialize. Mirrors Marten's
+    ///     <c>StreamPagedMany</c> (JasperFx/marten#5014). Envelope key names/shape are byte-for-byte
+    ///     identical to Marten so clients are interchangeable.
+    /// </summary>
+    internal async Task StreamPagedJsonArrayAsync(
+        Expression expression, int pageNumber, int pageSize, Stream destination, CancellationToken token)
+    {
+        if (pageNumber < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(pageNumber), pageNumber,
+                "pageNumber must be greater than or equal to 1.");
+        }
+
+        if (pageSize < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize,
+                "pageSize must be greater than or equal to 1.");
+        }
+
+        var documentType = FindDocumentType(expression);
+        var provider = _providers.GetProvider(documentType);
+        await _tableEnsurer.EnsureTableAsync(provider, token);
+
+        var memberFactory = new MemberFactory(_session.Options, provider.Mapping);
+        var parser = new LinqQueryParser(memberFactory, provider.Mapping.QualifiedTableName);
+        parser.Parse(expression);
+
+        // Ride the total-rows window column alongside the raw data column so the total comes back
+        // on the same round trip as the page. COUNT(*) OVER() returns int on SQL Server.
+        parser.Statement.SelectColumns = "data, COUNT(*) OVER() AS total_rows";
+        parser.Statement.Offset = (pageNumber - 1) * pageSize;
+        parser.Statement.Limit = pageSize;
+
+        if (parser.IsDistinct) parser.Statement.IsDistinct = true;
+
+        if (!parser.IsAnyTenant && IsConjoinedTenancy)
+        {
+            if (parser.TenantIds != null)
+            {
+                parser.Statement.Wheres.Add(new TenantInFilter(parser.TenantIds));
+            }
+            else
+            {
+                parser.Statement.Wheres.Add(new ComparisonFilter("tenant_id", "=", _session.TenantId));
+            }
+        }
+
+        if (provider.Mapping.DeleteStyle == DeleteStyle.SoftDelete && !parser.IsMaybeDeleted)
+        {
+            parser.Statement.Wheres.Add(new LiteralSqlFragment(parser.IsDeletedOnly ? "is_deleted = 1" : "is_deleted = 0"));
+        }
+
+        ApplyModifiedFilters(parser);
+
+        await using var batch = new SqlBatch();
+        var builder = new BatchBuilder(batch);
+        parser.Statement.Apply(builder);
+        builder.Compile();
+
+        await using var reader = await _session.ExecuteReaderAsync(batch, token);
+
+        // Read the first row up front: the window-function total lives on every row, so a zero-row
+        // page (empty match, or paging past the end) simply has no total → totalItemCount = 0.
+        var hasFirst = await reader.ReadAsync(token);
+        var total = hasFirst ? reader.GetInt32(1) : 0;
+
+        var pageCount = total > 0 ? (int)Math.Ceiling(total / (double)pageSize) : 0;
+        var hasNextPage = pageNumber < pageCount;
+        var hasPreviousPage = pageNumber > 1;
+
+        var prefix =
+            $"{{\"pageNumber\":{pageNumber},\"pageSize\":{pageSize},\"totalItemCount\":{total}," +
+            $"\"pageCount\":{pageCount}," +
+            $"\"hasNextPage\":{(hasNextPage ? "true" : "false")}," +
+            $"\"hasPreviousPage\":{(hasPreviousPage ? "true" : "false")}," +
+            "\"items\":[";
+        await destination.WriteAsync(Encoding.UTF8.GetBytes(prefix), token);
+
+        if (hasFirst)
+        {
+            await destination.WriteAsync(Encoding.UTF8.GetBytes(reader.GetString(0)), token);
+            while (await reader.ReadAsync(token))
+            {
+                await destination.WriteAsync(","u8.ToArray(), token);
+                await destination.WriteAsync(Encoding.UTF8.GetBytes(reader.GetString(0)), token);
+            }
+        }
+
+        await destination.WriteAsync("]}"u8.ToArray(), token);
+    }
+
     [RequiresDynamicCode("LINQ-to-SQL execution closes ListQueryHandler<>/DeserializingSelector<>/etc. over the document type via Type.MakeGenericType.")]
     [RequiresUnreferencedCode("LINQ-to-SQL execution reflects over the document type (Activator.CreateInstance on handler types, MethodInfo.Invoke on HandleAsync). AOT consumers must preserve handler + document members through DAM or source generation.")]
     public async Task<TResult> ExecuteAsync<TResult>(Expression expression, CancellationToken token)


### PR DESCRIPTION
Closes #355.

Ports Marten's `StreamPaged<T>` (JasperFx/marten#5014) to SQL Server. Streams a single page of documents **plus** paging metadata as one JSON envelope directly to the HTTP response in **one** database round trip.

## Mechanism
- The total row count rides along on every row via `COUNT(*) OVER() AS total_rows` alongside the `OFFSET/FETCH` page query — no separate `COUNT` query.
- Raw persisted `data` column JSON is streamed straight into `items` with no deserialize/reserialize (Polecat's first true raw-JSON streaming endpoint).
- Envelope key names/shape are **byte-for-byte identical** to Marten so clients are interchangeable:

```json
{"pageNumber":3,"pageSize":25,"totalItemCount":1207,"pageCount":49,"hasNextPage":true,"hasPreviousPage":true,"items":[...]}
```

## Surface
- `PolecatLinqQueryProvider.StreamPagedJsonArrayAsync(expression, pageNumber, pageSize, Stream, ct)` — core.
- `JsonQueryExtensions.StreamPagedJsonArray<T>(this IQueryable<T>, pageNumber, pageSize, Stream, ct)` — public entry, validates `pageNumber/pageSize >= 1` (`ArgumentOutOfRangeException`).
- `Polecat.AspNetCore.StreamPaged<T>` — `IResult` + `IEndpointMetadataProvider`, mirrors `StreamMany<T>`.

## Metadata math (mirrors `PagedList`)
`pageCount = total>0 ? ceil(total/pageSize) : 0`; `hasNextPage = pageNumber < pageCount`; `hasPreviousPage = pageNumber > 1`. A zero-row page (empty match **or** paging past the end of a non-empty set) → `totalItemCount: 0, pageCount: 0, items: []` — the documented window-function quirk, pinned so we don't diverge from Marten without a coordinated decision.

## Tests
- **9 unit facts** (`stream_paged_tests`): first / middle / last-partial / single page, no-hits, `page>1` on empty set (`hasPreviousPage=true`), page-number/size validation, and the paging-past-end quirk.
- **4 Alba HTTP scenarios** over `/api/issues/paged/{pageNumber}/{pageSize}`.
- Docs added to `docs/documents/aspnetcore.md`.

9/9 unit + 4/4 HTTP green on net10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)