### PR TITLE
feat(#358): simple Select() → server-side JSON object + correctness guards (marten#5017 parity)

### DIFF
--- a/docs/documents/querying/query-json.md
+++ b/docs/documents/querying/query-json.md
@@ -24,6 +24,34 @@ string jsonArray = await session.Query<User>()
 // Returns: [{"id":"...","firstName":"Alice",...},{"id":"...","firstName":"Bob",...}]
 ```
 
+### Projecting with Select()
+
+A **simple** `Select()` projection — an anonymous type or DTO composed only of (optionally
+nested) document member accesses — is translated to a server-side JSON object and streamed
+without hydrating the documents (SQL Server 2025 native JSON, via `JSON_OBJECT`):
+
+```cs
+string jsonArray = await session.Query<Customer>()
+    .Where(x => x.Active)
+    .Select(x => new { x.Name, City = x.Address.City })
+    .ToJsonArrayAsync();
+
+// Returns: [{"name":"Alice","city":"Austin"}, ...]
+```
+
+Emitted keys honor the serializer naming policy and `[JsonPropertyName]`, exactly as
+System.Text.Json would serialize the projected shape. Safe/widening conversions (`int`→`long`,
+`T`→`object`, enum↔underlying, non-null→nullable) are transparent.
+
+::: warning
+A projection that is **not** a simple member projection — a scalar select (`Select(x => x.Name)`),
+a method call (`x.Name.ToUpper()`), arithmetic (`x.Age * 2`), a conditional, etc. — **cannot** be
+streamed as raw JSON and throws `BadLinqExpressionException` rather than silently returning the raw
+documents. Materialize those with `ToListAsync()` (which runs the projection client-side) instead
+of a JSON-streaming call. The server-side JSON-object translation requires a native-JSON
+(SQL Server 2025) store; on other stores a `Select()` projection likewise throws when streaming.
+:::
+
 ## Use Cases
 
 Raw JSON queries are useful when:

--- a/src/Polecat.Tests/Linq/select_projection_json_tests.cs
+++ b/src/Polecat.Tests/Linq/select_projection_json_tests.cs
@@ -1,0 +1,191 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Polecat.Linq;
+using Polecat.TestUtils;
+using Polecat.Tests.Harness;
+
+namespace Polecat.Tests.Linq;
+
+/// <summary>
+///     Coverage for translating simple <c>Select()</c> projections to a server-side JSON object plus
+///     the two correctness guards (marten#5017 parity, polecat#358). The JSON_OBJECT optimization
+///     requires SQL Server 2025 native JSON, so those facts skip on non-native (edge) stores; the
+///     guards (throw on non-streamable projection; client-side fallback for ToList) are universal.
+/// </summary>
+[Collection("integration")]
+public class select_projection_json_tests : IntegrationContext
+{
+    public select_projection_json_tests(DefaultStoreFixture fixture) : base(fixture)
+    {
+    }
+
+    public class NameYears
+    {
+        public string? PersonName { get; set; }
+        public int Years { get; set; }
+
+        [JsonPropertyName("custom_city")]
+        public string? City { get; set; }
+    }
+
+    private async Task<string> SeedAsync(int count)
+    {
+        var name = $"Proj_{Guid.NewGuid():N}";
+        for (var i = 0; i < count; i++)
+        {
+            theSession.Store(new LinqTarget
+            {
+                Id = Guid.NewGuid(),
+                Name = name,
+                Age = i,
+                BigNumber = i,
+                Address = new Address { City = $"City{i}", State = "TX" }
+            });
+        }
+
+        await theSession.SaveChangesAsync();
+        return name;
+    }
+
+    [Fact]
+    public async Task simple_anonymous_projection_streams_json_object()
+    {
+        if (!ConnectionSource.SupportsNativeJson) return;
+
+        var name = await SeedAsync(3);
+
+        await using var query = theStore.QuerySession();
+        var json = await query.Query<LinqTarget>()
+            .Where(x => x.Name == name)
+            .Select(x => new { x.Name, x.Age })
+            .ToJsonArrayAsync();
+
+        var array = JsonDocument.Parse(json).RootElement;
+        array.GetArrayLength().ShouldBe(3);
+
+        foreach (var element in array.EnumerateArray())
+        {
+            element.GetProperty("name").GetString().ShouldBe(name);
+            element.TryGetProperty("age", out _).ShouldBeTrue();
+            // The projection must NOT leak un-projected members.
+            element.TryGetProperty("id", out _).ShouldBeFalse();
+            element.TryGetProperty("address", out _).ShouldBeFalse();
+        }
+    }
+
+    [Fact]
+    public async Task nested_member_projection_streams_json_object()
+    {
+        if (!ConnectionSource.SupportsNativeJson) return;
+
+        var name = await SeedAsync(2);
+
+        await using var query = theStore.QuerySession();
+        var json = await query.Query<LinqTarget>()
+            .Where(x => x.Name == name)
+            .OrderBy(x => x.Age)
+            .Select(x => new { x.Age, City = x.Address!.City })
+            .ToJsonArrayAsync();
+
+        var array = JsonDocument.Parse(json).RootElement;
+        array[0].GetProperty("city").GetString().ShouldBe("City0");
+        array[0].GetProperty("age").GetInt32().ShouldBe(0);
+        array[1].GetProperty("city").GetString().ShouldBe("City1");
+    }
+
+    [Fact]
+    public async Task dto_projection_honors_json_property_name_and_naming_policy()
+    {
+        if (!ConnectionSource.SupportsNativeJson) return;
+
+        var name = await SeedAsync(1);
+
+        await using var query = theStore.QuerySession();
+        var json = await query.Query<LinqTarget>()
+            .Where(x => x.Name == name)
+            .Select(x => new NameYears { PersonName = x.Name, Years = x.Age, City = x.Address!.City })
+            .ToJsonArrayAsync();
+
+        var obj = JsonDocument.Parse(json).RootElement[0];
+        obj.GetProperty("personName").GetString().ShouldBe(name);   // naming policy (camelCase)
+        obj.GetProperty("years").GetInt32().ShouldBe(0);
+        obj.GetProperty("custom_city").GetString().ShouldBe("City0"); // [JsonPropertyName] wins verbatim
+    }
+
+    [Fact]
+    public async Task safe_widening_conversion_stays_simple()
+    {
+        if (!ConnectionSource.SupportsNativeJson) return;
+
+        var name = await SeedAsync(2);
+
+        await using var query = theStore.QuerySession();
+        var json = await query.Query<LinqTarget>()
+            .Where(x => x.Name == name)
+            .OrderBy(x => x.Age)
+            .Select(x => new { Big = (long)x.Age })
+            .ToJsonArrayAsync();
+
+        var array = JsonDocument.Parse(json).RootElement;
+        array[0].GetProperty("big").GetInt64().ShouldBe(0L);
+        array[1].GetProperty("big").GetInt64().ShouldBe(1L);
+    }
+
+    // ---------- Correctness guards (universal — run on native and non-native alike) ----------
+
+    [Fact]
+    public async Task streaming_a_method_call_projection_throws()
+    {
+        var name = await SeedAsync(1);
+
+        await using var query = theStore.QuerySession();
+        await Should.ThrowAsync<BadLinqExpressionException>(async () =>
+            await query.Query<LinqTarget>()
+                .Where(x => x.Name == name)
+                .Select(x => new { Upper = x.Name!.ToUpper() })
+                .ToJsonArrayAsync());
+    }
+
+    [Fact]
+    public async Task streaming_an_arithmetic_projection_throws()
+    {
+        var name = await SeedAsync(1);
+
+        await using var query = theStore.QuerySession();
+        await Should.ThrowAsync<BadLinqExpressionException>(async () =>
+            await query.Query<LinqTarget>()
+                .Where(x => x.Name == name)
+                .Select(x => new { Doubled = x.Age * 2 })
+                .ToJsonArrayAsync());
+    }
+
+    [Fact]
+    public async Task streaming_a_scalar_projection_throws()
+    {
+        var name = await SeedAsync(1);
+
+        await using var query = theStore.QuerySession();
+        await Should.ThrowAsync<BadLinqExpressionException>(async () =>
+            await query.Query<LinqTarget>()
+                .Where(x => x.Name == name)
+                .Select(x => x.Name)
+                .ToJsonArrayAsync());
+    }
+
+    [Fact]
+    public async Task non_simple_projection_falls_back_to_client_side_for_to_list()
+    {
+        // Guard 1: a non-translatable Select() must NOT silently drop the unsupported operation — it
+        // falls back to a client-side transform when the results are materialized (not streamed).
+        var name = await SeedAsync(1);
+
+        await using var query = theStore.QuerySession();
+        var results = await query.Query<LinqTarget>()
+            .Where(x => x.Name == name)
+            .Select(x => new { Upper = x.Name!.ToUpper() })
+            .ToListAsync();
+
+        results.Count.ShouldBe(1);
+        results[0].Upper.ShouldBe(name.ToUpper());
+    }
+}

--- a/src/Polecat/Linq/BadLinqExpressionException.cs
+++ b/src/Polecat/Linq/BadLinqExpressionException.cs
@@ -1,0 +1,17 @@
+namespace Polecat.Linq;
+
+/// <summary>
+///     Thrown when a LINQ expression cannot be translated to a valid SQL Server query — for example,
+///     attempting to stream a client-side-fallback projection as raw JSON, which would silently
+///     return incorrect results. Mirrors Marten's <c>BadLinqExpressionException</c>.
+/// </summary>
+public class BadLinqExpressionException : Exception
+{
+    public BadLinqExpressionException(string message) : base(message)
+    {
+    }
+
+    public BadLinqExpressionException(string message, Exception innerException) : base(message, innerException)
+    {
+    }
+}

--- a/src/Polecat/Linq/Members/MemberFactory.cs
+++ b/src/Polecat/Linq/Members/MemberFactory.cs
@@ -55,6 +55,14 @@ internal class MemberFactory : IMemberResolver
         return CreateMember(jsonPath, memberType);
     }
 
+    /// <summary>
+    ///     Formats the JSON key a projection member would serialize to — an explicit
+    ///     <c>[JsonPropertyName]</c> wins verbatim over the configured naming policy, exactly as
+    ///     System.Text.Json serializes it. Used when translating a simple <c>Select()</c> projection
+    ///     to a server-side JSON object so the emitted keys match what a client would deserialize.
+    /// </summary>
+    public string FormatProjectedKey(MemberInfo member) => GetJsonPropertyName(member);
+
     private IQueryableMember CreateMember(string jsonPath, Type memberType)
     {
         var rawLocator = $"JSON_VALUE(data, '{jsonPath}')";

--- a/src/Polecat/Linq/Parsing/SelectProjectionAnalyzer.cs
+++ b/src/Polecat/Linq/Parsing/SelectProjectionAnalyzer.cs
@@ -1,0 +1,184 @@
+using System.Linq.Expressions;
+using System.Reflection;
+using Polecat.Linq.Members;
+
+namespace Polecat.Linq.Parsing;
+
+/// <summary>
+///     One projected column of a "simple" <c>Select()</c> projection: the emitted JSON key and the
+///     SQL locator that produces its value.
+/// </summary>
+internal sealed record SimpleProjectionColumn(string JsonKey, string Locator, Type MemberType);
+
+/// <summary>
+///     Detects whether a <c>Select()</c> projection is "simple" — composed only of (optionally
+///     nested) scalar member accesses, with no method calls, arithmetic, or conditionals — and, if
+///     so, returns the key/locator columns needed to build a server-side JSON object. Mirrors
+///     Marten's <c>SelectParser</c> "simple projection" detection (JasperFx/marten#5017), adopting
+///     the #5031 refinement that strips safe/widening conversions (int→long, T→object, enum→int,
+///     non-null→nullable) rather than over-bailing on them.
+/// </summary>
+internal static class SelectProjectionAnalyzer
+{
+    /// <summary>
+    ///     Returns the projected columns if <paramref name="select"/> is a simple object projection
+    ///     (anonymous type or DTO with member assignments, every value a scalar member access), or
+    ///     <c>null</c> when it is not translatable to a server-side JSON object.
+    /// </summary>
+    public static IReadOnlyList<SimpleProjectionColumn>? TryAnalyze(
+        LambdaExpression select, MemberFactory memberFactory)
+    {
+        var body = StripSafeConvert(select.Body);
+
+        return body switch
+        {
+            NewExpression newExpression => AnalyzeNew(newExpression, memberFactory),
+            MemberInitExpression memberInit => AnalyzeMemberInit(memberInit, memberFactory),
+            _ => null
+        };
+    }
+
+    private static IReadOnlyList<SimpleProjectionColumn>? AnalyzeNew(
+        NewExpression newExpression, MemberFactory memberFactory)
+    {
+        // Anonymous types (and record-style positional ctors) expose the projected member names via
+        // NewExpression.Members. Without them we cannot name the JSON keys → not translatable.
+        if (newExpression.Members is null || newExpression.Members.Count != newExpression.Arguments.Count)
+        {
+            return null;
+        }
+
+        var columns = new List<SimpleProjectionColumn>(newExpression.Arguments.Count);
+        for (var i = 0; i < newExpression.Arguments.Count; i++)
+        {
+            var column = TryColumn(newExpression.Members[i], newExpression.Arguments[i], memberFactory);
+            if (column is null) return null;
+            columns.Add(column);
+        }
+
+        return columns;
+    }
+
+    private static IReadOnlyList<SimpleProjectionColumn>? AnalyzeMemberInit(
+        MemberInitExpression memberInit, MemberFactory memberFactory)
+    {
+        // Only a parameterless `new Dto { A = x.A, ... }` shape is simple.
+        if (memberInit.NewExpression.Arguments.Count != 0) return null;
+
+        var columns = new List<SimpleProjectionColumn>(memberInit.Bindings.Count);
+        foreach (var binding in memberInit.Bindings)
+        {
+            if (binding is not MemberAssignment assignment) return null;
+
+            var column = TryColumn(assignment.Member, assignment.Expression, memberFactory);
+            if (column is null) return null;
+            columns.Add(column);
+        }
+
+        return columns.Count > 0 ? columns : null;
+    }
+
+    private static SimpleProjectionColumn? TryColumn(
+        MemberInfo projectionMember, Expression valueExpression, MemberFactory memberFactory)
+    {
+        var value = StripSafeConvert(valueExpression);
+
+        // The value must be a (possibly nested) member access rooted at the lambda parameter.
+        if (value is not MemberExpression memberExpression || !IsRootedAtParameter(memberExpression))
+        {
+            return null;
+        }
+
+        var member = memberFactory.ResolveMember(memberExpression);
+
+        // Only scalar leaf members translate cleanly to a JSON_VALUE locator. Projecting a whole
+        // nested object/array would need JSON_QUERY handling → treat as not simple.
+        if (!IsScalar(member.MemberType)) return null;
+
+        var key = memberFactory.FormatProjectedKey(projectionMember);
+        return new SimpleProjectionColumn(key, member.TypedLocator, member.MemberType);
+    }
+
+    private static bool IsRootedAtParameter(MemberExpression expression)
+    {
+        Expression? current = expression;
+        while (current is MemberExpression m)
+        {
+            current = m.Expression;
+        }
+
+        return current is ParameterExpression;
+    }
+
+    private static bool IsScalar(Type type)
+    {
+        var underlying = Nullable.GetUnderlyingType(type) ?? type;
+        return underlying.IsPrimitive
+               || underlying.IsEnum
+               || underlying == typeof(string)
+               || underlying == typeof(Guid)
+               || underlying == typeof(decimal)
+               || underlying == typeof(DateTime)
+               || underlying == typeof(DateTimeOffset)
+               || underlying == typeof(TimeSpan)
+               || underlying == typeof(DateOnly)
+               || underlying == typeof(TimeOnly);
+    }
+
+    // Strip no-op / safe / widening conversions (marten#5031 fixed behavior): boxing to object,
+    // widening numeric conversions, enum <-> underlying, and non-null -> nullable. Bail (leave the
+    // node in place, so the caller treats the projection as non-simple) on lossy/narrowing casts.
+    private static Expression StripSafeConvert(Expression expression)
+    {
+        while (expression is UnaryExpression { NodeType: ExpressionType.Convert or ExpressionType.ConvertChecked } convert)
+        {
+            if (!IsSafeConversion(convert.Operand.Type, convert.Type)) break;
+            expression = convert.Operand;
+        }
+
+        return expression;
+    }
+
+    private static bool IsSafeConversion(Type from, Type to)
+    {
+        if (to == from) return true;
+        if (to == typeof(object)) return true;
+
+        // non-null T -> Nullable<T>
+        if (Nullable.GetUnderlyingType(to) == from) return true;
+
+        var fromUnderlying = Nullable.GetUnderlyingType(from) ?? from;
+        var toUnderlying = Nullable.GetUnderlyingType(to) ?? to;
+
+        // enum <-> its underlying integral type
+        if (fromUnderlying.IsEnum && Enum.GetUnderlyingType(fromUnderlying) == toUnderlying) return true;
+        if (toUnderlying.IsEnum && Enum.GetUnderlyingType(toUnderlying) == fromUnderlying) return true;
+
+        // widening numeric conversions
+        return IsWideningNumeric(fromUnderlying, toUnderlying);
+    }
+
+    private static bool IsWideningNumeric(Type from, Type to)
+    {
+        if (!WideningRank.TryGetValue(from, out var fromRank)) return false;
+        if (!WideningRank.TryGetValue(to, out var toRank)) return false;
+        return toRank >= fromRank;
+    }
+
+    // Coarse widening ranks: a conversion is widening when the target rank >= the source rank within
+    // the same signed/float family. Kept intentionally conservative — anything not covered is treated
+    // as non-simple rather than risking a lossy cast being silently translated.
+    private static readonly Dictionary<Type, int> WideningRank = new()
+    {
+        [typeof(sbyte)] = 1,
+        [typeof(short)] = 2,
+        [typeof(int)] = 3,
+        [typeof(long)] = 4,
+        [typeof(byte)] = 1,
+        [typeof(ushort)] = 2,
+        [typeof(uint)] = 3,
+        [typeof(ulong)] = 4,
+        [typeof(float)] = 5,
+        [typeof(double)] = 6,
+    };
+}

--- a/src/Polecat/Linq/PolecatLinqQueryProvider.cs
+++ b/src/Polecat/Linq/PolecatLinqQueryProvider.cs
@@ -141,8 +141,12 @@ internal class PolecatLinqQueryProvider : IPolecatAsyncQueryProvider
         var parser = new LinqQueryParser(memberFactory, provider.Mapping.QualifiedTableName);
         parser.Parse(expression);
 
-        // Force select only the data column
-        parser.Statement.SelectColumns = "data";
+        // Choose the streamed columns. A whole-document query streams the raw `data` column. A
+        // Select(...) projection must translate to a server-side JSON object (#358) — otherwise
+        // streaming would silently ignore the projection and return the raw documents. A projection
+        // that isn't a simple, translatable member shape can't be streamed and throws a clear error
+        // rather than producing wrong JSON.
+        parser.Statement.SelectColumns = ResolveStreamingSelectColumns(parser, memberFactory);
 
         if (parser.IsDistinct) parser.Statement.IsDistinct = true;
 
@@ -439,6 +443,59 @@ internal class PolecatLinqQueryProvider : IPolecatAsyncQueryProvider
         var nextCursor = hasMore ? CursorPagination.Encode(lastKeyValues[count - 1]) : null;
 
         return new CursorPageResult(sb.ToString(), count, nextCursor);
+    }
+
+    /// <summary>
+    ///     Resolves the SELECT columns for a raw-JSON streaming query (#358). No projection → the
+    ///     raw <c>data</c> column. A simple <c>Select(x =&gt; new { … })</c> projection of document
+    ///     members → a server-side <c>JSON_OBJECT(...)</c> (native-JSON / SQL Server 2025 only). Any
+    ///     other projection (scalar select, method calls, arithmetic, non-native store, …) cannot be
+    ///     streamed faithfully and throws <see cref="BadLinqExpressionException"/> rather than
+    ///     silently returning the raw documents.
+    /// </summary>
+    private string ResolveStreamingSelectColumns(LinqQueryParser parser, MemberFactory memberFactory)
+    {
+        if (parser.SelectExpression is null)
+        {
+            return "data";
+        }
+
+        var columns = _session.Options.UseNativeJsonType
+            ? SelectProjectionAnalyzer.TryAnalyze(parser.SelectExpression, memberFactory)
+            : null;
+
+        if (columns is null)
+        {
+            throw new BadLinqExpressionException(
+                "This query cannot be streamed as raw JSON because its Select(...) projection is not a " +
+                "simple object of document members. Either project into an anonymous type / DTO composed " +
+                "only of document member accesses (e.g. Select(x => new { x.Name, x.Address.City })) on a " +
+                "native-JSON store (SQL Server 2025), or materialize the results with ToListAsync() " +
+                "instead of a JSON-streaming call.");
+        }
+
+        return BuildJsonObjectSelect(columns);
+    }
+
+    /// <summary>
+    ///     Emits a native SQL Server <c>JSON_OBJECT('key': locator, …) AS data</c> for a simple
+    ///     projection. Keys honor the serializer naming policy / <c>[JsonPropertyName]</c>; values
+    ///     come from each member's typed JSON locator, so numbers stay numbers and strings stay
+    ///     quoted. NULL members are kept as JSON <c>null</c> (JSON_OBJECT's default NULL ON NULL),
+    ///     matching how System.Text.Json serializes the same shape.
+    /// </summary>
+    private static string BuildJsonObjectSelect(IReadOnlyList<SimpleProjectionColumn> columns)
+    {
+        var sb = new StringBuilder("JSON_OBJECT(");
+        for (var i = 0; i < columns.Count; i++)
+        {
+            if (i > 0) sb.Append(", ");
+            sb.Append('\'').Append(columns[i].JsonKey.Replace("'", "''")).Append("': ");
+            sb.Append(columns[i].Locator);
+        }
+
+        sb.Append(") AS data");
+        return sb.ToString();
     }
 
     [RequiresDynamicCode("LINQ-to-SQL execution closes ListQueryHandler<>/DeserializingSelector<>/etc. over the document type via Type.MakeGenericType.")]


### PR DESCRIPTION
Closes #358.

Investigation outcome **and** implementation of the Marten #5017 parity (JasperFx/marten#5017).

## Optimization (SQL Server 2025 native JSON)
A **simple** `Select()` projection — an anonymous type / DTO composed only of (optionally nested) **scalar** document member accesses — is translated to a server-side `JSON_OBJECT(...)` and streamed with no hydrate/reserialize:

```cs
session.Query<Customer>().Where(x => x.Active)
    .Select(x => new { x.Name, City = x.Address.City })
    .ToJsonArrayAsync();   // → [{"name":"Alice","city":"Austin"}, ...]
```

Keys honor the serializer naming policy / `[JsonPropertyName]`; values come from each member's typed JSON locator (numbers stay numbers, strings stay quoted; `NULL ON NULL` matches STJ).

**SQL Server mechanics decision:** `JSON_OBJECT` (native, SQL Server 2025 — the project's target per CLAUDE.md) maps almost 1:1 to Postgres `jsonb_build_object`, so it is used directly rather than the `FOR JSON PATH` / CONCAT fallback. On non-native stores a `Select()` projection can't be streamed faithfully and throws the guard exception (no silent wrong JSON).

## Correctness guards (shipped regardless of the optimization — the must-have)
1. A non-translatable `Select()` **falls back to a client-side transform** when materialized with `ToListAsync()` (already Polecat's behavior — locked in with a test), never a silent drop of the unsupported operation.
2. Attempting to **stream** a client-side-fallback projection now throws **`BadLinqExpressionException`** (new type, mirrors Marten) instead of silently ignoring the `Select` and returning raw documents.

Adopts the **marten#5031 refinement**: `SelectProjectionAnalyzer` strips safe/widening conversions (`int→long`, `T→object`, enum↔underlying, non-null→nullable) and only bails on lossy/computed shapes (method calls, arithmetic, conditionals, narrowing casts).

## Tests
- **4 native-JSON facts**: anonymous projection, nested member, DTO with `[JsonPropertyName]` + naming policy, safe widening.
- **4 universal guard facts**: method-call / arithmetic / scalar projections throw when streamed; non-simple projection falls back client-side for `ToListAsync`.
- Docs added to `query-json.md`.

8/8 green on net10 (native). Guard facts run on native and non-native (edge) alike.

🤖 Generated with [Claude Code](https://claude.com/claude-code)