### PR TITLE
fix(#363): bind string identifiers as varchar to restore index seeks (StreamIdentity.AsString performance)

### DIFF
--- a/src/Polecat.Tests/Storage/sqlserver_storage_dialect_tests.cs
+++ b/src/Polecat.Tests/Storage/sqlserver_storage_dialect_tests.cs
@@ -1,5 +1,6 @@
 using System.Data;
 using Microsoft.Data.SqlClient;
+using Polecat.Internal;
 using Polecat.Storage;
 using Polecat.Tests.Harness;
 using Weasel.SqlServer;
@@ -29,6 +30,33 @@ public class sqlserver_storage_dialect_tests : OneOffConfigurationsContext
         sql.Parameters["tenant_id"].Value.ShouldBe("t1");
     }
 
+    // #363 regression: string ids and tenant ids must bind as varchar to match the varchar(250)
+    // columns; nvarchar parameters turn the id/tenant index seeks into full scans.
+    [Fact]
+    public void build_load_command_binds_string_id_and_tenant_as_varchar()
+    {
+        var stringDialect = SqlServerStorageDialect<string>.Instance;
+        var command = stringDialect.BuildLoadCommand(
+            "SELECT data FROM t WHERE id = @id AND tenant_id = @tenant_id", "customer-1", "t1");
+
+        var sql = command.ShouldBeOfType<SqlCommand>();
+        sql.Parameters["id"].SqlDbType.ShouldBe(SqlDbType.VarChar);
+        sql.Parameters["tenant_id"].SqlDbType.ShouldBe(SqlDbType.VarChar);
+    }
+
+    // #363 regression: the LINQ by-id filter for string identities must also bind varchar.
+    [Fact]
+    public void by_id_filter_binds_string_ids_as_varchar()
+    {
+        var fragment = SqlServerStorageDialect<string>.Instance.ByIdFilter("customer-1");
+
+        var builder = new CommandBuilder();
+        fragment.Apply(builder);
+        var command = builder.Compile();
+
+        command.Parameters[0].SqlDbType.ShouldBe(SqlDbType.VarChar);
+    }
+
     [Fact]
     public void build_load_command_omits_tenant_when_null()
     {
@@ -36,8 +64,10 @@ public class sqlserver_storage_dialect_tests : OneOffConfigurationsContext
         command.Parameters.Count.ShouldBe(1);
     }
 
+    // #363: String maps to VarChar, not NVarChar — every string-typed storage column in Polecat is
+    // varchar, and an nvarchar parameter forces CONVERT_IMPLICIT onto the column, killing index seeks.
     [Theory]
-    [InlineData(StorageColumnType.String, SqlDbType.NVarChar)]
+    [InlineData(StorageColumnType.String, SqlDbType.VarChar)]
     [InlineData(StorageColumnType.Guid, SqlDbType.UniqueIdentifier)]
     [InlineData(StorageColumnType.Long, SqlDbType.BigInt)]
     [InlineData(StorageColumnType.Int, SqlDbType.Int)]
@@ -143,5 +173,25 @@ public class sqlserver_storage_dialect_tests : OneOffConfigurationsContext
     {
         Should.Throw<ArgumentOutOfRangeException>(() =>
             theDialect.CreateIdArrayParameter(new[] { 1.5, 2.5 }, typeof(double)));
+    }
+
+    // #363 regression: the AddWithValue replacements bind strings as varchar (fixed 8000 size for
+    // plan-cache stability) and pass non-string ids through untouched.
+    [Fact]
+    public void add_varchar_and_add_id_parameter_bind_expected_types()
+    {
+        using var command = new SqlCommand();
+
+        var text = command.Parameters.AddVarChar("@a", "value");
+        text.SqlDbType.ShouldBe(SqlDbType.VarChar);
+        text.Size.ShouldBe(8000);
+
+        var nullText = command.Parameters.AddVarChar("@b", null);
+        nullText.Value.ShouldBe(DBNull.Value);
+        nullText.SqlDbType.ShouldBe(SqlDbType.VarChar);
+
+        command.Parameters.AddIdParameter("@c", "stream-key").SqlDbType.ShouldBe(SqlDbType.VarChar);
+        command.Parameters.AddIdParameter("@d", Guid.NewGuid()).SqlDbType.ShouldBe(SqlDbType.UniqueIdentifier);
+        command.Parameters.AddIdParameter("@e", 42L).SqlDbType.ShouldBe(SqlDbType.BigInt);
     }
 }

--- a/src/Polecat/DocumentStore.DocumentDiagnostics.cs
+++ b/src/Polecat/DocumentStore.DocumentDiagnostics.cs
@@ -8,6 +8,7 @@ using JasperFx.Documents;
 using JasperFx.MultiTenancy;
 using Microsoft.Data.SqlClient;
 
+using Polecat.Internal;
 namespace Polecat;
 
 public partial class DocumentStore : IDocumentStoreDiagnostics
@@ -71,10 +72,10 @@ public partial class DocumentStore : IDocumentStoreDiagnostics
         void BindParameters(SqlCommand command)
         {
             if (options.IdEquals != null) command.Parameters.AddWithValue("@id", options.IdEquals);
-            if (filterByTenant) command.Parameters.AddWithValue("@tenant", options.TenantId!);
-            if (filterCorrelation) command.Parameters.AddWithValue("@correlation", options.CorrelationId!);
-            if (filterCausation) command.Parameters.AddWithValue("@causation", options.CausationId!);
-            if (filterLastModifiedBy) command.Parameters.AddWithValue("@last_modified_by", options.LastModifiedBy!);
+            if (filterByTenant) command.Parameters.AddVarChar("@tenant", options.TenantId!);
+            if (filterCorrelation) command.Parameters.AddVarChar("@correlation", options.CorrelationId!);
+            if (filterCausation) command.Parameters.AddVarChar("@causation", options.CausationId!);
+            if (filterLastModifiedBy) command.Parameters.AddVarChar("@last_modified_by", options.LastModifiedBy!);
         }
 
         await using var conn = new SqlConnection(Database.ConnectionString);

--- a/src/Polecat/DocumentStore.EventStore.cs
+++ b/src/Polecat/DocumentStore.EventStore.cs
@@ -17,6 +17,7 @@ using Polecat.Projections;
 using Polecat.Storage;
 using Polecat.Subscriptions;
 
+using Polecat.Internal;
 namespace Polecat;
 
 public partial class DocumentStore : IEventStore<IDocumentSession, IQuerySession>,
@@ -413,7 +414,7 @@ public partial class DocumentStore : IEventStore<IDocumentSession, IQuerySession
             {
                 await using var cmd = conn.CreateCommand();
                 cmd.CommandText = $"DELETE FROM {progressionTable} WHERE name LIKE @name;";
-                cmd.Parameters.AddWithValue("@name", name + "%");
+                cmd.Parameters.AddVarChar("@name", name + "%");
                 await cmd.ExecuteNonQueryAsync(ct);
             }
             else
