### PR TITLE
feat(#364): AggregateToManyAsync() + HasTag DCB tag operator in LINQ Where() (marten#4998/#4999 parity)

### DIFF
--- a/docs/events/dcb.md
+++ b/docs/events/dcb.md
@@ -59,6 +59,25 @@ Use `EventTagQuery` to build a query, then execute it with `QueryByTagsAsync`:
 
 Events are always returned ordered by sequence number (global append order).
 
+### Tag Predicates in LINQ (`HasTag`)
+
+Tag predicates can also compose directly into a LINQ `Where()` over an event query, alongside ordinary event predicates (timestamp, event type, stream). Use the `IEvent.HasTag<TTag>(value)` marker method:
+
+<!-- snippet: sample_polecat_dcb_has_tag_linq -->
+<!-- endSnippet -->
+
+`HasTag` compiles to the same tag-table subquery that `QueryByTagsAsync` emits (a correlated `seq_id IN (SELECT seq_id FROM pc_event_tag_{suffix} WHERE value = @p)` predicate), and under conjoined tenancy it is automatically tenant-scoped. AND-ing several `HasTag` calls with normal predicates is supported:
+
+```cs
+var events = await session.Events.QueryAllRawEvents()
+    .Where(e => e.HasTag<StudentId>(alice)
+             && e.HasTag<CourseId>(math)
+             && e.Timestamp > cutoff)
+    .ToListAsync();
+```
+
+For OR-across-tags or the richer tag/event-type interplay, keep using the `EventTagQuery` builder with `QueryByTagsAsync` — that remains the rich escape hatch. `HasTag` is a marker method recognized by the LINQ provider; calling it outside a Polecat event query throws `NotSupportedException`, and using an unregistered tag type throws `InvalidOperationException`.
+
 ## Aggregating by Tags
 
 Build an aggregate from tagged events, similar to `AggregateStreamAsync` but across streams. First define an aggregate that applies the tagged events:

--- a/docs/events/querying.md
+++ b/docs/events/querying.md
@@ -164,6 +164,22 @@ The queryable `IEvent` properties available for filtering and projection are:
 These queries search the entire event table and should be used judiciously. For routine application queries, prefer projected views or tag-based queries.
 :::
 
+### AggregateToManyAsync
+
+`AggregateToManyAsync<T>()` is a LINQ terminal that runs the events matched by an event query through the **multi-stream projection** registered for `T` and returns the aggregate it produces for each resulting identity. It drives the projection's real slicer/grouper, `EnrichEventsAsync`, and per-slice build against the live query session — the same building blocks the projection step-through and the async daemon use — so custom groupers that read present-day reference data from the session work for free. Nothing is persisted.
+
+Given a multi-stream projection:
+
+<!-- snippet: sample_aggregate_to_many_projection -->
+<!-- endSnippet -->
+
+query any slice of the event store and fan it out to one aggregate per identity:
+
+<!-- snippet: sample_aggregate_to_many -->
+<!-- endSnippet -->
+
+Each returned aggregate has its identity stamped from the projection's slice id. Aggregates whose event slice resolves to a delete (`ShouldDelete`) are omitted, an empty query returns an empty list, and calling it for an aggregate type with no registered projection throws `ArgumentException`.
+
 ## QueryForNonStaleData
 
 Wait for async projections to catch up before querying:

--- a/docs/events/querying.md
+++ b/docs/events/querying.md
@@ -164,6 +164,25 @@ The queryable `IEvent` properties available for filtering and projection are:
 These queries search the entire event table and should be used judiciously. For routine application queries, prefer projected views or tag-based queries.
 :::
 
+### AggregateToAsync
+
+`AggregateToAsync<T>()` is a LINQ terminal that folds **every** event matched by an event query into a single live aggregate of type `T`, regardless of which stream each event came from. It uses the same conventional `Create`/`Apply` aggregation that `AggregateStreamAsync` uses, but over an arbitrary event query instead of one stream:
+
+<!-- snippet: sample_aggregate_to_async -->
+<!-- endSnippet -->
+
+You can also seed the fold with initial state:
+
+```cs
+var initial = new QuestParty { Members = ["Lan"] };
+
+var questParty = await session.Events.QueryAllRawEvents()
+    .Where(x => x.StreamId == streamId)
+    .AggregateToAsync(initial);
+```
+
+The aggregate's identity is stamped from the last queried event's stream (`StreamId` or `StreamKey` depending on the store's `StreamIdentity`), and `null` is returned when the query matches no events.
+
 ### AggregateToManyAsync
 
 `AggregateToManyAsync<T>()` is a LINQ terminal that runs the events matched by an event query through the **multi-stream projection** registered for `T` and returns the aggregate it produces for each resulting identity. It drives the projection's real slicer/grouper, `EnrichEventsAsync`, and per-slice build against the live query session — the same building blocks the projection step-through and the async daemon use — so custom groupers that read present-day reference data from the session work for free. Nothing is persisted.
@@ -179,6 +198,8 @@ query any slice of the event store and fan it out to one aggregate per identity:
 <!-- endSnippet -->
 
 Each returned aggregate has its identity stamped from the projection's slice id. Aggregates whose event slice resolves to a delete (`ShouldDelete`) are omitted, an empty query returns an empty list, and calling it for an aggregate type with no registered projection throws `ArgumentException`.
+
+Contrast `AggregateToAsync`, which folds every queried event into a single aggregate; `AggregateToManyAsync` fans them out through the projection's slicer to one aggregate per identity.
 
 ## QueryForNonStaleData
 

--- a/src/Polecat.Tests/Events/dcb_tag_linq_where_tests.cs
+++ b/src/Polecat.Tests/Events/dcb_tag_linq_where_tests.cs
@@ -1,0 +1,171 @@
+#nullable enable
+using JasperFx.Events;
+using JasperFx.Events.Tags;
+using Polecat.Linq;
+using Polecat.Tests.Harness;
+
+namespace Polecat.Tests.Events;
+
+// Reuses the StudentId / CourseId tag types and the StudentEnrolled / AssignmentSubmitted events
+// declared in dcb_tag_query_and_consistency_tests.cs (same namespace).
+//
+// #364 (marten#4999 parity): IEvent.HasTag<TTag>(value) is a marker method recognized by the LINQ
+// provider, compiling to the same correlated tag-table subquery QueryByTagsAsync emits, so DCB tag
+// predicates compose into the same Where() as ordinary event predicates. AND-of-tag-predicates +
+// normal predicates is the v1 scope; EventTagQuery remains the OR/rich escape hatch.
+public class dcb_tag_linq_where_tests : OneOffConfigurationsContext
+{
+    private async Task<DocumentStore> CreateStore()
+    {
+        ConfigureStore(opts =>
+        {
+            opts.Events.RegisterTagType<StudentId>("student");
+            opts.Events.RegisterTagType<CourseId>("course");
+        });
+        await theDatabase.ApplyAllConfiguredChangesToDatabaseAsync();
+        return theStore;
+    }
+
+    private static async Task AppendTagged(IDocumentSession session, Guid streamId, object eventData,
+        params object[] tags)
+    {
+        var wrapped = session.Events.BuildEvent(eventData);
+        wrapped.WithTag(tags);
+        session.Events.Append(streamId, wrapped);
+        await session.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task has_tag_matches_only_events_carrying_that_tag_value()
+    {
+        var store = await CreateStore();
+        await using var session = store.LightweightSession();
+
+        var alice = new StudentId(Guid.NewGuid());
+        var bob = new StudentId(Guid.NewGuid());
+
+        await AppendTagged(session, Guid.NewGuid(), new StudentEnrolled("Alice", "Math"), alice);
+        await AppendTagged(session, Guid.NewGuid(), new StudentEnrolled("Bob", "Math"), bob);
+
+        #region sample_polecat_dcb_has_tag_linq
+
+        var events = await session.Events.QueryAllRawEvents()
+            .Where(e => e.HasTag<StudentId>(alice))
+            .ToListAsync();
+
+        #endregion
+
+        events.Count.ShouldBe(1);
+        events.Single().Data.ShouldBeOfType<StudentEnrolled>().StudentName.ShouldBe("Alice");
+    }
+
+    [Fact]
+    public async Task has_tag_composes_with_a_normal_event_predicate_in_one_where()
+    {
+        var store = await CreateStore();
+        await using var session = store.LightweightSession();
+
+        var alice = new StudentId(Guid.NewGuid());
+        var streamId = Guid.NewGuid();
+
+        // Two events for Alice, both tagged with her StudentId, but of different event types.
+        await AppendTagged(session, streamId, new StudentEnrolled("Alice", "Math"), alice);
+        await AppendTagged(session, streamId, new AssignmentSubmitted("HW1", 95), alice);
+
+        // "Alice's events, but only the enrollments" — the tag predicate AND a normal event predicate.
+        var enrolledTypeName = store.Options.EventGraph
+            .EventMappingFor(typeof(StudentEnrolled)).EventTypeName;
+
+        var events = await session.Events.QueryAllRawEvents()
+            .Where(e => e.HasTag<StudentId>(alice) && e.EventTypeName == enrolledTypeName)
+            .ToListAsync();
+
+        events.Count.ShouldBe(1);
+        events.Single().Data.ShouldBeOfType<StudentEnrolled>();
+    }
+
+    [Fact]
+    public async Task has_tag_composes_with_a_timestamp_predicate()
+    {
+        var store = await CreateStore();
+        await using var session = store.LightweightSession();
+
+        var alice = new StudentId(Guid.NewGuid());
+        await AppendTagged(session, Guid.NewGuid(), new StudentEnrolled("Alice", "Math"), alice);
+
+        var cutoff = DateTimeOffset.UtcNow.AddDays(-1);
+
+        var events = await session.Events.QueryAllRawEvents()
+            .Where(e => e.HasTag<StudentId>(alice) && e.Timestamp > cutoff)
+            .ToListAsync();
+
+        events.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task and_of_two_tag_predicates_requires_both_tags()
+    {
+        var store = await CreateStore();
+        await using var session = store.LightweightSession();
+
+        var alice = new StudentId(Guid.NewGuid());
+        var math = new CourseId(Guid.NewGuid());
+
+        // Event 1 carries BOTH tags; event 2 carries only the student tag.
+        await AppendTagged(session, Guid.NewGuid(), new StudentEnrolled("Alice", "Math"), alice, math);
+        await AppendTagged(session, Guid.NewGuid(), new StudentEnrolled("Alice", "Science"), alice);
+
+        var events = await session.Events.QueryAllRawEvents()
+            .Where(e => e.HasTag<StudentId>(alice) && e.HasTag<CourseId>(math))
+            .ToListAsync();
+
+        // Only the event tagged with both survives the AND.
+        events.Count.ShouldBe(1);
+        events.Single().Data.ShouldBeOfType<StudentEnrolled>().CourseName.ShouldBe("Math");
+    }
+
+    [Fact]
+    public async Task has_tag_is_isolated_by_tenant_under_conjoined_tenancy()
+    {
+        ConfigureStore(opts =>
+        {
+            opts.Events.TenancyStyle = TenancyStyle.Conjoined;
+            opts.Events.RegisterTagType<StudentId>("student");
+        });
+        await theDatabase.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        var alice = new StudentId(Guid.NewGuid());
+
+        // The SAME tag value is appended in two tenants; HasTag must only match the session's tenant.
+        await using var redSession = theStore.LightweightSession(new SessionOptions { TenantId = "Red" });
+        await AppendTagged(redSession, Guid.NewGuid(), new StudentEnrolled("Alice", "Math"), alice);
+
+        await using var blueSession = theStore.LightweightSession(new SessionOptions { TenantId = "Blue" });
+        await AppendTagged(blueSession, Guid.NewGuid(), new StudentEnrolled("Alice", "Science"), alice);
+
+        var redEvents = await redSession.Events.QueryAllRawEvents()
+            .Where(e => e.HasTag<StudentId>(alice))
+            .ToListAsync();
+
+        redEvents.Count.ShouldBe(1);
+        redEvents.Single().Data.ShouldBeOfType<StudentEnrolled>().CourseName.ShouldBe("Math");
+    }
+
+    [Fact]
+    public async Task has_tag_for_an_unregistered_tag_type_throws()
+    {
+        var store = await CreateStore();
+        await using var session = store.LightweightSession();
+
+        var unknown = new UnregisteredTag(Guid.NewGuid());
+
+        await Should.ThrowAsync<InvalidOperationException>(async () =>
+        {
+            await session.Events.QueryAllRawEvents()
+                .Where(e => e.HasTag<UnregisteredTag>(unknown))
+                .ToListAsync();
+        });
+    }
+
+    public record UnregisteredTag(Guid Value);
+}

--- a/src/Polecat.Tests/Projections/aggregate_to_many_tests.cs
+++ b/src/Polecat.Tests/Projections/aggregate_to_many_tests.cs
@@ -1,0 +1,224 @@
+using JasperFx.Events;
+using JasperFx.Events.Grouping;
+using JasperFx.Events.Projections;
+using Polecat.Events;
+using Polecat.Linq;
+using Polecat.Projections;
+using Polecat.Tests.Harness;
+
+namespace Polecat.Tests.Projections;
+
+#region sample_aggregate_to_many_projection
+
+public record MoneyDeposited(Guid AccountId, int Amount);
+public record AccountFrozen(Guid AccountId);
+
+public class Balance
+{
+    public Guid Id { get; set; }
+    public int Amount { get; set; }
+}
+
+public partial class BalanceProjection : MultiStreamProjection<Balance, Guid>
+{
+    public BalanceProjection()
+    {
+        Identity<MoneyDeposited>(e => e.AccountId);
+        Identity<AccountFrozen>(e => e.AccountId);
+    }
+
+    public void Apply(MoneyDeposited e, Balance b) => b.Amount += e.Amount;
+
+    public bool ShouldDelete(AccountFrozen e) => true;
+}
+
+#endregion
+
+public record LoyaltyEarned(Guid CardId, int Points);
+
+public class CardOwner
+{
+    public Guid Id { get; set; } // card id
+    public Guid MemberId { get; set; }
+}
+
+public class MemberLoyalty
+{
+    public Guid Id { get; set; }
+    public int Points { get; set; }
+}
+
+public partial class MemberLoyaltyProjection : MultiStreamProjection<MemberLoyalty, Guid>
+{
+    public MemberLoyaltyProjection()
+    {
+        CustomGrouping(new Grouper());
+    }
+
+    public void Apply(LoyaltyEarned e, MemberLoyalty agg) => agg.Points += e.Points;
+
+    public class Grouper : IJasperFxAggregateGrouper<Guid, IQuerySession>
+    {
+        public async Task Group(IQuerySession session, IReadOnlyList<IEvent> events, IEventGrouping<Guid> grouping)
+        {
+            var earned = events.OfType<IEvent<LoyaltyEarned>>().ToList();
+            if (earned.Count == 0) return;
+
+            var cardIds = earned.Select(e => e.Data.CardId).Distinct().ToArray();
+            var owners = await session.Query<CardOwner>().Where(x => cardIds.Contains(x.Id)).ToListAsync();
+            var map = owners.ToDictionary(x => x.Id, x => x.MemberId);
+
+            foreach (var e in earned)
+            {
+                if (map.TryGetValue(e.Data.CardId, out var member))
+                {
+                    grouping.AddEvent(member, e);
+                }
+            }
+        }
+    }
+}
+
+// #364 (marten#4998 parity): AggregateToManyAsync runs an event query through the multi-stream
+// projection registered for T — the projection's real slicer/grouper + enrichment + per-slice build
+// against the live session — and returns one aggregate per resulting identity.
+public class aggregate_to_many_tests : OneOffConfigurationsContext
+{
+    private async Task<DocumentStore> CreateStore()
+    {
+        ConfigureStore(opts =>
+        {
+            opts.Projections.Add(new BalanceProjection(), ProjectionLifecycle.Async);
+            opts.Projections.Add(new MemberLoyaltyProjection(), ProjectionLifecycle.Async);
+        });
+        await theDatabase.ApplyAllConfiguredChangesToDatabaseAsync();
+        return theStore;
+    }
+
+    [Fact]
+    public async Task fans_a_cross_stream_query_out_to_one_aggregate_per_identity()
+    {
+        var store = await CreateStore();
+
+        var acctA = Guid.NewGuid();
+        var acctB = Guid.NewGuid();
+        var stream1 = Guid.NewGuid();
+        var stream2 = Guid.NewGuid();
+
+        await using var session = store.LightweightSession();
+
+        // acctA deposited across two streams; acctB in one — the fan-out keys on AccountId, not stream.
+        session.Events.Append(stream1, new MoneyDeposited(acctA, 100), new MoneyDeposited(acctB, 50));
+        session.Events.Append(stream2, new MoneyDeposited(acctA, 25));
+        await session.SaveChangesAsync();
+
+        #region sample_aggregate_to_many
+
+        var aggregates = await session.Events.QueryAllRawEvents()
+            .Where(e => e.StreamId == stream1 || e.StreamId == stream2)
+            .AggregateToManyAsync<Balance>();
+
+        #endregion
+
+        aggregates.Count.ShouldBe(2);
+
+        // Identity is stamped on each aggregate...
+        aggregates.Single(x => x.Id == acctA).Amount.ShouldBe(125);
+        aggregates.Single(x => x.Id == acctB).Amount.ShouldBe(50);
+    }
+
+    [Fact]
+    public async Task excludes_aggregates_that_should_delete()
+    {
+        var store = await CreateStore();
+
+        var acctA = Guid.NewGuid();
+        var acctB = Guid.NewGuid();
+        var stream = Guid.NewGuid();
+
+        await using var session = store.LightweightSession();
+
+        session.Events.Append(stream,
+            new MoneyDeposited(acctA, 100),
+            new MoneyDeposited(acctB, 200),
+            new AccountFrozen(acctB));
+        await session.SaveChangesAsync();
+
+        var aggregates = await session.Events.QueryAllRawEvents()
+            .Where(e => e.StreamId == stream)
+            .AggregateToManyAsync<Balance>();
+
+        // acctB is frozen (ShouldDelete) and so is absent; only acctA survives.
+        aggregates.Count.ShouldBe(1);
+        aggregates.Single().Id.ShouldBe(acctA);
+        aggregates.Single().Amount.ShouldBe(100);
+    }
+
+    [Fact]
+    public async Task enrichment_reads_reference_data_from_the_live_session()
+    {
+        var store = await CreateStore();
+
+        var cardA = Guid.NewGuid();
+        var cardB = Guid.NewGuid();
+        var cardC = Guid.NewGuid();
+        var memberX = Guid.NewGuid();
+        var memberY = Guid.NewGuid();
+
+        await using var session = store.LightweightSession();
+
+        // Present-day reference data the grouper reads during enrichment.
+        session.Store(new CardOwner { Id = cardA, MemberId = memberX });
+        session.Store(new CardOwner { Id = cardB, MemberId = memberX });
+        session.Store(new CardOwner { Id = cardC, MemberId = memberY });
+        await session.SaveChangesAsync();
+
+        var stream = Guid.NewGuid();
+        session.Events.Append(stream,
+            new LoyaltyEarned(cardA, 10),
+            new LoyaltyEarned(cardB, 5),
+            new LoyaltyEarned(cardC, 20));
+        await session.SaveChangesAsync();
+
+        var aggregates = await session.Events.QueryAllRawEvents()
+            .Where(e => e.StreamId == stream)
+            .AggregateToManyAsync<MemberLoyalty>();
+
+        // Member-keyed, not card-keyed — only possible because the grouper read CardOwner from the session.
+        aggregates.Count.ShouldBe(2);
+        aggregates.Single(x => x.Id == memberX).Points.ShouldBe(15);
+        aggregates.Single(x => x.Id == memberY).Points.ShouldBe(20);
+    }
+
+    [Fact]
+    public async Task empty_query_returns_empty_list()
+    {
+        var store = await CreateStore();
+
+        await using var session = store.LightweightSession();
+
+        var aggregates = await session.Events.QueryAllRawEvents()
+            .Where(e => e.StreamId == Guid.NewGuid()) // matches nothing
+            .AggregateToManyAsync<Balance>();
+
+        aggregates.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task throws_when_no_projection_produces_the_aggregate_type()
+    {
+        var store = await CreateStore();
+
+        await using var session = store.LightweightSession();
+
+        await Should.ThrowAsync<ArgumentException>(async () =>
+        {
+            await session.Events.QueryAllRawEvents().AggregateToManyAsync<UnrelatedAggregate>();
+        });
+    }
+
+    public class UnrelatedAggregate
+    {
+        public Guid Id { get; set; }
+    }
+}

--- a/src/Polecat.Tests/Projections/aggregateto_linq_operator_tests.cs
+++ b/src/Polecat.Tests/Projections/aggregateto_linq_operator_tests.cs
@@ -1,0 +1,125 @@
+using JasperFx.Events;
+using Polecat.Events;
+using Polecat.Linq;
+using Polecat.Tests.Harness;
+
+namespace Polecat.Tests.Projections;
+
+// #364 follow-up (Marten parity): AggregateToAsync<T>() folds every event matched by an event query
+// into a single aggregate, regardless of stream, optionally starting from supplied state. The
+// aggregate's identity is stamped from the last queried event's stream. Reuses the self-aggregating
+// QuestParty (inline_projection_tests.cs) and SelfAggregatingStringQuest
+// (single_stream_projection_with_string_identity_tests.cs) declared in this namespace.
+public class aggregateto_linq_operator_tests : OneOffConfigurationsContext
+{
+    private readonly MembersJoined _joined1 = new(1, "Emond's Field", ["Rand", "Matrim", "Perrin", "Thom"]);
+    private readonly MembersDeparted _departed1 = new(2, "Baerlon", ["Thom"]);
+
+    private readonly MembersJoined _joined2 = new(3, "Tar Valon", ["Elayne", "Moiraine", "Elmindreda"]);
+    private readonly MembersDeparted _departed2 = new(4, "Caemlyn", ["Moiraine"]);
+
+    private async Task<DocumentStore> CreateStore()
+    {
+        ConfigureStore(_ => { });
+        await theDatabase.ApplyAllConfiguredChangesToDatabaseAsync();
+        return theStore;
+    }
+
+    [Fact]
+    public async Task can_aggregate_events_to_aggregate_type_asynchronously()
+    {
+        var store = await CreateStore();
+        await using var session = store.LightweightSession();
+
+        session.Events.StartStream(Guid.NewGuid(), _joined1, _departed1);
+        session.Events.StartStream(Guid.NewGuid(), _joined2, _departed2);
+        await session.SaveChangesAsync();
+
+        #region sample_aggregate_to_async
+
+        var questParty = await session.Events
+            .QueryAllRawEvents()
+
+            // You could of course chain all the Linq
+            // Where()/OrderBy()/Take()/Skip() operators
+            // you need here
+
+            .AggregateToAsync<QuestParty>();
+
+        #endregion
+
+        questParty.ShouldNotBeNull();
+        questParty.Members.ShouldBe(["Rand", "Matrim", "Perrin", "Elayne", "Elmindreda"]);
+    }
+
+    [Fact]
+    public async Task can_aggregate_with_initial_state_asynchronously()
+    {
+        var store = await CreateStore();
+        await using var session = store.LightweightSession();
+
+        var initialParty = new QuestParty { Members = ["Lan"] };
+        session.Events.StartStream(Guid.NewGuid(), _joined1, _departed1);
+        session.Events.StartStream(Guid.NewGuid(), _joined2, _departed2);
+        await session.SaveChangesAsync();
+
+        var questParty = await session.Events.QueryAllRawEvents().AggregateToAsync(initialParty);
+
+        questParty.ShouldNotBeNull();
+        questParty.Members.ShouldBe(["Lan", "Rand", "Matrim", "Perrin", "Elayne", "Elmindreda"]);
+    }
+
+    [Fact]
+    public async Task returns_null_when_the_query_matches_no_events()
+    {
+        var store = await CreateStore();
+        await using var session = store.LightweightSession();
+
+        var questParty = await session.Events.QueryAllRawEvents()
+            .Where(x => x.StreamId == Guid.NewGuid())
+            .AggregateToAsync<QuestParty>();
+
+        questParty.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task gets_the_id_set()
+    {
+        var store = await CreateStore();
+        await using var session = store.LightweightSession();
+
+        var id = Guid.NewGuid();
+        session.Events.StartStream(id, _joined1, _departed1);
+        session.Events.StartStream(Guid.NewGuid(), _joined2, _departed2);
+        await session.SaveChangesAsync();
+
+        var questParty = await session.Events.QueryAllRawEvents()
+            .Where(x => x.StreamId == id)
+            .AggregateToAsync<QuestParty>();
+
+        questParty.ShouldNotBeNull();
+        questParty.Id.ShouldBe(id);
+    }
+
+    [Fact]
+    public async Task gets_the_key_set()
+    {
+        ConfigureStore(opts => opts.Events.StreamIdentity = StreamIdentity.AsString);
+        await theDatabase.ApplyAllConfiguredChangesToDatabaseAsync();
+        await using var session = theStore.LightweightSession();
+
+        var key = Guid.NewGuid().ToString();
+        session.Events.StartStream(key, new QuestStarted("Save the World"), _joined1);
+        session.Events.StartStream(Guid.NewGuid().ToString(), new QuestStarted("Other"), _joined2);
+        await session.SaveChangesAsync();
+
+        var quest = await session.Events.QueryAllRawEvents()
+            .Where(x => x.StreamKey == key)
+            .AggregateToAsync<SelfAggregatingStringQuest>();
+
+        quest.ShouldNotBeNull();
+        quest.Id.ShouldBe(key);
+        quest.Name.ShouldBe("Save the World");
+        quest.Members.ShouldBe(["Rand", "Matrim", "Perrin", "Thom"]);
+    }
+}

--- a/src/Polecat/Events/AggregateToExtensions.cs
+++ b/src/Polecat/Events/AggregateToExtensions.cs
@@ -32,12 +32,53 @@ public static class AggregateToExtensions
             nameof(queryable));
     }
 
+    private static void setIdentity<T>(QuerySession session, T aggregate, IReadOnlyList<IEvent> events)
+        where T : class
+    {
+        object streamId = session.Options.Events.StreamIdentity == StreamIdentity.AsGuid
+            ? events[^1].StreamId
+            : events[^1].StreamKey!;
+
+        QueryEventStore.TrySetIdentity(aggregate, streamId);
+    }
+
+    /// <summary>
+    ///     Aggregate the events matched by this query into a single instance of <typeparamref name="T"/>,
+    ///     folding every queried event into one aggregate regardless of stream, optionally starting from
+    ///     <paramref name="state"/>. The aggregate's identity is stamped from the last queried event's
+    ///     stream. Returns null when the query matches no events. Contrast
+    ///     <see cref="AggregateToManyAsync{T}"/>, which fans the queried events out through a multi-stream
+    ///     projection to one aggregate per identity.
+    /// </summary>
+    public static async Task<T?> AggregateToAsync<T>(this IQueryable<IEvent> queryable, T? state = null,
+        CancellationToken token = default) where T : class
+    {
+        var session = SessionFor(queryable);
+
+        var events = await queryable.ToListAsync(token).ConfigureAwait(false);
+        if (events.Count == 0)
+        {
+            return null;
+        }
+
+        var aggregator = session.Options.Projections.AggregatorFor<T>();
+        var aggregate = await aggregator.BuildAsync(events, session, state, token).ConfigureAwait(false);
+
+        if (aggregate != null)
+        {
+            setIdentity(session, aggregate, events);
+        }
+
+        return aggregate;
+    }
+
     /// <summary>
     ///     Run the events matched by this query through the multi-stream projection registered for
     ///     <typeparamref name="T"/> and return the aggregate it produces for each resulting identity. This is
     ///     the live-query twin of the projection step-through's multi-stream run: it drives the projection's
     ///     REAL slicer/grouper and per-slice build (the same core the step-through uses, minus the step
     ///     observer) against the live query session, so enrichment that reads reference data works for free.
+    ///     Contrast <see cref="AggregateToAsync{T}"/>, which folds every queried event into a single aggregate.
     /// </summary>
     [RequiresUnreferencedCode("Reflects over the projection's JasperFxAggregationProjectionBase base to close the fold over its TId.")]
     [RequiresDynamicCode("Closes aggregateManyAsync over (T, TId) via MakeGenericMethod.")]

--- a/src/Polecat/Events/AggregateToExtensions.cs
+++ b/src/Polecat/Events/AggregateToExtensions.cs
@@ -1,0 +1,140 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using JasperFx.Core.Reflection;
+using JasperFx.Events;
+using JasperFx.Events.Aggregation;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Grouping;
+using Polecat.Events.Linq;
+using Polecat.Internal;
+using Polecat.Linq;
+
+namespace Polecat.Events;
+
+/// <summary>
+///     LINQ terminals that run the events matched by an event query (session.Events.QueryAllRawEvents())
+///     through registered aggregations. Mirrors Marten's AggregateToExtensions (marten#4998 parity).
+/// </summary>
+public static class AggregateToExtensions
+{
+    private static readonly MethodInfo AggregateManyMethod = typeof(AggregateToExtensions)
+        .GetMethod(nameof(aggregateManyAsync), BindingFlags.Static | BindingFlags.NonPublic)!;
+
+    private static QuerySession SessionFor(IQueryable<IEvent> queryable)
+    {
+        if (queryable is PolecatLinqQueryable<IEvent> { PolecatProvider: EventLinqQueryProvider provider })
+        {
+            return provider.Session;
+        }
+
+        throw new ArgumentException(
+            "AggregateTo*() can only be used on a Polecat event query, e.g. session.Events.QueryAllRawEvents().Where(...).",
+            nameof(queryable));
+    }
+
+    /// <summary>
+    ///     Run the events matched by this query through the multi-stream projection registered for
+    ///     <typeparamref name="T"/> and return the aggregate it produces for each resulting identity. This is
+    ///     the live-query twin of the projection step-through's multi-stream run: it drives the projection's
+    ///     REAL slicer/grouper and per-slice build (the same core the step-through uses, minus the step
+    ///     observer) against the live query session, so enrichment that reads reference data works for free.
+    /// </summary>
+    [RequiresUnreferencedCode("Reflects over the projection's JasperFxAggregationProjectionBase base to close the fold over its TId.")]
+    [RequiresDynamicCode("Closes aggregateManyAsync over (T, TId) via MakeGenericMethod.")]
+    public static async Task<IReadOnlyList<T>> AggregateToManyAsync<T>(this IQueryable<IEvent> queryable,
+        CancellationToken token = default) where T : class
+    {
+        var session = SessionFor(queryable);
+        var options = session.Options;
+
+        // Validate the projection up front (even for an empty result set) so a call for an aggregate type
+        // that has no registered projection is a clear programming error rather than a silent empty list.
+        var projection = options.Projections.All
+                             .OfType<IAggregateProjection>()
+                             .FirstOrDefault(x => x.AggregateType == typeof(T))
+                         ?? throw new ArgumentException(
+                             $"No aggregate projection is registered that produces '{typeof(T).FullNameInCode()}'. AggregateToManyAsync() runs an event query through a registered (multi-stream) projection.",
+                             nameof(queryable));
+
+        var idType = findAggregateIdType(projection.GetType())
+                     ?? throw new ArgumentException(
+                         $"Projection '{projection.GetType().FullNameInCode()}' for '{typeof(T).FullNameInCode()}' is not a slicing aggregate projection that AggregateToManyAsync() can drive.",
+                         nameof(queryable));
+
+        var events = await queryable.ToListAsync(token).ConfigureAwait(false);
+        if (events.Count == 0)
+        {
+            return Array.Empty<T>();
+        }
+
+        var closed = AggregateManyMethod.MakeGenericMethod(typeof(T), idType);
+        var task = (Task<IReadOnlyList<T>>)closed.Invoke(null, [projection, events, session, token])!;
+        return await task.ConfigureAwait(false);
+    }
+
+    // TId is not statically known at the AggregateToManyAsync<T> call site, so drive the strongly-typed
+    // slice -> enrich -> build fold through a TId-closed helper invoked via reflection.
+    private static async Task<IReadOnlyList<T>> aggregateManyAsync<T, TId>(
+        JasperFxAggregationProjectionBase<T, TId, IDocumentSession, IQuerySession> projection,
+        IReadOnlyList<IEvent> events,
+        QuerySession session,
+        CancellationToken token)
+        where T : class where TId : notnull
+    {
+        // The SAME building blocks the step-through fold uses (BuildTimelinesAsync): the projection's own
+        // slicer/grouper, then EnrichEventsAsync per group, then DetermineActionAsync (Create/Apply/
+        // ShouldDelete dispatch) per slice — so the live-query result can't diverge from the step-through.
+        var slicer = projection.BuildSlicer(session);
+        var groups = await slicer.SliceAsync(events).ConfigureAwait(false);
+
+        var identitySetter = new NulloIdentitySetter<T, TId>();
+        var results = new List<T>();
+
+        foreach (var groupObject in groups)
+        {
+            if (groupObject is not SliceGroup<T, TId> group)
+            {
+                continue;
+            }
+
+            await projection.EnrichEventsAsync(group, session, token).ConfigureAwait(false);
+
+            foreach (var slice in group.Slices)
+            {
+                var (aggregate, action) = await projection
+                    .DetermineActionAsync(session, default, slice.Id, identitySetter, slice.Events(), token)
+                    .ConfigureAwait(false);
+
+                if (action == ActionType.Delete || aggregate is null)
+                {
+                    continue;
+                }
+
+                // The fold uses a Nullo identity setter, so stamp the aggregate's own id from the slice.
+                QueryEventStore.TrySetIdentity(aggregate, slice.Id);
+                results.Add(aggregate);
+            }
+        }
+
+        return results;
+    }
+
+    // Walk the projection's base chain for the closed JasperFxAggregationProjectionBase<TDoc, TId, ...>
+    // and return its TId argument.
+    private static Type? findAggregateIdType(Type projectionType)
+    {
+        var type = projectionType;
+        while (type != null && type != typeof(object))
+        {
+            if (type.IsGenericType
+                && type.GetGenericTypeDefinition() == typeof(JasperFxAggregationProjectionBase<,,,>))
+            {
+                return type.GetGenericArguments()[1];
+            }
+
+            type = type.BaseType;
+        }
+
+        return null;
+    }
+}

--- a/src/Polecat/Events/Linq/EventLinqQueryProvider.cs
+++ b/src/Polecat/Events/Linq/EventLinqQueryProvider.cs
@@ -31,6 +31,12 @@ internal class EventLinqQueryProvider : IPolecatAsyncQueryProvider
     private readonly Type? _eventDataType;
 
     /// <summary>
+    ///     The owning session, surfaced for event-query terminals that need live-session context
+    ///     (AggregateToAsync / AggregateToManyAsync).
+    /// </summary>
+    internal QuerySession Session => _session;
+
+    /// <summary>
     ///     Create provider for QueryAllRawEvents().
     /// </summary>
     public EventLinqQueryProvider(QuerySession session, EventGraph events)
@@ -91,7 +97,9 @@ internal class EventLinqQueryProvider : IPolecatAsyncQueryProvider
     [RequiresUnreferencedCode("Event-store LINQ execution reflects over the event type (Activator.CreateInstance on handler types, MethodInfo.Invoke on HandleAsync). AOT consumers must preserve event + handler members through DAM or source generation.")]
     public async Task<TResult> ExecuteAsync<TResult>(Expression expression, CancellationToken token)
     {
-        var parser = new LinqQueryParser(_memberFactory, _eventsTable);
+        // HasTag() is only meaningful over IEvent queries, where the FROM table is pc_events.
+        var parser = new LinqQueryParser(_memberFactory, _eventsTable,
+            _isAllEvents ? [new HasTagParser(_events)] : null);
         parser.Parse(expression);
 
         ApplySingleValueMode(parser);

--- a/src/Polecat/Events/Linq/HasTagParser.cs
+++ b/src/Polecat/Events/Linq/HasTagParser.cs
@@ -1,0 +1,81 @@
+using System.Linq.Expressions;
+using Polecat.Linq.Members;
+using Polecat.Linq.Parsing;
+using Polecat.Linq.Parsing.Methods;
+using Polecat.Linq.SqlGeneration;
+using Weasel.SqlServer;
+
+namespace Polecat.Events.Linq;
+
+/// <summary>
+///     Compiles the <see cref="LinqExtensions.HasTag{TTag}" /> marker method into the same tag SQL that
+///     <c>QueryByTagsAsync</c> emits: a correlated <c>seq_id IN (SELECT seq_id FROM pc_event_tag_{suffix}
+///     WHERE value = @p)</c> subquery against the registered tag type's table. Under conjoined tenancy the
+///     subquery also correlates on tenant_id so a tag value shared across tenants can't leak rows. Only
+///     wired into event-store LINQ queries (QueryAllRawEvents), where the outer table is pc_events.
+/// </summary>
+internal class HasTagParser : IMethodCallParser
+{
+    private readonly EventGraph _events;
+
+    public HasTagParser(EventGraph events)
+    {
+        _events = events;
+    }
+
+    public bool Matches(MethodCallExpression expression)
+    {
+        return expression.Method.Name == nameof(LinqExtensions.HasTag)
+               && expression.Method.DeclaringType == typeof(LinqExtensions);
+    }
+
+    public ISqlFragment Parse(IMemberResolver memberFactory, MethodCallExpression expression)
+    {
+        var tagType = expression.Method.GetGenericArguments()[0];
+        var value = WhereClauseParser.ExtractValue(expression.Arguments[^1])
+                    ?? throw new ArgumentException("HasTag() requires a non-null tag value.", nameof(expression));
+
+        var registration = _events.FindTagType(tagType)
+                           ?? throw new InvalidOperationException(
+                               $"Tag type '{tagType.Name}' is not registered. Call RegisterTagType<{tagType.Name}>() first.");
+
+        var extracted = registration.ExtractValue(value);
+        var schema = _events.DatabaseSchemaName;
+        var suffix = registration.TableSuffix;
+
+        // Under conjoined tenancy a tag value is only unique per tenant, so the correlated subquery must
+        // also match the outer event row's tenant_id (the outer query is already tenant-scoped).
+        var correlation = _events.TenancyStyle == JasperFx.MultiTenancy.TenancyStyle.Conjoined
+            ? " AND pt.tenant_id = [pc_events].[tenant_id]"
+            : string.Empty;
+
+        return new HasTagFilter(
+            $"seq_id IN (SELECT pt.seq_id FROM [{schema}].[pc_event_tag_{suffix}] pt WHERE pt.value = ",
+            extracted,
+            $"{correlation})");
+    }
+}
+
+/// <summary>
+///     WHERE fragment with a single bound parameter spliced between two literal SQL segments.
+/// </summary>
+internal class HasTagFilter : ISqlFragment
+{
+    private readonly string _prefix;
+    private readonly object _value;
+    private readonly string _suffix;
+
+    public HasTagFilter(string prefix, object value, string suffix)
+    {
+        _prefix = prefix;
+        _value = value;
+        _suffix = suffix;
+    }
+
+    public void Apply(ICommandBuilder builder)
+    {
+        builder.Append(_prefix);
+        builder.AppendParameter(_value);
+        builder.Append(_suffix);
+    }
+}

--- a/src/Polecat/Linq/Parsing/LinqQueryParser.cs
+++ b/src/Polecat/Linq/Parsing/LinqQueryParser.cs
@@ -116,10 +116,11 @@ internal class LinqQueryParser : ExpressionVisitor
     /// </summary>
     public TimeSpan? NonStaleDataTimeout { get; private set; }
 
-    public LinqQueryParser(IMemberResolver memberFactory, string fromTable)
+    public LinqQueryParser(IMemberResolver memberFactory, string fromTable,
+        IReadOnlyList<Methods.IMethodCallParser>? additionalMethodParsers = null)
     {
         _memberFactory = memberFactory;
-        _whereParser = new WhereClauseParser(memberFactory);
+        _whereParser = new WhereClauseParser(memberFactory, additionalMethodParsers);
         Statement = new Statement { FromTable = fromTable };
     }
 

--- a/src/Polecat/Linq/Parsing/WhereClauseParser.cs
+++ b/src/Polecat/Linq/Parsing/WhereClauseParser.cs
@@ -25,10 +25,13 @@ internal class WhereClauseParser
     };
 
     private readonly IMemberResolver _memberFactory;
+    private readonly IReadOnlyList<IMethodCallParser>? _additionalParsers;
 
-    public WhereClauseParser(IMemberResolver memberFactory)
+    public WhereClauseParser(IMemberResolver memberFactory,
+        IReadOnlyList<IMethodCallParser>? additionalParsers = null)
     {
         _memberFactory = memberFactory;
+        _additionalParsers = additionalParsers;
     }
 
     public ISqlFragment Parse(Expression expression)
@@ -50,6 +53,15 @@ internal class WhereClauseParser
 
     private ISqlFragment ParseMethodCall(MethodCallExpression expression)
     {
+        if (_additionalParsers != null)
+        {
+            foreach (var additional in _additionalParsers)
+            {
+                if (additional.Matches(expression))
+                    return additional.Parse(_memberFactory, expression);
+            }
+        }
+
         var parser = MethodCallParserRegistry.FindParser(expression)
             ?? throw new NotSupportedException(
                 $"Unsupported method call in WHERE clause: {expression.Method.DeclaringType?.Name}.{expression.Method.Name}");

--- a/src/Polecat/LinqExtensions.cs
+++ b/src/Polecat/LinqExtensions.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using System.Reflection;
+using JasperFx.Events;
 
 namespace Polecat;
 
@@ -40,6 +41,21 @@ public static class LinqExtensions
     ///     Translated to OPENJSON count check.
     /// </summary>
     public static bool IsEmpty<T>(this IEnumerable<T> enumerable) => !enumerable.Any();
+
+    /// <summary>
+    ///     LINQ filter over an event query (e.g. <c>session.Events.QueryAllRawEvents()</c>) that matches only
+    ///     events carrying the given DCB tag value. Composes into the same <c>Where()</c> as ordinary event
+    ///     predicates (timestamp, event type, stream), so one query can express "these events, matching these
+    ///     tags". <typeparamref name="TTag"/> must be a registered tag type (see <c>RegisterTagType&lt;TTag&gt;()</c>).
+    ///     AND-ing several <c>HasTag</c> calls with normal predicates is supported; for OR-across-tags or the
+    ///     richer event-type interplay, use the <c>EventTagQuery</c> builder with <c>QueryByTagsAsync</c> instead.
+    ///     This is a marker method recognized by the LINQ provider and cannot be invoked directly.
+    /// </summary>
+    public static bool HasTag<TTag>(this IEvent e, TTag value) where TTag : notnull
+    {
+        throw new NotSupportedException(
+            "IEvent.HasTag<TTag>() is a marker method for LINQ event queries and cannot be invoked directly. Use it inside session.Events.QueryAllRawEvents().Where(...).");
+    }
 
     private static readonly MethodInfo AnyTenantMethodInfo =
         typeof(LinqExtensions).GetMethod(nameof(AnyTenant))!;


### PR DESCRIPTION
Closes #364 — brings Polecat to Marten 9.18.0 parity for the two end-user LINQ operators from the MultiStreamProjection-stepthrough epic that were titled "(Marten + Polecat)" but only shipped in Marten, plus the single-target `AggregateToAsync` that completes the `AggregateTo*` family the issue's evidence table flagged as absent.

## AggregateToManyAsync&lt;T&gt;() — marten#4998
- New `Polecat.Events.AggregateToExtensions`: a LINQ terminal over `session.Events.QueryAllRawEvents().Where(...)` that runs the matched events through the multi-stream projection registered for `T` and returns one identity-stamped aggregate per resulting identity.
- Drives the projection's **real** `BuildSlicer` / `EnrichEventsAsync` / `DetermineActionAsync` building blocks against the live query session — the same core the #346 step-through fold uses — so live-query results can't drift from the step-through, and enrichment groupers that read reference documents work for free.
- `ShouldDelete` slices are omitted; empty query → empty list; unregistered aggregate type → `ArgumentException` up front. `TId` is closed via reflection from the projection's `JasperFxAggregationProjectionBase` base; identity stamping reuses `QueryEventStore.TrySetIdentity`.

## AggregateToAsync&lt;T&gt;() — single-target fold
- Folds **every** queried event into one aggregate regardless of stream via `Projections.AggregatorFor<T>()` (the same conventional `Create`/`Apply` core as `AggregateStreamAsync`), optionally seeded with initial state.
- Identity is stamped from the last queried event's stream (`StreamId`/`StreamKey` per the store's `StreamIdentity`); empty query returns `null`.

## IEvent.HasTag&lt;TTag&gt;(value) — marten#4999
- Marker method on `LinqExtensions`, recognized by the event LINQ provider so DCB tag predicates compose into the same `Where()` as ordinary event predicates (timestamp / event type / stream).
- `HasTagParser` compiles it to the same tag SQL `QueryByTagsAsync` emits: `seq_id IN (SELECT seq_id FROM pc_event_tag_{suffix} WHERE value = @p)`, with `tenant_id` correlation under conjoined tenancy. SQL Server has no HStore analogue, so tag tables are the only dialect.
- Wiring: `WhereClauseParser` / `LinqQueryParser` gain an optional additional-parser list (the static `MethodCallParserRegistry` has no `EventGraph` context); only `EventLinqQueryProvider` passes `HasTagParser`, and only for `QueryAllRawEvents` queries.
- v1 scope matches Marten: AND-of-tag-predicates + normal predicates. `EventTagQuery` remains the OR/rich escape hatch.

## Tests (16 new, all green locally alongside the event-LINQ + DCB regression suites)
- `aggregate_to_many_tests`: cross-stream fan-out keyed on identity, `ShouldDelete` exclusion, enrichment reading `CardOwner` reference documents through a custom grouper, empty query, missing-projection throw.
- `aggregateto_linq_operator_tests`: cross-stream fold, initial-state seeding, Guid id stamping, string-key stamping under `StreamIdentity.AsString`, empty query returns null.
- `dcb_tag_linq_where_tests`: single tag match, tag + event-type predicate, tag + timestamp predicate, AND of two tags requiring both, unregistered tag type throws, and a Polecat-specific conjoined-tenancy isolation test (replacing Marten's HStore-mode test).

## Docs
- `docs/events/querying.md`: new **AggregateToAsync** and **AggregateToManyAsync** sections with snippets from the new tests.
- `docs/events/dcb.md`: new **Tag Predicates in LINQ (HasTag)** section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)