### PR TITLE
feat(#370): FetchStreamStatePlan / FetchStreamPlan + batched event fetches + StreamEventState / StreamEvents (marten#5053 parity)

### DIFF
--- a/docs/documents/aspnetcore.md
+++ b/docs/documents/aspnetcore.md
@@ -125,6 +125,58 @@ Returns `200 application/json` with the latest projected aggregate state, or `40
 stream exists. A constructor overload accepts `string` ids for stores configured with
 string-keyed streams.
 
+## Streaming Event Stream Metadata and Events
+
+`StreamEventState` and `StreamEvents` are the event-side siblings of `StreamAggregate<T>`, backed by
+the `FetchStreamStatePlan` / `FetchStreamPlan` query plans — so the same plan can be batched through
+`IBatchedQuery.QueryByPlan()` and returned from an endpoint.
+
+```csharp
+app.MapGet("/orders/{id:guid}/state",  (Guid id, IQuerySession s) => new StreamEventState(s, id));
+app.MapGet("/orders/{id:guid}/events", (Guid id, IQuerySession s) => new StreamEvents(s, id));
+```
+
+Both take `Guid`, `string` and pre-built-plan constructors, and both implement `IResult` and
+`IEndpointMetadataProvider` so OpenAPI advertises the right `200` and `404` shapes.
+
+### StreamEventState vs StreamAggregate
+
+- **`StreamEventState`** writes the stream's *metadata* — version, created/last timestamps, archived flag.
+- **`StreamAggregate<T>`** writes the projected aggregate *state* built from the stream's events.
+
+### The response DTOs
+
+Neither result writes the framework's own types to the wire, because neither can. `StreamState.AggregateType`
+and `IEvent.EventType` are `System.Type`, and System.Text.Json refuses to serialize those:
+
+```
+NotSupportedException: Serialization and deserialization of 'System.Type' instances
+is not supported. Path: $.AggregateType.
+```
+
+So the bodies are `StreamStateResponse` and `EventResponse`: the aggregate type reduces to its simple
+name, and `IEvent`'s assembly-qualified `DotNetTypeName` is deliberately kept off the wire — use
+`EventTypeName`, Polecat's stable event type alias, as the client-side discriminator. The property names
+match Marten's equivalents, so a client can move between the two stores unchanged.
+
+### Empty streams are ambiguous
+
+`FetchStream` yields an empty list both for a stream that does not exist and for a filter that excludes
+every event, and the two cannot be told apart. `StreamEvents` exposes `OnEmptyStatus`, defaulting to `404`
+to match the other single-resource results. Set it to `200` to return an empty array instead — which is
+what you want when paging forward with `fromVersion` and running off the end is expected:
+
+```csharp
+app.MapGet("/orders/{id:guid}/events", (Guid id, long fromVersion, IQuerySession s) =>
+    new StreamEvents(s, id, fromVersion: fromVersion)
+    {
+        OnEmptyStatus = StatusCodes.Status200OK
+    });
+```
+
+Both responses set `Content-Length`, and serialization buffers through an `ArrayBufferWriter<byte>` so the
+JSON never round-trips through a .NET string.
+
 ### StreamOne vs StreamAggregate
 
 - **`StreamOne<T>`** is for regular documents — objects stored via `session.Store()` and

--- a/docs/documents/querying/batched-queries.md
+++ b/docs/documents/querying/batched-queries.md
@@ -67,3 +67,56 @@ Query plans can also be used independently:
 ```cs
 var orders = await session.QueryByPlanAsync(new ActiveOrdersPlan());
 ```
+
+## Batched Event Store Fetches
+
+`batch.Events` exposes the batched counterparts of `FetchStreamStateAsync` and `FetchStreamAsync`, so a
+raw event-stream read can share the batch's single round trip with document loads and LINQ queries:
+
+```cs
+var batch = session.CreateBatchQuery();
+
+var stateTask = batch.Events.FetchStreamState(streamId);
+var eventsTask = batch.Events.FetchStream(streamId);
+var orderTask = batch.Load<Order>(orderId);
+
+await batch.Execute();
+
+var state = await stateTask;    // StreamState?, null when the stream does not exist
+var events = await eventsTask;  // IReadOnlyList<IEvent>, empty when the stream does not exist
+var order = await orderTask;
+```
+
+Both come in `Guid` and `string` overloads for the two stream identity modes, and `FetchStream` carries the
+same optional `version` / `timestamp` / `fromVersion` filters as `FetchStreamAsync`:
+
+```cs
+// Events up to and including version 5
+var capped = batch.Events.FetchStream(streamId, version: 5);
+
+// Everything appended from version 10 onward
+var tail = batch.Events.FetchStream(streamId, fromVersion: 10);
+```
+
+## Event Stream Query Plans
+
+`FetchStreamStatePlan` and `FetchStreamPlan` wrap those fetches as query plans. Both implement **both**
+`IQueryPlan<T>` and `IBatchQueryPlan<T>`, so the same plan instance works standalone or in a batch:
+
+```cs
+// Standalone
+var state  = await session.QueryByPlanAsync(new FetchStreamStatePlan(streamId));
+var events = await session.QueryByPlanAsync(new FetchStreamPlan(streamId, version: 5));
+
+// Batched — one round trip
+var batch = session.CreateBatchQuery();
+var stateFetcher  = batch.QueryByPlan(new FetchStreamStatePlan(streamId));
+var eventsFetcher = batch.QueryByPlan(new FetchStreamPlan(streamId));
+await batch.Execute();
+```
+
+::: tip
+Implementing both interfaces matters beyond convenience. Through Wolverine's fetch-specification feature,
+a plan that implements only `IBatchQueryPlan<T>` produces uncompilable generated code — so a custom plan
+you intend to route through a handler's `Load` should implement the pair as well.
+:::

--- a/docs/events/querying.md
+++ b/docs/events/querying.md
@@ -17,6 +17,33 @@ foreach (var @event in events)
 
 Events are returned in version order. Archived streams are automatically excluded.
 
+## Stream Fetches as Query Plans
+
+`FetchStreamStatePlan` and `FetchStreamPlan` wrap the two raw stream fetches as reusable query plans.
+Both implement `IQueryPlan<T>` **and** `IBatchQueryPlan<T>`, so the same plan works standalone or inside
+a batched query, and both offer `Guid streamId` / `string streamKey` constructor overloads:
+
+```cs
+// Standalone
+var state  = await session.QueryByPlanAsync(new FetchStreamStatePlan(streamId));
+var events = await session.QueryByPlanAsync(new FetchStreamPlan(streamId, version: 5));
+
+// Batched — one round trip
+var batch = session.CreateBatchQuery();
+var stateFetcher  = batch.QueryByPlan(new FetchStreamStatePlan(streamId));
+var eventsFetcher = batch.QueryByPlan(new FetchStreamPlan(streamId));
+await batch.Execute();
+```
+
+`FetchStreamStatePlan` yields `null` when the stream does not exist; `FetchStreamPlan` yields an empty
+list and carries `FetchStream`'s optional `version` / `timestamp` / `fromVersion` arguments.
+
+The underlying batched fetchers are also available directly as `batch.Events.FetchStreamState(...)` and
+`batch.Events.FetchStream(...)` — see [Batched Queries](/documents/querying/batched-queries#batched-event-store-fetches).
+
+To return either straight from an ASP.NET Core endpoint, see the `StreamEventState` and `StreamEvents`
+result types in [ASP.NET Core Integration](/documents/aspnetcore#streaming-event-stream-metadata-and-events).
+
 ## AggregateStreamAsync
 
 Replay events to build the current aggregate state:

--- a/src/Polecat.AspNetCore.Testing/Program.cs
+++ b/src/Polecat.AspNetCore.Testing/Program.cs
@@ -59,6 +59,29 @@ app.MapGet("/api/issues/paged-cursor/{pageSize:int}",
         new StreamPagedByCursor<StreamingIssue>(
             session.Query<StreamingIssue>().OrderBy(x => x.Number).ThenBy(x => x.Id), cursor, pageSize));
 
+// #370 StreamEventState endpoint — stream metadata (version/timestamps/archived) or 404
+app.MapGet("/api/streams/{id:guid}/state", (Guid id, IQuerySession session) =>
+    new StreamEventState(session, id));
+
+// #370 StreamEvents endpoint — the stream's raw events as a JSON array, or 404 when empty
+app.MapGet("/api/streams/{id:guid}/events", (Guid id, IQuerySession session) =>
+    new StreamEvents(session, id));
+
+// OnEmptyStatus opt-out — an empty stream answers 200 with an empty array rather than 404, which is
+// what a caller paging forward with fromVersion wants when it runs off the end.
+app.MapGet("/api/streams/{id:guid}/events-empty200", (Guid id, long? fromVersion, IQuerySession session) =>
+    new StreamEvents(session, id, fromVersion: fromVersion ?? 0)
+    {
+        OnEmptyStatus = StatusCodes.Status200OK
+    });
+
+// Pre-built plan constructor — a handler can build the plan once and either batch it or return it
+app.MapGet("/api/streams/{id:guid}/events-by-plan", (Guid id, IQuerySession session) =>
+    new StreamEvents(session, new FetchStreamPlan(id, version: 1)));
+
+app.MapGet("/api/streams/{id:guid}/state-by-plan", (Guid id, IQuerySession session) =>
+    new StreamEventState(session, new FetchStreamStatePlan(id)));
+
 app.Run();
 
 namespace Polecat.AspNetCore.Testing

--- a/src/Polecat.AspNetCore.Testing/stream_event_result_types_tests.cs
+++ b/src/Polecat.AspNetCore.Testing/stream_event_result_types_tests.cs
@@ -1,0 +1,248 @@
+using System.Text.Json;
+using Alba;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Xunit;
+
+namespace Polecat.AspNetCore.Testing;
+
+/// <summary>
+///     #370 (parity with marten#5053): the <c>StreamEventState</c> / <c>StreamEvents</c> endpoint result
+///     types over real Minimal API endpoints.
+/// </summary>
+public class stream_event_result_types_tests : IAsyncLifetime
+{
+    private IAlbaHost _host = null!;
+
+    public async Task InitializeAsync()
+    {
+        _host = await AlbaHost.For<Program>();
+
+        var store = (DocumentStore)_host.Services.GetRequiredService<IDocumentStore>();
+        await store.Database.ApplyAllConfiguredChangesToDatabaseAsync();
+    }
+
+    public async Task DisposeAsync() => await _host.DisposeAsync();
+
+    [Fact]
+    public async Task stream_event_state_returns_200_with_the_metadata()
+    {
+        var streamId = await StartPartyAsync();
+
+        var result = await _host.Scenario(s =>
+        {
+            s.Get.Url($"/api/streams/{streamId}/state");
+            s.StatusCodeShouldBeOk();
+            s.ContentTypeShouldBe("application/json");
+        });
+
+        var state = Read<StreamStateResponse>(result);
+        state.Id.ShouldBe(streamId);
+        state.Version.ShouldBe(2);
+        state.IsArchived.ShouldBeFalse();
+        state.Created.ShouldNotBe(default);
+        state.LastTimestamp.ShouldNotBe(default);
+    }
+
+    [Fact]
+    public async Task stream_event_state_returns_404_for_a_missing_stream()
+    {
+        await _host.Scenario(s =>
+        {
+            s.Get.Url($"/api/streams/{Guid.NewGuid()}/state");
+            s.StatusCodeShouldBe(404);
+        });
+    }
+
+    [Fact]
+    public async Task stream_event_state_accepts_a_prebuilt_plan()
+    {
+        var streamId = await StartPartyAsync();
+
+        var result = await _host.Scenario(s =>
+        {
+            s.Get.Url($"/api/streams/{streamId}/state-by-plan");
+            s.StatusCodeShouldBeOk();
+        });
+
+        Read<StreamStateResponse>(result).Version.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task stream_events_returns_200_with_the_serialized_events()
+    {
+        var streamId = await StartPartyAsync();
+
+        var result = await _host.Scenario(s =>
+        {
+            s.Get.Url($"/api/streams/{streamId}/events");
+            s.StatusCodeShouldBeOk();
+            s.ContentTypeShouldBe("application/json");
+        });
+
+        var events = Read<EventResponse[]>(result);
+        events.Length.ShouldBe(2);
+        events[0].Version.ShouldBe(1);
+        events[1].Version.ShouldBe(2);
+        events.ShouldAllBe(x => x.StreamId == streamId);
+        events.ShouldAllBe(x => x.Id != Guid.Empty);
+        events.ShouldAllBe(x => x.Sequence > 0);
+    }
+
+    /// <summary>
+    ///     The event body itself has to survive the DTO projection — an endpoint that returned only
+    ///     metadata would pass every other assertion here.
+    /// </summary>
+    [Fact]
+    public async Task stream_events_writes_the_event_body()
+    {
+        var streamId = await StartPartyAsync();
+
+        var result = await _host.Scenario(s =>
+        {
+            s.Get.Url($"/api/streams/{streamId}/events");
+            s.StatusCodeShouldBeOk();
+        });
+
+        var body = result.ReadAsText();
+        body.ShouldContain("Fellowship");
+        body.ShouldContain("Frodo");
+    }
+
+    /// <summary>
+    ///     The reason the DTOs exist at all: <c>IEvent.EventType</c> is a <see cref="Type" />, and STJ
+    ///     throws NotSupportedException outright on those. <c>EventTypeName</c> is the alias a client
+    ///     discriminates on; the assembly-qualified .NET type name is deliberately kept off the wire.
+    /// </summary>
+    [Fact]
+    public async Task stream_events_writes_the_alias_and_not_the_dotnet_type()
+    {
+        var streamId = await StartPartyAsync();
+
+        var result = await _host.Scenario(s =>
+        {
+            s.Get.Url($"/api/streams/{streamId}/events");
+            s.StatusCodeShouldBeOk();
+        });
+
+        var events = Read<EventResponse[]>(result);
+        events.ShouldAllBe(x => !string.IsNullOrEmpty(x.EventTypeName));
+
+        var body = result.ReadAsText();
+        body.ShouldNotContain("Polecat.AspNetCore.Testing, Version=");
+        body.ShouldNotContain("\"EventType\"");
+    }
+
+    [Fact]
+    public async Task stream_events_returns_404_for_a_missing_stream_by_default()
+    {
+        await _host.Scenario(s =>
+        {
+            s.Get.Url($"/api/streams/{Guid.NewGuid()}/events");
+            s.StatusCodeShouldBe(404);
+        });
+    }
+
+    [Fact]
+    public async Task on_empty_status_opts_out_of_the_404()
+    {
+        var result = await _host.Scenario(s =>
+        {
+            s.Get.Url($"/api/streams/{Guid.NewGuid()}/events-empty200");
+            s.StatusCodeShouldBeOk();
+        });
+
+        Read<EventResponse[]>(result).ShouldBeEmpty();
+    }
+
+    /// <summary>
+    ///     The case OnEmptyStatus exists for: paging forward with fromVersion and running off the end of
+    ///     a stream that really does exist is expected, not a 404.
+    /// </summary>
+    [Fact]
+    public async Task on_empty_status_covers_paging_off_the_end_of_a_real_stream()
+    {
+        var streamId = await StartPartyAsync();
+
+        var result = await _host.Scenario(s =>
+        {
+            s.Get.Url($"/api/streams/{streamId}/events-empty200?fromVersion=99");
+            s.StatusCodeShouldBeOk();
+        });
+
+        Read<EventResponse[]>(result).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task stream_events_accepts_a_prebuilt_plan_and_honors_its_filters()
+    {
+        var streamId = await StartPartyAsync();
+
+        var result = await _host.Scenario(s =>
+        {
+            s.Get.Url($"/api/streams/{streamId}/events-by-plan");
+            s.StatusCodeShouldBeOk();
+        });
+
+        // The endpoint's plan caps at version 1
+        var events = Read<EventResponse[]>(result);
+        events.Length.ShouldBe(1);
+        events[0].Version.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task both_results_set_content_length()
+    {
+        var streamId = await StartPartyAsync();
+
+        foreach (var url in new[] { $"/api/streams/{streamId}/state", $"/api/streams/{streamId}/events" })
+        {
+            var result = await _host.Scenario(s =>
+            {
+                s.Get.Url(url);
+                s.StatusCodeShouldBeOk();
+            });
+
+            result.Context.Response.ContentLength.ShouldNotBeNull($"{url} must set Content-Length");
+            result.Context.Response.ContentLength!.Value.ShouldBeGreaterThan(0);
+        }
+    }
+
+    [Fact]
+    public async Task both_results_advertise_their_openapi_metadata()
+    {
+        var sources = _host.Services.GetServices<Microsoft.AspNetCore.Routing.EndpointDataSource>();
+        var endpoints = sources.SelectMany(x => x.Endpoints).OfType<Microsoft.AspNetCore.Routing.RouteEndpoint>();
+
+        foreach (var pattern in new[] { "/api/streams/{id:guid}/state", "/api/streams/{id:guid}/events" })
+        {
+            var endpoint = endpoints.Single(x => x.RoutePattern.RawText == pattern);
+            var produces = endpoint.Metadata
+                .OfType<Microsoft.AspNetCore.Http.Metadata.IProducesResponseTypeMetadata>()
+                .ToList();
+
+            produces.ShouldContain(x => x.StatusCode == 200, $"{pattern} should advertise a 200");
+            produces.ShouldContain(x => x.StatusCode == 404, $"{pattern} should advertise a 404");
+        }
+    }
+
+    private async Task<Guid> StartPartyAsync()
+    {
+        var store = _host.Services.GetRequiredService<IDocumentStore>();
+        var streamId = Guid.NewGuid();
+
+        await using var session = store.LightweightSession();
+        session.Events.StartStream(streamId,
+            new StreamingQuestStarted("Fellowship"),
+            new StreamingMembersJoined(["Frodo", "Sam"]));
+        await session.SaveChangesAsync();
+
+        return streamId;
+    }
+
+    private static T Read<T>(IScenarioResult result)
+    {
+        return JsonSerializer.Deserialize<T>(result.ReadAsText(),
+            new JsonSerializerOptions(JsonSerializerDefaults.Web))!;
+    }
+}

--- a/src/Polecat.AspNetCore/EventStreamExtensions.cs
+++ b/src/Polecat.AspNetCore/EventStreamExtensions.cs
@@ -1,0 +1,123 @@
+using System.Buffers;
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+using Microsoft.AspNetCore.Http;
+
+namespace Polecat.AspNetCore;
+
+/// <summary>
+/// #370: the body writers behind <see cref="StreamEventState"/> and <see cref="StreamEvents"/>,
+/// exposed as <see cref="IQuerySession"/> extensions so a handler that does not want the
+/// <c>IResult</c> wrapper can write the same responses itself.
+/// </summary>
+public static class EventStreamExtensions
+{
+    /// <summary>
+    /// Resolve a <see cref="FetchStreamStatePlan"/> and write the resulting stream metadata to the
+    /// <paramref name="context"/> response as JSON, or <c>404</c> when the stream does not exist.
+    /// <para>
+    /// The response body is a <see cref="StreamStateResponse"/> rather than Polecat's
+    /// <c>StreamState</c> — see that type for why.
+    /// </para>
+    /// </summary>
+    /// <param name="session"></param>
+    /// <param name="plan"></param>
+    /// <param name="context"></param>
+    /// <param name="contentType"></param>
+    /// <param name="onFoundStatus">Defaults to 200</param>
+    [RequiresDynamicCode("Serializes StreamStateResponse with System.Text.Json, which uses runtime codegen.")]
+    [RequiresUnreferencedCode("Reflects over StreamStateResponse via System.Text.Json.")]
+    public static async Task WriteStreamState(
+        this IQuerySession session,
+        FetchStreamStatePlan plan,
+        HttpContext context,
+        string contentType = "application/json",
+        int onFoundStatus = StatusCodes.Status200OK)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+        ArgumentNullException.ThrowIfNull(plan);
+        ArgumentNullException.ThrowIfNull(context);
+
+        var state = await plan.Fetch(session, context.RequestAborted).ConfigureAwait(false);
+
+        if (state == null)
+        {
+            context.Response.StatusCode = StatusCodes.Status404NotFound;
+            context.Response.ContentLength = 0;
+            return;
+        }
+
+        await WriteJson(StreamStateResponse.From(state), context, contentType, onFoundStatus)
+            .ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Resolve a <see cref="FetchStreamPlan"/> and write the resulting raw events to the
+    /// <paramref name="context"/> response as a JSON array.
+    /// <para>
+    /// <c>FetchStream</c> yields an empty list both for a stream that does not exist and for a filter
+    /// that excludes every event, so the two cases cannot be told apart here.
+    /// <paramref name="onEmptyStatus"/> decides which answer the endpoint gives; it defaults to
+    /// <c>404</c> to match the other single-resource results. Pass <c>200</c> to return an empty JSON
+    /// array instead.
+    /// </para>
+    /// <para>
+    /// Each element is an <see cref="EventResponse"/> rather than Polecat's <c>IEvent</c> — see that
+    /// type for why.
+    /// </para>
+    /// </summary>
+    /// <param name="session"></param>
+    /// <param name="plan"></param>
+    /// <param name="context"></param>
+    /// <param name="contentType"></param>
+    /// <param name="onFoundStatus">Defaults to 200</param>
+    /// <param name="onEmptyStatus">Defaults to 404</param>
+    [RequiresDynamicCode("Serializes EventResponse[] with System.Text.Json, which uses runtime codegen for each event's Data payload.")]
+    [RequiresUnreferencedCode("Reflects over EventResponse and each event's Data payload via System.Text.Json.")]
+    public static async Task WriteEvents(
+        this IQuerySession session,
+        FetchStreamPlan plan,
+        HttpContext context,
+        string contentType = "application/json",
+        int onFoundStatus = StatusCodes.Status200OK,
+        int onEmptyStatus = StatusCodes.Status404NotFound)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+        ArgumentNullException.ThrowIfNull(plan);
+        ArgumentNullException.ThrowIfNull(context);
+
+        var events = await plan.Fetch(session, context.RequestAborted).ConfigureAwait(false);
+
+        if (events.Count == 0 && onEmptyStatus == StatusCodes.Status404NotFound)
+        {
+            context.Response.StatusCode = StatusCodes.Status404NotFound;
+            context.Response.ContentLength = 0;
+            return;
+        }
+
+        await WriteJson(EventResponse.From(events), context, contentType,
+            events.Count == 0 ? onEmptyStatus : onFoundStatus).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Serialize <paramref name="value"/> and write it to the response with <c>Content-Length</c> set.
+    /// Buffers through an <see cref="ArrayBufferWriter{T}"/> so the JSON never round-trips through a
+    /// .NET string on its way to the socket.
+    /// </summary>
+    [RequiresDynamicCode("Serializes the response DTO with System.Text.Json, which uses runtime codegen for the event Data payload.")]
+    [RequiresUnreferencedCode("Reflects over the response DTO and the event Data payload via System.Text.Json.")]
+    private static async Task WriteJson<T>(T value, HttpContext context, string contentType, int statusCode)
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        await using (var writer = new Utf8JsonWriter(buffer))
+        {
+            JsonSerializer.Serialize(writer, value);
+        }
+
+        context.Response.StatusCode = statusCode;
+        context.Response.ContentType = contentType;
+        context.Response.ContentLength = buffer.WrittenCount;
+        await context.Response.Body.WriteAsync(buffer.WrittenMemory, context.RequestAborted)
+            .ConfigureAwait(false);
+    }
+}

--- a/src/Polecat.AspNetCore/EventStreamResponses.cs
+++ b/src/Polecat.AspNetCore/EventStreamResponses.cs
@@ -1,0 +1,151 @@
+using JasperFx.Events;
+
+namespace Polecat.AspNetCore;
+
+/// <summary>
+/// The HTTP wire shape written by <see cref="StreamEventState"/> for a single event stream's
+/// <see cref="StreamState"/> metadata.
+/// <para>
+/// <see cref="StreamState"/> is not written directly because <c>StreamState.AggregateType</c> is a
+/// <see cref="Type"/>, and System.Text.Json refuses to serialize <see cref="Type"/> instances
+/// ("Serialization and deserialization of 'System.Type' instances is not supported"). This record
+/// projects the aggregate type down to its simple name and is a stable contract for HTTP clients.
+/// </para>
+/// <para>
+/// Property names match Marten's <c>StreamStateResponse</c> so a client can move between the two
+/// stores unchanged.
+/// </para>
+/// </summary>
+public sealed record StreamStateResponse
+{
+    /// <summary>Identity of the stream when using Guid identity; <see cref="Guid.Empty"/> for string-keyed streams.</summary>
+    public Guid Id { get; init; }
+
+    /// <summary>Identity of the stream when using string identity; null for Guid-keyed streams.</summary>
+    public string? Key { get; init; }
+
+    /// <summary>Current version of the stream, i.e. the count of events.</summary>
+    public long Version { get; init; }
+
+    /// <summary>Simple name of the aggregate type the stream was tagged with, when it was tagged at all.</summary>
+    public string? AggregateTypeName { get; init; }
+
+    /// <summary>The last time this stream was appended to.</summary>
+    public DateTimeOffset LastTimestamp { get; init; }
+
+    /// <summary>The time at which this stream was created.</summary>
+    public DateTimeOffset Created { get; init; }
+
+    /// <summary>Whether the stream has been archived.</summary>
+    public bool IsArchived { get; init; }
+
+    /// <summary>
+    /// Project a <see cref="StreamState"/> onto the wire shape.
+    /// </summary>
+    public static StreamStateResponse From(StreamState state)
+    {
+        ArgumentNullException.ThrowIfNull(state);
+
+        return new StreamStateResponse
+        {
+            Id = state.Id,
+            Key = state.Key,
+            Version = state.Version,
+            AggregateTypeName = state.AggregateType?.Name,
+            LastTimestamp = state.LastTimestamp,
+            Created = state.Created,
+            IsArchived = state.IsArchived
+        };
+    }
+}
+
+/// <summary>
+/// The HTTP wire shape written by <see cref="StreamEvents"/> for one raw event in a stream.
+/// <para>
+/// <see cref="IEvent"/> is not written directly because <c>IEvent.EventType</c> is a
+/// <see cref="Type"/>, which System.Text.Json refuses to serialize. <c>DotNetTypeName</c> — the
+/// assembly qualified .NET type name — is deliberately left off the wire as well; use
+/// <see cref="EventTypeName"/>, Polecat's stable event type alias, to discriminate event types on
+/// the client.
+/// </para>
+/// <para>
+/// Property names match Marten's <c>EventResponse</c> so a client can move between the two stores
+/// unchanged.
+/// </para>
+/// </summary>
+public sealed record EventResponse
+{
+    /// <summary>Unique identifier of the event.</summary>
+    public Guid Id { get; init; }
+
+    /// <summary>The event's position within its stream.</summary>
+    public long Version { get; init; }
+
+    /// <summary>The event's sequential position across the entire event store.</summary>
+    public long Sequence { get; init; }
+
+    /// <summary>Owning stream's id when using Guid identity; <see cref="Guid.Empty"/> otherwise.</summary>
+    public Guid StreamId { get; init; }
+
+    /// <summary>Owning stream's key when using string identity; null otherwise.</summary>
+    public string? StreamKey { get; init; }
+
+    /// <summary>Polecat's event type alias — the stable discriminator for clients.</summary>
+    public string? EventTypeName { get; init; }
+
+    /// <summary>The time at which the event was captured.</summary>
+    public DateTimeOffset Timestamp { get; init; }
+
+    /// <summary>The owning tenant id.</summary>
+    public string? TenantId { get; init; }
+
+    /// <summary>Whether the event has been archived.</summary>
+    public bool IsArchived { get; init; }
+
+    /// <summary>Optional causation id metadata.</summary>
+    public string? CausationId { get; init; }
+
+    /// <summary>Optional correlation id metadata.</summary>
+    public string? CorrelationId { get; init; }
+
+    /// <summary>Optional user defined metadata. Null when no headers were set.</summary>
+    public Dictionary<string, object>? Headers { get; init; }
+
+    /// <summary>The event body itself.</summary>
+    public object Data { get; init; } = default!;
+
+    /// <summary>
+    /// Project an <see cref="IEvent"/> onto the wire shape.
+    /// </summary>
+    public static EventResponse From(IEvent @event)
+    {
+        ArgumentNullException.ThrowIfNull(@event);
+
+        return new EventResponse
+        {
+            Id = @event.Id,
+            Version = @event.Version,
+            Sequence = @event.Sequence,
+            StreamId = @event.StreamId,
+            StreamKey = @event.StreamKey,
+            EventTypeName = @event.EventTypeName,
+            Timestamp = @event.Timestamp,
+            TenantId = @event.TenantId,
+            IsArchived = @event.IsArchived,
+            CausationId = @event.CausationId,
+            CorrelationId = @event.CorrelationId,
+            Headers = @event.Headers,
+            Data = @event.Data
+        };
+    }
+
+    /// <summary>
+    /// Project a list of <see cref="IEvent"/> onto the wire shape.
+    /// </summary>
+    public static EventResponse[] From(IReadOnlyList<IEvent> events)
+    {
+        ArgumentNullException.ThrowIfNull(events);
+
+        return events.Select(From).ToArray();
+    }
+}

--- a/src/Polecat.AspNetCore/StreamEventState.cs
+++ b/src/Polecat.AspNetCore/StreamEventState.cs
@@ -1,0 +1,98 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Metadata;
+
+namespace Polecat.AspNetCore;
+
+/// <summary>
+/// Minimal-API endpoint return value that writes the high level metadata of a single event stream —
+/// Polecat's <c>StreamState</c> — to the <see cref="HttpContext"/> response as JSON. Backed by
+/// <see cref="FetchStreamStatePlan"/>, the same query plan that can be batched through
+/// <c>IBatchedQuery.QueryByPlan()</c>.
+/// <para>
+/// Returns HTTP <c>404</c> when the stream does not exist, <see cref="OnFoundStatus"/> (default 200)
+/// when it does.
+/// </para>
+/// <para>
+/// The response body is a <see cref="StreamStateResponse"/>, not Polecat's <c>StreamState</c>
+/// directly: <c>StreamState.AggregateType</c> is a <see cref="Type"/> and System.Text.Json refuses
+/// to serialize those, so the aggregate type is projected down to its simple name.
+/// </para>
+/// <para>
+/// <b>StreamEventState vs StreamAggregate.</b> Use <see cref="StreamEventState"/> when you want the
+/// stream's <i>metadata</i> — version, timestamps, archived flag. Use <see cref="StreamAggregate{T}"/>
+/// when you want the projected aggregate <i>state</i> built from the stream's events.
+/// </para>
+/// </summary>
+public sealed class StreamEventState : IResult, IEndpointMetadataProvider
+{
+    private readonly IQuerySession _session;
+    private readonly FetchStreamStatePlan _plan;
+
+    /// <summary>
+    /// Write the stream metadata for the Guid-identified stream <paramref name="streamId"/>.
+    /// </summary>
+    public StreamEventState(IQuerySession session, Guid streamId)
+        : this(session, new FetchStreamStatePlan(streamId))
+    {
+    }
+
+    /// <summary>
+    /// Write the stream metadata for the string-keyed stream <paramref name="streamKey"/>.
+    /// </summary>
+    public StreamEventState(IQuerySession session, string streamKey)
+        : this(session, new FetchStreamStatePlan(
+            streamKey ?? throw new ArgumentNullException(nameof(streamKey))))
+    {
+    }
+
+    /// <summary>
+    /// Write the stream metadata resolved by an existing <see cref="FetchStreamStatePlan"/>. Lets a
+    /// handler build the plan once and either batch it or return it straight from an endpoint.
+    /// </summary>
+    public StreamEventState(IQuerySession session, FetchStreamStatePlan plan)
+    {
+        _session = session ?? throw new ArgumentNullException(nameof(session));
+        _plan = plan ?? throw new ArgumentNullException(nameof(plan));
+    }
+
+    /// <summary>
+    /// Status code written when the stream is found. Defaults to 200.
+    /// </summary>
+    public int OnFoundStatus { get; init; } = StatusCodes.Status200OK;
+
+    /// <summary>
+    /// Response content type. Defaults to <c>application/json</c>.
+    /// </summary>
+    public string ContentType { get; init; } = "application/json";
+
+    /// <inheritdoc />
+    [UnconditionalSuppressMessage("Trimming", "IL2046",
+        Justification = "IResult.ExecuteAsync is not RUC-annotated; the contract lives on this override.")]
+    [UnconditionalSuppressMessage("AOT", "IL3051",
+        Justification = "IResult.ExecuteAsync is not RDC-annotated; the contract lives on this override.")]
+    [RequiresDynamicCode("Serializes StreamStateResponse with System.Text.Json, which uses runtime codegen.")]
+    [RequiresUnreferencedCode("Reflects over StreamStateResponse via System.Text.Json.")]
+    public Task ExecuteAsync(HttpContext httpContext)
+    {
+        ArgumentNullException.ThrowIfNull(httpContext);
+
+        return _session.WriteStreamState(_plan, httpContext, ContentType, OnFoundStatus);
+    }
+
+    /// <summary>
+    /// Populates endpoint metadata so OpenAPI correctly advertises a
+    /// <c>200: StreamStateResponse</c> and <c>404</c> response for this endpoint.
+    /// </summary>
+    public static void PopulateMetadata(MethodInfo method, EndpointBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.Metadata.Add(new ProducesResponseTypeMetadata(
+            StatusCodes.Status200OK, typeof(StreamStateResponse), ["application/json"]));
+        builder.Metadata.Add(new ProducesResponseTypeMetadata(
+            StatusCodes.Status404NotFound, typeof(void), []));
+    }
+}

--- a/src/Polecat.AspNetCore/StreamEvents.cs
+++ b/src/Polecat.AspNetCore/StreamEvents.cs
@@ -1,0 +1,117 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Metadata;
+
+namespace Polecat.AspNetCore;
+
+/// <summary>
+/// Minimal-API endpoint return value that writes the raw events of a single event stream to the
+/// <see cref="HttpContext"/> response as a JSON array. Backed by <see cref="FetchStreamPlan"/>, the
+/// same query plan that can be batched through <c>IBatchedQuery.QueryByPlan()</c>, and carrying the
+/// same optional <c>version</c>, <c>timestamp</c> and <c>fromVersion</c> filters as
+/// <c>FetchStreamAsync()</c>.
+/// <para>
+/// <c>FetchStream</c> yields an empty list both for a stream that does not exist and for a filter
+/// that excludes every event, so the two cannot be told apart here. <see cref="OnEmptyStatus"/>
+/// decides which answer the endpoint gives; it defaults to <c>404</c> to match the other
+/// single-resource results. Set it to 200 to return an empty JSON array instead — the right choice
+/// for an endpoint that pages through a stream with <c>fromVersion</c>, where running off the end is
+/// expected rather than exceptional.
+/// </para>
+/// <para>
+/// Elements are <see cref="EventResponse"/>, not Polecat's <c>IEvent</c> directly:
+/// <c>IEvent.EventType</c> is a <see cref="Type"/> and System.Text.Json refuses to serialize those.
+/// Use <c>EventTypeName</c>, Polecat's stable event type alias, to discriminate event types client
+/// side; the assembly qualified .NET type name is deliberately not written to the wire.
+/// </para>
+/// </summary>
+public sealed class StreamEvents : IResult, IEndpointMetadataProvider
+{
+    private readonly IQuerySession _session;
+    private readonly FetchStreamPlan _plan;
+
+    /// <summary>
+    /// Write the events of the Guid-identified stream <paramref name="streamId"/>.
+    /// </summary>
+    /// <param name="session"></param>
+    /// <param name="streamId"></param>
+    /// <param name="version">If set, writes events up to and including this version</param>
+    /// <param name="timestamp">If set, writes events captured on or before this timestamp</param>
+    /// <param name="fromVersion">If set, writes events on or from this version</param>
+    public StreamEvents(IQuerySession session, Guid streamId, long version = 0,
+        DateTimeOffset? timestamp = null, long fromVersion = 0)
+        : this(session, new FetchStreamPlan(streamId, version, timestamp, fromVersion))
+    {
+    }
+
+    /// <summary>
+    /// Write the events of the string-keyed stream <paramref name="streamKey"/>.
+    /// </summary>
+    /// <param name="session"></param>
+    /// <param name="streamKey"></param>
+    /// <param name="version">If set, writes events up to and including this version</param>
+    /// <param name="timestamp">If set, writes events captured on or before this timestamp</param>
+    /// <param name="fromVersion">If set, writes events on or from this version</param>
+    public StreamEvents(IQuerySession session, string streamKey, long version = 0,
+        DateTimeOffset? timestamp = null, long fromVersion = 0)
+        : this(session, new FetchStreamPlan(
+            streamKey ?? throw new ArgumentNullException(nameof(streamKey)), version, timestamp, fromVersion))
+    {
+    }
+
+    /// <summary>
+    /// Write the events resolved by an existing <see cref="FetchStreamPlan"/>. Lets a handler build
+    /// the plan once and either batch it or return it straight from an endpoint.
+    /// </summary>
+    public StreamEvents(IQuerySession session, FetchStreamPlan plan)
+    {
+        _session = session ?? throw new ArgumentNullException(nameof(session));
+        _plan = plan ?? throw new ArgumentNullException(nameof(plan));
+    }
+
+    /// <summary>
+    /// Status code written when the stream yields at least one event. Defaults to 200.
+    /// </summary>
+    public int OnFoundStatus { get; init; } = StatusCodes.Status200OK;
+
+    /// <summary>
+    /// Status code written when the stream yields no events at all. Defaults to 404.
+    /// Set to 200 to write an empty JSON array instead.
+    /// </summary>
+    public int OnEmptyStatus { get; init; } = StatusCodes.Status404NotFound;
+
+    /// <summary>
+    /// Response content type. Defaults to <c>application/json</c>.
+    /// </summary>
+    public string ContentType { get; init; } = "application/json";
+
+    /// <inheritdoc />
+    [UnconditionalSuppressMessage("Trimming", "IL2046",
+        Justification = "IResult.ExecuteAsync is not RUC-annotated; the contract lives on this override.")]
+    [UnconditionalSuppressMessage("AOT", "IL3051",
+        Justification = "IResult.ExecuteAsync is not RDC-annotated; the contract lives on this override.")]
+    [RequiresDynamicCode("Serializes EventResponse[] with System.Text.Json, which uses runtime codegen for each event's Data payload.")]
+    [RequiresUnreferencedCode("Reflects over EventResponse and each event's Data payload via System.Text.Json.")]
+    public Task ExecuteAsync(HttpContext httpContext)
+    {
+        ArgumentNullException.ThrowIfNull(httpContext);
+
+        return _session.WriteEvents(_plan, httpContext, ContentType, OnFoundStatus, OnEmptyStatus);
+    }
+
+    /// <summary>
+    /// Populates endpoint metadata so OpenAPI correctly advertises a
+    /// <c>200: EventResponse[]</c> and <c>404</c> response for this endpoint.
+    /// </summary>
+    public static void PopulateMetadata(MethodInfo method, EndpointBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.Metadata.Add(new ProducesResponseTypeMetadata(
+            StatusCodes.Status200OK, typeof(EventResponse[]), ["application/json"]));
+        builder.Metadata.Add(new ProducesResponseTypeMetadata(
+            StatusCodes.Status404NotFound, typeof(void), []));
+    }
+}

--- a/src/Polecat.Tests/Batching/batch_event_fetching.cs
+++ b/src/Polecat.Tests/Batching/batch_event_fetching.cs
@@ -1,0 +1,223 @@
+using JasperFx.Events.Projections;
+using Polecat.Projections;
+using Polecat.Tests.Harness;
+using Shouldly;
+
+namespace Polecat.Tests.Batching;
+
+/// <summary>
+///     #370: <c>IBatchedQuery.Events</c> — the batched counterparts of <c>FetchStreamStateAsync</c> and
+///     <c>FetchStreamAsync</c>. These pin the surface directly rather than through the query plans that
+///     sit on top of it, and pin that the batched read agrees with the standalone one row for row: the
+///     batch item composes its own SQL, so drift between the two paths is the risk worth guarding.
+/// </summary>
+[Collection("integration")]
+public class batch_event_fetching : IntegrationContext
+{
+    public batch_event_fetching(DefaultStoreFixture fixture) : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task fetch_stream_state_in_a_batch()
+    {
+        var streamId = await StartQuestStreamAsync();
+
+        await using var query = theStore.QuerySession();
+        var batch = query.CreateBatchQuery();
+        var fetcher = batch.Events.FetchStreamState(streamId);
+        await batch.Execute();
+
+        var state = await fetcher;
+        state.ShouldNotBeNull();
+        state.Id.ShouldBe(streamId);
+        state.Version.ShouldBe(3);
+    }
+
+    /// <summary>
+    ///     #370: <c>pc_streams.type</c> was always projected and never read, so
+    ///     <c>StreamState.AggregateType</c> came back null on every stream — which would have made the
+    ///     <c>StreamStateResponse.AggregateTypeName</c> wire field structurally dead. Both the standalone
+    ///     and batched reads resolve it now.
+    /// </summary>
+    [Fact]
+    public async Task stream_state_reports_the_aggregate_type_it_was_tagged_with()
+    {
+        await StoreOptions(opts =>
+            opts.Projections.Add<SingleStreamProjection<BatchTaggedAggregate, Guid>>(
+                ProjectionLifecycle.Live));
+
+        var streamId = Guid.NewGuid();
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Events.StartStream<BatchTaggedAggregate>(streamId, new QuestStarted("Tagged"));
+            await session.SaveChangesAsync();
+        }
+
+        await using var query = theStore.QuerySession();
+
+        (await query.Events.FetchStreamStateAsync(streamId))!.AggregateType.ShouldBe(typeof(BatchTaggedAggregate));
+
+        var batch = query.CreateBatchQuery();
+        var fetcher = batch.Events.FetchStreamState(streamId);
+        await batch.Execute();
+        (await fetcher)!.AggregateType.ShouldBe(typeof(BatchTaggedAggregate));
+    }
+
+    /// <summary>
+    ///     An untagged stream simply has no aggregate type — not an error, and not a reason to fail the
+    ///     metadata read.
+    /// </summary>
+    [Fact]
+    public async Task stream_state_reports_no_aggregate_type_for_an_untagged_stream()
+    {
+        var streamId = await StartQuestStreamAsync();
+
+        await using var query = theStore.QuerySession();
+        var batch = query.CreateBatchQuery();
+        var fetcher = batch.Events.FetchStreamState(streamId);
+        await batch.Execute();
+
+        (await fetcher)!.AggregateType.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task fetch_stream_state_is_null_for_a_missing_stream()
+    {
+        await using var query = theStore.QuerySession();
+        var batch = query.CreateBatchQuery();
+        var fetcher = batch.Events.FetchStreamState(Guid.NewGuid());
+        await batch.Execute();
+
+        (await fetcher).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task fetch_stream_in_a_batch_matches_the_standalone_fetch()
+    {
+        var streamId = await StartQuestStreamAsync();
+
+        await using var query = theStore.QuerySession();
+        var expected = await query.Events.FetchStreamAsync(streamId);
+
+        var batch = query.CreateBatchQuery();
+        var fetcher = batch.Events.FetchStream(streamId);
+        await batch.Execute();
+
+        var actual = await fetcher;
+        actual.Count.ShouldBe(expected.Count);
+        actual.Select(x => x.Id).ShouldBe(expected.Select(x => x.Id));
+        actual.Select(x => x.Version).ShouldBe(expected.Select(x => x.Version));
+        actual.Select(x => x.Sequence).ShouldBe(expected.Select(x => x.Sequence));
+        actual.ShouldAllBe(x => x.StreamId == streamId);
+        actual[0].Data.ShouldBeOfType<QuestStarted>().Name.ShouldBe("Quest 1");
+    }
+
+    [Fact]
+    public async Task fetch_stream_applies_the_optional_filters()
+    {
+        var streamId = await StartQuestStreamAsync();
+
+        await using var query = theStore.QuerySession();
+        var batch = query.CreateBatchQuery();
+        var capped = batch.Events.FetchStream(streamId, version: 2);
+        var from = batch.Events.FetchStream(streamId, fromVersion: 2);
+        var window = batch.Events.FetchStream(streamId, version: 2, fromVersion: 2);
+        await batch.Execute();
+
+        (await capped).Select(x => x.Version).ShouldBe([1, 2]);
+        (await from).Select(x => x.Version).ShouldBe([2, 3]);
+        (await window).Select(x => x.Version).ShouldBe([2]);
+    }
+
+    /// <summary>
+    ///     The timestamp filter gets its own test because it is the one parameter whose binding differs in
+    ///     kind from the rest — a DateTimeOffset going through the batch's ICommandBuilder rather than the
+    ///     standalone fetch's AddWithValue.
+    /// </summary>
+    [Fact]
+    public async Task fetch_stream_applies_the_timestamp_filter()
+    {
+        var streamId = await StartQuestStreamAsync();
+
+        await using var query = theStore.QuerySession();
+        var all = await query.Events.FetchStreamAsync(streamId);
+        var cutoff = all[^1].Timestamp;
+
+        var batch = query.CreateBatchQuery();
+        var upToCutoff = batch.Events.FetchStream(streamId, timestamp: cutoff);
+        var beforeEverything = batch.Events.FetchStream(streamId, timestamp: all[0].Timestamp.AddMinutes(-5));
+        await batch.Execute();
+
+        (await upToCutoff).Count.ShouldBe(3);
+        (await beforeEverything).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task fetch_stream_is_empty_for_a_missing_stream()
+    {
+        await using var query = theStore.QuerySession();
+        var batch = query.CreateBatchQuery();
+        var fetcher = batch.Events.FetchStream(Guid.NewGuid());
+        await batch.Execute();
+
+        (await fetcher).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task several_event_fetches_and_a_document_load_resolve_in_one_batch()
+    {
+        var first = await StartQuestStreamAsync();
+        var second = await StartQuestStreamAsync();
+
+        var target = new Target { Id = Guid.NewGuid(), Color = "Green", Number = 42 };
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Store(target);
+            await session.SaveChangesAsync();
+        }
+
+        await using var query = theStore.QuerySession();
+        var batch = query.CreateBatchQuery();
+
+        // Interleaved deliberately: every item reads the result set at its own ordinal, so an item that
+        // consumed the wrong one would show up as a cross-wired answer here rather than as a clean error.
+        var firstState = batch.Events.FetchStreamState(first);
+        var doc = batch.Load<Target>(target.Id);
+        var secondEvents = batch.Events.FetchStream(second);
+        var secondState = batch.Events.FetchStreamState(second);
+        var firstEvents = batch.Events.FetchStream(first);
+        await batch.Execute();
+
+        (await firstState)!.Id.ShouldBe(first);
+        (await secondState)!.Id.ShouldBe(second);
+        (await firstEvents).ShouldAllBe(x => x.StreamId == first);
+        (await secondEvents).ShouldAllBe(x => x.StreamId == second);
+        (await doc)!.Number.ShouldBe(42);
+    }
+
+    private async Task<Guid> StartQuestStreamAsync()
+    {
+        var streamId = Guid.NewGuid();
+        await using var session = theStore.LightweightSession();
+        session.Events.StartStream(streamId,
+            new QuestStarted("Quest 1"), new QuestStarted("Quest 2"), new QuestStarted("Quest 3"));
+        await session.SaveChangesAsync();
+        return streamId;
+    }
+}
+
+/// <summary>
+///     Tagged onto a stream by <c>StartStream&lt;T&gt;</c> and registered as a projection, which is what
+///     makes the persisted alias resolvable — Polecat's QuickAppend writer stores
+///     <c>AggregateType.Name</c> directly and never goes through <c>StreamAction.PrepareEvents</c>, so the
+///     registered projections are the source of truth for resolving it back.
+/// </summary>
+public class BatchTaggedAggregate
+{
+    public Guid Id { get; set; }
+
+    public void Apply(QuestStarted e)
+    {
+    }
+}

--- a/src/Polecat.Tests/Querying/fetching_stream_query_plans.cs
+++ b/src/Polecat.Tests/Querying/fetching_stream_query_plans.cs
@@ -1,0 +1,232 @@
+using JasperFx;
+using JasperFx.Events;
+using Polecat.Tests.Harness;
+using Polecat.TestUtils;
+using Shouldly;
+
+namespace Polecat.Tests.Querying;
+
+/// <summary>
+///     #370 (parity with marten#5053): <see cref="FetchStreamStatePlan" /> and
+///     <see cref="FetchStreamPlan" /> wrap the raw event-stream fetches as query plans. Both implement
+///     <b>both</b> <see cref="IQueryPlan{T}" /> and <see cref="IBatchQueryPlan{T}" />, so each is
+///     exercised standalone and through a batch here.
+/// </summary>
+[Collection("integration")]
+public class fetching_stream_query_plans : IntegrationContext
+{
+    public fetching_stream_query_plans(DefaultStoreFixture fixture) : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task fetch_stream_state_plan_standalone()
+    {
+        var streamId = await StartQuestStreamAsync();
+
+        await using var query = theStore.QuerySession();
+        var state = await query.QueryByPlanAsync(new FetchStreamStatePlan(streamId));
+
+        state.ShouldNotBeNull();
+        state.Id.ShouldBe(streamId);
+        state.Version.ShouldBe(3);
+        state.IsArchived.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task fetch_stream_state_plan_batched()
+    {
+        var streamId = await StartQuestStreamAsync();
+
+        await using var query = theStore.QuerySession();
+        var batch = query.CreateBatchQuery();
+        var fetcher = batch.QueryByPlan(new FetchStreamStatePlan(streamId));
+        await batch.Execute();
+
+        var state = await fetcher;
+        state.ShouldNotBeNull();
+        state.Id.ShouldBe(streamId);
+        state.Version.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task fetch_stream_state_plan_yields_null_for_a_missing_stream()
+    {
+        await using var query = theStore.QuerySession();
+
+        (await query.QueryByPlanAsync(new FetchStreamStatePlan(Guid.NewGuid()))).ShouldBeNull();
+
+        var batch = query.CreateBatchQuery();
+        var fetcher = batch.QueryByPlan(new FetchStreamStatePlan(Guid.NewGuid()));
+        await batch.Execute();
+        (await fetcher).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task fetch_stream_plan_standalone()
+    {
+        var streamId = await StartQuestStreamAsync();
+
+        await using var query = theStore.QuerySession();
+        var events = await query.QueryByPlanAsync(new FetchStreamPlan(streamId));
+
+        events.Count.ShouldBe(3);
+        events.Select(x => x.Version).ShouldBe([1, 2, 3]);
+        events[0].Data.ShouldBeOfType<QuestStarted>().Name.ShouldBe("Quest 1");
+    }
+
+    [Fact]
+    public async Task fetch_stream_plan_batched()
+    {
+        var streamId = await StartQuestStreamAsync();
+
+        await using var query = theStore.QuerySession();
+        var batch = query.CreateBatchQuery();
+        var fetcher = batch.QueryByPlan(new FetchStreamPlan(streamId));
+        await batch.Execute();
+
+        var events = await fetcher;
+        events.Count.ShouldBe(3);
+        events.Select(x => x.Version).ShouldBe([1, 2, 3]);
+        events.ShouldAllBe(x => x.StreamId == streamId);
+    }
+
+    [Fact]
+    public async Task fetch_stream_plan_honors_the_version_cap()
+    {
+        var streamId = await StartQuestStreamAsync();
+
+        await using var query = theStore.QuerySession();
+
+        // Standalone and batched must apply the filter identically — the batched item composes its own
+        // SQL, so the cap is the thing most likely to drift between the two paths.
+        var standalone = await query.QueryByPlanAsync(new FetchStreamPlan(streamId, version: 2));
+        standalone.Count.ShouldBe(2);
+
+        var batch = query.CreateBatchQuery();
+        var fetcher = batch.QueryByPlan(new FetchStreamPlan(streamId, version: 2));
+        await batch.Execute();
+        (await fetcher).Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task fetch_stream_plan_honors_from_version()
+    {
+        var streamId = await StartQuestStreamAsync();
+
+        await using var query = theStore.QuerySession();
+        var batch = query.CreateBatchQuery();
+        var fetcher = batch.QueryByPlan(new FetchStreamPlan(streamId, fromVersion: 3));
+        await batch.Execute();
+
+        var events = await fetcher;
+        events.Count.ShouldBe(1);
+        events[0].Version.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task fetch_stream_plan_yields_an_empty_list_for_a_missing_stream()
+    {
+        await using var query = theStore.QuerySession();
+
+        (await query.QueryByPlanAsync(new FetchStreamPlan(Guid.NewGuid()))).ShouldBeEmpty();
+
+        var batch = query.CreateBatchQuery();
+        var fetcher = batch.QueryByPlan(new FetchStreamPlan(Guid.NewGuid()));
+        await batch.Execute();
+        (await fetcher).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task both_plans_share_one_round_trip_with_document_loads()
+    {
+        var streamId = await StartQuestStreamAsync();
+
+        var target = new Target { Id = Guid.NewGuid(), Color = "Blue", Number = 7 };
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Store(target);
+            await session.SaveChangesAsync();
+        }
+
+        await using var query = theStore.QuerySession();
+        var batch = query.CreateBatchQuery();
+        var stateFetcher = batch.QueryByPlan(new FetchStreamStatePlan(streamId));
+        var eventsFetcher = batch.QueryByPlan(new FetchStreamPlan(streamId));
+        var docFetcher = batch.Load<Target>(target.Id);
+        await batch.Execute();
+
+        (await stateFetcher)!.Version.ShouldBe(3);
+        (await eventsFetcher).Count.ShouldBe(3);
+        (await docFetcher)!.Number.ShouldBe(7);
+    }
+
+    private async Task<Guid> StartQuestStreamAsync()
+    {
+        var streamId = Guid.NewGuid();
+        await using var session = theStore.LightweightSession();
+        session.Events.StartStream(streamId,
+            new QuestStarted("Quest 1"), new QuestStarted("Quest 2"), new QuestStarted("Quest 3"));
+        await session.SaveChangesAsync();
+        return streamId;
+    }
+}
+
+/// <summary>
+///     #370: the string-identity half. Stream identity is fixed at store construction, so the
+///     <c>streamKey</c> constructor overloads need their own store rather than the shared Guid fixture.
+/// </summary>
+public class fetching_stream_query_plans_by_string_key : IAsyncLifetime
+{
+    private const string Schema = "fetch_stream_plans_str";
+    private DocumentStore _store = null!;
+
+    public Task InitializeAsync()
+    {
+        _store = DocumentStore.For(opts =>
+        {
+            opts.ConnectionString = ConnectionSource.ConnectionString;
+            opts.DatabaseSchemaName = Schema;
+            opts.AutoCreateSchemaObjects = AutoCreate.All;
+            opts.UseNativeJsonType = ConnectionSource.SupportsNativeJson;
+            opts.Events.StreamIdentity = StreamIdentity.AsString;
+        });
+
+        return Task.CompletedTask;
+    }
+
+    public Task DisposeAsync()
+    {
+        _store.Dispose();
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task both_plans_resolve_a_string_keyed_stream()
+    {
+        var streamKey = "quest/" + Guid.NewGuid().ToString("N");
+
+        await using (var session = _store.LightweightSession())
+        {
+            session.Events.StartStream(streamKey, new QuestStarted("A"), new QuestStarted("B"));
+            await session.SaveChangesAsync();
+        }
+
+        await using var query = _store.QuerySession();
+
+        var state = await query.QueryByPlanAsync(new FetchStreamStatePlan(streamKey));
+        state.ShouldNotBeNull();
+        state.Key.ShouldBe(streamKey);
+        state.Version.ShouldBe(2);
+
+        var batch = query.CreateBatchQuery();
+        var stateFetcher = batch.QueryByPlan(new FetchStreamStatePlan(streamKey));
+        var eventsFetcher = batch.QueryByPlan(new FetchStreamPlan(streamKey));
+        await batch.Execute();
+
+        (await stateFetcher)!.Key.ShouldBe(streamKey);
+        var events = await eventsFetcher;
+        events.Count.ShouldBe(2);
+        events.ShouldAllBe(x => x.StreamKey == streamKey);
+    }
+}

--- a/src/Polecat/Batching/IBatchEvents.cs
+++ b/src/Polecat/Batching/IBatchEvents.cs
@@ -1,0 +1,51 @@
+using JasperFx.Events;
+
+namespace Polecat.Batching;
+
+/// <summary>
+///     The event-store surface of a batched query — the batched counterparts of
+///     <see cref="IQueryEventStore.FetchStreamStateAsync(Guid, CancellationToken)" /> and
+///     <see cref="IQueryEventStore.FetchStreamAsync(Guid, long, DateTimeOffset?, long, CancellationToken)" />.
+/// </summary>
+/// <remarks>
+///     #370 (parity with marten#5053). Reached through <see cref="IBatchedQuery.Events" />. Every method
+///     returns immediately with an unresolved <see cref="Task{T}" />; the task completes when
+///     <see cref="IBatchedQuery.Execute" /> runs the whole batch as a single round trip and walks its
+///     result sets in order.
+/// </remarks>
+public interface IBatchEvents
+{
+    /// <summary>
+    ///     Fetch the high level metadata about the stream identified by <paramref name="streamId" />.
+    ///     Yields null if the stream does not exist.
+    /// </summary>
+    Task<StreamState?> FetchStreamState(Guid streamId);
+
+    /// <summary>
+    ///     Fetch the high level metadata about the stream identified by <paramref name="streamKey" />.
+    ///     Yields null if the stream does not exist.
+    /// </summary>
+    Task<StreamState?> FetchStreamState(string streamKey);
+
+    /// <summary>
+    ///     Fetch the raw events of the stream identified by <paramref name="streamId" />. Yields an empty
+    ///     list if the stream does not exist.
+    /// </summary>
+    /// <param name="streamId"></param>
+    /// <param name="version">If set, fetches events up to and including this version</param>
+    /// <param name="timestamp">If set, fetches events captured on or before this timestamp</param>
+    /// <param name="fromVersion">If set, fetches events on or from this version</param>
+    Task<IReadOnlyList<IEvent>> FetchStream(Guid streamId, long version = 0,
+        DateTimeOffset? timestamp = null, long fromVersion = 0);
+
+    /// <summary>
+    ///     Fetch the raw events of the stream identified by <paramref name="streamKey" />. Yields an empty
+    ///     list if the stream does not exist.
+    /// </summary>
+    /// <param name="streamKey"></param>
+    /// <param name="version">If set, fetches events up to and including this version</param>
+    /// <param name="timestamp">If set, fetches events captured on or before this timestamp</param>
+    /// <param name="fromVersion">If set, fetches events on or from this version</param>
+    Task<IReadOnlyList<IEvent>> FetchStream(string streamKey, long version = 0,
+        DateTimeOffset? timestamp = null, long fromVersion = 0);
+}

--- a/src/Polecat/Batching/IBatchedQuery.cs
+++ b/src/Polecat/Batching/IBatchedQuery.cs
@@ -15,6 +15,13 @@ public interface IBatchedQuery
     IQuerySession Parent { get; }
 
     /// <summary>
+    ///     The batched event store fetches — <c>FetchStreamState</c> and <c>FetchStream</c> — so a raw
+    ///     stream read can share the batch's single round trip with document loads and LINQ queries.
+    ///     See <see cref="IBatchEvents" /> (#370).
+    /// </summary>
+    IBatchEvents Events { get; }
+
+    /// <summary>
     ///     Check if a document of type T with the given Guid id exists in the database
     ///     without loading or deserializing the document.
     /// </summary>

--- a/src/Polecat/Events/EventGraph.cs
+++ b/src/Polecat/Events/EventGraph.cs
@@ -341,6 +341,47 @@ public class EventGraph : EventRegistry, IAggregationSourceFactory<IQuerySession
             $"Unknown aggregate type name '{aggregateTypeName}'.");
     }
 
+    /// <summary>
+    ///     #370: resolve the alias persisted in <c>pc_streams.type</c> back to its aggregate type, or null
+    ///     when this deployment has no registration for it.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///     Unlike <see cref="AggregateTypeFor" /> this never throws: a stream tagged by a deployment that
+    ///     knew a type this one does not must still report its version and timestamps.
+    ///     </para>
+    ///     <para>
+    ///     <c>_aggregateTypes</c> alone is not enough. It is only populated by
+    ///     <see cref="AggregateAliasFor" />, which JasperFx.Events calls from
+    ///     <c>StreamAction.PrepareEvents</c> — a path Polecat's QuickAppend closed-shape writer does not go
+    ///     through, since the SQL Server dialect writes <c>stream.AggregateType?.Name</c> straight into the
+    ///     column. So the registered projections are the primary source and the map is the fallback,
+    ///     matching what the event store explorer's <c>ResolveAggregateType</c> already does.
+    ///     </para>
+    /// </remarks>
+    internal Type? TryResolveAggregateType(string? aggregateTypeName)
+    {
+        if (string.IsNullOrEmpty(aggregateTypeName)) return null;
+
+        if (_aggregateTypes.TryGetValue(aggregateTypeName, out var known)) return known;
+
+        foreach (var source in _options.Projections.All)
+        {
+            foreach (var published in source.PublishedTypes())
+            {
+                if (string.Equals(published.Name, aggregateTypeName, StringComparison.Ordinal)
+                    || string.Equals(published.FullName, aggregateTypeName, StringComparison.Ordinal))
+                {
+                    // Cache it so the next row on this reader is a dictionary hit.
+                    _aggregateTypes.TryAdd(aggregateTypeName, published);
+                    return published;
+                }
+            }
+        }
+
+        return null;
+    }
+
     public override string AggregateAliasFor(Type aggregateType)
     {
         _aggregateTypes.TryAdd(aggregateType.Name, aggregateType);

--- a/src/Polecat/Events/Internal/PcStreamsRowReader.cs
+++ b/src/Polecat/Events/Internal/PcStreamsRowReader.cs
@@ -44,7 +44,17 @@ internal static class PcStreamsRowReader
     ///     <see cref="StreamState"/>. The caller is responsible for
     ///     <c>await reader.ReadAsync(...)</c> beforehand.
     /// </summary>
-    internal static StreamState ReadStreamState(DbDataReader reader, StreamIdentity streamIdentity)
+    /// <param name="reader"></param>
+    /// <param name="streamIdentity"></param>
+    /// <param name="events">
+    ///     Supply to resolve the <c>type</c> column's alias into
+    ///     <see cref="StreamState.AggregateType"/>. #370: the column has always been projected but never
+    ///     read, so <c>AggregateType</c> came back null on every stream that was in fact tagged with an
+    ///     aggregate type. An unregistered alias resolves to null rather than throwing — a stream tagged
+    ///     by a deployment that knew a type this one does not is not an error for a metadata read.
+    /// </param>
+    internal static StreamState ReadStreamState(DbDataReader reader, StreamIdentity streamIdentity,
+        EventGraph? events = null)
     {
         var state = new StreamState
         {
@@ -53,6 +63,11 @@ internal static class PcStreamsRowReader
             LastTimestamp = reader.GetFieldValue<DateTimeOffset>(4),
             IsArchived = reader.GetBoolean(6)
         };
+
+        if (events != null && !reader.IsDBNull(1))
+        {
+            state.AggregateType = events.TryResolveAggregateType(reader.GetString(1));
+        }
 
         if (streamIdentity == StreamIdentity.AsGuid)
         {

--- a/src/Polecat/Events/QueryEventStore.cs
+++ b/src/Polecat/Events/QueryEventStore.cs
@@ -288,7 +288,7 @@ internal class QueryEventStore : IQueryEventStore, IReadOnlyEventStore
         await using var reader = await _session.ExecuteReaderAsync(cmd, token);
         if (await reader.ReadAsync(token))
         {
-            return PcStreamsRowReader.ReadStreamState(reader, _events.StreamIdentity);
+            return PcStreamsRowReader.ReadStreamState(reader, _events.StreamIdentity, _events);
         }
 
         return null;

--- a/src/Polecat/IQueryPlan.cs
+++ b/src/Polecat/IQueryPlan.cs
@@ -1,3 +1,4 @@
+using JasperFx.Events;
 using Polecat.Batching;
 using Polecat.Internal.Batching;
 using Polecat.Linq;
@@ -53,5 +54,125 @@ public abstract class QueryListPlan<T> : IQueryPlan<IReadOnlyList<T>>, IBatchQue
 
         // Fallback for non-Polecat batch implementations
         return Query(query.Parent).ToListAsync();
+    }
+}
+
+/// <summary>
+///     Query plan for the high level metadata of a single event stream, identified by either a Guid
+///     stream id or a string stream key. Yields null if the stream does not exist.
+/// </summary>
+/// <remarks>
+///     #370 (parity with marten#5053). Implements <b>both</b> <see cref="IQueryPlan{T}" /> and
+///     <see cref="IBatchQueryPlan{T}" />, so the same plan instance works with
+///     <c>session.QueryByPlanAsync()</c> and <c>batch.QueryByPlan()</c>. Implementing only the batched
+///     half matters beyond convenience: through Wolverine's fetch-specification feature, a plan that is
+///     only an <see cref="IBatchQueryPlan{T}" /> produces uncompilable generated code.
+/// </remarks>
+public class FetchStreamStatePlan : IQueryPlan<StreamState?>, IBatchQueryPlan<StreamState?>
+{
+    private readonly Guid _streamId;
+    private readonly string? _streamKey;
+
+    /// <summary>
+    ///     Fetch the stream state for the stream identified by <paramref name="streamId" />.
+    /// </summary>
+    public FetchStreamStatePlan(Guid streamId)
+    {
+        _streamId = streamId;
+    }
+
+    /// <summary>
+    ///     Fetch the stream state for the stream identified by <paramref name="streamKey" />.
+    /// </summary>
+    public FetchStreamStatePlan(string streamKey)
+    {
+        _streamKey = streamKey ?? throw new ArgumentNullException(nameof(streamKey));
+    }
+
+    public Task<StreamState?> Fetch(IQuerySession session, CancellationToken token)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+
+        return _streamKey is not null
+            ? session.Events.FetchStreamStateAsync(_streamKey, token)
+            : session.Events.FetchStreamStateAsync(_streamId, token);
+    }
+
+    public Task<StreamState?> Fetch(IBatchedQuery query)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        return _streamKey is not null
+            ? query.Events.FetchStreamState(_streamKey)
+            : query.Events.FetchStreamState(_streamId);
+    }
+}
+
+/// <summary>
+///     Query plan for the raw events of a single event stream, identified by either a Guid stream id or
+///     a string stream key, carrying <c>FetchStream</c>'s optional <c>version</c> / <c>timestamp</c> /
+///     <c>fromVersion</c> filters. Yields an empty list if the stream does not exist.
+/// </summary>
+/// <remarks>
+///     #370 (parity with marten#5053). Implements both <see cref="IQueryPlan{T}" /> and
+///     <see cref="IBatchQueryPlan{T}" /> — see <see cref="FetchStreamStatePlan" /> for why the pair
+///     matters.
+/// </remarks>
+public class FetchStreamPlan : IQueryPlan<IReadOnlyList<IEvent>>, IBatchQueryPlan<IReadOnlyList<IEvent>>
+{
+    private readonly Guid _streamId;
+    private readonly string? _streamKey;
+    private readonly long _version;
+    private readonly DateTimeOffset? _timestamp;
+    private readonly long _fromVersion;
+
+    /// <summary>
+    ///     Fetch the events for the stream identified by <paramref name="streamId" />.
+    /// </summary>
+    /// <param name="streamId"></param>
+    /// <param name="version">If set, queries for events up to and including this version</param>
+    /// <param name="timestamp">If set, queries for events captured on or before this timestamp</param>
+    /// <param name="fromVersion">If set, queries for events on or from this version</param>
+    public FetchStreamPlan(Guid streamId, long version = 0, DateTimeOffset? timestamp = null,
+        long fromVersion = 0)
+    {
+        _streamId = streamId;
+        _version = version;
+        _timestamp = timestamp;
+        _fromVersion = fromVersion;
+    }
+
+    /// <summary>
+    ///     Fetch the events for the stream identified by <paramref name="streamKey" />.
+    /// </summary>
+    /// <param name="streamKey"></param>
+    /// <param name="version">If set, queries for events up to and including this version</param>
+    /// <param name="timestamp">If set, queries for events captured on or before this timestamp</param>
+    /// <param name="fromVersion">If set, queries for events on or from this version</param>
+    public FetchStreamPlan(string streamKey, long version = 0, DateTimeOffset? timestamp = null,
+        long fromVersion = 0)
+    {
+        _streamKey = streamKey ?? throw new ArgumentNullException(nameof(streamKey));
+        _version = version;
+        _timestamp = timestamp;
+        _fromVersion = fromVersion;
+    }
+
+    public Task<IReadOnlyList<IEvent>> Fetch(IQuerySession session, CancellationToken token)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+
+        return _streamKey is not null
+            ? session.Events.FetchStreamAsync(_streamKey, _version, _timestamp, _fromVersion, token)
+            : session.Events.FetchStreamAsync(_streamId, _version, _timestamp, _fromVersion, token);
+    }
+
+    public Task<IReadOnlyList<IEvent>> Fetch(IBatchedQuery query)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        return _streamKey is not null
+            ? query.Events.FetchStream(_streamKey, _version, _timestamp, _fromVersion)
+            : query.Events.FetchStream(_streamId, _version, _timestamp, _fromVersion);
     }
 }

--- a/src/Polecat/Internal/Batching/BatchEvents.cs
+++ b/src/Polecat/Internal/Batching/BatchEvents.cs
@@ -1,0 +1,56 @@
+using JasperFx.Events;
+using Polecat.Batching;
+using Polecat.Events;
+
+namespace Polecat.Internal.Batching;
+
+/// <summary>
+///     #370: <see cref="IBatchEvents" /> over <see cref="BatchedQuery" />. Each call appends one item to
+///     the batch and hands back its unresolved task; the tasks complete when
+///     <see cref="BatchedQuery.Execute" /> walks the result sets.
+/// </summary>
+internal class BatchEvents : IBatchEvents
+{
+    private readonly BatchedQuery _parent;
+    private readonly QuerySession _session;
+
+    public BatchEvents(BatchedQuery parent, QuerySession session)
+    {
+        _parent = parent;
+        _session = session;
+    }
+
+    public Task<StreamState?> FetchStreamState(Guid streamId) => AddStateItem(streamId);
+
+    public Task<StreamState?> FetchStreamState(string streamKey)
+        => AddStateItem(streamKey ?? throw new ArgumentNullException(nameof(streamKey)));
+
+    public Task<IReadOnlyList<IEvent>> FetchStream(Guid streamId, long version = 0,
+        DateTimeOffset? timestamp = null, long fromVersion = 0)
+        => AddStreamItem(streamId, version, timestamp, fromVersion);
+
+    public Task<IReadOnlyList<IEvent>> FetchStream(string streamKey, long version = 0,
+        DateTimeOffset? timestamp = null, long fromVersion = 0)
+        => AddStreamItem(streamKey ?? throw new ArgumentNullException(nameof(streamKey)),
+            version, timestamp, fromVersion);
+
+    private Task<StreamState?> AddStateItem(object streamId)
+    {
+        var item = new FetchStreamStateBatchItem(EventGraph(), streamId, _session.TenantId);
+        _parent.RequireEventStore();
+        _parent.AddItem(item);
+        return item.Result;
+    }
+
+    private Task<IReadOnlyList<IEvent>> AddStreamItem(object streamId, long version,
+        DateTimeOffset? timestamp, long fromVersion)
+    {
+        var item = new FetchStreamBatchItem(EventGraph(), _session.Serializer, streamId, _session.TenantId,
+            version, timestamp, fromVersion);
+        _parent.RequireEventStore();
+        _parent.AddItem(item);
+        return item.Result;
+    }
+
+    private EventGraph EventGraph() => _session.Options.EventGraph;
+}

--- a/src/Polecat/Internal/Batching/BatchedQuery.cs
+++ b/src/Polecat/Internal/Batching/BatchedQuery.cs
@@ -26,7 +26,18 @@ internal class BatchedQuery : IBatchedQuery
 
     public IQuerySession Parent => _session;
 
+    // #370: lazily built so a batch that never touches the event store pays nothing for it.
+    public IBatchEvents Events => _events ??= new BatchEvents(this, _session);
+    private IBatchEvents? _events;
+
     internal void AddItem(IBatchQueryItem item) => _items.Add(item);
+
+    // #219 create-on-first-use: the standalone FetchStream/FetchStreamState calls ensure the event store
+    // schema before reading. A batched fetch has to do the same, or the very first event read against a
+    // fresh store fails on a missing table. Flagged rather than ensured eagerly so a document-only batch
+    // never pays for it.
+    internal void RequireEventStore() => _needsEventStore = true;
+    private bool _needsEventStore;
 
     internal void TrackProvider(DocumentProvider provider) => _involvedProviders.Add(provider);
 
@@ -103,6 +114,11 @@ internal class BatchedQuery : IBatchedQuery
 
         // Ensure tables exist for all involved document types
         await _tableEnsurer.EnsureTablesAsync(_involvedProviders, token);
+
+        if (_needsEventStore)
+        {
+            await _tableEnsurer.EnsureEventStoreSchemaAsync(token);
+        }
 
         // Build the combined batch (connection-less; lifetime sets it at execution)
         await using var batch = new SqlBatch();

--- a/src/Polecat/Internal/Batching/FetchStreamBatchItem.cs
+++ b/src/Polecat/Internal/Batching/FetchStreamBatchItem.cs
@@ -1,0 +1,107 @@
+using System.Data;
+using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
+using JasperFx.Events;
+using Polecat.Events;
+using Polecat.Events.Internal;
+using Polecat.Serialization;
+using Weasel.SqlServer;
+
+namespace Polecat.Internal.Batching;
+
+/// <summary>
+///     #370: the batched half of <c>QueryEventStore.FetchStreamAsync</c>, carrying the same optional
+///     <c>version</c> / <c>timestamp</c> / <c>fromVersion</c> filters. Composes its projection with
+///     <see cref="PcEventsRowReader" /> and hydrates through the same readers as the standalone fetch,
+///     so the two can never drift apart across a schema migration.
+/// </summary>
+[UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
+    Justification = "Class-level: hydrates IEvent batches via PcEventsRowReader (routed through ISerializer.FromJson). Event types are preserved by EventGraph registration on the caller side per the AOT publishing guide.")]
+[UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+    Justification = "Class-level: ISerializer.FromJson and Event<T>.MakeGenericType are annotated RDC. AOT consumers register concrete event types ahead of time.")]
+internal class FetchStreamBatchItem : IBatchQueryItem
+{
+    private readonly TaskCompletionSource<IReadOnlyList<IEvent>> _tcs = new();
+    private readonly EventGraph _events;
+    private readonly ISerializer _serializer;
+    private readonly object _streamId;
+    private readonly string _tenantId;
+    private readonly long _version;
+    private readonly DateTimeOffset? _timestamp;
+    private readonly long _fromVersion;
+
+    public FetchStreamBatchItem(EventGraph events, ISerializer serializer, object streamId, string tenantId,
+        long version, DateTimeOffset? timestamp, long fromVersion)
+    {
+        _events = events;
+        _serializer = serializer;
+        _streamId = streamId;
+        _tenantId = tenantId;
+        _version = version;
+        _timestamp = timestamp;
+        _fromVersion = fromVersion;
+    }
+
+    public Task<IReadOnlyList<IEvent>> Result => _tcs.Task;
+
+    public void WriteSql(ICommandBuilder builder)
+    {
+        builder.Append(
+            $"SELECT {PcEventsRowReader.ComposeSelectColumns(_events.EventOptions)} FROM {_events.EventsTableName} WHERE stream_id = ");
+        builder.AppendParameter(_streamId, _streamId is string ? SqlDbType.VarChar : null);
+        builder.Append(" AND tenant_id = ");
+        builder.AppendParameter(_tenantId, SqlDbType.VarChar);
+        builder.Append(" AND is_archived = 0");
+
+        if (_version > 0)
+        {
+            builder.Append(" AND version <= ");
+            builder.AppendParameter(_version);
+        }
+
+        if (_timestamp.HasValue)
+        {
+            builder.Append(" AND timestamp <= ");
+            builder.AppendParameter(_timestamp.Value);
+        }
+
+        if (_fromVersion > 0)
+        {
+            builder.Append(" AND version >= ");
+            builder.AppendParameter(_fromVersion);
+        }
+
+        builder.Append(" ORDER BY version;\n");
+    }
+
+    public async Task ReadResultSetAsync(DbDataReader reader, CancellationToken token)
+    {
+        var ctx = new EventHydrationContext(_events, _serializer, _streamId, defaultTenantId: _tenantId);
+
+        // Same per-batch hoists as the standalone fetch: metadata ordinals computed once, a single-slot
+        // type→mapping cache, and the StreamIdentity specialization picked once rather than per row.
+        var slots = MetadataSlots.Compute(_events.EventOptions);
+        var cache = new EventTypeCache();
+
+        var results = new List<IEvent>();
+
+        if (_events.StreamIdentity == StreamIdentity.AsGuid)
+        {
+            while (await reader.ReadAsync(token).ConfigureAwait(false))
+            {
+                var @event = PcEventsRowReader.ReadEventAsGuid(reader, ctx, slots, ref cache);
+                if (@event != null) results.Add(@event);
+            }
+        }
+        else
+        {
+            while (await reader.ReadAsync(token).ConfigureAwait(false))
+            {
+                var @event = PcEventsRowReader.ReadEventAsString(reader, ctx, slots, ref cache);
+                if (@event != null) results.Add(@event);
+            }
+        }
+
+        _tcs.SetResult(results);
+    }
+}

--- a/src/Polecat/Internal/Batching/FetchStreamStateBatchItem.cs
+++ b/src/Polecat/Internal/Batching/FetchStreamStateBatchItem.cs
@@ -1,0 +1,52 @@
+using System.Data;
+using System.Data.Common;
+using JasperFx.Events;
+using Polecat.Events;
+using Polecat.Events.Internal;
+using Weasel.SqlServer;
+
+namespace Polecat.Internal.Batching;
+
+/// <summary>
+///     #370: the batched half of <c>QueryEventStore.FetchStreamStateAsync</c>. Reads the same
+///     <c>pc_streams</c> column projection through the same <see cref="PcStreamsRowReader" />, so a
+///     batched fetch and a standalone one can never drift apart across a schema migration.
+/// </summary>
+internal class FetchStreamStateBatchItem : IBatchQueryItem
+{
+    private readonly TaskCompletionSource<StreamState?> _tcs = new();
+    private readonly EventGraph _events;
+    private readonly object _streamId;
+    private readonly string _tenantId;
+
+    public FetchStreamStateBatchItem(EventGraph events, object streamId, string tenantId)
+    {
+        _events = events;
+        _streamId = streamId;
+        _tenantId = tenantId;
+    }
+
+    public Task<StreamState?> Result => _tcs.Task;
+
+    public void WriteSql(ICommandBuilder builder)
+    {
+        builder.Append($"SELECT {PcStreamsRowReader.SelectColumns} FROM {_events.StreamsTableName} WHERE id = ");
+        builder.AppendParameter(_streamId, _streamId is string ? SqlDbType.VarChar : null);
+        builder.Append(" AND tenant_id = ");
+        builder.AppendParameter(_tenantId, SqlDbType.VarChar);
+        builder.Append(";\n");
+    }
+
+    public async Task ReadResultSetAsync(DbDataReader reader, CancellationToken token)
+    {
+        if (await reader.ReadAsync(token).ConfigureAwait(false))
+        {
+            _tcs.SetResult(PcStreamsRowReader.ReadStreamState(reader, _events.StreamIdentity, _events));
+        }
+        else
+        {
+            // A stream that does not exist is null, not an error — same answer as the standalone fetch.
+            _tcs.SetResult(null);
+        }
+    }
+}


### PR DESCRIPTION
Parity port of [marten#5053](https://github.com/JasperFx/marten/pull/5053) (which supersedes marten#5043, original plans by @uniquelau). Polecat already had the matching `IQueryPlan<T>` / `IBatchQueryPlan<T>` / `QueryListPlan<T>` abstractions and the `Stream*` result family, so this is a port rather than a design exercise.

Closes #370.

Both halves are here rather than plans-only. The issue calls that out and it is worth repeating: through Wolverine's fetch-specification feature, a plan implementing only `IBatchQueryPlan<T>` produces uncompilable generated code, so a partial implementation would have been actively worse than none.

## Part 1 — the batched event surface (the prerequisite)

`Polecat.Batching.IBatchedQuery` had `QueryByPlan`, `Load`/`LoadMany`/`CheckExists`, `EventsExist` and `FetchForWritingByTags`, but no `Events` surface at all — no batched counterpart to `QueryEventStore.FetchStreamAsync` / `FetchStreamStateAsync`.

* New `IBatchEvents`, reached as `batch.Events`, with `FetchStreamState` and `FetchStream` in `Guid` and `string` overloads. `FetchStream` carries the same optional `version` / `timestamp` / `fromVersion` filters as the standalone fetch.
* Two new batch items compose their SQL from the **same** canonical projections (`PcStreamsRowReader.SelectColumns`, `PcEventsRowReader.ComposeSelectColumns`) and hydrate through the **same** readers as the standalone path, so a batched fetch and a standalone one cannot drift apart across a schema migration. Same per-batch hoists too — metadata ordinals computed once, single-slot type→mapping cache, `StreamIdentity` specialization picked once rather than per row.
* The batch now ensures the event store schema when it holds an event item (#219 create-on-first-use). Flagged rather than ensured eagerly, so a document-only batch pays nothing for it.

`IBatchedQuery` is a public interface, so the new `Events` member is technically breaking for anyone who implements it outside Polecat. Same call Marten made with `IBatchEvents`, and the interface is store-owned in practice.

## Also fixed: `StreamState.AggregateType` was never populated

Not in the issue, but the port surfaced it and it would have shipped a dead wire field. `pc_streams.type` has always been in the canonical projection and never read back, so `StreamState.AggregateType` came back null for every stream — which would have made `StreamStateResponse.AggregateTypeName` structurally always-null on a brand new HTTP contract.

The alias is written by the SQL Server dialect straight from `stream.AggregateType?.Name`, and the JasperFx path that would register it for lookup (`StreamAction.PrepareEvents` → `AggregateAliasFor`) is one Polecat's QuickAppend closed-shape writer never goes through — so `EventGraph.AggregateTypeFor` could never resolve it. New `EventGraph.TryResolveAggregateType` resolves against the registered projections first (the same strategy `DocumentStore.EventStoreExplorer.ResolveAggregateType` already used), caches the hit, and returns null instead of throwing for an alias this deployment does not know — a stream tagged by a deployment that knew a type this one does not must still report its version and timestamps.

This fixes `FetchStreamStateAsync` for every caller, not just the new endpoint. Covered both ways: a stream tagged with a registered aggregate resolves standalone and batched, an untagged stream reports null.

## Part 2 — the plans

`FetchStreamStatePlan` and `FetchStreamPlan` in the `Polecat` namespace, both implementing `IQueryPlan<T>` **and** `IBatchQueryPlan<T>`, both with `Guid streamId` / `string streamKey` constructor overloads. `FetchStreamStatePlan` yields null for a missing stream; `FetchStreamPlan` yields an empty list.

## Part 3 — `Polecat.AspNetCore`

`StreamEventState` and `StreamEvents`, the event-side siblings of `StreamAggregate<T>`, backed by the plans above. Both implement `IResult` and `IEndpointMetadataProvider`, both take `Guid` / `string` / pre-built-plan constructors, and both delegate the body write to new `WriteStreamState` / `WriteEvents` extensions on `IQuerySession`.

Two things carried over verbatim from upstream:

**Neither writes the framework's own types to the wire, because neither can.** `StreamState.AggregateType` and `IEvent.EventType` are `System.Type`, and System.Text.Json refuses to serialize those outright — a result that serialized them naively fails at runtime for every user. `StreamStateResponse` and `EventResponse` project them down: the aggregate type reduces to its simple name, and `IEvent`'s assembly-qualified `DotNetTypeName` is deliberately kept off the wire, leaving `EventTypeName` as the client-side discriminator. Property names match Marten's DTOs so clients can move between the two stores unchanged.

**Empty streams are ambiguous.** `FetchStream` yields an empty list both for a stream that does not exist and for a filter that excludes every event. `StreamEvents.OnEmptyStatus` defaults to `404` to match the other single-resource results; set it to `200` to return an empty array, which is what you want paging forward with `fromVersion`.

Serialization buffers through an `ArrayBufferWriter<byte>` so the JSON never round-trips through a .NET string, and `Content-Length` is set on both responses.

## Tests

* `batch_event_fetching` — the batched surface directly: state and stream fetches, missing-stream answers, each optional filter (including a dedicated timestamp case, the one parameter whose binding differs in kind from the rest), agreement with the standalone fetch row for row, and an interleaved batch of event fetches and a document load where a mis-ordered result set would surface as a cross-wired answer rather than a clean error.
* `fetching_stream_query_plans` — each plan standalone and batched, missing stream, version cap, `fromVersion`, both plans sharing one round trip with a document load, plus a separate string-identity store for the `streamKey` overloads.
* `stream_event_result_types_tests` — 12 Alba tests over real Minimal API endpoints: both result types, the plan constructor, the `OnEmptyStatus` opt-out (including paging off the end of a stream that really exists), `Content-Length`, the serialized event body, the alias-not-dotnet-type wire contract, and OpenAPI metadata.

## Docs

Sections in `documents/querying/batched-queries.md` (batched event fetches + event stream query plans), `events/querying.md` (stream fetches as query plans), and `documents/aspnetcore.md` (the two result types, the DTO rationale, and the empty-stream ambiguity).