@@ -426,7 +427,7 @@ public partial class DocumentStore : IEventStore<IDocumentSession, IQuerySession
                     WHEN NOT MATCHED THEN INSERT (name, last_seq_id, last_updated)
                         VALUES (@name, @seq, SYSDATETIMEOFFSET());
                     """;
-                cmd.Parameters.AddWithValue("@name", name);
+                cmd.Parameters.AddVarChar("@name", name);
                 cmd.Parameters.AddWithValue("@seq", seqFloor.Value);
                 await cmd.ExecuteNonQueryAsync(ct);
             }
@@ -451,7 +452,7 @@ public partial class DocumentStore : IEventStore<IDocumentSession, IQuerySession
                 WHEN NOT MATCHED THEN INSERT (name, last_seq_id, last_updated)
                     VALUES (@name, @seq, SYSDATETIMEOFFSET());
                 """;
-            cmd.Parameters.AddWithValue("@name", name);
+            cmd.Parameters.AddVarChar("@name", name);
             cmd.Parameters.AddWithValue("@seq", seqFloor);
             await cmd.ExecuteNonQueryAsync(ct);
         }, (connStr, Events.ProgressionTableName, shardName, sequenceFloor), token);
@@ -479,7 +480,7 @@ public partial class DocumentStore : IEventStore<IDocumentSession, IQuerySession
 
             await using var cmd = conn.CreateCommand();
             cmd.CommandText = $"DELETE FROM {progressionTable} WHERE name LIKE @name;";
-            cmd.Parameters.AddWithValue("@name", name + "%");
+            cmd.Parameters.AddVarChar("@name", name + "%");
             await cmd.ExecuteNonQueryAsync(ct);
         }, (connStr, Events.ProgressionTableName, subscriptionName), token);
     }
@@ -533,7 +534,7 @@ public partial class DocumentStore : IEventStore<IDocumentSession, IQuerySession
                     await using var delProg = conn.CreateCommand();
                     delProg.Transaction = tx;
                     delProg.CommandText = $"DELETE FROM {progressionTable} WHERE name = @id;";
-                    delProg.Parameters.AddWithValue("@id", identity);
+                    delProg.Parameters.AddVarChar("@id", identity);
                     await delProg.ExecuteNonQueryAsync(ct);
                 }
 
@@ -548,7 +549,7 @@ public partial class DocumentStore : IEventStore<IDocumentSession, IQuerySession
                     delDocs.CommandText = isConjoined
                         ? $"IF OBJECT_ID('{tableName}', 'U') IS NOT NULL DELETE FROM {tableName} WHERE tenant_id = @tenant;"
                         : $"IF OBJECT_ID('{tableName}', 'U') IS NOT NULL DELETE FROM {tableName};";
-                    if (isConjoined) delDocs.Parameters.AddWithValue("@tenant", tenant);
+                    if (isConjoined) delDocs.Parameters.AddVarChar("@tenant", tenant);
                     await delDocs.ExecuteNonQueryAsync(ct);
                 }
 
@@ -625,7 +626,7 @@ public partial class DocumentStore : IEventStore<IDocumentSession, IQuerySession
 
             await using var cmd = conn.CreateCommand();
             cmd.CommandText = $"DELETE FROM {progressionTable} WHERE name LIKE @name;";
-            cmd.Parameters.AddWithValue("@name", name + "%");
+            cmd.Parameters.AddVarChar("@name", name + "%");
             await cmd.ExecuteNonQueryAsync(ct);
 
             foreach (var tableName in tableNames)

--- a/src/Polecat/DocumentStore.EventStoreExplorer.cs
+++ b/src/Polecat/DocumentStore.EventStoreExplorer.cs
@@ -12,6 +12,7 @@ using Polecat.Events;
 using Polecat.Events.Internal;
 using Polecat.Storage;
 
+using Polecat.Internal;
 namespace Polecat;
 
 /// <summary>
@@ -57,7 +58,7 @@ public partial class DocumentStore
             {tenantFilter}ORDER BY timestamp DESC;
             """;
         cmd.Parameters.AddWithValue("@count", count);
-        if (tenantId != null) cmd.Parameters.AddWithValue("@tenant_id", tenantId);
+        if (tenantId != null) cmd.Parameters.AddVarChar("@tenant_id", tenantId);
 
         await using var reader = await session.ExecuteReaderAsync(cmd, ct);
         while (await reader.ReadAsync(ct))
@@ -106,8 +107,8 @@ public partial class DocumentStore
             WHERE stream_id = @stream_id
             {tenantFilter}ORDER BY version;
             """;
