### PR TITLE
feat(#367,#368,#369): JasperFx.Events 2.36.1 — classified shard failures, widened natural key contract, drain-timeout docs

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -36,9 +36,23 @@
              onto every published ShardState, so the ExtendedProgressionWriter can carry the running node
              into WriteExtendedProgressionAsync's running_on_node column under managed distribution.
              JasperFx 2.34.0: jasperfx#555 (tenant-scoped QueryByTagsAsync + EventQuery.TenantId explorer
-             reads, #353) and jasperfx#557 (extended-progression writer shutdown drain). -->
-        <PackageVersion Include="JasperFx" Version="2.34.0" />
-        <PackageVersion Include="JasperFx.Events" Version="2.34.0" />
+             reads, #353) and jasperfx#557 (extended-progression writer shutdown drain).
+             JasperFx 2.36.1: three Polecat issues ride on this line —
+             (a) jasperfx#564: DaemonSettings.StopAndDrainTimeout, the configurable per-shard bound on the
+                 daemon's graceful stop-and-drain (docs, polecat#367);
+             (b) jasperfx#565: ShardFailureCategory / IEventFailureContext / EventFailureDetails /
+                 ShardFailure + ShardState.Failure — the classified reason a shard paused or stopped.
+                 Polecat implements IEventFailureContext on its read-path exceptions and persists the
+                 failure_* extended-progression columns (polecat#368). The daemon has NO fallback
+                 type-name sniffing, so a store that does not implement this classifies every failure as
+                 ShardFailureCategory.Other;
+             (c) jasperfx#569/#571: NaturalKeyEventMapping.Extractor widens from Func<object, object?> to
+                 Func<IEvent, object?> — SOURCE BREAKING, which is why the bump and the call-site change
+                 land together — plus reachable NaturalKeyBuilder / NaturalKeyFor() and loud failure on an
+                 unbindable [NaturalKeySource] (polecat#369).
+             Also carries jasperfx#568/#572 daemon race fixes, picked up for free. -->
+        <PackageVersion Include="JasperFx" Version="2.36.1" />
+        <PackageVersion Include="JasperFx.Events" Version="2.36.1" />
         <!-- Pin the sibling JasperFx packages for parity with Marten 9's matrix
              even though Polecat doesn't currently reference them directly —
              keeps the lockstep matrix coherent when transitive resolution
@@ -46,7 +60,7 @@
              RuntimeCompiler 5.x line is the active continuation of the 4.x
              lineage; do not pin against the parallel stale 2.0.x series. -->
         <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.34.0" />
+        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.36.1" />
         <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
@@ -91,7 +105,7 @@
         <PackageVersion Include="StronglyTypedId" Version="1.0.0-beta08" />
 
         <!-- Source generators (matched to JasperFx.Events above) -->
-        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.34.0" />
+        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.36.1" />
 
         <!-- Build automation -->
         <PackageVersion Include="Nuke.Common" Version="9.0.4" />

--- a/docs/events/natural-keys.md
+++ b/docs/events/natural-keys.md
@@ -25,6 +25,40 @@ Every event type that sets or changes the natural key must be declared through t
 
 Events that do not affect the natural key (like `NkOrderItemAdded` in the example above) do not need any mapping.
 
+A `[NaturalKeySource]` method that cannot be bound to an extraction strategy is now a configuration-time
+error — `AssembleAndAssertValidity()` throws an `InvalidProjectionException` naming the method and the
+reason. Previously such a method registered nothing at all, silently, and the lookup table was simply
+never written for that event type.
+
+## Explicit Mappings with `NaturalKeyFor()`
+
+When attribute discovery cannot bind your method — or when you would simply rather be explicit — register
+the mapping directly from the projection:
+
+```cs
+public class OrderProjection: SingleStreamProjection<Order, Guid>
+{
+    public OrderProjection()
+    {
+        NaturalKeyFor(x => x
+            // From the event body
+            .SetBy<ProductRegistered>(e => new ProductCode(e.Code))
+            // From the whole IEvent, when the key depends on event metadata
+            .SetByEvent<ProductCodeChanged>(e => new ProductCode(e.Data.NewCode)));
+    }
+}
+```
+
+An explicit registration replaces any discovered mapping for the same event type, so it always wins over
+the attribute.
+
+::: warning
+The natural key has to be a function of **the event alone**. The lookup table is maintained inline at
+append time, where no prior aggregate exists under an `Async` snapshot lifecycle, so an extraction that
+depends on the current aggregate state has nothing to read. This is the constraint the attribute path now
+enforces as well.
+:::
+
 ## Storage
 
 Polecat automatically creates and manages a lookup table (prefixed with `pc_`) for each aggregate type that has a natural key configured. The table maps natural key values to stream ids and is:

--- a/docs/events/projections/async-daemon.md
+++ b/docs/events/projections/async-daemon.md
@@ -61,6 +61,42 @@ Unlike Marten's PostgreSQL `LISTEN/NOTIFY`, Polecat uses **polling** to detect n
 // Default: 500ms
 ```
 
+## Graceful Shutdown and the Drain Timeout
+
+When a projection or subscription shard is stopped, the daemon does not simply cancel it. It first tries to
+*drain* the agent: let the in-flight page of events finish being applied, then flush the shard's progression row
+so the next start picks up exactly where this one left off. `StopAndDrainTimeout` bounds how long the daemon
+waits for that drain on **a single** shard:
+
+```cs
+// The default is 5 seconds
+opts.Projections.StopAndDrainTimeout = TimeSpan.FromSeconds(30);
+```
+
+The bound applies to every stop path: stopping one agent, stopping all agents (the `SIGTERM`/host shutdown
+path), and the internal stop-if-already-running replacement that happens when an agent is reassigned.
+
+**Why you would raise it.** If the drain is cut off before the progression flush lands, the shard restarts
+against a stale progression row and throws `ProgressionProgressOutOfOrderException` on its next start. Raise
+the timeout when in-flight batches legitimately take longer than five seconds — a large `BatchSize`, expensive
+projection code, heavy rebuild load, or a slow or contended SQL Server. This is most visible shutting down a
+host with a large agent universe: a [database-per-tenant](/documents/multi-tenancy) deployment with thousands of
+(projection × tenant) shards all draining inside a Kubernetes termination grace window.
+
+::: tip
+A per-shard bound is only useful if the process lives long enough to spend it. Match a raised
+`StopAndDrainTimeout` with the host's own `HostOptions.ShutdownTimeout` and, on Kubernetes, the pod's
+`terminationGracePeriodSeconds`.
+:::
+
+**Why you would lower it.** A deployment that would rather cut a wedged shard loose quickly and take the
+progression replay hit — to keep node failover and reassignment latency low, for instance — can set it below
+the default.
+
+**Opting out.** `Timeout.InfiniteTimeSpan`, or any non-positive value, removes the separate bound so the drain
+is limited only by the daemon's own cancellation. Be aware that this means a genuinely wedged shard can hold up
+shutdown indefinitely.
+
 ## Waiting for Non-Stale Data
 
 ### CatchUpAsync

--- a/src/Polecat.Tests/Daemon/event_loader_resiliency_tests.cs
+++ b/src/Polecat.Tests/Daemon/event_loader_resiliency_tests.cs
@@ -2,6 +2,7 @@ using JasperFx.Events.Daemon;
 using JasperFx.Events.Projections;
 using Microsoft.Data.SqlClient;
 using Polecat.Events.Daemon;
+using Polecat.Exceptions;
 using Polecat.Tests.Harness;
 
 namespace Polecat.Tests.Daemon;
@@ -73,8 +74,11 @@ public class event_loader_resiliency_tests : IntegrationContext
         var request = CreateRequest(0, highWater, batchSize: 100,
             skipUnknown: false, skipSerialization: false);
 
-        await Should.ThrowAsync<InvalidOperationException>(
+        // #368 / jasperfx#565: a typed exception that declares its own ShardFailureCategory. This used to
+        // be a bare InvalidOperationException, which the daemon could only classify as Other.
+        var ex = await Should.ThrowAsync<UnknownEventTypeException>(
             loader.LoadAsync(request, CancellationToken.None));
+        ex.Category.ShouldBe(ShardFailureCategory.UnknownEventType);
     }
 
     // ===== SkipSerializationErrors =====
@@ -122,8 +126,12 @@ public class event_loader_resiliency_tests : IntegrationContext
         var request = CreateRequest(0, highWater, batchSize: 100,
             skipUnknown: false, skipSerialization: false);
 
-        await Should.ThrowAsync<InvalidOperationException>(
+        // #368 / jasperfx#565: EventSerialization is kept distinct from UnknownEventType on purpose —
+        // bad data is a different operator action from a missing registration.
+        var ex = await Should.ThrowAsync<EventDeserializationFailureException>(
             loader.LoadAsync(request, CancellationToken.None));
+        ex.Category.ShouldBe(ShardFailureCategory.EventSerialization);
+        ex.EventTypeName.ShouldBe(questStartedTypeName);
     }
 
     // ===== Both skip options enabled =====

--- a/src/Polecat.Tests/Daemon/event_loader_tests.cs
+++ b/src/Polecat.Tests/Daemon/event_loader_tests.cs
@@ -2,6 +2,7 @@ using JasperFx.Events.Daemon;
 using JasperFx.Events.Projections;
 using Microsoft.Data.SqlClient;
 using Polecat.Events.Daemon;
+using Polecat.Exceptions;
 using Polecat.Tests.Harness;
 
 namespace Polecat.Tests.Daemon;
@@ -102,6 +103,74 @@ public class event_loader_tests : IntegrationContext
         var page = await loader.LoadAsync(request, CancellationToken.None);
 
         page.Count.ShouldBe(0);
+    }
+
+    // #368 / jasperfx#565: the daemon classifies a paused shard purely from what the store's exception
+    // declares through IEventFailureContext — there is deliberately no fallback type-name sniffing. These
+    // two pin the throw sites that used to raise a bare InvalidOperationException, which classified as
+    // ShardFailureCategory.Other with no event details at all.
+    [Fact]
+    public async Task unresolvable_event_type_throws_a_classified_failure_naming_the_sequence()
+    {
+        await InsertEventsAsync(1);
+        var seqId = (await GetAllSeqIdsAsync()).Single();
+        await CorruptDotNetTypeAsync(seqId, "Nope.NotARealEventType, Nope");
+
+        var loader = CreateLoader();
+        var request = CreateRequest(0, seqId, batchSize: 100);
+
+        var ex = await Should.ThrowAsync<UnknownEventTypeException>(
+            async () => await loader.LoadAsync(request, CancellationToken.None));
+
+        ShardFailure.For(ex, DateTimeOffset.UtcNow).Category.ShouldBe(ShardFailureCategory.UnknownEventType);
+        ex.Sequence.ShouldBe(seqId);
+    }
+
+    [Fact]
+    public async Task corrupted_event_body_throws_a_classified_failure_naming_the_event_type()
+    {
+        await InsertEventsAsync(1);
+        var seqId = (await GetAllSeqIdsAsync()).Single();
+        var alias = theStore.Database.Events.EventMappingFor(typeof(QuestStarted)).EventTypeName;
+        await CorruptEventBodyAsync(seqId);
+
+        var loader = CreateLoader();
+        var request = CreateRequest(0, seqId, batchSize: 100);
+
+        var ex = await Should.ThrowAsync<EventDeserializationFailureException>(
+            async () => await loader.LoadAsync(request, CancellationToken.None));
+
+        // The acceptance case from the issue: EventSerialization, with the failing sequence AND the
+        // store's type alias — the alias a consumer can act on, not the assembly-qualified dotnet_type.
+        var failure = ShardFailure.For(ex, DateTimeOffset.UtcNow);
+        failure.Category.ShouldBe(ShardFailureCategory.EventSerialization);
+        failure.Event.ShouldNotBeNull();
+        failure.Event.Sequence.ShouldBe(seqId);
+        failure.Event.EventTypeName.ShouldBe(alias);
+    }
+
+    private async Task CorruptDotNetTypeAsync(long seqId, string dotNetType)
+    {
+        await using var conn = await OpenConnectionAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = "UPDATE [dbo].[pc_events] SET dotnet_type = @type WHERE seq_id = @seq;";
+        cmd.Parameters.AddWithValue("@type", dotNetType);
+        cmd.Parameters.AddWithValue("@seq", seqId);
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    private async Task CorruptEventBodyAsync(long seqId)
+    {
+        // Well-formed JSON (so the native `json` column accepts it) that cannot bind to the event type at
+        // all, so the row reads back fine but STJ throws on materialization — the shape of the failure the
+        // issue is about. A JSON array rather than a bad property value: property NAMES are subject to the
+        // serializer's naming policy, so an unmatched name would silently bind to the default instead.
+        await using var conn = await OpenConnectionAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = "UPDATE [dbo].[pc_events] SET data = @data WHERE seq_id = @seq;";
+        cmd.Parameters.AddWithValue("@data", "[1, 2, 3]");
+        cmd.Parameters.AddWithValue("@seq", seqId);
+        (await cmd.ExecuteNonQueryAsync()).ShouldBe(1);
     }
 
     private PolecatEventLoader CreateLoader()

--- a/src/Polecat.Tests/Daemon/shard_failure_progression_columns_tests.cs
+++ b/src/Polecat.Tests/Daemon/shard_failure_progression_columns_tests.cs
@@ -1,0 +1,214 @@
+using JasperFx.Events;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Projections;
+using Polecat.Tests.Harness;
+
+namespace Polecat.Tests.Daemon;
+
+/// <summary>
+///     #368 / jasperfx#565: <c>ShardState.Failure</c> now rides along on the paused/stopped states the
+///     daemon publishes; these pin the persistence half. A supervisor polling the database — CritterWatch
+///     when the publishing node is DOWN, which is exactly when this matters — must see the same classified
+///     reason an in-process observer does, and must stop seeing it once the shard recovers.
+///     <para>
+///     The progression rows are seeded directly rather than by running a daemon, so the only writer
+///     against them is the call under test.
+///     </para>
+/// </summary>
+public class shard_failure_progression_columns_tests : OneOffConfigurationsContext
+{
+    private const string TheShard = "FailureTelemetry:All";
+
+    [Fact]
+    public async Task persists_the_classified_failure_on_a_paused_shard()
+    {
+        await SeedProgressionRowAsync();
+
+        await ((IEventDatabase)theDatabase).WriteExtendedProgressionAsync(
+            Paused(ShardFailureCategory.EventSerialization, 4815, "quest_started", "tenant-a"));
+
+        var row = await ReadFailureAsync();
+
+        // The enum NAME, never the ordinal — reordering ShardFailureCategory must not silently re-label
+        // rows that were written by an older deployment.
+        row.Category.ShouldBe(nameof(ShardFailureCategory.EventSerialization));
+        row.Sequence.ShouldBe(4815);
+        row.EventType.ShouldBe("quest_started");
+        row.TenantId.ShouldBe("tenant-a");
+    }
+
+    [Fact]
+    public async Task a_recovered_shard_stops_reporting_the_reason_it_paused()
+    {
+        await SeedProgressionRowAsync();
+
+        await ((IEventDatabase)theDatabase).WriteExtendedProgressionAsync(
+            Paused(ShardFailureCategory.ApplyEvent, 99, "quest_started"));
+        (await ReadFailureAsync()).Category.ShouldNotBeNull();
+
+        // A restart supersedes whatever paused the agent last. Without this, every supervisor built on
+        // these columns alerts forever on a failure the operator already fixed.
+        await ((IEventDatabase)theDatabase).WriteExtendedProgressionAsync(
+            WithoutFailure(ShardAction.Started, "Running"));
+
+        var row = await ReadFailureAsync();
+        row.Category.ShouldBeNull();
+        row.Sequence.ShouldBeNull();
+        row.EventType.ShouldBeNull();
+        row.TenantId.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task a_failureless_non_start_publication_leaves_the_reason_alone()
+    {
+        await SeedProgressionRowAsync();
+
+        await ((IEventDatabase)theDatabase).WriteExtendedProgressionAsync(
+            Paused(ShardFailureCategory.EventSerialization, 4815, "quest_started"));
+
+        // The load-bearing case: SubscriptionAgent publishes a plain Stopped state (no Failure) right
+        // behind the Paused one, and a heartbeat can arrive with no failure at all. An unconditional
+        // write would erase the reason microseconds after recording it.
+        await ((IEventDatabase)theDatabase).WriteExtendedProgressionAsync(
+            WithoutFailure(ShardAction.Stopped, "Stopped"));
+        await ((IEventDatabase)theDatabase).WriteExtendedProgressionAsync(
+            WithoutFailure(ShardAction.Updated, "Running"));
+
+        var row = await ReadFailureAsync();
+        row.Category.ShouldBe(nameof(ShardFailureCategory.EventSerialization));
+        row.Sequence.ShouldBe(4815);
+    }
+
+    [Fact]
+    public async Task rehydrates_the_failure_on_the_read_side()
+    {
+        await SeedProgressionRowAsync();
+
+        await ((IEventDatabase)theDatabase).WriteExtendedProgressionAsync(
+            Paused(ShardFailureCategory.UnknownEventType, 1623, "trip_started", "tenant-b"));
+
+        // A poller must get the same shape as a live ShardState observer, not just "it's Paused".
+        var states = await theDatabase.AllProjectionProgress();
+        var state = states.Single(x => x.ShardName == TheShard);
+
+        state.Failure.ShouldNotBeNull();
+        state.Failure.Category.ShouldBe(ShardFailureCategory.UnknownEventType);
+        state.Failure.Event.ShouldNotBeNull();
+        state.Failure.Event.Sequence.ShouldBe(1623);
+        state.Failure.Event.EventTypeName.ShouldBe("trip_started");
+        state.Failure.Event.TenantId.ShouldBe("tenant-b");
+
+        // ShardFailure.Detail is exactly what PauseReason has always carried, which is why the reason
+        // text needed no column of its own.
+        state.Failure.Detail.ShouldBe(state.PauseReason);
+    }
+
+    [Fact]
+    public async Task a_healthy_shard_reports_no_failure()
+    {
+        await SeedProgressionRowAsync();
+
+        await ((IEventDatabase)theDatabase).WriteExtendedProgressionAsync(
+            WithoutFailure(ShardAction.Started, "Running"));
+
+        var states = await theDatabase.AllProjectionProgress();
+        states.Single(x => x.ShardName == TheShard).Failure.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task never_inserts_a_row_and_never_touches_committed_progression()
+    {
+        await SeedProgressionRowAsync();
+
+        await ((IEventDatabase)theDatabase).WriteExtendedProgressionAsync(
+        [
+            Paused(ShardFailureCategory.ApplyEvent, 7, "quest_started"),
+            // A shard that has never committed progression has nowhere to record a reason: skipped
+            // silently, exactly like every other extended-progression write.
+            new ShardState("NoSuchProjection:All:98123456", 10)
+            {
+                Action = ShardAction.Paused, AgentStatus = "Paused", LastHeartbeat = DateTimeOffset.UtcNow
+            }
+        ]);
+
+        await using var conn = await OpenConnectionAsync();
+
+        var count = conn.CreateCommand();
+        count.CommandText = $"SELECT COUNT(*) FROM {theDatabase.Events.ProgressionTableName};";
+        Convert.ToInt64(await count.ExecuteScalarAsync()).ShouldBe(1);
+
+        var seq = conn.CreateCommand();
+        seq.CommandText =
+            $"SELECT last_seq_id FROM {theDatabase.Events.ProgressionTableName} WHERE name = @name;";
+        seq.Parameters.AddWithValue("@name", TheShard);
+        Convert.ToInt64(await seq.ExecuteScalarAsync()).ShouldBe(10); // committed progress untouched
+    }
+
+    private async Task SeedProgressionRowAsync()
+    {
+        ConfigureStore(opts => opts.Events.EnableExtendedProgressionTracking = true);
+        await theDatabase.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        await using var conn = await OpenConnectionAsync();
+        var insert = conn.CreateCommand();
+        insert.CommandText =
+            $"INSERT INTO {theDatabase.Events.ProgressionTableName} (name, last_seq_id) VALUES (@name, 10);";
+        insert.Parameters.AddWithValue("@name", TheShard);
+        await insert.ExecuteNonQueryAsync();
+    }
+
+    private async Task<(string? Category, long? Sequence, string? EventType, string? TenantId)> ReadFailureAsync()
+    {
+        await using var conn = await OpenConnectionAsync();
+        var cmd = conn.CreateCommand();
+        cmd.CommandText = $"""
+            SELECT failure_category, failure_event_sequence, failure_event_type, failure_event_tenant_id
+            FROM {theDatabase.Events.ProgressionTableName} WHERE name = @name;
+            """;
+        cmd.Parameters.AddWithValue("@name", TheShard);
+
+        await using var reader = await cmd.ExecuteReaderAsync();
+        if (!await reader.ReadAsync()) return (null, null, null, null);
+
+        return (
+            reader.IsDBNull(0) ? null : reader.GetString(0),
+            reader.IsDBNull(1) ? null : reader.GetInt64(1),
+            reader.IsDBNull(2) ? null : reader.GetString(2),
+            reader.IsDBNull(3) ? null : reader.GetString(3));
+    }
+
+    private static ShardState Paused(ShardFailureCategory category, long sequence, string eventTypeName,
+        string? tenantId = null)
+    {
+        var failure = new ShardFailure
+        {
+            Category = category,
+            ExceptionType = "Polecat.Exceptions.EventDeserializationFailureException",
+            RootExceptionType = "System.DivideByZeroException",
+            Message = "Boom!",
+            Detail = "Polecat.Exceptions.EventDeserializationFailureException: Boom!\n   at Somewhere",
+            OccurredAt = DateTimeOffset.UtcNow,
+            Event = new EventFailureDetails
+            {
+                Sequence = sequence, EventTypeName = eventTypeName, TenantId = tenantId
+            }
+        };
+
+        return new ShardState(TheShard, 10)
+        {
+            Action = ShardAction.Paused,
+            AgentStatus = "Paused",
+            PauseReason = failure.Detail,
+            Failure = failure,
+            LastHeartbeat = DateTimeOffset.UtcNow
+        };
+    }
+
+    private static ShardState WithoutFailure(ShardAction action, string status)
+    {
+        return new ShardState(TheShard, 10)
+        {
+            Action = action, AgentStatus = status, LastHeartbeat = DateTimeOffset.UtcNow
+        };
+    }
+}

--- a/src/Polecat.Tests/Events/Bug_369_natural_key_source_discovery.cs
+++ b/src/Polecat.Tests/Events/Bug_369_natural_key_source_discovery.cs
@@ -1,0 +1,209 @@
+using JasperFx;
+using JasperFx.Events;
+using JasperFx.Events.Aggregation;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Projections;
+using Microsoft.Data.SqlClient;
+using Polecat.Projections;
+using Polecat.TestUtils;
+using Shouldly;
+
+namespace Polecat.Tests.Events;
+
+/// <summary>
+///     #369 / jasperfx#569 (sibling of marten#5052). <c>NaturalKeyEventMapping.Extractor</c> widened from
+///     <c>Func&lt;object /* event data */, object?&gt;</c> to <c>Func&lt;IEvent, object?&gt;</c>, which is
+///     what makes an <c>IEvent&lt;T&gt;</c> <c>[NaturalKeySource]</c> handler bindable at all.
+///     <para>
+///     Before the widening, discovery silently dropped those handlers: no mapping, no error, no log — so
+///     <c>pc_natural_key_X</c> was simply never written for that event type and a lookup after a key
+///     change came back null, live and on rebuild alike. Polecat maintains its own lookup table off the
+///     same <c>NaturalKeyDefinition</c>, so it had the same exposure, and its rebuild re-emit path
+///     (#259) is its own code — hence a Polecat-side regression test rather than relying on upstream's.
+///     </para>
+/// </summary>
+public class Bug_369_natural_key_source_discovery : IAsyncLifetime
+{
+    private const string Schema = "bug_369_natural_key";
+    private const string Table = "pc_natural_key_nkproduct";
+
+    public async Task InitializeAsync() => await DropSchemaTablesAsync(Schema);
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    private static DocumentStore CreateStore(Action<SingleStreamProjection<NkProduct, Guid>>? configure = null)
+    {
+        return DocumentStore.For(opts =>
+        {
+            opts.ConnectionString = ConnectionSource.ConnectionString;
+            opts.DatabaseSchemaName = Schema;
+            opts.AutoCreateSchemaObjects = AutoCreate.All;
+            opts.UseNativeJsonType = ConnectionSource.SupportsNativeJson;
+
+            var projection = new SingleStreamProjection<NkProduct, Guid>();
+            configure?.Invoke(projection);
+            opts.Projections.Add(projection, ProjectionLifecycle.Inline);
+        });
+    }
+
+    // The regression the widened contract exists for: the key source's parameter is IEvent<T>, which
+    // yielded no extractor at all before jasperfx#571, so the rename never reached the lookup table.
+    [Fact]
+    public async Task natural_key_is_maintained_when_the_handler_takes_IEvent()
+    {
+        using var store = CreateStore();
+
+        var streamId = Guid.NewGuid();
+        await using (var session = store.LightweightSession())
+        {
+            session.Events.StartStream(streamId, new NkProductRegistered(streamId, "PROD-001"));
+            await session.SaveChangesAsync();
+        }
+
+        await using (var session = store.LightweightSession())
+        {
+            session.Events.Append(streamId, new NkProductCodeChanged(streamId, "PROD-999"));
+            await session.SaveChangesAsync();
+        }
+
+        // Inline append: the IEvent<T>-sourced rename is what used to go missing.
+        await using (var query = store.LightweightSession())
+        {
+            var product = await query.Events.FetchLatest<NkProduct, NkProductCode>(new NkProductCode("PROD-999"));
+            product.ShouldNotBeNull();
+            product.Id.ShouldBe(streamId);
+            product.Code.Value.ShouldBe("PROD-999");
+        }
+    }
+
+    // Polecat's rebuild re-emits the natural-key upserts per page (#259) through the same
+    // QueueOperationForEvent, so the widened contract has to hold on that path too.
+    [Fact]
+    public async Task natural_key_from_an_IEvent_handler_survives_a_rebuild()
+    {
+        using var store = CreateStore();
+
+        var streamId = Guid.NewGuid();
+        await using (var session = store.LightweightSession())
+        {
+            session.Events.StartStream(streamId, new NkProductRegistered(streamId, "PROD-001"));
+            session.Events.Append(streamId, new NkProductCodeChanged(streamId, "PROD-999"));
+            await session.SaveChangesAsync();
+        }
+
+        await ExecuteAsync($"DELETE FROM [{Schema}].[{Table}];");
+        (await CountRowsAsync()).ShouldBe(0);
+
+        using var daemon = (IProjectionDaemon)await store.BuildProjectionDaemonAsync();
+        await daemon.RebuildProjectionAsync(store.Options.Projections.All.Single().Name, CancellationToken.None);
+
+        await using var query = store.LightweightSession();
+        var product = await query.Events.FetchLatest<NkProduct, NkProductCode>(new NkProductCode("PROD-999"));
+        product.ShouldNotBeNull();
+        product!.Id.ShouldBe(streamId);
+    }
+
+    // jasperfx#571 made NaturalKeyBuilder reachable — its constructor was internal and nothing ever
+    // constructed one, so SetBy/SetByEvent were dead code. This is the supported escape hatch when
+    // discovery cannot bind a handler, and an explicit registration replaces the discovered mapping.
+    [Fact]
+    public async Task natural_key_is_maintained_through_an_explicit_registration()
+    {
+        using var store = CreateStore(p => p.NaturalKeyFor(x => x
+            .SetBy<NkProductRegistered>(e => new NkProductCode(e.Code))
+            .SetByEvent<NkProductCodeChanged>(e => new NkProductCode(e.Data.NewCode))));
+
+        var streamId = Guid.NewGuid();
+        await using (var session = store.LightweightSession())
+        {
+            session.Events.StartStream(streamId, new NkProductRegistered(streamId, "PROD-001"));
+            session.Events.Append(streamId, new NkProductCodeChanged(streamId, "PROD-777"));
+            await session.SaveChangesAsync();
+        }
+
+        await using var query = store.LightweightSession();
+        var product = await query.Events.FetchLatest<NkProduct, NkProductCode>(new NkProductCode("PROD-777"));
+        product.ShouldNotBeNull();
+        product!.Id.ShouldBe(streamId);
+    }
+
+    private static Task<int> CountRowsAsync() => ScalarAsync($"SELECT COUNT(*) FROM [{Schema}].[{Table}];");
+
+    private static async Task<int> ScalarAsync(string sql)
+    {
+        await using var conn = new SqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = sql;
+        return Convert.ToInt32(await cmd.ExecuteScalarAsync());
+    }
+
+    private static async Task ExecuteAsync(string sql)
+    {
+        await using var conn = new SqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = sql;
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    private static async Task DropSchemaTablesAsync(string schema)
+    {
+        await using var conn = new SqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = """
+            DECLARE @sql nvarchar(max) = N'';
+            SELECT @sql = @sql + 'ALTER TABLE [' + s.name + '].[' + t.name + '] DROP CONSTRAINT [' + fk.name + '];'
+            FROM sys.foreign_keys fk
+            JOIN sys.tables t ON fk.parent_object_id = t.object_id
+            JOIN sys.schemas s ON t.schema_id = s.schema_id
+            WHERE s.name = @schema;
+
+            SELECT @sql = @sql + 'DROP TABLE [' + s.name + '].[' + t.name + '];'
+            FROM sys.tables t
+            JOIN sys.schemas s ON t.schema_id = s.schema_id
+            WHERE s.name = @schema;
+            EXEC sp_executesql @sql;
+            """;
+        cmd.Parameters.AddWithValue("@schema", schema);
+        await cmd.ExecuteNonQueryAsync();
+    }
+}
+
+public sealed record NkProductCode(string Value);
+
+public sealed record NkProductRegistered(Guid ProductId, string Code);
+
+public sealed record NkProductCodeChanged(Guid ProductId, string NewCode);
+
+/// <summary>
+///     The key is a pure function of the event: a static <c>[NaturalKeySource]</c> returning the natural
+///     key type and taking <c>IEvent&lt;T&gt;</c>. That is the highest-ranked extraction strategy under
+///     jasperfx#571 — nothing is fabricated and no user aggregation code has to run to work out the key —
+///     and it is exactly the shape that could not bind before the contract widened.
+/// </summary>
+public partial class NkProduct
+{
+    public Guid Id { get; set; }
+
+    [NaturalKey]
+    public NkProductCode Code { get; set; } = null!;
+
+    [NaturalKeySource]
+    public static NkProductCode KeyOnRegistration(IEvent<NkProductRegistered> e) => new(e.Data.Code);
+
+    [NaturalKeySource]
+    public static NkProductCode KeyOnRename(IEvent<NkProductCodeChanged> e) => new(e.Data.NewCode);
+
+    public void Apply(NkProductRegistered e)
+    {
+        Id = e.ProductId;
+        Code = new NkProductCode(e.Code);
+    }
+
+    public void Apply(NkProductCodeChanged e)
+    {
+        Code = new NkProductCode(e.NewCode);
+    }
+}

--- a/src/Polecat.Tests/Events/event_failure_context_tests.cs
+++ b/src/Polecat.Tests/Events/event_failure_context_tests.cs
@@ -1,0 +1,101 @@
+using JasperFx.Events.Daemon;
+using Polecat.Exceptions;
+
+namespace Polecat.Tests.Events;
+
+/// <summary>
+///     #368 / jasperfx#565: the daemon classifies a paused shard purely from what the store's exception
+///     declares — <c>ShardFailure.For</c> looks for an <see cref="IEventFailureContext" /> and there is
+///     deliberately NO fallback type-name sniffing. So these pin the contract Polecat's read-path
+///     exceptions have to hold up: the right category, the failing sequence, and the event type alias
+///     surviving as data rather than only as prose in the message.
+/// </summary>
+public class event_failure_context_tests
+{
+    [Fact]
+    public void deserialization_failure_declares_the_serialization_category()
+    {
+        var ex = new EventDeserializationFailureException(4815, "quest_started", new DivideByZeroException("Boom!"));
+
+        IEventFailureContext context = ex;
+        context.Category.ShouldBe(ShardFailureCategory.EventSerialization);
+        context.Sequence.ShouldBe(4815);
+        context.EventTypeName.ShouldBe("quest_started");
+
+        // Raised while reading a pc_events row, BEFORE there is an IEvent — nothing else is knowable.
+        context.EventId.ShouldBeNull();
+        context.StreamId.ShouldBeNull();
+        context.StreamKey.ShouldBeNull();
+        context.TenantId.ShouldBeNull();
+        context.Version.ShouldBeNull();
+    }
+
+    [Fact]
+    public void unknown_event_type_is_kept_distinct_from_a_serialization_failure()
+    {
+        // A missing registration or a rollback past the event type's introduction is a deployment fix,
+        // not a data fix, so an operator responds to it differently.
+        IEventFailureContext context = new UnknownEventTypeException("Some.Removed.EventType, SomeAsm", 1623);
+
+        context.Category.ShouldBe(ShardFailureCategory.UnknownEventType);
+        context.Sequence.ShouldBe(1623);
+    }
+
+    [Fact]
+    public void unknown_event_type_reports_the_sentinel_when_the_throw_site_had_no_row()
+    {
+        IEventFailureContext context = new UnknownEventTypeException("Some.Removed.EventType, SomeAsm");
+        context.Sequence.ShouldBe(UnknownEventTypeException.UnknownSequence);
+    }
+
+    [Fact]
+    public void shard_failure_classifies_a_deserialization_failure()
+    {
+        var ex = new EventDeserializationFailureException(4815, "quest_started", new DivideByZeroException("Boom!"));
+
+        var failure = ShardFailure.For(ex, DateTimeOffset.UtcNow);
+
+        failure.Category.ShouldBe(ShardFailureCategory.EventSerialization);
+        failure.RootExceptionType.ShouldBe("System.DivideByZeroException");
+        failure.Event.ShouldNotBeNull();
+        failure.Event.Sequence.ShouldBe(4815);
+        failure.Event.EventTypeName.ShouldBe("quest_started");
+    }
+
+    [Fact]
+    public void shard_failure_finds_the_context_through_a_wrapping_exception()
+    {
+        // The per-event exceptions routinely arrive wrapped — a ShardStopException around the real
+        // failure is the daemon's normal shape — so classification has to walk the whole graph.
+        var inner = new EventDeserializationFailureException(99, "quest_started", new DivideByZeroException("Boom!"));
+        var wrapped = new InvalidOperationException("Shard stopping", inner);
+
+        var failure = ShardFailure.For(wrapped, DateTimeOffset.UtcNow);
+
+        failure.Category.ShouldBe(ShardFailureCategory.EventSerialization);
+        failure.Event!.Sequence.ShouldBe(99);
+    }
+
+    [Fact]
+    public void shard_failure_takes_the_lowest_sequence_out_of_an_aggregate()
+    {
+        // A batch can produce several failures at once; the shard stops at the earliest failing event.
+        var aggregate = new AggregateException(
+            new EventDeserializationFailureException(200, "b", new Exception()),
+            new EventDeserializationFailureException(100, "a", new Exception()));
+
+        var failure = ShardFailure.For(aggregate, DateTimeOffset.UtcNow);
+
+        failure.Event!.Sequence.ShouldBe(100);
+        failure.Event.EventTypeName.ShouldBe("a");
+    }
+
+    [Fact]
+    public void anything_that_names_no_event_still_classifies_as_other()
+    {
+        var failure = ShardFailure.For(new TimeoutException("database went away"), DateTimeOffset.UtcNow);
+
+        failure.Category.ShouldBe(ShardFailureCategory.Other);
+        failure.Event.ShouldBeNull();
+    }
+}

--- a/src/Polecat.Tests/Events/event_store_instrumentation_tests.cs
+++ b/src/Polecat.Tests/Events/event_store_instrumentation_tests.cs
@@ -22,7 +22,9 @@ public class event_store_instrumentation_tests : IAsyncLifetime
     private static readonly string[] ExtendedColumns =
     [
         "heartbeat", "agent_status", "pause_reason", "running_on_node",
-        "warning_behind_threshold", "critical_behind_threshold"
+        "warning_behind_threshold", "critical_behind_threshold",
+        // #368 / jasperfx#565: the classified reason a shard is paused or stopped
+        "failure_category", "failure_event_sequence", "failure_event_type", "failure_event_tenant_id"
     ];
 
     public async Task InitializeAsync()
@@ -70,7 +72,7 @@ public class event_store_instrumentation_tests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task enabling_adds_the_six_columns_on_schema_apply()
+    public async Task enabling_adds_the_extended_columns_on_schema_apply()
     {
         using var store = CreateStore(OnSchema, extended: true);
         await store.Database.ApplyAllConfiguredChangesToDatabaseAsync();

--- a/src/Polecat/Events/Daemon/PolecatEventLoader.cs
+++ b/src/Polecat/Events/Daemon/PolecatEventLoader.cs
@@ -4,6 +4,7 @@ using JasperFx.Events.Daemon;
 using JasperFx.Events.Projections;
 using Microsoft.Data.SqlClient;
 
+using Polecat.Exceptions;
 using Polecat.Internal;
 namespace Polecat.Events.Daemon;
 
@@ -122,8 +123,11 @@ internal class PolecatEventLoader : IEventLoader
                     continue;
                 }
 
-                throw new InvalidOperationException(
-                    $"Unable to resolve event type for dotnet_type '{dotNetTypeName}' at seq_id {seqId}.");
+                // #368 / jasperfx#565: a typed exception carrying its own ShardFailureCategory, so a shard
+                // paused by an unregistered event type reports UnknownEventType with the offending
+                // sequence rather than classifying as Other with no detail. The daemon does not sniff
+                // exception type names — the exception has to declare its own kind.
+                throw new UnknownEventTypeException(dotNetTypeName, seqId);
             }
 
             object data;
@@ -139,8 +143,10 @@ internal class PolecatEventLoader : IEventLoader
                     continue;
                 }
 
-                throw new InvalidOperationException(
-                    $"Failed to deserialize event at seq_id {seqId} of type '{dotNetTypeName}'.", ex);
+                // #368 / jasperfx#565: report the store's type alias (the `type` column) rather than the
+                // assembly-qualified dotnet_type, matching what ShardFailure.Event.EventTypeName carries
+                // everywhere else and what a client-side consumer can act on.
+                throw new EventDeserializationFailureException(seqId, typeName, ex);
             }
 
             var mapping = _events.EventMappingFor(resolvedType);

--- a/src/Polecat/Events/EventOperations.cs
+++ b/src/Polecat/Events/EventOperations.cs
@@ -743,9 +743,15 @@ internal class EventOperations : QueryEventStore, IEventOperations
             if (definition != null) return definition;
         }
 
+        // #369 / jasperfx#571: this used to point users at a "NaturalKey()" API that exists in neither
+        // Polecat nor JasperFx.Events. NaturalKeyFor() is the real escape hatch — it reaches the
+        // NaturalKeyBuilder<TDoc> that was unreachable dead code until jasperfx#571 made its constructor
+        // public.
         throw new InvalidOperationException(
             $"No natural key definition found for aggregate type '{typeof(T).Name}'. " +
-            "Configure a natural key via NaturalKey() in a SingleStreamProjection registration.");
+            $"Mark the key property on {typeof(T).Name} with [NaturalKey] and annotate the event handler(s) " +
+            "that set it with [NaturalKeySource], or register the mapping explicitly from the projection with " +
+            "NaturalKeyFor(x => x.SetBy<TEvent>(e => ...)).");
     }
 
     public async Task CompactStreamAsync<T>(Guid streamId, Action<StreamCompactingRequest<T>>? configure = null)

--- a/src/Polecat/Events/Projections/NaturalKeyProjection.cs
+++ b/src/Polecat/Events/Projections/NaturalKeyProjection.cs
@@ -93,7 +93,12 @@ internal class NaturalKeyProjection : IInlineProjection<IDocumentSession>
 
         if (mapping == null) return;
 
-        var naturalKeyValue = mapping.Extractor(e.Data);
+        // #369 / jasperfx#569: the extraction contract widened from the event *data* to the whole IEvent,
+        // which is what makes an IEvent<T> [NaturalKeySource] handler bindable at all (before, discovery
+        // silently dropped those and the lookup table was simply never written for that event type) and
+        // what lets a key be derived from event metadata. Both call sites into this method — the inline
+        // append path and the rebuild path — already hold the real IEvent.
+        var naturalKeyValue = mapping.Extractor(e);
         if (naturalKeyValue == null) return;
 
         // Unwrap strong-typed id to primitive value

--- a/src/Polecat/Events/Schema/EventProgressionTable.cs
+++ b/src/Polecat/Events/Schema/EventProgressionTable.cs
@@ -27,6 +27,17 @@ internal class EventProgressionTable : Table
             AddColumn("running_on_node", "int").AllowNulls();
             AddColumn("warning_behind_threshold", "bigint").AllowNulls();
             AddColumn("critical_behind_threshold", "bigint").AllowNulls();
+
+            // #368 / jasperfx#565: the classified reason this shard is paused or stopped, so a consumer
+            // polling the database (CritterWatch when the publishing node is DOWN, which is exactly when
+            // it matters) sees the same reason an in-process ShardState observer does. The reason *text*
+            // needs no new column — ShardFailure.Detail is precisely what pause_reason has always
+            // carried. failure_category stores the enum NAME, never the ordinal, so reordering
+            // ShardFailureCategory can never silently re-label persisted rows.
+            AddColumn("failure_category", "varchar(50)").AllowNulls();
+            AddColumn("failure_event_sequence", "bigint").AllowNulls();
+            AddColumn("failure_event_type", "varchar(500)").AllowNulls();
+            AddColumn("failure_event_tenant_id", "varchar(500)").AllowNulls();
         }
     }
 }

--- a/src/Polecat/Exceptions/EventDeserializationFailureException.cs
+++ b/src/Polecat/Exceptions/EventDeserializationFailureException.cs
@@ -1,0 +1,52 @@
+using JasperFx.Events.Daemon;
+
+namespace Polecat.Exceptions;
+
+/// <summary>
+///     Thrown when Polecat cannot deserialize a persisted event body out of <c>pc_events</c>.
+/// </summary>
+/// <remarks>
+///     #368 / jasperfx#565: this exception declares its own <see cref="ShardFailureCategory" /> through
+///     <see cref="IEventFailureContext" />, which is how a paused shard reports <em>why</em> it is down.
+///     The daemon deliberately has no fallback — it never sniffs a store's exception type names — so
+///     without this a corrupted event body classified as <see cref="ShardFailureCategory.Other" /> with
+///     no event details at all.
+/// </remarks>
+public class EventDeserializationFailureException : Exception, IEventFailureContext
+{
+    public EventDeserializationFailureException(long sequence, string? eventTypeName, Exception innerException)
+        : base($"Event deserialization error on sequence = {sequence} for event type {eventTypeName}",
+            innerException)
+    {
+        Sequence = sequence;
+        EventTypeName = eventTypeName;
+    }
+
+    /// <summary>
+    ///     Store-wide <c>seq_id</c> of the event whose body could not be read.
+    /// </summary>
+    public long Sequence { get; }
+
+    /// <summary>
+    ///     The event store's type alias for the failing event (the <c>type</c> column, e.g.
+    ///     <c>trip_started</c>), when the row supplied one. Retained as data rather than being buried in
+    ///     the message string so the daemon can report it on <see cref="ShardFailure" />.
+    /// </summary>
+    public string? EventTypeName { get; }
+
+    /// <summary>
+    ///     A body Polecat could not deserialize is a serializer or data problem — governed by
+    ///     <c>SkipSerializationErrors</c> — which is a different operator action from an unregistered
+    ///     event type. See <see cref="UnknownEventTypeException" />.
+    /// </summary>
+    public ShardFailureCategory Category => ShardFailureCategory.EventSerialization;
+
+    // Everything below is raised while reading a pc_events row, BEFORE there is an IEvent to inspect, so
+    // nothing but the sequence and the stored type alias is knowable here. IEventFailureContext makes
+    // every one of these nullable for exactly this case.
+    Guid? IEventFailureContext.EventId => null;
+    Guid? IEventFailureContext.StreamId => null;
+    string? IEventFailureContext.StreamKey => null;
+    string? IEventFailureContext.TenantId => null;
+    long? IEventFailureContext.Version => null;
+}

--- a/src/Polecat/Exceptions/UnknownEventTypeException.cs
+++ b/src/Polecat/Exceptions/UnknownEventTypeException.cs
@@ -1,0 +1,56 @@
+using JasperFx.Events.Daemon;
+
+namespace Polecat.Exceptions;
+
+/// <summary>
+///     Thrown when an event's persisted <c>dotnet_type</c> resolves to no known .NET type in this
+///     deployment.
+/// </summary>
+/// <remarks>
+///     #368 / jasperfx#565: kept deliberately distinct from
+///     <see cref="ShardFailureCategory.EventSerialization" />. An alias that resolves to nothing is
+///     normally a missing registration or a rollback past the event type's introduction — a deployment
+///     fix, not a data fix — so an operator responds to it differently.
+/// </remarks>
+public class UnknownEventTypeException : Exception, IEventFailureContext
+{
+    /// <summary>
+    ///     The sequence reported when the throw site had no <c>pc_events</c> row in hand.
+    ///     <see cref="IEventFailureContext.Sequence" /> is non-nullable by contract, so a sentinel is
+    ///     unavoidable.
+    /// </summary>
+    public const long UnknownSequence = -1;
+
+    public UnknownEventTypeException(string? eventTypeName)
+        : this(eventTypeName, UnknownSequence)
+    {
+    }
+
+    public UnknownEventTypeException(string? eventTypeName, long sequence)
+        : base(
+            $"Unknown event type name alias '{eventTypeName}'. You may need to register this event type through StoreOptions.Events.AddEventType(type)")
+    {
+        EventTypeName = eventTypeName;
+        Sequence = sequence;
+    }
+
+    /// <summary>
+    ///     Store-wide <c>seq_id</c> of the offending row, or <see cref="UnknownSequence" /> when the throw
+    ///     site had no row.
+    /// </summary>
+    public long Sequence { get; }
+
+    /// <summary>
+    ///     The unresolvable type name from the row.
+    /// </summary>
+    public string? EventTypeName { get; }
+
+    public ShardFailureCategory Category => ShardFailureCategory.UnknownEventType;
+
+    // The type never resolved, so no event was ever materialized to read these from.
+    Guid? IEventFailureContext.EventId => null;
+    Guid? IEventFailureContext.StreamId => null;
+    string? IEventFailureContext.StreamKey => null;
+    string? IEventFailureContext.TenantId => null;
+    long? IEventFailureContext.Version => null;
+}

--- a/src/Polecat/Storage/PolecatDatabase.cs
+++ b/src/Polecat/Storage/PolecatDatabase.cs
@@ -186,6 +186,14 @@ public class PolecatDatabase : DatabaseBase<SqlConnection>, IEventDatabase, IPro
     // "clobber" defect). If no row exists yet, the zero-row UPDATE simply skips until the first commit
     // creates it. running_on_node stays NULL until a distribution layer stamps AssignedNodeNumber onto
     // the published ShardState (Wolverine-managed distribution), which the writer carries into RunningOnNode.
+    //
+    // #368 / jasperfx#565: the four failure_* columns follow a DIFFERENT rule from the rest. They are
+    // written when the state carries a ShardFailure, CLEARED when a ShardAction.Started arrives without
+    // one (a recovered shard must stop reporting the reason it paused an hour ago, or every supervisor
+    // built on this alerts forever), and otherwise LEFT ALONE. That last case is load-bearing:
+    // SubscriptionAgent publishes a plain Stopped right behind a Paused, and an unconditional write would
+    // erase the reason microseconds after recording it. The CASE expressions keep that conditional in the
+    // one statement rather than branching the SQL.
     public async Task WriteExtendedProgressionAsync(ShardState state, CancellationToken token = default)
     {
         await _resilience.ExecuteAsync(static async (s, ct) =>
@@ -200,7 +208,11 @@ public class PolecatDatabase : DatabaseBase<SqlConnection>, IEventDatabase, IPro
                 SET heartbeat = @heartbeat,
                     agent_status = @status,
                     pause_reason = @reason,
-                    running_on_node = @node
+                    running_on_node = @node,
+                    failure_category = CASE WHEN @touchFailure = 1 THEN @failureCategory ELSE failure_category END,
+                    failure_event_sequence = CASE WHEN @touchFailure = 1 THEN @failureSequence ELSE failure_event_sequence END,
+                    failure_event_type = CASE WHEN @touchFailure = 1 THEN @failureEventType ELSE failure_event_type END,
+                    failure_event_tenant_id = CASE WHEN @touchFailure = 1 THEN @failureTenantId ELSE failure_event_tenant_id END
                 WHERE name = @name;
                 """;
             cmd.Parameters.AddVarChar("@name", shardState.ShardName);
@@ -208,6 +220,17 @@ public class PolecatDatabase : DatabaseBase<SqlConnection>, IEventDatabase, IPro
             cmd.Parameters.AddWithValue("@status", (object?)shardState.AgentStatus ?? DBNull.Value);
             cmd.Parameters.AddWithValue("@reason", (object?)shardState.PauseReason ?? DBNull.Value);
             cmd.Parameters.AddWithValue("@node", (object?)shardState.RunningOnNode ?? DBNull.Value);
+
+            var failure = shardState.Failure;
+            var touchFailure = failure != null || shardState.Action == ShardAction.Started;
+            cmd.Parameters.AddWithValue("@touchFailure", touchFailure ? 1 : 0);
+            // The enum NAME, never the ordinal — reordering ShardFailureCategory must not silently
+            // re-label rows written by an older deployment.
+            cmd.Parameters.AddVarChar("@failureCategory", failure?.Category.ToString());
+            cmd.Parameters.AddWithValue("@failureSequence", (object?)failure?.Event?.Sequence ?? DBNull.Value);
+            cmd.Parameters.AddVarChar("@failureEventType", failure?.Event?.EventTypeName);
+            cmd.Parameters.AddVarChar("@failureTenantId", failure?.Event?.TenantId);
+
             await cmd.ExecuteNonQueryAsync(ct);
         }, (_connectionString, _events.ProgressionTableName, state), token);
     }
@@ -225,7 +248,7 @@ public class PolecatDatabase : DatabaseBase<SqlConnection>, IEventDatabase, IPro
             await using var cmd = conn.CreateCommand();
             if (events.EnableExtendedProgressionTracking)
             {
-                cmd.CommandText = $"SELECT name, last_seq_id, heartbeat, agent_status, pause_reason, running_on_node, warning_behind_threshold, critical_behind_threshold FROM {events.ProgressionTableName};";
+                cmd.CommandText = $"SELECT name, last_seq_id, heartbeat, agent_status, pause_reason, running_on_node, warning_behind_threshold, critical_behind_threshold, failure_category, failure_event_sequence, failure_event_type, failure_event_tenant_id FROM {events.ProgressionTableName};";
             }
             else
             {
@@ -247,6 +270,17 @@ public class PolecatDatabase : DatabaseBase<SqlConnection>, IEventDatabase, IPro
                     if (!reader.IsDBNull(5)) shardState.RunningOnNode = reader.GetInt32(5);
                     if (!reader.IsDBNull(6)) shardState.WarningBehindThreshold = reader.GetInt64(6);
                     if (!reader.IsDBNull(7)) shardState.CriticalBehindThreshold = reader.GetInt64(7);
+
+                    // #368 / jasperfx#565: rehydrate the classified failure so a consumer polling the
+                    // database — which is the only channel left when the publishing node is down — gets
+                    // the same shape a live ShardState observer does, rather than only being able to see
+                    // that the shard is Paused.
+                    shardState.Failure = BuildFailure(
+                        reader.IsDBNull(8) ? null : reader.GetString(8),
+                        reader.IsDBNull(9) ? null : reader.GetInt64(9),
+                        reader.IsDBNull(10) ? null : reader.GetString(10),
+                        reader.IsDBNull(11) ? null : reader.GetString(11),
+                        shardState);
                 }
 
                 list.Add(shardState);
@@ -254,6 +288,55 @@ public class PolecatDatabase : DatabaseBase<SqlConnection>, IEventDatabase, IPro
 
             return (IReadOnlyList<ShardState>)list;
         }, (_connectionString, _events), token);
+    }
+
+    /// <summary>
+    ///     Placeholder for <see cref="ShardFailure.ExceptionType" /> / <see cref="ShardFailure.RootExceptionType" />
+    ///     on a failure rehydrated from the database, where the exception types were never persisted. Both
+    ///     members are <c>required</c> on the record, so a sentinel is unavoidable; a distinctive one beats
+    ///     an empty string that reads like a real (blank) type name.
+    /// </summary>
+    internal const string UnknownExceptionType = "Unknown";
+
+    /// <summary>
+    ///     #368 / jasperfx#565: the persisted row is a lossy projection of <see cref="ShardFailure" /> — by
+    ///     design, since the columns exist to answer "why is this shard down" and not to reconstitute an
+    ///     exception. <c>failure_category</c> is the presence flag: no category means no failure to report,
+    ///     and an unparseable one (a category name written by a newer deployment) is treated the same way
+    ///     rather than guessing.
+    /// </summary>
+    private static ShardFailure? BuildFailure(string? category, long? sequence, string? eventTypeName,
+        string? tenantId, ShardState state)
+    {
+        if (string.IsNullOrEmpty(category) || !Enum.TryParse<ShardFailureCategory>(category, out var parsed))
+        {
+            return null;
+        }
+
+        // ShardFailure.Detail is exactly what PauseReason has always carried, which is why the text needed
+        // no column of its own. Message is the same text here: the short form is a property of the live
+        // Exception, and that is not persisted.
+        var detail = state.PauseReason ?? string.Empty;
+
+        return new ShardFailure
+        {
+            Category = parsed,
+            // Not persisted — the reason text in Detail is what an operator acts on, and inventing a type
+            // name would be worse than admitting we don't have one.
+            ExceptionType = UnknownExceptionType,
+            RootExceptionType = UnknownExceptionType,
+            Message = detail,
+            Detail = detail,
+            // The pause/stop publication stamps LastHeartbeat at the moment it classifies the failure, so
+            // the persisted heartbeat is the closest thing the row has to the failure's timestamp.
+            OccurredAt = state.LastHeartbeat ?? default,
+            Event = sequence.HasValue
+                ? new EventFailureDetails
+                {
+                    Sequence = sequence.Value, EventTypeName = eventTypeName, TenantId = tenantId
+                }
+                : null
+        };
     }
 
     // #324 (jasperfx#435 / jasperfx#518): targeted per-cell progression read. The JasperFx.Events

--- a/src/Polecat/StoreOptions.cs
+++ b/src/Polecat/StoreOptions.cs
@@ -420,7 +420,9 @@ public class EventStoreOptions : IEventStoreInstrumentation
     /// <summary>
     ///     Opt into extended columns on the event progression table for CritterWatch alerting.
     ///     Adds nullable heartbeat, agent_status, pause_reason, running_on_node,
-    ///     warning_behind_threshold, and critical_behind_threshold columns. This is the
+    ///     warning_behind_threshold, critical_behind_threshold, and the #368 classified-failure columns
+    ///     (failure_category, failure_event_sequence, failure_event_type, failure_event_tenant_id) that
+    ///     carry <see cref="JasperFx.Events.Daemon.ShardFailure" /> onto the row. This is the
     ///     Polecat-named alias for <see cref="IEventStoreInstrumentation.ExtendedProgressionEnabled" />;
     ///     both read and write the same setting.
     /// </summary>


### PR DESCRIPTION
Bumps the JasperFx family 2.34.0 → 2.36.1 and lands the three Polecat issues that ride on that line. They are batched because the natural key half is **source breaking** — `NaturalKeyEventMapping.Extractor` widens from `Func<object, object?>` to `Func<IEvent, object?>`, so the bump does not compile without the call-site change.

Closes #367, closes #368, closes #369.

## #369 — natural key extraction on the widened contract (jasperfx#569 / #571)

* `NaturalKeyProjection.QueueOperationForEvent` passes the whole `IEvent` to `mapping.Extractor` instead of `e.Data`. One call site, shared by the inline append path and the #259 rebuild re-emit path.
* Fixed the error message in `EventOperations.FindNaturalKeyDefinition`, which told users to *"Configure a natural key via NaturalKey() in a SingleStreamProjection registration"* — an API that exists in neither Polecat nor JasperFx.Events. It now names `[NaturalKey]`/`[NaturalKeySource]` and the real escape hatch, `NaturalKeyFor()`.
* Regression tests (`Bug_369_natural_key_source_discovery`) for what Polecat inherits from upstream: an `IEvent<T>`-parameter `[NaturalKeySource]` used to yield no mapping at all — silently, no error, no log — so `pc_natural_key_X` was simply never written for that event type. Pinned live and after a rebuild, since Polecat's rebuild path is its own code. Plus the explicit `NaturalKeyFor(x => x.SetBy/SetByEvent)` registration, which was unreachable dead code until jasperfx#571.
* Docs: a `NaturalKeyFor()` section in `events/natural-keys.md`, the loud-failure behaviour, and the constraint the attribute path now enforces — the key has to be a function of the event alone, because the lookup table is maintained inline at append time where no prior aggregate exists under an `Async` snapshot lifecycle.

## #368 — `IEventFailureContext` + classified failure columns (jasperfx#565)

The daemon deliberately has **no** fallback type-name sniffing: a store's exception declares its own category, or the failure classifies as `Other` with no event details. Both halves land here.

**Part 1 — the read-path exceptions.** Polecat's event loader raised bare `InvalidOperationException`s, so every serialization or unknown-type failure reached `ShardFailure` as `Other`. Two new exceptions in `Polecat.Exceptions` implement `IEventFailureContext`:

* `EventDeserializationFailureException` → `EventSerialization`, carrying the sequence and the store's event type alias (the `type` column, not the assembly-qualified `dotnet_type` — the alias is what a client can act on).
* `UnknownEventTypeException` → `UnknownEventType`, kept distinct on purpose: a missing registration or a rollback is a deployment fix, not a data fix.

**Part 2 — four extended-progression columns** behind the existing `EnableExtendedProgressionTracking` gate: `failure_category` (the enum **name**, never the ordinal), `failure_event_sequence`, `failure_event_type`, `failure_event_tenant_id`. No column for the reason text — `ShardFailure.Detail` is exactly what `pause_reason` has always carried.

The failure columns follow a different write rule from the rest of extended progression: written when the state carries a `Failure`, **cleared** on a `ShardAction.Started` that has none (a recovered shard must stop reporting the reason it paused an hour ago), and otherwise **left alone**. That last case is load-bearing — `SubscriptionAgent` publishes a plain `Stopped` right behind a `Paused`, and an unconditional write would erase the reason microseconds after recording it. `AllProjectionProgress` rehydrates `ShardState.Failure` from the columns so a poller gets the same shape as a live observer.

The columns are nullable and additive, so no backfill is needed; stores that already have extended tracking on do need the migration, and until it runs the write degrades to no telemetry rather than failing anything (extended progression is best-effort by contract).

## #367 — `StopAndDrainTimeout` docs (jasperfx#564)

New "Graceful Shutdown and the Drain Timeout" section in `events/projections/async-daemon.md`: what the timeout bounds (the in-flight page plus the progression flush, on all three stop paths), the `ProgressionProgressOutOfOrderException` it prevents when the drain is cut short, pairing a raised value with `HostOptions.ShutdownTimeout` and `terminationGracePeriodSeconds`, why a deployment might instead lower it, and what opting out with `Timeout.InfiniteTimeSpan` costs.

## Tests

New: `event_failure_context_tests` (exception contract + `ShardFailure.For` classification through wrapping and `AggregateException`), `shard_failure_progression_columns_tests` (write / clear / preserve / rehydrate / never-insert), `Bug_369_natural_key_source_discovery`, plus two event-loader cases covering the classified throw sites. `event_store_instrumentation_tests` extended for the four new columns.
