### PR TITLE
test(#374): give Polecat.AspNetCore.Testing its own schema so it can run back-to-back with Polecat.Tests

### DIFF
--- a/src/Polecat.AspNetCore.Testing/Program.cs
+++ b/src/Polecat.AspNetCore.Testing/Program.cs
@@ -14,6 +14,16 @@ var builder = WebApplication.CreateBuilder(new WebApplicationOptions
 builder.Services.AddPolecat(opts =>
 {
     opts.ConnectionString = ConnectionSource.ConnectionString;
+
+    // #374: an isolated schema, NOT the default dbo. Polecat.Tests owns dbo, and its per-tenant
+    // partitioning coverage reshapes dbo.pc_streams; this host's ApplyAllConfiguredChangesToDatabaseAsync
+    // would then try to migrate that back, which means dropping the pc_streams primary key that
+    // pc_events has a foreign key onto — "Could not drop constraint", 37 failures that look exactly
+    // like a regression in whatever you just changed. CI never sees it (fresh database per project),
+    // so it only ever bites locally. Mirrors what Polecat.EntityFrameworkCore.Tests and this
+    // assembly's own HighWaterHealthCheckTests already do.
+    opts.DatabaseSchemaName = "polecat_aspnetcore";
+
     opts.UseNativeJsonType = ConnectionSource.SupportsNativeJson;
     opts.AutoCreateSchemaObjects = AutoCreate.All;
     opts.Events.StreamIdentity = StreamIdentity.AsGuid;


### PR DESCRIPTION
Closes #374.

The Alba host registered its store with no `DatabaseSchemaName`, so it landed in the default `dbo` — the same schema `Polecat.Tests` owns. Running the two suites back to back locally failed **37 of 65** AspNetCore tests with:

```
The constraint 'pkey_pc_streams_id' is being referenced by table 'pc_events',
foreign key constraint 'fk_pc_events_stream_id'. Could not drop constraint.
```

The cause is schema **shape** drift, not leftover rows. `Polecat.Tests` includes per-tenant partitioning coverage that reshapes `dbo.pc_streams`; the AspNetCore host's `ApplyAllConfiguredChangesToDatabaseAsync()` then tries to migrate it back, which means dropping the primary key `pc_events` has a foreign key onto.

CI never sees this because each project gets a fresh database — so it only ever bites locally, which is the worst place for it. It looks exactly like a regression in whatever you just changed, and I lost time to precisely that while working on #370.

## The change

One line: the host gets `polecat_aspnetcore`. This mirrors what `Polecat.EntityFrameworkCore.Tests` already does (`efcore_ss_*`, `efcore_ms_*`, …) and what this assembly's own `HighWaterHealthCheckTests` already does (`hw_health_*`). Nothing in the project hardcodes `dbo`, and everything else goes through the host's store, so the host config is the only thing that needed to move.

## Verification

Ran the acceptance case end to end rather than just re-running the suite in isolation:

1. Dropped the new schema's tables so the host built from scratch.
2. Full `Polecat.Tests` — **1594 passed**, leaving `dbo.pc_streams` in the reshaped state.
3. `Polecat.AspNetCore.Testing` immediately after, **no cleanup in between** — **65/65**.

Step 3 is the exact point that previously produced the 37 failures.