-        cmd.Parameters.AddWithValue("@stream_id", resolvedStreamId);
-        if (tenantId != null) cmd.Parameters.AddWithValue("@tenant_id", tenantId);
+        cmd.Parameters.AddIdParameter("@stream_id", resolvedStreamId);
+        if (tenantId != null) cmd.Parameters.AddVarChar("@tenant_id", tenantId);
 
         var ctx = new EventHydrationContext(
             Events,
@@ -151,7 +152,7 @@ public partial class DocumentStore
             WHERE s.id = @id
             GROUP BY s.id, s.type, s.version, s.created, s.timestamp, s.tenant_id, s.is_archived;
             """;
-        cmd.Parameters.AddWithValue("@id", resolvedStreamId);
+        cmd.Parameters.AddIdParameter("@id", resolvedStreamId);
 
         await using var reader = await session.ExecuteReaderAsync(cmd, ct);
         if (!await reader.ReadAsync(ct))
@@ -248,7 +249,7 @@ public partial class DocumentStore
         }
 
         sb.Append(" AND e.tenant_id = @tenant_id ORDER BY e.seq_id");
-        cmd.Parameters.AddWithValue("@tenant_id", tenantId);
+        cmd.Parameters.AddVarChar("@tenant_id", tenantId);
         cmd.CommandText = sb.ToString();
 
         var ctx = new EventHydrationContext(

--- a/src/Polecat/Events/Daemon/PolecatEventLoader.cs
+++ b/src/Polecat/Events/Daemon/PolecatEventLoader.cs
@@ -4,6 +4,7 @@ using JasperFx.Events.Daemon;
 using JasperFx.Events.Projections;
 using Microsoft.Data.SqlClient;
 
+using Polecat.Internal;
 namespace Polecat.Events.Daemon;
 
 /// <summary>
@@ -87,7 +88,7 @@ internal class PolecatEventLoader : IEventLoader
         cmd.Parameters.AddWithValue("@batchSize", request.BatchSize);
         cmd.Parameters.AddWithValue("@floor", request.Floor);
         cmd.Parameters.AddWithValue("@ceiling", request.HighWater);
-        if (_tenantFilter != null) cmd.Parameters.AddWithValue("@tenant", _tenantFilter);
+        if (_tenantFilter != null) cmd.Parameters.AddVarChar("@tenant", _tenantFilter);
 
         var skippedEvents = 0;
 

--- a/src/Polecat/Events/Daemon/PolecatHighWaterDetector.cs
+++ b/src/Polecat/Events/Daemon/PolecatHighWaterDetector.cs
@@ -6,6 +6,7 @@ using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Logging;
 using Polly;
 
+using Polecat.Internal;
 namespace Polecat.Events.Daemon;
 
 /// <summary>
@@ -296,7 +297,7 @@ internal class PolecatHighWaterDetector : IHighWaterDetector
 
             await using var cmd = conn.CreateCommand();
             cmd.CommandText = $"""
-                WITH inputs AS (SELECT value AS tenant_id FROM OPENJSON(@tenants))
+                WITH inputs AS (SELECT CAST(value AS varchar(250)) AS tenant_id FROM OPENJSON(@tenants))
                 SELECT
                     i.tenant_id,
                     CAST(ISNULL(sq.current_value, 0) AS bigint) AS last_value,
@@ -313,7 +314,7 @@ internal class PolecatHighWaterDetector : IHighWaterDetector
                 """;
             cmd.Parameters.AddWithValue("@tenants", tenantsJson);
             cmd.Parameters.AddWithValue("@schema", schema);
-            cmd.Parameters.AddWithValue("@prefix", prefix);
+            cmd.Parameters.AddVarChar("@prefix", prefix);
 
             var results = new List<HighWaterStatistics>();
             await using var reader = await cmd.ExecuteReaderAsync(ct);

--- a/src/Polecat/Events/EventOperations.cs
+++ b/src/Polecat/Events/EventOperations.cs
@@ -447,8 +447,8 @@ internal class EventOperations : QueryEventStore, IEventOperations
             SELECT version FROM {_events.StreamsTableName}{lockHint}
             WHERE id = @id AND tenant_id = @tenant_id;
             """;
-        cmd.Parameters.AddWithValue("@id", streamId);
-        cmd.Parameters.AddWithValue("@tenant_id", _tenantId);
+        cmd.Parameters.AddIdParameter("@id", streamId);
+        cmd.Parameters.AddVarChar("@tenant_id", _tenantId);
 
         long version = 0;
         try
@@ -554,8 +554,8 @@ internal class EventOperations : QueryEventStore, IEventOperations
                 SELECT version FROM {_events.StreamsTableName}{lockHint}
                 WHERE id = @id AND tenant_id = @tenant_id;
                 """;
-            cmd.Parameters.AddWithValue("@id", streamId);
-            cmd.Parameters.AddWithValue("@tenant_id", _tenantId);
+            cmd.Parameters.AddIdParameter("@id", streamId);
+            cmd.Parameters.AddVarChar("@tenant_id", _tenantId);
 
             var result = await _sessionBase.ExecuteScalarAsync(cmd, cancellation);
             if (result != null && result != DBNull.Value)
@@ -697,10 +697,10 @@ internal class EventOperations : QueryEventStore, IEventOperations
             FROM [{schema}].[{tableName}] nk
             WHERE nk.natural_key_value = @naturalKey AND nk.is_archived = 0{tenantFilter};
             """;
-        cmd.Parameters.AddWithValue("@naturalKey", unwrapped);
+        cmd.Parameters.AddWithValue("@naturalKey", unwrapped); // natural_key_value is nvarchar(200)
         if (_events.TenancyStyle == TenancyStyle.Conjoined)
         {
-            cmd.Parameters.AddWithValue("@tenantId", _tenantId);
+            cmd.Parameters.AddVarChar("@tenantId", _tenantId);
         }
 
         var result = await _sessionBase.ExecuteScalarAsync(cmd, cancellation);
@@ -819,14 +819,14 @@ internal class EventOperations : QueryEventStore, IEventOperations
             var value = registration.ExtractValue(condition.TagValue);
 
             sb.Append($"(t{tagIndex}.value = @p{paramIndex}");
-            cmd.Parameters.AddWithValue($"@p{paramIndex}", value);
+            cmd.Parameters.AddIdParameter($"@p{paramIndex}", value);
             paramIndex++;
 
             if (condition.EventType != null)
             {
                 sb.Append($" AND e.type = @p{paramIndex}");
                 var eventTypeName = _events.EventMappingFor(condition.EventType).EventTypeName;
-                cmd.Parameters.AddWithValue($"@p{paramIndex}", eventTypeName);
+                cmd.Parameters.AddVarChar($"@p{paramIndex}", eventTypeName);
                 paramIndex++;
             }
 
@@ -839,7 +839,7 @@ internal class EventOperations : QueryEventStore, IEventOperations
         if (_events.TenancyStyle == TenancyStyle.Conjoined)
         {
             sb.Append($" AND t0.tenant_id = @p{paramIndex}");
-            cmd.Parameters.AddWithValue($"@p{paramIndex}", _tenantId);
+            cmd.Parameters.AddVarChar($"@p{paramIndex}", _tenantId);
             paramIndex++;
         }
 
@@ -900,14 +900,14 @@ internal class EventOperations : QueryEventStore, IEventOperations
             var value = registration.ExtractValue(condition.TagValue);
 
             sb.Append($"(t{tagIndex}.value = @p{paramIndex}");
-            cmd.Parameters.AddWithValue($"@p{paramIndex}", value);
+            cmd.Parameters.AddIdParameter($"@p{paramIndex}", value);
             paramIndex++;
 
             if (condition.EventType != null)
             {
                 sb.Append($" AND e.type = @p{paramIndex}");
                 var eventTypeName = _events.EventMappingFor(condition.EventType).EventTypeName;
-                cmd.Parameters.AddWithValue($"@p{paramIndex}", eventTypeName);
+                cmd.Parameters.AddVarChar($"@p{paramIndex}", eventTypeName);
                 paramIndex++;
             }
 
@@ -920,7 +920,7 @@ internal class EventOperations : QueryEventStore, IEventOperations
         if (_events.TenancyStyle == TenancyStyle.Conjoined)
         {
             sb.Append($" AND e.tenant_id = @p{paramIndex}");
-            cmd.Parameters.AddWithValue($"@p{paramIndex}", _tenantId);
+            cmd.Parameters.AddVarChar($"@p{paramIndex}", _tenantId);
             paramIndex++;
         }
 
@@ -1089,13 +1089,13 @@ internal class EventOperations : QueryEventStore, IEventOperations
             var value = registration.ExtractValue(condition.TagValue);
 
             builder.Append($"(t{tagIndex}.value = ");
-            builder.AppendParameter(value);
+            builder.AppendParameter(value, value is string ? System.Data.SqlDbType.VarChar : null);
 
             if (condition.EventType != null)
             {
                 builder.Append(" AND e.type = ");
                 var eventTypeName = eventGraph.EventMappingFor(condition.EventType).EventTypeName;
-                builder.AppendParameter(eventTypeName);
+                builder.AppendParameter(eventTypeName, System.Data.SqlDbType.VarChar);
             }
 
             builder.Append(")");
@@ -1107,7 +1107,7 @@ internal class EventOperations : QueryEventStore, IEventOperations
         if (eventGraph.TenancyStyle == TenancyStyle.Conjoined && tenantId != null)
         {
             builder.Append(" AND e.tenant_id = ");
-            builder.AppendParameter(tenantId);
+            builder.AppendParameter(tenantId, System.Data.SqlDbType.VarChar);
         }
 
         builder.Append(" ORDER BY e.seq_id");

--- a/src/Polecat/Events/Fetching/NaturalKeyFetchPlanner.cs
+++ b/src/Polecat/Events/Fetching/NaturalKeyFetchPlanner.cs
@@ -49,8 +49,8 @@ internal static class NaturalKeyFetchPlanner
             AND s.tenant_id = @tenantId;
             """;
 
-        cmd.Parameters.AddWithValue("@naturalKey", unwrapped);
-        cmd.Parameters.AddWithValue("@tenantId", tenantId);
+        cmd.Parameters.AddWithValue("@naturalKey", unwrapped); // natural_key_value is nvarchar(200)
+        cmd.Parameters.AddVarChar("@tenantId", tenantId);
 
         long version = 0;
         object? streamId = null;

--- a/src/Polecat/Events/Projections/NaturalKeyArchiveOperation.cs
+++ b/src/Polecat/Events/Projections/NaturalKeyArchiveOperation.cs
@@ -36,12 +36,13 @@ internal class NaturalKeyArchiveOperation : Polecat.Internal.IStorageOperation
         var streamColumn = _isGuidStream ? "stream_id" : "stream_key";
 
         builder.Append($"UPDATE {_tableName} SET is_archived = 1 WHERE {streamColumn} = ");
-        builder.AppendParameter(_streamId);
+        // #363: string stream keys must bind varchar to seek the varchar(250) stream_key column.
+        builder.AppendParameter(_streamId, _streamId is string ? System.Data.SqlDbType.VarChar : null);
 
         if (_isConjoined)
         {
             builder.Append(" AND tenant_id = ");
-            builder.AppendParameter(_tenantId!);
+            builder.AppendParameter(_tenantId!, System.Data.SqlDbType.VarChar);
         }
 
         builder.Append(";");

--- a/src/Polecat/Events/Projections/NaturalKeyUpsertOperation.cs
+++ b/src/Polecat/Events/Projections/NaturalKeyUpsertOperation.cs
@@ -45,9 +45,9 @@ internal class NaturalKeyUpsertOperation : Polecat.Internal.IStorageOperation
                 """);
             builder.AppendParameter(_naturalKeyValue);
             builder.Append(", ");
