### PR TITLE
feat(#357): StreamPagedByCursor<T> — keyset (cursor) pagination (marten#5016 parity)

### DIFF
--- a/docs/documents/aspnetcore.md
+++ b/docs/documents/aspnetcore.md
@@ -21,6 +21,7 @@ that dispatch any `IResult` return value), Polecat.AspNetCore ships three typed 
 | `StreamOne<T>` | `IQueryable<T>` — document query | Single `T` | yes |
 | `StreamMany<T>` | `IQueryable<T>` — document query | JSON array `T[]` | no (empty array = 200) |
 | `StreamPaged<T>` | `IQueryable<T>` + page number/size | Paged JSON envelope | no (empty page = 200) |
+| `StreamPagedByCursor<T>` | `IQueryable<T>` + cursor/page size | Keyset page envelope | no (empty page = 200) |
 | `StreamAggregate<T>` | `IQuerySession` + stream id — event-sourced | Single `T` | yes |
 
 Each type implements both `IResult` (so ASP.NET dispatches it via `ExecuteAsync`) and
@@ -89,6 +90,28 @@ Core via `StreamPagedJsonArray`:
 await session.Query<Issue>().OrderBy(x => x.Number)
     .StreamPagedJsonArray(pageNumber, pageSize, destinationStream);
 ```
+
+### StreamPagedByCursor — keyset (cursor) pagination
+
+```csharp
+app.MapGet("/issues/paged-cursor/{pageSize:int}",
+    (int pageSize, string? cursor, IQuerySession session) =>
+        new StreamPagedByCursor<Issue>(
+            session.Query<Issue>().OrderBy(x => x.Number).ThenBy(x => x.Id), cursor, pageSize));
+```
+
+Streams one keyset (seek) page — constant cost at any depth — as a JSON envelope, and echoes
+the continuation cursor in a `Polecat-Continuation` response header:
+
+```json
+{"items":[...],"nextCursor":"v1:..."}
+```
+
+`nextCursor` is `null` at the end of the set. The wrapped query must order so its terminal key
+is the document identity (e.g. `OrderBy(x => x.Number).ThenBy(x => x.Id)`); a query lacking an
+`OrderBy` or with a non-identity terminal key is rejected. See
+[Keyset (Cursor) Pagination](./querying/linq/paging.md#keyset-cursor-pagination) for the
+mechanics and rules.
 
 ### StreamAggregate — event-sourced aggregate (latest)
 

--- a/docs/documents/querying/linq/paging.md
+++ b/docs/documents/querying/linq/paging.md
@@ -57,3 +57,54 @@ var page2 = await session.Query<User>()
 ::: warning
 Always use `OrderBy` with paging to ensure consistent results across pages.
 :::
+
+## Keyset (Cursor) Pagination
+
+Offset paging (`Skip`/`Take`, `ToPagedListAsync`) gets more expensive the deeper you go — the
+database still scans and discards every skipped row. **Keyset** (a.k.a. seek or cursor)
+pagination is instead **constant cost at any depth**: each page seeks directly to where the
+previous one ended. It is ideal for infinite scroll, "load more", and export feeds.
+
+`ToJsonPageByCursorAsync` fetches one page as raw JSON plus an opaque continuation cursor:
+
+```cs
+// First page: cursor = null
+var page = await session.Query<User>()
+    .OrderBy(x => x.LastName).ThenBy(x => x.Id)
+    .ToJsonPageByCursorAsync(cursor: null, pageSize: 25);
+
+// page.ItemsJson  -> "[ {...}, {...}, ... ]"  (raw persisted document JSON)
+// page.Count      -> number of items on this page
+// page.NextCursor -> opaque cursor for the next page, or null at the end of the set
+
+// Next page: pass the previous page's NextCursor
+var next = await session.Query<User>()
+    .OrderBy(x => x.LastName).ThenBy(x => x.Id)
+    .ToJsonPageByCursorAsync(page.NextCursor, 25);
+```
+
+When a page returns fewer than `pageSize` items, `NextCursor` is `null` — you have reached the
+end of the set.
+
+### Rules
+
+- **You must `OrderBy`.** A query with no ordering is rejected.
+- **The terminal ordering key must be the document identity (`Id`).** This guarantees a *total
+  order*, so pagination can never skip or duplicate rows across ties. End your ordering with
+  `.ThenBy(x => x.Id)` (or order by `Id` alone). A non-identity terminal key is rejected.
+- Mixed ascending/descending orderings are supported; the seek predicate flips direction per key.
+
+### How it works
+
+Polecat composes a keyset seek predicate
+`(k1 > v1) OR (k1 = v1 AND k2 > v2) OR …` (direction-flipped per ordering key), using the
+**same** SQL locators as the `ORDER BY` so the seek boundary lines up with the sort. The last
+row's sort-key values are carried in an opaque, versioned (`v1:`) base64-JSON cursor. Cursor
+values are **typed on decode** by the query's ordering key types (the cursor never dictates
+types) and enter the query as **bound parameters** — no injection.
+
+::: tip SQL Server ordering
+String seeks use the column's collation and `uniqueidentifier` (`Guid`) seeks use SQL Server's
+byte-group ordering — the same ordering the `ORDER BY` uses, so the boundary always matches.
+(Note this differs from PostgreSQL `uuid` ordering, so cursors are not portable across stores.)
+:::

--- a/src/Polecat.AspNetCore.Testing/Program.cs
+++ b/src/Polecat.AspNetCore.Testing/Program.cs
@@ -53,6 +53,12 @@ app.MapGet("/api/issues-noetag/{id:guid}", (Guid id, IQuerySession session) =>
 app.MapGet("/api/aggregates-noetag/{id:guid}", (Guid id, IQuerySession session) =>
     new StreamAggregate<StreamingQuestParty>(session, id) { EmitETag = false });
 
+// StreamPagedByCursor endpoint — one keyset page + continuation cursor
+app.MapGet("/api/issues/paged-cursor/{pageSize:int}",
+    (int pageSize, string? cursor, IQuerySession session) =>
+        new StreamPagedByCursor<StreamingIssue>(
+            session.Query<StreamingIssue>().OrderBy(x => x.Number).ThenBy(x => x.Id), cursor, pageSize));
+
 app.Run();
 
 namespace Polecat.AspNetCore.Testing
@@ -64,7 +70,7 @@ namespace Polecat.AspNetCore.Testing
         public string Title { get; set; } = "";
         public bool IsOpen { get; set; } = true;
 
-        // Stable ordering key for paged streaming endpoints.
+        // Ordering key for paged / cursor streaming endpoints.
         public int Number { get; set; }
     }
 

--- a/src/Polecat.AspNetCore.Testing/stream_paged_by_cursor_tests.cs
+++ b/src/Polecat.AspNetCore.Testing/stream_paged_by_cursor_tests.cs
@@ -1,0 +1,110 @@
+using System.Text.Json;
+using Alba;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Xunit;
+
+namespace Polecat.AspNetCore.Testing;
+
+/// <summary>
+///     Alba HTTP coverage for the <c>StreamPagedByCursor&lt;T&gt;</c> minimal-API result over
+///     <c>/api/issues/paged-cursor/{pageSize}?cursor=</c> (marten#5016 parity, polecat#357).
+/// </summary>
+public class stream_paged_by_cursor_tests : IAsyncLifetime
+{
+    private IAlbaHost _host = null!;
+
+    public async Task InitializeAsync()
+    {
+        _host = await AlbaHost.For<Program>();
+
+        var store = (DocumentStore)_host.Services.GetRequiredService<IDocumentStore>();
+        await store.Database.ApplyAllConfiguredChangesToDatabaseAsync();
+        await store.Advanced.CleanAllDocumentsAsync();
+
+        await using var session = store.LightweightSession();
+        for (var i = 0; i < 10; i++)
+        {
+            session.Store(new StreamingIssue { Id = Guid.NewGuid(), Title = $"Issue {i}", Number = i });
+        }
+
+        await session.SaveChangesAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _host.DisposeAsync();
+    }
+
+    private async Task<(int[] numbers, string? nextCursor, string? header)> GetPageAsync(int pageSize, string? cursor)
+    {
+        var url = $"/api/issues/paged-cursor/{pageSize}";
+        if (cursor != null) url += $"?cursor={Uri.EscapeDataString(cursor)}";
+
+        var result = await _host.Scenario(s =>
+        {
+            s.Get.Url(url);
+            s.StatusCodeShouldBe(200);
+            s.ContentTypeShouldBe("application/json");
+        });
+
+        var root = JsonDocument.Parse(result.ReadAsText()).RootElement;
+        var numbers = root.GetProperty("items").EnumerateArray()
+            .Select(x => x.GetProperty("number").GetInt32()).ToArray();
+
+        var nextCursor = root.GetProperty("nextCursor").ValueKind == JsonValueKind.Null
+            ? null
+            : root.GetProperty("nextCursor").GetString();
+
+        var header = result.Context.Response.Headers.TryGetValue("Polecat-Continuation", out var h)
+            ? h.ToString()
+            : null;
+
+        return (numbers, nextCursor, header);
+    }
+
+    [Fact]
+    public async Task first_page_sets_cursor_and_continuation_header()
+    {
+        var (numbers, nextCursor, header) = await GetPageAsync(3, null);
+
+        numbers.ShouldBe([0, 1, 2]);
+        nextCursor.ShouldNotBeNull();
+        header.ShouldBe(nextCursor);
+    }
+
+    [Fact]
+    public async Task follows_cursor_to_next_page()
+    {
+        var (_, firstCursor, _) = await GetPageAsync(3, null);
+        var (numbers, _, _) = await GetPageAsync(3, firstCursor);
+
+        numbers.ShouldBe([3, 4, 5]);
+    }
+
+    [Fact]
+    public async Task paginates_entire_set_in_order()
+    {
+        var all = new List<int>();
+        string? cursor = null;
+        do
+        {
+            var (numbers, nextCursor, _) = await GetPageAsync(3, cursor);
+            all.AddRange(numbers);
+            cursor = nextCursor;
+        } while (cursor != null);
+
+        all.ShouldBe([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    }
+
+    [Fact]
+    public async Task last_page_has_null_cursor_and_no_header()
+    {
+        // Page size 25 → all 10 items in one page → end of set, no continuation.
+        var (numbers, nextCursor, header) = await GetPageAsync(25, null);
+
+        numbers.Length.ShouldBe(10);
+        nextCursor.ShouldBeNull();
+        header.ShouldBeNull();
+    }
+}

--- a/src/Polecat.AspNetCore/StreamPagedByCursor.cs
+++ b/src/Polecat.AspNetCore/StreamPagedByCursor.cs
@@ -1,0 +1,105 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using System.Text;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Metadata;
+using Polecat.Linq.CursorPaging;
+
+namespace Polecat.AspNetCore;
+
+/// <summary>
+/// Minimal-API endpoint return value that streams one keyset (cursor / seek) page of Polecat
+/// documents as a JSON envelope directly to the HTTP response, and echoes the continuation cursor
+/// in a <c>Polecat-Continuation</c> response header.
+/// <para>
+/// The body shape mirrors Marten's <c>StreamPagedByCursor</c>:
+/// <code>{"items":[...],"nextCursor":"v1:..."}</code>
+/// where <c>nextCursor</c> is <c>null</c> at the end of the set. Keyset pagination is constant
+/// cost at any depth — ideal for infinite scroll / "load more" / export feeds.
+/// </para>
+/// <para>
+/// The wrapped query must order so its terminal key is the document identity (e.g.
+/// <c>OrderBy(x =&gt; x.Foo).ThenBy(x =&gt; x.Id)</c>); a query lacking an OrderBy or with a
+/// non-identity terminal key is rejected.
+/// </para>
+/// </summary>
+/// <typeparam name="T">The document type contained in the page.</typeparam>
+public sealed class StreamPagedByCursor<T> : IResult, IEndpointMetadataProvider
+{
+    private readonly IQueryable<T> _queryable;
+    private readonly string? _cursor;
+    private readonly int _pageSize;
+
+    /// <summary>
+    /// Create a <see cref="StreamPagedByCursor{T}"/> over a Polecat <see cref="IQueryable{T}"/>.
+    /// </summary>
+    /// <param name="queryable">The ordered query (terminal key must be the document identity).</param>
+    /// <param name="cursor">The opaque continuation cursor, or <c>null</c> for the first page.</param>
+    /// <param name="pageSize">Page size. Must be &gt;= 1.</param>
+    public StreamPagedByCursor(IQueryable<T> queryable, string? cursor, int pageSize)
+    {
+        _queryable = queryable ?? throw new ArgumentNullException(nameof(queryable));
+        _cursor = cursor;
+        _pageSize = pageSize;
+    }
+
+    /// <summary>
+    /// Status code written with the response. Defaults to 200.
+    /// </summary>
+    public int OnFoundStatus { get; init; } = StatusCodes.Status200OK;
+
+    /// <summary>
+    /// Response content type. Defaults to <c>application/json</c>.
+    /// </summary>
+    public string ContentType { get; init; } = "application/json";
+
+    /// <inheritdoc />
+    [UnconditionalSuppressMessage("Trimming", "IL2046",
+        Justification = "IResult.ExecuteAsync is not RUC-annotated; the contract lives on this override.")]
+    [UnconditionalSuppressMessage("AOT", "IL3051",
+        Justification = "IResult.ExecuteAsync is not RDC-annotated; the contract lives on this override.")]
+    [RequiresDynamicCode("StreamPagedByCursor<T>.ExecuteAsync routes through the Polecat LINQ provider, which closes generic handler types over T via MakeGenericType.")]
+    [RequiresUnreferencedCode("StreamPagedByCursor<T>.ExecuteAsync routes through the Polecat LINQ provider, which reflects over T. AOT consumers must preserve T's members through DynamicallyAccessedMembers or source generation.")]
+    public async Task ExecuteAsync(HttpContext httpContext)
+    {
+        ArgumentNullException.ThrowIfNull(httpContext);
+
+        var page = await _queryable.ToJsonPageByCursorAsync(_cursor, _pageSize, httpContext.RequestAborted);
+
+        httpContext.Response.StatusCode = OnFoundStatus;
+        httpContext.Response.ContentType = ContentType;
+
+        if (page.NextCursor != null)
+        {
+            httpContext.Response.Headers[CursorPagination.ContinuationHeader] = page.NextCursor;
+        }
+
+        var nextCursorJson = page.NextCursor is null
+            ? "null"
+            : JsonEncodedString(page.NextCursor);
+
+        var envelope = $"{{\"items\":{page.ItemsJson},\"nextCursor\":{nextCursorJson}}}";
+        await httpContext.Response.Body.WriteAsync(Encoding.UTF8.GetBytes(envelope), httpContext.RequestAborted);
+    }
+
+    // The cursor is "v1:" + base64 (chars A-Za-z0-9+/=:), none of which require JSON escaping.
+    // Escape the JSON metacharacters defensively anyway and wrap in quotes — AOT-clean, no STJ.
+    private static string JsonEncodedString(string value)
+    {
+        var escaped = value.Replace("\\", "\\\\").Replace("\"", "\\\"");
+        return $"\"{escaped}\"";
+    }
+
+    /// <summary>
+    /// Populates endpoint metadata so OpenAPI advertises a <c>200</c> JSON response. No 404 is
+    /// advertised because an empty page is a valid response.
+    /// </summary>
+    public static void PopulateMetadata(MethodInfo method, EndpointBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.Metadata.Add(new ProducesResponseTypeMetadata(
+            StatusCodes.Status200OK, typeof(object), ["application/json"]));
+    }
+}

--- a/src/Polecat.Tests/Linq/cursor_paging_tests.cs
+++ b/src/Polecat.Tests/Linq/cursor_paging_tests.cs
@@ -1,0 +1,282 @@
+using System.Text.Json;
+using Polecat.Linq.CursorPaging;
+using Polecat.Tests.Harness;
+
+namespace Polecat.Tests.Linq;
+
+/// <summary>
+///     Keyset (cursor / seek) pagination coverage — marten#5016 parity, polecat#357. Each test
+///     isolates its own document set behind a unique color filter, and orders with the document
+///     identity (Id) as the terminal key so the ordering is a total order.
+/// </summary>
+[Collection("integration")]
+public class cursor_paging_tests : IntegrationContext
+{
+    public cursor_paging_tests(DefaultStoreFixture fixture) : base(fixture)
+    {
+    }
+
+    private async Task<string> SeedNumberedAsync(int count)
+    {
+        var color = $"Cursor_{Guid.NewGuid():N}";
+        for (var i = 0; i < count; i++)
+        {
+            theSession.Store(new Target { Id = Guid.NewGuid(), Color = color, Number = i });
+        }
+
+        await theSession.SaveChangesAsync();
+        return color;
+    }
+
+    private IQueryable<Target> Ascending(string color) =>
+        theStore.QuerySession().Query<Target>()
+            .Where(t => t.Color == color)
+            .OrderBy(t => t.Number).ThenBy(t => t.Id);
+
+    private static int[] Numbers(CursorPageResult page) =>
+        JsonDocument.Parse(page.ItemsJson).RootElement.EnumerateArray()
+            .Select(x => x.GetProperty("number").GetInt32())
+            .ToArray();
+
+    private async Task<List<int>> PageAllNumbersAscendingAsync(string color, int pageSize)
+    {
+        var all = new List<int>();
+        string? cursor = null;
+        while (true)
+        {
+            await using var q = theStore.QuerySession();
+            var page = await q.Query<Target>()
+                .Where(t => t.Color == color)
+                .OrderBy(t => t.Number).ThenBy(t => t.Id)
+                .ToJsonPageByCursorAsync(cursor, pageSize);
+
+            all.AddRange(Numbers(page));
+            if (page.NextCursor is null) break;
+            cursor = page.NextCursor;
+
+            if (all.Count > 100_000) throw new InvalidOperationException("cursor pagination did not terminate");
+        }
+
+        return all;
+    }
+
+    [Fact]
+    public async Task first_page()
+    {
+        var color = await SeedNumberedAsync(10);
+
+        await using var q = theStore.QuerySession();
+        var page = await q.Query<Target>().Where(t => t.Color == color)
+            .OrderBy(t => t.Number).ThenBy(t => t.Id)
+            .ToJsonPageByCursorAsync(null, 3);
+
+        Numbers(page).ShouldBe([0, 1, 2]);
+        page.Count.ShouldBe(3);
+        page.NextCursor.ShouldNotBeNull();
+        page.NextCursor!.ShouldStartWith("v1:");
+    }
+
+    [Fact]
+    public async Task subsequent_page()
+    {
+        var color = await SeedNumberedAsync(10);
+
+        await using var q = theStore.QuerySession();
+        var first = await q.Query<Target>().Where(t => t.Color == color)
+            .OrderBy(t => t.Number).ThenBy(t => t.Id)
+            .ToJsonPageByCursorAsync(null, 3);
+
+        var second = await q.Query<Target>().Where(t => t.Color == color)
+            .OrderBy(t => t.Number).ThenBy(t => t.Id)
+            .ToJsonPageByCursorAsync(first.NextCursor, 3);
+
+        Numbers(second).ShouldBe([3, 4, 5]);
+        second.NextCursor.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task last_page_has_null_cursor()
+    {
+        var color = await SeedNumberedAsync(5);
+
+        await using var q = theStore.QuerySession();
+        var first = await q.Query<Target>().Where(t => t.Color == color)
+            .OrderBy(t => t.Number).ThenBy(t => t.Id)
+            .ToJsonPageByCursorAsync(null, 3);
+        var last = await q.Query<Target>().Where(t => t.Color == color)
+            .OrderBy(t => t.Number).ThenBy(t => t.Id)
+            .ToJsonPageByCursorAsync(first.NextCursor, 3);
+
+        Numbers(last).ShouldBe([3, 4]);
+        last.Count.ShouldBe(2);
+        last.NextCursor.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task exact_multiple_of_page_size_terminates()
+    {
+        var color = await SeedNumberedAsync(6);
+
+        var all = await PageAllNumbersAscendingAsync(color, 3);
+        all.ShouldBe([0, 1, 2, 3, 4, 5]);
+    }
+
+    [Fact]
+    public async Task paginates_entire_set_in_order()
+    {
+        var color = await SeedNumberedAsync(10);
+
+        var all = await PageAllNumbersAscendingAsync(color, 3);
+        all.ShouldBe([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    }
+
+    [Fact]
+    public async Task empty_set()
+    {
+        var color = $"CursorNever_{Guid.NewGuid():N}";
+
+        await using var q = theStore.QuerySession();
+        var page = await q.Query<Target>().Where(t => t.Color == color)
+            .OrderBy(t => t.Number).ThenBy(t => t.Id)
+            .ToJsonPageByCursorAsync(null, 3);
+
+        page.Count.ShouldBe(0);
+        page.NextCursor.ShouldBeNull();
+        page.ItemsJson.ShouldBe("[]");
+    }
+
+    [Fact]
+    public async Task mixed_ascending_descending()
+    {
+        var color = await SeedNumberedAsync(10);
+
+        var all = new List<int>();
+        string? cursor = null;
+        while (true)
+        {
+            await using var q = theStore.QuerySession();
+            var page = await q.Query<Target>().Where(t => t.Color == color)
+                .OrderByDescending(t => t.Number).ThenBy(t => t.Id)
+                .ToJsonPageByCursorAsync(cursor, 3);
+
+            all.AddRange(Numbers(page));
+            if (page.NextCursor is null) break;
+            cursor = page.NextCursor;
+        }
+
+        all.ShouldBe([9, 8, 7, 6, 5, 4, 3, 2, 1, 0]);
+    }
+
+    [Fact]
+    public async Task exhaustive_pagination_through_duplicate_leading_keys()
+    {
+        // 20 targets that ALL share the same leading sort key (Number = 5). The Id tie-breaker makes
+        // the ordering a total order; paginating with a small page must visit every id exactly once —
+        // no skips, no duplicates across the tie. This is the core keyset-correctness invariant.
+        var color = $"CursorTie_{Guid.NewGuid():N}";
+        var expected = new List<Guid>();
+        for (var i = 0; i < 20; i++)
+        {
+            var id = Guid.NewGuid();
+            expected.Add(id);
+            theSession.Store(new Target { Id = id, Color = color, Number = 5 });
+        }
+
+        await theSession.SaveChangesAsync();
+
+        var seen = new List<Guid>();
+        string? cursor = null;
+        while (true)
+        {
+            await using var q = theStore.QuerySession();
+            var page = await q.Query<Target>().Where(t => t.Color == color)
+                .OrderBy(t => t.Number).ThenBy(t => t.Id)
+                .ToJsonPageByCursorAsync(cursor, 3);
+
+            foreach (var el in JsonDocument.Parse(page.ItemsJson).RootElement.EnumerateArray())
+            {
+                seen.Add(el.GetProperty("id").GetGuid());
+            }
+
+            if (page.NextCursor is null) break;
+            cursor = page.NextCursor;
+        }
+
+        seen.Count.ShouldBe(20);
+        seen.Distinct().Count().ShouldBe(20);
+        seen.OrderBy(x => x).ShouldBe(expected.OrderBy(x => x));
+    }
+
+    [Fact]
+    public async Task uniqueidentifier_ordering_seek_matches_order_by()
+    {
+        // SQL Server orders `uniqueidentifier` by byte groups (differs from Postgres uuid). As long as
+        // the seek predicate compares the same `id` column with the same operator as the ORDER BY, the
+        // boundary lines up and pagination neither skips nor duplicates. Order by Id alone (Id is the
+        // identity terminal key) and page through, verifying every id is visited once.
+        var color = $"CursorGuid_{Guid.NewGuid():N}";
+        var ids = new List<Guid>();
+        for (var i = 0; i < 25; i++)
+        {
+            var id = Guid.NewGuid();
+            ids.Add(id);
+            theSession.Store(new Target { Id = id, Color = color, Number = i });
+        }
+
+        await theSession.SaveChangesAsync();
+
+        var seen = new List<Guid>();
+        string? cursor = null;
+        while (true)
+        {
+            await using var q = theStore.QuerySession();
+            var page = await q.Query<Target>().Where(t => t.Color == color)
+                .OrderBy(t => t.Id)
+                .ToJsonPageByCursorAsync(cursor, 4);
+
+            foreach (var el in JsonDocument.Parse(page.ItemsJson).RootElement.EnumerateArray())
+            {
+                seen.Add(el.GetProperty("id").GetGuid());
+            }
+
+            if (page.NextCursor is null) break;
+            cursor = page.NextCursor;
+        }
+
+        seen.Count.ShouldBe(25);
+        seen.Distinct().Count().ShouldBe(25);
+        // The visited order must be strictly ascending in SQL Server's uniqueidentifier ordering.
+        seen.ShouldBe(seen.OrderBy(x => x, new SqlGuidComparer()).ToList());
+    }
+
+    [Fact]
+    public async Task refuses_query_without_order_by()
+    {
+        await using var q = theStore.QuerySession();
+        await Should.ThrowAsync<InvalidOperationException>(async () =>
+            await q.Query<Target>().Where(t => t.Number > 0).ToJsonPageByCursorAsync(null, 3));
+    }
+
+    [Fact]
+    public async Task refuses_non_identity_terminal_key()
+    {
+        await using var q = theStore.QuerySession();
+        await Should.ThrowAsync<InvalidOperationException>(async () =>
+            await q.Query<Target>().OrderBy(t => t.Number).ToJsonPageByCursorAsync(null, 3));
+    }
+
+    [Fact]
+    public async Task refuses_non_positive_page_size()
+    {
+        await using var q = theStore.QuerySession();
+        await Should.ThrowAsync<ArgumentOutOfRangeException>(async () =>
+            await q.Query<Target>().OrderBy(t => t.Id).ToJsonPageByCursorAsync(null, 0));
+    }
+
+    // Mirrors System.Data.SqlTypes.SqlGuid ordering (the byte-group order SQL Server uses).
+    private sealed class SqlGuidComparer : IComparer<Guid>
+    {
+        public int Compare(Guid x, Guid y) =>
+            new System.Data.SqlTypes.SqlGuid(x).CompareTo(new System.Data.SqlTypes.SqlGuid(y));
+    }
+}

--- a/src/Polecat/Linq/CursorPaging/CursorPageResult.cs
+++ b/src/Polecat/Linq/CursorPaging/CursorPageResult.cs
@@ -1,0 +1,11 @@
+namespace Polecat.Linq.CursorPaging;
+
+/// <summary>
+///     The result of a keyset (cursor / seek) page: the raw JSON array of the page's documents,
+///     the number of items returned, and an opaque continuation cursor for the next page
+///     (<c>null</c> when the end of the set has been reached).
+/// </summary>
+/// <param name="ItemsJson">A JSON array (<c>[...]</c>) of the raw persisted document JSON for the page.</param>
+/// <param name="Count">The number of items on this page (0..pageSize).</param>
+/// <param name="NextCursor">The opaque cursor to fetch the next page, or <c>null</c> at end of set.</param>
+public sealed record CursorPageResult(string ItemsJson, int Count, string? NextCursor);

--- a/src/Polecat/Linq/CursorPaging/CursorPagination.cs
+++ b/src/Polecat/Linq/CursorPaging/CursorPagination.cs
@@ -1,0 +1,159 @@
+using System.Text;
+using System.Text.Json;
+using Polecat.Linq.Members;
+using Polecat.Linq.SqlGeneration;
+
+namespace Polecat.Linq.CursorPaging;
+
+/// <summary>
+///     Keyset (seek) pagination mechanics — cursor encode/decode and the composite seek-predicate
+///     builder. Mirrors Marten's <c>CursorPagination</c> (JasperFx/marten#5016). The cursor is an
+///     opaque, versioned (<c>v1:</c>) base64-JSON value carrying the last row's sort-key values.
+///     Values are typed on <em>decode</em> by the server-side ordering key type (the cursor never
+///     dictates types) and enter the query as bound parameters — no injection.
+/// </summary>
+internal static class CursorPagination
+{
+    private const string Version = "v1:";
+
+    /// <summary>
+    ///     The HTTP response header carrying the continuation cursor (mirrors Marten's
+    ///     <c>Marten-Continuation</c>).
+    /// </summary>
+    public const string ContinuationHeader = "Polecat-Continuation";
+
+    /// <summary>
+    ///     Validates that the query's ordering can support keyset pagination: at least one
+    ///     ORDER BY, and the terminal ordering key must be the unique document identity member so
+    ///     the ordering is a total order (no skips/duplicates across ties). Throws
+    ///     <see cref="InvalidOperationException"/> otherwise.
+    /// </summary>
+    public static void ValidateOrdering(IReadOnlyList<(IQueryableMember Member, bool Descending)> orderBy)
+    {
+        if (orderBy.Count == 0)
+        {
+            throw new InvalidOperationException(
+                "Keyset (cursor) pagination requires an OrderBy clause. Add an OrderBy whose terminal key is the document identity (e.g. OrderBy(x => x.Something).ThenBy(x => x.Id)).");
+        }
+
+        if (orderBy[^1].Member is not IdMember)
+        {
+            throw new InvalidOperationException(
+                "Keyset (cursor) pagination requires the terminal ordering key to be the unique document identity member (Id) so the ordering is a total order. End your ordering with ThenBy(x => x.Id) (or OrderBy(x => x.Id)).");
+        }
+    }
+
+    /// <summary>
+    ///     Encodes the sort-key values of the last row on a page into an opaque continuation cursor.
+    /// </summary>
+    public static string Encode(IReadOnlyList<object?> keyValues)
+    {
+        var array = new object?[keyValues.Count];
+        for (var i = 0; i < keyValues.Count; i++)
+        {
+            array[i] = NormalizeForCursor(keyValues[i]);
+        }
+
+        var json = JsonSerializer.Serialize(array);
+        return Version + Convert.ToBase64String(Encoding.UTF8.GetBytes(json));
+    }
+
+    /// <summary>
+    ///     Decodes a cursor into typed sort-key values, one per ordering key. The values are typed by
+    ///     each ordering member's CLR type — the cursor payload itself carries no type information.
+    /// </summary>
+    public static object?[] Decode(string cursor,
+        IReadOnlyList<(IQueryableMember Member, bool Descending)> orderBy)
+    {
+        if (!cursor.StartsWith(Version, StringComparison.Ordinal))
+        {
+            throw new ArgumentException(
+                $"Unrecognized or unversioned cursor. Expected a '{Version}' prefixed value.", nameof(cursor));
+        }
+
+        JsonElement[] slots;
+        try
+        {
+            var json = Encoding.UTF8.GetString(Convert.FromBase64String(cursor[Version.Length..]));
+            slots = JsonSerializer.Deserialize<JsonElement[]>(json) ?? [];
+        }
+        catch (Exception ex) when (ex is FormatException or JsonException)
+        {
+            throw new ArgumentException("Malformed cursor payload.", nameof(cursor), ex);
+        }
+
+        if (slots.Length != orderBy.Count)
+        {
+            throw new ArgumentException(
+                $"Cursor carries {slots.Length} key(s) but the query orders by {orderBy.Count}. The cursor does not match this query's ordering.",
+                nameof(cursor));
+        }
+
+        var values = new object?[slots.Length];
+        for (var i = 0; i < slots.Length; i++)
+        {
+            values[i] = ConvertSlot(slots[i], orderBy[i].Member.MemberType);
+        }
+
+        return values;
+    }
+
+    /// <summary>
+    ///     Builds the composite keyset seek predicate for the values of the previous page's last row:
+    ///     <c>(k0 op0 v0) OR (k0 = v0 AND k1 op1 v1) OR …</c> where <c>opN</c> is <c>&gt;</c> for an
+    ///     ascending key and <c>&lt;</c> for a descending one. Every value enters as a bound
+    ///     parameter, and each locator is the exact <see cref="IQueryableMember.TypedLocator"/> used
+    ///     in the ORDER BY so the seek boundary lines up with the sort.
+    /// </summary>
+    public static ISqlFragment BuildSeekPredicate(
+        IReadOnlyList<(IQueryableMember Member, bool Descending)> orderBy, object?[] values)
+    {
+        ISqlFragment? predicate = null;
+
+        for (var i = 0; i < orderBy.Count; i++)
+        {
+            // Clause i: (k0 = v0 AND … AND k[i-1] = v[i-1] AND k[i] op v[i])
+            ISqlFragment? clause = null;
+            for (var j = 0; j <= i; j++)
+            {
+                var locator = orderBy[j].Member.TypedLocator;
+                var op = j < i ? "=" : (orderBy[j].Descending ? "<" : ">");
+                ISqlFragment comparison = new ComparisonFilter(locator, op, values[j]!);
+                clause = clause is null ? comparison : new CompoundWhereFragment("AND", clause, comparison);
+            }
+
+            predicate = predicate is null ? clause! : new CompoundWhereFragment("OR", predicate, clause!);
+        }
+
+        return predicate!;
+    }
+
+    // Read-side values arrive already normalized to CLR primitives / Guid / DateTimeOffset, which STJ
+    // serializes losslessly. Guid/DateTimeOffset become strings; numbers/bools stay native.
+    private static object? NormalizeForCursor(object? value) =>
+        value is DBNull ? null : value;
+
+    private static object? ConvertSlot(JsonElement slot, Type memberType)
+    {
+        var target = Nullable.GetUnderlyingType(memberType) ?? memberType;
+
+        if (slot.ValueKind == JsonValueKind.Null) return null;
+
+        if (target == typeof(Guid)) return slot.GetGuid();
+        if (target == typeof(string)) return slot.GetString();
+        if (target == typeof(int)) return slot.GetInt32();
+        if (target == typeof(long)) return slot.GetInt64();
+        if (target == typeof(short)) return slot.GetInt16();
+        if (target == typeof(byte)) return slot.GetByte();
+        if (target == typeof(bool)) return slot.GetBoolean();
+        if (target == typeof(decimal)) return slot.GetDecimal();
+        if (target == typeof(double)) return slot.GetDouble();
+        if (target == typeof(float)) return slot.GetSingle();
+        if (target == typeof(DateTimeOffset)) return slot.GetDateTimeOffset();
+        if (target == typeof(DateTime)) return slot.GetDateTime();
+
+        throw new NotSupportedException(
+            $"Keyset (cursor) pagination does not support an ordering key of type '{memberType.Name}'. " +
+            "Order by primitive/Guid/DateTime(Offset) keys with the document identity as the terminal key.");
+    }
+}

--- a/src/Polecat/Linq/CursorPaging/CursorPagingQueryableExtensions.cs
+++ b/src/Polecat/Linq/CursorPaging/CursorPagingQueryableExtensions.cs
@@ -1,0 +1,37 @@
+namespace Polecat.Linq.CursorPaging;
+
+/// <summary>
+///     Keyset (cursor / seek) pagination entry points on Polecat <see cref="IQueryable{T}"/>.
+///     Constant cost at any depth — ideal for infinite scroll, "load more", and export feeds.
+/// </summary>
+public static class CursorPagingQueryableExtensions
+{
+    /// <summary>
+    ///     Fetches one keyset page as raw JSON plus a continuation cursor. On the first request pass
+    ///     <paramref name="cursor"/> = <c>null</c>; on subsequent requests pass the previous page's
+    ///     <see cref="CursorPageResult.NextCursor"/>. When the page returns fewer than
+    ///     <paramref name="pageSize"/> items the returned <see cref="CursorPageResult.NextCursor"/> is
+    ///     <c>null</c> (end of set).
+    /// </summary>
+    /// <param name="queryable">
+    ///     A Polecat query ordered so its terminal key is the document identity (e.g.
+    ///     <c>OrderBy(x =&gt; x.Foo).ThenBy(x =&gt; x.Id)</c>). Ordering that lacks an OrderBy, or whose
+    ///     terminal key is not the identity member, is rejected.
+    /// </param>
+    /// <param name="cursor">The opaque continuation cursor, or <c>null</c> for the first page.</param>
+    /// <param name="pageSize">Page size. Must be &gt;= 1.</param>
+    /// <param name="token">Cancellation token.</param>
+    /// <exception cref="ArgumentOutOfRangeException">If <paramref name="pageSize"/> is below 1.</exception>
+    /// <exception cref="InvalidOperationException">If the query has no OrderBy or a non-identity terminal key.</exception>
+    public static async Task<CursorPageResult> ToJsonPageByCursorAsync<T>(
+        this IQueryable<T> queryable, string? cursor, int pageSize, CancellationToken token = default)
+    {
+        if (queryable.Provider is not PolecatLinqQueryProvider provider)
+        {
+            throw new InvalidOperationException(
+                "ToJsonPageByCursorAsync can only be used with Polecat IQueryable instances.");
+        }
+
+        return await provider.ExecuteCursorPageJsonAsync(queryable.Expression, cursor, pageSize, token);
+    }
+}

--- a/src/Polecat/Linq/Parsing/LinqQueryParser.cs
+++ b/src/Polecat/Linq/Parsing/LinqQueryParser.cs
@@ -34,6 +34,13 @@ internal class LinqQueryParser : ExpressionVisitor
     public IQueryableMember? AggregationMember { get; private set; }
 
     /// <summary>
+    ///     The resolved members behind each ORDER BY / THEN BY clause, in order. Parallel to
+    ///     <see cref="SqlGeneration.Statement.OrderBys"/> but carrying the member CLR type and
+    ///     identity information needed for keyset (cursor) pagination.
+    /// </summary>
+    public List<(IQueryableMember Member, bool Descending)> OrderByMembers { get; } = [];
+
+    /// <summary>
     ///     The Select() lambda, if present. Used for projections.
     /// </summary>
     public LambdaExpression? SelectExpression { get; private set; }
@@ -367,6 +374,7 @@ internal class LinqQueryParser : ExpressionVisitor
         if (replace)
         {
             Statement.OrderBys.Clear();
+            OrderByMembers.Clear();
         }
 
         var lambda = GetLambda(node.Arguments[1]);
@@ -385,6 +393,7 @@ internal class LinqQueryParser : ExpressionVisitor
 
         var member = _memberFactory.ResolveMember(memberExpr);
         Statement.OrderBys.Add((member.TypedLocator, descending));
+        OrderByMembers.Add((member, descending));
     }
 
     private void HandleTake(MethodCallExpression node)

--- a/src/Polecat/Linq/PolecatLinqQueryProvider.cs
+++ b/src/Polecat/Linq/PolecatLinqQueryProvider.cs
@@ -4,6 +4,7 @@ using System.Linq.Expressions;
 using System.Text;
 using Microsoft.Data.SqlClient;
 using Polecat.Internal;
+using Polecat.Linq.CursorPaging;
 using Polecat.Linq.Joins;
 using Polecat.Linq.Members;
 using Polecat.Linq.Parsing;
@@ -332,6 +333,112 @@ internal class PolecatLinqQueryProvider : IPolecatAsyncQueryProvider
         }
 
         await destination.WriteAsync("]}"u8.ToArray(), token);
+    }
+
+    /// <summary>
+    ///     Executes one keyset (cursor / seek) page: streams the page's raw document JSON and builds
+    ///     the continuation cursor from the last row's sort-key values — all in a single round trip
+    ///     that also selects the ordering-key columns so the cursor is built without hydrating.
+    ///     Mirrors Marten's <c>StreamPagedByCursor</c> mechanics (JasperFx/marten#5016), adapted to
+    ///     SQL Server (composite seek predicate + <c>TOP(pageSize + 1)</c> to detect a next page).
+    /// </summary>
+    internal async Task<CursorPageResult> ExecuteCursorPageJsonAsync(
+        Expression expression, string? cursor, int pageSize, CancellationToken token)
+    {
+        if (pageSize < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize,
+                "pageSize must be greater than or equal to 1.");
+        }
+
+        var documentType = FindDocumentType(expression);
+        var provider = _providers.GetProvider(documentType);
+        await _tableEnsurer.EnsureTableAsync(provider, token);
+
+        var memberFactory = new MemberFactory(_session.Options, provider.Mapping);
+        var parser = new LinqQueryParser(memberFactory, provider.Mapping.QualifiedTableName);
+        parser.Parse(expression);
+
+        var orderBy = parser.OrderByMembers;
+        CursorPagination.ValidateOrdering(orderBy);
+
+        // Select the raw data column plus each ordering-key column (aliased) so the cursor is built
+        // from the last row without hydrating the document.
+        var select = new StringBuilder("data");
+        for (var i = 0; i < orderBy.Count; i++)
+        {
+            select.Append(", ").Append(orderBy[i].Member.TypedLocator).Append(" AS __pc_k").Append(i);
+        }
+
+        parser.Statement.SelectColumns = select.ToString();
+
+        // Fetch one extra row to detect whether a next page exists.
+        parser.Statement.Limit = pageSize + 1;
+
+        if (cursor != null)
+        {
+            var values = CursorPagination.Decode(cursor, orderBy);
+            parser.Statement.Wheres.Add(CursorPagination.BuildSeekPredicate(orderBy, values));
+        }
+
+        if (!parser.IsAnyTenant && IsConjoinedTenancy)
+        {
+            if (parser.TenantIds != null)
+            {
+                parser.Statement.Wheres.Add(new TenantInFilter(parser.TenantIds));
+            }
+            else
+            {
+                parser.Statement.Wheres.Add(new ComparisonFilter("tenant_id", "=", _session.TenantId));
+            }
+        }
+
+        if (provider.Mapping.DeleteStyle == DeleteStyle.SoftDelete && !parser.IsMaybeDeleted)
+        {
+            parser.Statement.Wheres.Add(new LiteralSqlFragment(parser.IsDeletedOnly ? "is_deleted = 1" : "is_deleted = 0"));
+        }
+
+        ApplyModifiedFilters(parser);
+
+        await using var batch = new SqlBatch();
+        var builder = new BatchBuilder(batch);
+        parser.Statement.Apply(builder);
+        builder.Compile();
+
+        await using var reader = await _session.ExecuteReaderAsync(batch, token);
+
+        var items = new List<string>(pageSize + 1);
+        var lastKeyValues = new List<object?[]>(pageSize + 1);
+        while (await reader.ReadAsync(token))
+        {
+            items.Add(reader.GetString(0));
+
+            var keys = new object?[orderBy.Count];
+            for (var i = 0; i < orderBy.Count; i++)
+            {
+                keys[i] = reader.IsDBNull(i + 1) ? null : reader.GetValue(i + 1);
+            }
+
+            lastKeyValues.Add(keys);
+        }
+
+        // If the probe row came back, there is a next page. Trim to pageSize and build the cursor
+        // from the last kept row's sort-key values.
+        var hasMore = items.Count > pageSize;
+        var count = hasMore ? pageSize : items.Count;
+
+        var sb = new StringBuilder("[");
+        for (var i = 0; i < count; i++)
+        {
+            if (i > 0) sb.Append(',');
+            sb.Append(items[i]);
+        }
+
+        sb.Append(']');
+
+        var nextCursor = hasMore ? CursorPagination.Encode(lastKeyValues[count - 1]) : null;
+
+        return new CursorPageResult(sb.ToString(), count, nextCursor);
     }
 
     [RequiresDynamicCode("LINQ-to-SQL execution closes ListQueryHandler<>/DeserializingSelector<>/etc. over the document type via Type.MakeGenericType.")]


### PR DESCRIPTION
Closes #357.

Ports Marten's keyset / seek pagination (JasperFx/marten#5016) to SQL Server — **constant cost at any depth**, ideal for infinite scroll / "load more" / export feeds.

## Surface
- `ToJsonPageByCursorAsync<T>(cursor, pageSize)` on `IQueryable<T>` → `CursorPageResult(ItemsJson, Count, NextCursor)`.
- `Polecat.AspNetCore.StreamPagedByCursor<T>` — `IResult` streaming `{"items":[...],"nextCursor":"v1:..."}` and echoing the cursor in a `Polecat-Continuation` response header.
- First request: `cursor == null`. Subsequent: pass the prior page's `NextCursor`. Fewer than `pageSize` rows → `NextCursor == null` (end of set).

## Correctness invariants (the important part)
- **Composite seek predicate** `(k1>v1) OR (k1=v1 AND k2>v2) OR …`, direction-flipped per key, built from `ComparisonFilter`/`CompoundWhereFragment` using the **same `TypedLocator`** as the `ORDER BY`, values as **bound parameters** (no injection).
- **Terminal key must be the unique document identity (`Id`)** → total order, so pagination can't skip/duplicate across ties. Rejected otherwise. `OrderBy` is required.
- **Opaque, versioned (`v1:`) base64-JSON cursor**; values typed on **decode** by the query's ordering key types (cursor never dictates types).

## SQL Server mechanics
- `>`/`<` on `nvarchar`/`uniqueidentifier`/`datetimeoffset` translate to real T-SQL comparisons (verified — not client-eval).
- `uniqueidentifier` seeks use SQL Server's byte-group ordering — the **same** ordering `ORDER BY` uses, so the boundary lines up (differs from Postgres `uuid`; a pinning test asserts strict `SqlGuid` order). `TOP(pageSize + 1)` detects the next page.
- `LinqQueryParser` now exposes resolved `OrderByMembers` (member CLR type + identity) alongside `Statement.OrderBys`.

## Tests
- **12 unit facts** (`cursor_paging_tests`): first / subsequent / last / empty / exact-multiple boundary, mixed asc-desc, the **must-have exhaustive tie-breaking** through 20 duplicate leading keys (every id once, no skips/dupes), `uniqueidentifier`-ordering seek match, and all three validation errors.
- **4 Alba scenarios** over `/api/issues/paged-cursor/{pageSize}?cursor=`.
- Docs: keyset section in `paging.md` + result-type entry in `aspnetcore.md`.

12/12 unit + full net9 AspNetCore suite 29/29 green. Includes the assembly-level test-parallelization fix for the shared-DB integration project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)