-            builder.AppendParameter(_tenantId!);
+            builder.AppendParameter(_tenantId!, System.Data.SqlDbType.VarChar);
             builder.Append(", ");
-            builder.AppendParameter(_streamId);
+            builder.AppendParameter(_streamId, _streamId is string ? System.Data.SqlDbType.VarChar : null);
             builder.Append($"""
                 , 0)) AS source (natural_key_value, tenant_id, {streamColumn}, is_archived)
                 ON target.natural_key_value = source.natural_key_value AND target.tenant_id = source.tenant_id
@@ -63,7 +63,7 @@ internal class NaturalKeyUpsertOperation : Polecat.Internal.IStorageOperation
                 """);
             builder.AppendParameter(_naturalKeyValue);
             builder.Append(", ");
-            builder.AppendParameter(_streamId);
+            builder.AppendParameter(_streamId, _streamId is string ? System.Data.SqlDbType.VarChar : null);
             builder.Append($"""
                 , 0)) AS source (natural_key_value, {streamColumn}, is_archived)
                 ON target.natural_key_value = source.natural_key_value

--- a/src/Polecat/Events/QueryEventStore.cs
+++ b/src/Polecat/Events/QueryEventStore.cs
@@ -148,8 +148,8 @@ internal class QueryEventStore : IQueryEventStore, IReadOnlyEventStore
             WHERE stream_id = @stream_id AND tenant_id = @tenant_id AND is_archived = 0
             """;
 
-        cmd.Parameters.AddWithValue("@stream_id", streamId);
-        cmd.Parameters.AddWithValue("@tenant_id", _session.TenantId);
+        cmd.Parameters.AddIdParameter("@stream_id", streamId);
+        cmd.Parameters.AddVarChar("@tenant_id", _session.TenantId);
 
         if (version > 0)
         {
@@ -231,8 +231,8 @@ internal class QueryEventStore : IQueryEventStore, IReadOnlyEventStore
             FROM {_events.EventsTableName}
             WHERE id = @id AND tenant_id = @tenant_id AND is_archived = 0;
             """;
-        cmd.Parameters.AddWithValue("@id", id);
-        cmd.Parameters.AddWithValue("@tenant_id", _session.TenantId);
+        cmd.Parameters.AddWithValue("@id", id); // event id — uniqueidentifier
+        cmd.Parameters.AddVarChar("@tenant_id", _session.TenantId);
 
         await using var reader = await _session.ExecuteReaderAsync(cmd, token);
         if (!await reader.ReadAsync(token)) return null;
@@ -282,8 +282,8 @@ internal class QueryEventStore : IQueryEventStore, IReadOnlyEventStore
             FROM {_events.StreamsTableName}
             WHERE id = @id AND tenant_id = @tenant_id;
             """;
-        cmd.Parameters.AddWithValue("@id", streamId);
-        cmd.Parameters.AddWithValue("@tenant_id", _session.TenantId);
+        cmd.Parameters.AddIdParameter("@id", streamId);
+        cmd.Parameters.AddVarChar("@tenant_id", _session.TenantId);
 
         await using var reader = await _session.ExecuteReaderAsync(cmd, token);
         if (await reader.ReadAsync(token))

--- a/src/Polecat/Internal/Batching/CheckExistsBatchQueryItem.cs
+++ b/src/Polecat/Internal/Batching/CheckExistsBatchQueryItem.cs
@@ -27,11 +27,11 @@ internal class CheckExistsBatchQueryItem<T> : IBatchQueryItem where T : class
             : "";
 
         builder.Append($"SELECT CAST(CASE WHEN EXISTS(SELECT 1 FROM {_provider.Mapping.QualifiedTableName} WHERE id = ");
-        builder.AppendParameter(_id);
+        builder.AppendParameter(_id, _id is string ? System.Data.SqlDbType.VarChar : null);
         if (_provider.Mapping.TenancyStyle == TenancyStyle.Conjoined) // #234
         {
             builder.Append(" AND tenant_id = ");
-            builder.AppendParameter(_tenantId);
+            builder.AppendParameter(_tenantId, System.Data.SqlDbType.VarChar);
         }
 
         builder.Append(softDeleteFilter);

--- a/src/Polecat/Internal/Batching/EventsExistBatchItem.cs
+++ b/src/Polecat/Internal/Batching/EventsExistBatchItem.cs
@@ -69,13 +69,13 @@ internal class EventsExistBatchItem : IBatchQueryItem
             var value = registration.ExtractValue(condition.TagValue);
 
             builder.Append($"(t{tagIndex}.value = ");
-            builder.AppendParameter(value);
+            builder.AppendParameter(value, value is string ? System.Data.SqlDbType.VarChar : null);
 
             if (condition.EventType != null)
             {
                 builder.Append(" AND e.type = ");
                 var eventTypeName = _eventGraph.EventMappingFor(condition.EventType).EventTypeName;
-                builder.AppendParameter(eventTypeName);
+                builder.AppendParameter(eventTypeName, System.Data.SqlDbType.VarChar);
             }
 
             builder.Append(")");
@@ -87,7 +87,7 @@ internal class EventsExistBatchItem : IBatchQueryItem
         if (_eventGraph.TenancyStyle == TenancyStyle.Conjoined)
         {
             builder.Append(" AND t0.tenant_id = ");
-            builder.AppendParameter(_tenantId);
+            builder.AppendParameter(_tenantId, System.Data.SqlDbType.VarChar);
         }
 
         builder.Append(") THEN 1 ELSE 0 END");

--- a/src/Polecat/Internal/DocumentSessionBase.cs
+++ b/src/Polecat/Internal/DocumentSessionBase.cs
@@ -816,8 +816,8 @@ internal abstract class DocumentSessionBase : QuerySession, IDocumentSession
         await using var cmd = new SqlCommand();
         cmd.CommandText =
             $"SELECT version, is_archived FROM {_eventGraph.StreamsTableName} WITH (UPDLOCK, HOLDLOCK) WHERE id = @id AND tenant_id = @tenant_id;";
-        cmd.Parameters.AddWithValue("@id", streamId);
-        cmd.Parameters.AddWithValue("@tenant_id", TenantId);
+        cmd.Parameters.AddIdParameter("@id", streamId);
+        cmd.Parameters.AddVarChar("@tenant_id", TenantId);
 
         await using var reader = await ExecuteReaderAsync(cmd, token);
         if (await reader.ReadAsync(token))
@@ -893,8 +893,8 @@ internal abstract class DocumentSessionBase : QuerySession, IDocumentSession
         await using var cmd = new SqlCommand();
         cmd.CommandText =
             $"SELECT version FROM {_eventGraph.StreamsTableName} WHERE id = @id AND tenant_id = @tenant_id;";
-        cmd.Parameters.AddWithValue("@id", streamId);
-        cmd.Parameters.AddWithValue("@tenant_id", TenantId);
+        cmd.Parameters.AddIdParameter("@id", streamId);
+        cmd.Parameters.AddVarChar("@tenant_id", TenantId);
 
         await using var reader = await ExecuteReaderAsync(cmd, token);
         if (!await reader.ReadAsync(token))

--- a/src/Polecat/Internal/Operations/AssertDcbConsistencyOperation.cs
+++ b/src/Polecat/Internal/Operations/AssertDcbConsistencyOperation.cs
@@ -83,13 +83,14 @@ internal class AssertDcbConsistencyOperation : IStorageOperation
 
             var registration = _events.FindTagType(condition.TagType)!;
             var value = registration.ExtractValue(condition.TagValue);
-            builder.AppendParameter(value);
+            // #363: string tag values bind varchar to seek the varchar(250) tag value column.
+            builder.AppendParameter(value, value is string ? System.Data.SqlDbType.VarChar : null);
 
             if (condition.EventType != null)
             {
                 builder.Append(" AND e.type = ");
                 var eventTypeName = _events.EventMappingFor(condition.EventType).EventTypeName;
-                builder.AppendParameter(eventTypeName);
+                builder.AppendParameter(eventTypeName, System.Data.SqlDbType.VarChar);
             }
 
             builder.Append(")");
@@ -101,7 +102,7 @@ internal class AssertDcbConsistencyOperation : IStorageOperation
         if (_events.TenancyStyle == TenancyStyle.Conjoined && _tenantId != null)
         {
             builder.Append(" AND t0.tenant_id = ");
-            builder.AppendParameter(_tenantId);
+            builder.AppendParameter(_tenantId, System.Data.SqlDbType.VarChar);
         }
 
         builder.Append(") THEN 1 ELSE 0 END");

--- a/src/Polecat/Internal/Operations/DeleteWhereOperation.cs
+++ b/src/Polecat/Internal/Operations/DeleteWhereOperation.cs
@@ -43,7 +43,7 @@ internal class DeleteWhereOperation : IStorageOperation
         if (_conjoined)
         {
             builder.Append("tenant_id = ");
-            builder.AppendParameter(_tenantId);
+            builder.AppendParameter(_tenantId, System.Data.SqlDbType.VarChar);
             builder.Append(" AND ");
         }
 

--- a/src/Polecat/Internal/Operations/UnDeleteByIdOperation.cs
+++ b/src/Polecat/Internal/Operations/UnDeleteByIdOperation.cs
@@ -37,12 +37,12 @@ internal class UnDeleteByIdOperation : IStorageOperation
     {
         _undeleteFragment.Apply(builder);
         builder.Append(" WHERE id = ");
-        builder.AppendParameter(_id);
+        builder.AppendParameter(_id, _id is string ? System.Data.SqlDbType.VarChar : null);
         // #234: single-tenant tables have no tenant_id column.
         if (_conjoined)
         {
             builder.Append(" AND tenant_id = ");
-            builder.AppendParameter(_tenantId);
+            builder.AppendParameter(_tenantId, System.Data.SqlDbType.VarChar);
         }
 
         builder.Append(";");

--- a/src/Polecat/Internal/Operations/UndoDeleteWhereOperation.cs
+++ b/src/Polecat/Internal/Operations/UndoDeleteWhereOperation.cs
@@ -40,7 +40,7 @@ internal class UndoDeleteWhereOperation : IStorageOperation
         if (_conjoined) // #234
         {
             builder.Append("tenant_id = ");
-            builder.AppendParameter(_tenantId);
+            builder.AppendParameter(_tenantId, System.Data.SqlDbType.VarChar);
             builder.Append(" AND ");
         }
 

--- a/src/Polecat/Internal/QuerySession.Metadata.cs
+++ b/src/Polecat/Internal/QuerySession.Metadata.cs
@@ -62,8 +62,8 @@ internal partial class QuerySession
         cmd.CommandText =
             $"SELECT {string.Join(", ", columns)} FROM {mapping.QualifiedTableName} " +
             (isConjoined ? "WHERE id = @id AND tenant_id = @tenant_id" : "WHERE id = @id");
-        cmd.Parameters.AddWithValue("@id", id);
-        if (isConjoined) cmd.Parameters.AddWithValue("@tenant_id", TenantId);
+        cmd.Parameters.AddIdParameter("@id", id);
+        if (isConjoined) cmd.Parameters.AddVarChar("@tenant_id", TenantId);
 
         Logger.OnBeforeExecute(cmd.CommandText);
         try

--- a/src/Polecat/Internal/QuerySession.cs
+++ b/src/Polecat/Internal/QuerySession.cs
@@ -204,8 +204,8 @@ internal partial class QuerySession : IQuerySession
         // #234: tenant_id predicate is conjoined-only.
         var tenantFilter = provider.Mapping.TenancyStyle == TenancyStyle.Conjoined ? " AND tenant_id = @tenant_id" : "";
         cmd.CommandText = $"SELECT CAST(CASE WHEN EXISTS(SELECT 1 FROM {provider.Mapping.QualifiedTableName} WHERE id = @id{tenantFilter}{softDeleteFilter}) THEN 1 ELSE 0 END AS BIT);";
-        cmd.Parameters.AddWithValue("@id", id);
-        if (provider.Mapping.TenancyStyle == TenancyStyle.Conjoined) cmd.Parameters.AddWithValue("@tenant_id", TenantId);
+        cmd.Parameters.AddIdParameter("@id", id);
+        if (provider.Mapping.TenancyStyle == TenancyStyle.Conjoined) cmd.Parameters.AddVarChar("@tenant_id", TenantId);
 
         Logger.OnBeforeExecute(cmd.CommandText);
         try
@@ -324,8 +324,8 @@ internal partial class QuerySession : IQuerySession
         // #234: tenant_id predicate is conjoined-only.
         var tenantFilter = provider.Mapping.TenancyStyle == TenancyStyle.Conjoined ? " AND tenant_id = @tenant_id" : "";
         cmd.CommandText = $"SELECT data FROM {provider.Mapping.QualifiedTableName} WHERE id = @id{tenantFilter}{softDeleteFilter};";
-        cmd.Parameters.AddWithValue("@id", id);
-        if (provider.Mapping.TenancyStyle == TenancyStyle.Conjoined) cmd.Parameters.AddWithValue("@tenant_id", TenantId);
+        cmd.Parameters.AddIdParameter("@id", id);
+        if (provider.Mapping.TenancyStyle == TenancyStyle.Conjoined) cmd.Parameters.AddVarChar("@tenant_id", TenantId);
 
         Logger.OnBeforeExecute(cmd.CommandText);
         try

--- a/src/Polecat/Internal/SqlParameterCollectionExtensions.cs
+++ b/src/Polecat/Internal/SqlParameterCollectionExtensions.cs
@@ -1,0 +1,38 @@
+using System.Data;
+using Microsoft.Data.SqlClient;
+
+namespace Polecat.Internal;
+
+/// <summary>
+///     #363: typed replacements for <c>AddWithValue</c> on values compared against Polecat's
+///     <c>varchar</c> columns (ids, stream ids, tenant ids, names). <c>AddWithValue</c> binds .NET
+///     strings as <c>nvarchar</c>, which forces CONVERT_IMPLICIT onto the varchar column side and
+///     turns index seeks into full scans under SQL collations. The fixed 8000 size keeps one plan
+///     per statement instead of one per distinct value length.
+/// </summary>
+internal static class SqlParameterCollectionExtensions
+{
+    /// <summary>Bind a string compared against a varchar column (id, tenant_id, name, type).</summary>
+    public static SqlParameter AddVarChar(this SqlParameterCollection parameters, string name, string? value)
+    {
+        var parameter = new SqlParameter(name, SqlDbType.VarChar, 8000)
+        {
+            Value = (object?)value ?? DBNull.Value
+        };
+        parameters.Add(parameter);
+        return parameter;
+    }
+
+    /// <summary>
+    ///     Bind a stream/document identity whose runtime type is Guid or string (the two stream
+    ///     identity modes). Strings bind as varchar to match the varchar(250) id columns.
+    /// </summary>
+    public static SqlParameter AddIdParameter(this SqlParameterCollection parameters, string name, object id)
+    {
+        return id switch
+        {
+            string text => parameters.AddVarChar(name, text),
+            _ => parameters.AddWithValue(name, id)
+        };
+    }
+}

--- a/src/Polecat/Linq/SqlGeneration/TenantInFilter.cs
+++ b/src/Polecat/Linq/SqlGeneration/TenantInFilter.cs
@@ -33,7 +33,7 @@ internal class TenantInFilter : ISqlFragment
         for (var i = 0; i < _tenantIds.Length; i++)
         {
             if (i > 0) builder.Append(", ");
-            builder.AppendParameter(_tenantIds[i]);
+            builder.AppendParameter(_tenantIds[i], System.Data.SqlDbType.VarChar);
         }
 
         builder.Append(")");

--- a/src/Polecat/Schema/Identity/Sequences/HiloSequence.cs
+++ b/src/Polecat/Schema/Identity/Sequences/HiloSequence.cs
@@ -48,7 +48,7 @@ internal class HiloSequence : HiloSequenceBase
             cmd.CommandText =
                 $"UPDATE [{_schemaName}].[pc_hilo] SET hi_value = @floor WHERE entity_name = @name;";
             cmd.Parameters.AddWithValue("@floor", state);
-            cmd.Parameters.AddWithValue("@name", EntityName);
+            cmd.Parameters.AddVarChar("@name", EntityName);
             await cmd.ExecuteNonQueryAsync(ct);
         }, numberOfPages);
 
@@ -150,7 +150,7 @@ internal class HiloSequence : HiloSequenceBase
         {
             readCmd.CommandText =
                 $"SELECT hi_value FROM [{_schemaName}].[pc_hilo] WHERE entity_name = @entity;";
-            readCmd.Parameters.AddWithValue("@entity", EntityName);
+            readCmd.Parameters.AddVarChar("@entity", EntityName);
             var raw = await readCmd.ExecuteScalarAsync(ct);
             currentHi = raw == null || raw == DBNull.Value ? null : Convert.ToInt64(raw);
         }
@@ -163,7 +163,7 @@ internal class HiloSequence : HiloSequenceBase
                 await using var insertCmd = conn.CreateCommand();
                 insertCmd.CommandText =
                     $"INSERT INTO [{_schemaName}].[pc_hilo] (entity_name, hi_value) VALUES (@entity, 0);";
-                insertCmd.Parameters.AddWithValue("@entity", EntityName);
+                insertCmd.Parameters.AddVarChar("@entity", EntityName);
                 await insertCmd.ExecuteNonQueryAsync(ct);
                 return 0;
             }
@@ -181,7 +181,7 @@ internal class HiloSequence : HiloSequenceBase
             updateCmd.CommandText =
                 $"UPDATE [{_schemaName}].[pc_hilo] SET hi_value = @next WHERE entity_name = @entity AND hi_value = @current;";
             updateCmd.Parameters.AddWithValue("@next", nextHi);
-            updateCmd.Parameters.AddWithValue("@entity", EntityName);
+            updateCmd.Parameters.AddVarChar("@entity", EntityName);
             updateCmd.Parameters.AddWithValue("@current", currentHi.Value);
             var rows = await updateCmd.ExecuteNonQueryAsync(ct);
             return rows == 0 ? -1 : nextHi;
@@ -196,7 +196,7 @@ internal class HiloSequence : HiloSequenceBase
         {
             readCmd.CommandText =
                 $"SELECT hi_value FROM [{_schemaName}].[pc_hilo] WHERE entity_name = @entity;";
-            readCmd.Parameters.AddWithValue("@entity", EntityName);
+            readCmd.Parameters.AddVarChar("@entity", EntityName);
             var raw = readCmd.ExecuteScalar();
             currentHi = raw == null || raw == DBNull.Value ? null : Convert.ToInt64(raw);
         }
@@ -208,7 +208,7 @@ internal class HiloSequence : HiloSequenceBase
                 using var insertCmd = conn.CreateCommand();
                 insertCmd.CommandText =
                     $"INSERT INTO [{_schemaName}].[pc_hilo] (entity_name, hi_value) VALUES (@entity, 0);";
-                insertCmd.Parameters.AddWithValue("@entity", EntityName);
+                insertCmd.Parameters.AddVarChar("@entity", EntityName);
                 insertCmd.ExecuteNonQuery();
                 return 0;
             }
@@ -224,7 +224,7 @@ internal class HiloSequence : HiloSequenceBase
             updateCmd.CommandText =
                 $"UPDATE [{_schemaName}].[pc_hilo] SET hi_value = @next WHERE entity_name = @entity AND hi_value = @current;";
             updateCmd.Parameters.AddWithValue("@next", nextHi);
-            updateCmd.Parameters.AddWithValue("@entity", EntityName);
+            updateCmd.Parameters.AddVarChar("@entity", EntityName);
             updateCmd.Parameters.AddWithValue("@current", currentHi.Value);
             var rows = updateCmd.ExecuteNonQuery();
             return rows == 0 ? -1 : nextHi;

--- a/src/Polecat/Storage/ClosedShape/PolecatDocumentStorage.cs
+++ b/src/Polecat/Storage/ClosedShape/PolecatDocumentStorage.cs
@@ -172,8 +172,14 @@ internal abstract class PolecatDocumentStorage<TDoc, TId>
         // simply unreferenced by the SQL).
         var tenantFilter = _mapping.TenancyStyle == TenancyStyle.Conjoined ? " AND tenant_id = @tenant_id" : string.Empty;
         _loaderSql = $"{select} WHERE id = @id{tenantFilter}{SoftDeleteFilterSql()}";
+        // #363: OPENJSON's value column is nvarchar(4000); against a varchar(250) id column that
+        // forces CONVERT_IMPLICIT on the column side and a full scan, so string ids cast the
+        // extracted values back to varchar before the IN comparison.
+        var idsSelect = _mapping.InnerIdType == typeof(string)
+            ? "SELECT CAST(value AS varchar(250)) FROM OPENJSON(@ids)"
+            : "SELECT value FROM OPENJSON(@ids)";
         _loadManySql =
-            $"{select} WHERE id IN (SELECT value FROM OPENJSON(@ids)){tenantFilter}{SoftDeleteFilterSql()}";
+            $"{select} WHERE id IN ({idsSelect}){tenantFilter}{SoftDeleteFilterSql()}";
 
         _deleteFragment = _mapping.DeleteStyle == DeleteStyle.SoftDelete
             ? new HardCodedOperationFragment(
@@ -356,7 +362,7 @@ internal abstract class PolecatDocumentStorage<TDoc, TId>
     {
         builder.Append(_selectPrefixSql);
         builder.Append(" WHERE id = ");
-        builder.AppendParameter(id);
+        builder.AppendParameter(id, id is string ? System.Data.SqlDbType.VarChar : null);
         AppendBatchLoadFilters(builder, tenantId);
     }
 
@@ -373,7 +379,7 @@ internal abstract class PolecatDocumentStorage<TDoc, TId>
         for (var i = 0; i < ids.Count; i++)
         {
             if (i > 0) builder.Append(", ");
-            builder.AppendParameter(ids[i]);
+            builder.AppendParameter(ids[i], ids[i] is string ? System.Data.SqlDbType.VarChar : null);
         }
 
         builder.Append(")");
@@ -392,7 +398,7 @@ internal abstract class PolecatDocumentStorage<TDoc, TId>
         if (_mapping.TenancyStyle == TenancyStyle.Conjoined)
         {
             builder.Append(" AND tenant_id = ");
-            builder.AppendParameter(tenantId);
+            builder.AppendParameter(tenantId, System.Data.SqlDbType.VarChar);
         }
 
         builder.Append(SoftDeleteFilterSql());

--- a/src/Polecat/Storage/ClosedShape/SubClassPolecatStorage.cs
+++ b/src/Polecat/Storage/ClosedShape/SubClassPolecatStorage.cs
@@ -205,7 +205,7 @@ internal sealed class SubClassPolecatStorage<T, TRoot, TId>
     private void AppendDocTypeFilter(Weasel.SqlServer.ICommandBuilder builder)
     {
         builder.Append(" AND doc_type = ");
-        builder.AppendParameter(_alias);
+        builder.AppendParameter(_alias, System.Data.SqlDbType.VarChar);
     }
 
     public ISelector<T> BuildLoadSelector(IStorageSession session) => (ISelector<T>)BuildSelector(session);

--- a/src/Polecat/Storage/PolecatDatabase.cs
+++ b/src/Polecat/Storage/PolecatDatabase.cs
@@ -17,6 +17,7 @@ using Polly;
 using Weasel.Core.Migrations;
 using Weasel.SqlServer;
 
+using Polecat.Internal;
 namespace Polecat.Storage;
 
 /// <summary>
@@ -145,7 +146,7 @@ public class PolecatDatabase : DatabaseBase<SqlConnection>, IEventDatabase, IPro
                 SELECT last_seq_id FROM {progressionTable}
                 WHERE name = @name;
                 """;
-            cmd.Parameters.AddWithValue("@name", identity);
+            cmd.Parameters.AddVarChar("@name", identity);
 
             var result = await cmd.ExecuteScalarAsync(ct);
             return result is long seq ? seq : 0;
@@ -169,7 +170,7 @@ public class PolecatDatabase : DatabaseBase<SqlConnection>, IEventDatabase, IPro
 
             await using var cmd = conn.CreateCommand();
             cmd.CommandText = $"DELETE FROM {progressionTable} WHERE name = @identity;";
-            cmd.Parameters.AddWithValue("@identity", identity);
+            cmd.Parameters.AddVarChar("@identity", identity);
             await cmd.ExecuteNonQueryAsync(ct);
         }, (_connectionString, _events.ProgressionTableName, shardIdentity), token);
     }
@@ -202,7 +203,7 @@ public class PolecatDatabase : DatabaseBase<SqlConnection>, IEventDatabase, IPro
                     running_on_node = @node
                 WHERE name = @name;
                 """;
-            cmd.Parameters.AddWithValue("@name", shardState.ShardName);
+            cmd.Parameters.AddVarChar("@name", shardState.ShardName);
             cmd.Parameters.AddWithValue("@heartbeat", (object?)shardState.LastHeartbeat ?? DBNull.Value);
             cmd.Parameters.AddWithValue("@status", (object?)shardState.AgentStatus ?? DBNull.Value);
             cmd.Parameters.AddWithValue("@reason", (object?)shardState.PauseReason ?? DBNull.Value);
@@ -283,7 +284,7 @@ public class PolecatDatabase : DatabaseBase<SqlConnection>, IEventDatabase, IPro
             cmd.CommandText = events.EnableExtendedProgressionTracking
                 ? $"SELECT last_seq_id, heartbeat, agent_status FROM {events.ProgressionTableName} WHERE name = @name;"
                 : $"SELECT last_seq_id FROM {events.ProgressionTableName} WHERE name = @name;";
-            cmd.Parameters.AddWithValue("@name", lookupName);
+            cmd.Parameters.AddVarChar("@name", lookupName);
 
             await using var reader = await cmd.ExecuteReaderAsync(ct);
             if (!await reader.ReadAsync(ct))
@@ -325,7 +326,7 @@ public class PolecatDatabase : DatabaseBase<SqlConnection>, IEventDatabase, IPro
             cmd.CommandText = events.EnableExtendedProgressionTracking
                 ? $"SELECT last_seq_id, heartbeat, agent_status FROM {events.ProgressionTableName} WHERE name = @name;"
                 : $"SELECT last_seq_id FROM {events.ProgressionTableName} WHERE name = @name;";
-            cmd.Parameters.AddWithValue("@name", shard.Identity);
+            cmd.Parameters.AddVarChar("@name", shard.Identity);
 
             await using var reader = await cmd.ExecuteReaderAsync(ct);
             if (!await reader.ReadAsync(ct))

--- a/src/Polecat/Storage/SqlServerStorageDialect.cs
+++ b/src/Polecat/Storage/SqlServerStorageDialect.cs
@@ -23,10 +23,13 @@ internal sealed class SqlServerStorageDialect<TId> : IStorageDialect
     // NOTE: not derived from typeof(TId) — for strongly-typed ids TId is the wrapper type
     // while raw sql values are the unwrapped inner (Guid/string/int/long). Type from the
     // runtime value instead (#273 E2a).
+    // #363: string ids MUST bind as varchar — the id columns are varchar(250), and an nvarchar
+    // parameter forces CONVERT_IMPLICIT on the column side, turning every id seek into a scan
+    // under SQL collations.
     private static SqlDbType TypeForRawId(object rawId) => rawId switch
     {
         Guid => SqlDbType.UniqueIdentifier,
-        string => SqlDbType.NVarChar,
+        string => SqlDbType.VarChar,
         int => SqlDbType.Int,
         long => SqlDbType.BigInt,
         _ => SqlServerProvider.Instance.ToParameterType(rawId.GetType())
@@ -42,7 +45,7 @@ internal sealed class SqlServerStorageDialect<TId> : IStorageDialect
         command.Parameters.Add(new SqlParameter("id", rawId) { SqlDbType = TypeForRawId(rawId) });
         if (tenant is not null)
         {
-            command.Parameters.Add(new SqlParameter("tenant_id", tenant) { SqlDbType = SqlDbType.NVarChar });
+            command.Parameters.Add(new SqlParameter("tenant_id", tenant) { SqlDbType = SqlDbType.VarChar });
         }
 
         return command;
@@ -65,7 +68,7 @@ internal sealed class SqlServerStorageDialect<TId> : IStorageDialect
         command.Parameters.Add((SqlParameter)idArrayParameter);
         if (tenant is not null)
         {
-            command.Parameters.Add(new SqlParameter("tenant_id", tenant) { SqlDbType = SqlDbType.NVarChar });
+            command.Parameters.Add(new SqlParameter("tenant_id", tenant) { SqlDbType = SqlDbType.VarChar });
         }
 
         return command;
@@ -77,10 +80,13 @@ internal sealed class SqlServerStorageDialect<TId> : IStorageDialect
     public bool IsUndefinedTable(Exception exception)
         => exception is SqlException sql && sql.Number == 208;
 
+    // #363: StorageColumnType.String always targets Polecat's varchar columns (ids, tenant_id,
+    // type names, correlation/causation) — binding nvarchar defeats their index seeks. JSON stays
+    // nvarchar: payloads are Unicode and the json column type converts the parameter, not the column.
     public void SetParameterType(System.Data.Common.DbParameter parameter, StorageColumnType type)
         => ((SqlParameter)parameter).SqlDbType = type switch
         {
-            StorageColumnType.String => SqlDbType.NVarChar,
+            StorageColumnType.String => SqlDbType.VarChar,
             StorageColumnType.Guid => SqlDbType.UniqueIdentifier,
             StorageColumnType.Long => SqlDbType.BigInt,
             StorageColumnType.Int => SqlDbType.Int,


### PR DESCRIPTION
Fixes #363.

## Root cause

Every string-typed identifier column in Polecat (`pc_streams.id`, `pc_events.stream_id`, `tenant_id`, document `id`, progression `name`, tag `value`, …) is **`varchar(250)`**, but string parameters were bound as **`nvarchar`** — via `SqlDbType.NVarChar` in `SqlServerStorageDialect` and via `AddWithValue` / bare `AppendParameter` (SqlClient's default for .NET strings) in the bespoke paths.

When an `nvarchar` parameter is compared to a `varchar` column, SQL Server's data-type precedence converts the **column side** (`CONVERT_IMPLICIT`). Under SQL collations (e.g. the default `SQL_Latin1_General_CP1_CI_AS`) that turns every id-based index seek into a **full index scan**. Guid identities were unaffected, which is exactly the asymmetry reported.

## Measured impact (repro at 50,000 streams, single-event appends)

| | before | after |
|---|---|---|
| string identity throughput | **53 appends/sec** | **287 appends/sec** |
| guid identity throughput | 304 appends/sec | 249–304 appends/sec (unchanged, run noise) |
| version-read plan (string) | Clustered Index **Scan**, 7,814 µs CPU, 990 reads | Clustered Index **Seek**, 42 µs CPU, 3 reads |

The reporter's ~50/sec vs ~500/sec on a bottlenecked DB matches the before-column almost exactly.

## Changes

- **`SqlServerStorageDialect`**: `TypeForRawId` and `StorageColumnType.String` now map to `SqlDbType.VarChar`; tenant parameters likewise. `StorageColumnType.Json` stays `NVarChar` — JSON payloads are Unicode, and there the *parameter* converts, not the column.
- **`PolecatDocumentStorage`**: load-many SQL for string-id documents casts OPENJSON output back to `varchar(250)` (`OPENJSON`'s `value` is `nvarchar(4000)` and hit the same trap independent of parameter typing). Same fix in the high-water detector's tenant OPENJSON join.
- **New `SqlParameterCollectionExtensions.AddVarChar` / `AddIdParameter`** (internal): typed replacements for `AddWithValue` on values compared against varchar columns, with a fixed `Size = 8000` so the plan cache holds one plan per statement instead of one per distinct value length (the DMVs showed separate cached plans for `nvarchar(34)`…`nvarchar(41)`).
- Swept all bespoke `SqlCommand`/`AppendParameter` sites that filter varchar columns: stream version reads, `FetchStream`/stream-state reads, FetchForWriting, document exists/metadata loads, batched loads, DCB tag queries + consistency assertions, natural-key ops/planner, delete/undelete ops, subclass discriminator, tenant-in filter, daemon event loader + high-water detector, event progression, HiLo, projection rebuild/delete admin paths, store diagnostics.

## Deliberately unchanged

- `@naturalKey` params — `natural_key_value` is an `nvarchar(200)` column; nvarchar binding is correct there.
- `MasterTableTenancy` — `pc_tenants` columns are `NVARCHAR`; correct as-is.
- `@schema`-style params compared against `sys.*` catalog views (`sysname` is nvarchar).
- Generic LINQ value filters (`ComparisonFilter`, `StringEquals`, `IsOneOf`, `EnumerableContains`) — these compare against `JSON_VALUE(...)` output (nvarchar, Unicode document content); forcing varchar could corrupt non-Latin query values. The explorer's case-insensitive tag search likewise converts the column deliberately.

Note on Unicode: stream keys / tenant ids / string doc ids are stored in `varchar(250)` columns, so characters outside the database code page were already not round-trippable before this change; binding the parameters as varchar does not narrow anything further.

## Tests

- Updated `sqlserver_storage_dialect_tests` (`String → VarChar` mapping) and added #363 regression tests: string load command binds varchar id + tenant, string `ByIdFilter` binds varchar, and the `AddVarChar`/`AddIdParameter` helpers bind expected types/sizes.
- Full net10 suite green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VztWPUJjgRwyf5xRy4KANC
