### PR TITLE
fix(#373): make StreamState.AggregateType resolution robust and single-sourced

### DIFF
--- a/src/Polecat.Tests/Batching/batch_event_fetching.cs
+++ b/src/Polecat.Tests/Batching/batch_event_fetching.cs
@@ -1,5 +1,3 @@
-using JasperFx.Events.Projections;
-using Polecat.Projections;
 using Polecat.Tests.Harness;
 using Shouldly;
 
@@ -39,14 +37,14 @@ public class batch_event_fetching : IntegrationContext
     ///     <c>StreamState.AggregateType</c> came back null on every stream — which would have made the
     ///     <c>StreamStateResponse.AggregateTypeName</c> wire field structurally dead. Both the standalone
     ///     and batched reads resolve it now.
+    ///     <para>
+    ///     #373 dropped the projection registration this test used to need: the stream writer registers the
+    ///     alias as it stamps it, so a plain <c>StartStream&lt;T&gt;</c> tag is enough.
+    ///     </para>
     /// </summary>
     [Fact]
     public async Task stream_state_reports_the_aggregate_type_it_was_tagged_with()
     {
-        await StoreOptions(opts =>
-            opts.Projections.Add<SingleStreamProjection<BatchTaggedAggregate, Guid>>(
-                ProjectionLifecycle.Live));
-
         var streamId = Guid.NewGuid();
         await using (var session = theStore.LightweightSession())
         {

--- a/src/Polecat.Tests/Events/aggregate_type_resolution_tests.cs
+++ b/src/Polecat.Tests/Events/aggregate_type_resolution_tests.cs
@@ -1,0 +1,180 @@
+using JasperFx;
+using JasperFx.Events;
+using JasperFx.Events.Projections;
+using Polecat.Projections;
+using Polecat.TestUtils;
+using Shouldly;
+
+namespace Polecat.Tests.Events;
+
+/// <summary>
+///     #373 (follow-up to #370): <c>StreamState.AggregateType</c> is resolved from the alias persisted in
+///     <c>pc_streams.type</c>. These pin the two sources that resolution draws on and the boundary where
+///     it honestly gives up.
+/// </summary>
+public class aggregate_type_resolution_tests : IAsyncLifetime
+{
+    private const string Schema = "aggregate_type_resolution";
+
+    public async Task InitializeAsync() => await DropSchemaTablesAsync(Schema);
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    private static DocumentStore CreateStore(bool registerProjection = false)
+    {
+        return DocumentStore.For(opts =>
+        {
+            opts.ConnectionString = ConnectionSource.ConnectionString;
+            opts.DatabaseSchemaName = Schema;
+            opts.AutoCreateSchemaObjects = AutoCreate.All;
+            opts.UseNativeJsonType = ConnectionSource.SupportsNativeJson;
+
+            if (registerProjection)
+            {
+                opts.Projections.Add<SingleStreamProjection<UnregisteredTag, Guid>>(ProjectionLifecycle.Live);
+            }
+        });
+    }
+
+    /// <summary>
+    ///     The gap #373 closes. <c>StartStream&lt;T&gt;</c> accepts any type, but before this the ONLY
+    ///     source for resolving the alias back was the registered projections — so an aggregate tagged onto
+    ///     a stream without a projection was unresolvable even in the very process that had just written it.
+    /// </summary>
+    [Fact]
+    public async Task the_writing_process_resolves_a_type_that_is_not_a_registered_projection()
+    {
+        using var store = CreateStore();
+
+        var streamId = Guid.NewGuid();
+        await using (var session = store.LightweightSession())
+        {
+            session.Events.StartStream<UnregisteredTag>(streamId, new AtrThingHappened("one"));
+            await session.SaveChangesAsync();
+        }
+
+        await using var query = store.QuerySession();
+        var state = await query.Events.FetchStreamStateAsync(streamId);
+
+        state.ShouldNotBeNull();
+        state.AggregateType.ShouldBe(typeof(UnregisteredTag));
+    }
+
+    /// <summary>
+    ///     The other source, and the one that survives a process restart: a store that did not write the
+    ///     stream has an empty alias registry, so resolution falls through to the registered projections.
+    /// </summary>
+    [Fact]
+    public async Task a_fresh_store_resolves_through_its_registered_projections()
+    {
+        var streamId = Guid.NewGuid();
+
+        using (var writer = CreateStore())
+        {
+            await using var session = writer.LightweightSession();
+            session.Events.StartStream<UnregisteredTag>(streamId, new AtrThingHappened("one"));
+            await session.SaveChangesAsync();
+        }
+
+        // A brand new store — nothing has populated its alias registry, exactly like another process or a
+        // later run reading rows it did not write.
+        using var reader = CreateStore(registerProjection: true);
+        await using var query = reader.QuerySession();
+
+        (await query.Events.FetchStreamStateAsync(streamId))!.AggregateType.ShouldBe(typeof(UnregisteredTag));
+    }
+
+    /// <summary>
+    ///     The boundary, stated honestly: a reader with neither the alias registered nor a matching
+    ///     projection cannot resolve the type — and must still answer the metadata read rather than throw.
+    ///     A stream tagged by a deployment that knew a type this one does not is not an error.
+    /// </summary>
+    [Fact]
+    public async Task an_unresolvable_alias_yields_a_null_type_rather_than_an_exception()
+    {
+        var streamId = Guid.NewGuid();
+
+        using (var writer = CreateStore())
+        {
+            await using var session = writer.LightweightSession();
+            session.Events.StartStream<UnregisteredTag>(streamId, new AtrThingHappened("one"));
+            await session.SaveChangesAsync();
+        }
+
+        using var reader = CreateStore();
+        await using var query = reader.QuerySession();
+
+        var state = await query.Events.FetchStreamStateAsync(streamId);
+        state.ShouldNotBeNull();
+        state.AggregateType.ShouldBeNull();
+
+        // Everything else on the row still reads.
+        state.Id.ShouldBe(streamId);
+        state.Version.ShouldBe(1);
+    }
+
+    /// <summary>
+    ///     #373: the batched read goes through the same resolver as the standalone one, so the two cannot
+    ///     disagree about what a given stream is tagged with.
+    /// </summary>
+    [Fact]
+    public async Task the_batched_read_agrees_with_the_standalone_read()
+    {
+        using var store = CreateStore();
+
+        var streamId = Guid.NewGuid();
+        await using (var session = store.LightweightSession())
+        {
+            session.Events.StartStream<UnregisteredTag>(streamId, new AtrThingHappened("one"));
+            await session.SaveChangesAsync();
+        }
+
+        await using var query = store.QuerySession();
+        var standalone = await query.Events.FetchStreamStateAsync(streamId);
+
+        var batch = query.CreateBatchQuery();
+        var fetcher = batch.Events.FetchStreamState(streamId);
+        await batch.Execute();
+
+        (await fetcher)!.AggregateType.ShouldBe(standalone!.AggregateType);
+        (await fetcher)!.AggregateType.ShouldBe(typeof(UnregisteredTag));
+    }
+
+    private static async Task DropSchemaTablesAsync(string schema)
+    {
+        await using var conn = new Microsoft.Data.SqlClient.SqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = """
+            DECLARE @sql nvarchar(max) = N'';
+            SELECT @sql = @sql + 'ALTER TABLE [' + s.name + '].[' + t.name + '] DROP CONSTRAINT [' + fk.name + '];'
+            FROM sys.foreign_keys fk
+            JOIN sys.tables t ON fk.parent_object_id = t.object_id
+            JOIN sys.schemas s ON t.schema_id = s.schema_id
+            WHERE s.name = @schema;
+
+            SELECT @sql = @sql + 'DROP TABLE [' + s.name + '].[' + t.name + '];'
+            FROM sys.tables t
+            JOIN sys.schemas s ON t.schema_id = s.schema_id
+            WHERE s.name = @schema;
+            EXEC sp_executesql @sql;
+            """;
+        cmd.Parameters.AddWithValue("@schema", schema);
+        await cmd.ExecuteNonQueryAsync();
+    }
+}
+
+public record AtrThingHappened(string What);
+
+/// <summary>
+///     Only ever used as a <c>StartStream&lt;T&gt;</c> tag. Deliberately NOT registered as a projection by
+///     default — that is the whole point of the #373 cases.
+/// </summary>
+public class UnregisteredTag
+{
+    public Guid Id { get; set; }
+
+    public void Apply(AtrThingHappened e)
+    {
+    }
+}

--- a/src/Polecat/DocumentStore.EventStoreExplorer.cs
+++ b/src/Polecat/DocumentStore.EventStoreExplorer.cs
@@ -393,27 +393,10 @@ public partial class DocumentStore
         return statuses;
     }
 
+    // #373: one answer to "what type is this alias". This used to be a second, near-identical copy of the
+    // scan that now lives on EventGraph — same projection walk, same fallback, but with a bare `catch` that
+    // swallowed every exception rather than only the ArgumentOutOfRangeException an unknown alias raises.
+    // Delegating also means the explorer picks up the alias registry the stream writer populates.
     private Type? ResolveAggregateType(string aggregateTypeName)
-    {
-        foreach (var source in Options.Projections.All)
-        {
-            foreach (var published in source.PublishedTypes())
-            {
-                if (string.Equals(published.FullName, aggregateTypeName, StringComparison.Ordinal)
-                    || string.Equals(published.Name, aggregateTypeName, StringComparison.Ordinal))
-                {
-                    return published;
-                }
-            }
-        }
-
-        try
-        {
-            return Events.AggregateTypeFor(aggregateTypeName);
-        }
-        catch
-        {
-            return null;
-        }
-    }
+        => Events.TryResolveAggregateType(aggregateTypeName);
 }

--- a/src/Polecat/Events/EventGraph.cs
+++ b/src/Polecat/Events/EventGraph.cs
@@ -23,7 +23,7 @@ namespace Polecat.Events;
 [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
     Justification = "Class-level: extends JasperFx.Events.EventRegistry (annotated RUC) for type-aliased event construction; also wires aggregator sources via reflection. Event types are preserved by registration on the caller side per the AOT publishing guide.")]
 [UnconditionalSuppressMessage("Trimming", "IL2057:UnrecognizedTypeName",
-    Justification = "Class-level: AggregateTypeFor uses Type.GetType(string) as a fallback to resolve aggregate types persisted by .NET type name in event metadata. The aggregate types are preserved by projection registration on the caller side; AOT consumers should register all aggregate types ahead of time per the AOT publishing guide.")]
+    Justification = "Class-level: ResolveEventType uses Type.GetType(string) to resolve the dotnet_type name persisted on each event row. Event types are preserved by EventGraph registration on the caller side; AOT consumers should register all event types ahead of time per the AOT publishing guide. Aggregate types are NOT resolved this way — TryResolveAggregateType is a registry lookup over registered aliases and projections, no reflection over type names.")]
 [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
     Justification = "Class-level: aggregator-source factories and event-type registration use Type.MakeGenericType — runtime code generation. AOT consumers register concrete event types ahead of time.")]
 public class EventGraph : EventRegistry, IAggregationSourceFactory<IQuerySession>
@@ -342,21 +342,29 @@ public class EventGraph : EventRegistry, IAggregationSourceFactory<IQuerySession
     }
 
     /// <summary>
-    ///     #370: resolve the alias persisted in <c>pc_streams.type</c> back to its aggregate type, or null
-    ///     when this deployment has no registration for it.
+    ///     #370/#373: resolve the alias persisted in <c>pc_streams.type</c> back to its aggregate type, or
+    ///     null when this deployment has no registration for it. The single answer to "what type is this
+    ///     alias" — <see cref="StreamState.AggregateType" /> hydration and the event store explorer's
+    ///     rehydrate-by-name path both come through here.
     /// </summary>
     /// <remarks>
     ///     <para>
-    ///     Unlike <see cref="AggregateTypeFor" /> this never throws: a stream tagged by a deployment that
-    ///     knew a type this one does not must still report its version and timestamps.
+    ///     Unlike <see cref="AggregateTypeFor" /> this never throws. A stream tagged by a deployment that
+    ///     knew a type this one does not must still report its version and timestamps, and the explorer
+    ///     turns the null into its own argument exception with a message aimed at that caller.
     ///     </para>
     ///     <para>
-    ///     <c>_aggregateTypes</c> alone is not enough. It is only populated by
-    ///     <see cref="AggregateAliasFor" />, which JasperFx.Events calls from
-    ///     <c>StreamAction.PrepareEvents</c> — a path Polecat's QuickAppend closed-shape writer does not go
-    ///     through, since the SQL Server dialect writes <c>stream.AggregateType?.Name</c> straight into the
-    ///     column. So the registered projections are the primary source and the map is the fallback,
-    ///     matching what the event store explorer's <c>ResolveAggregateType</c> already does.
+    ///     Two sources, in order. The alias registry (<c>_aggregateTypes</c>) is authoritative for anything
+    ///     this process wrote, because #373 made the stream insert go through
+    ///     <see cref="AggregateAliasFor" /> as it stamps the column. The registered projections cover
+    ///     everything else — streams written by another process or an earlier run, where nothing has
+    ///     populated the registry yet.
+    ///     </para>
+    ///     <para>
+    ///     Note the alias is the SIMPLE name, because that is what the column stores. Two aggregate types
+    ///     with the same <c>Name</c> in different namespaces therefore share an alias and the first one
+    ///     seen wins. That ambiguity lives in the persisted format, not here — resolving it would mean
+    ///     changing what the column holds.
     ///     </para>
     /// </remarks>
     internal Type? TryResolveAggregateType(string? aggregateTypeName)

--- a/src/Polecat/Events/Internal/PcStreamsRowReader.cs
+++ b/src/Polecat/Events/Internal/PcStreamsRowReader.cs
@@ -47,14 +47,16 @@ internal static class PcStreamsRowReader
     /// <param name="reader"></param>
     /// <param name="streamIdentity"></param>
     /// <param name="events">
-    ///     Supply to resolve the <c>type</c> column's alias into
-    ///     <see cref="StreamState.AggregateType"/>. #370: the column has always been projected but never
-    ///     read, so <c>AggregateType</c> came back null on every stream that was in fact tagged with an
-    ///     aggregate type. An unregistered alias resolves to null rather than throwing — a stream tagged
-    ///     by a deployment that knew a type this one does not is not an error for a metadata read.
+    ///     Resolves the <c>type</c> column's alias into <see cref="StreamState.AggregateType"/>.
+    ///     <para>
+    ///     #373: deliberately REQUIRED rather than an optional null-defaulting parameter. #370 fixed
+    ///     <c>AggregateType</c> coming back null on every stream — the column had always been projected and
+    ///     never read — and an optional parameter would reintroduce exactly that failure mode one forgotten
+    ///     argument at a time, silently and with no compiler help.
+    ///     </para>
     /// </param>
     internal static StreamState ReadStreamState(DbDataReader reader, StreamIdentity streamIdentity,
-        EventGraph? events = null)
+        EventGraph events)
     {
         var state = new StreamState
         {
@@ -64,8 +66,10 @@ internal static class PcStreamsRowReader
             IsArchived = reader.GetBoolean(6)
         };
 
-        if (events != null && !reader.IsDBNull(1))
+        if (!reader.IsDBNull(1))
         {
+            // An unregistered alias resolves to null rather than throwing — a stream tagged by a deployment
+            // that knew a type this one does not is not an error for a metadata read.
             state.AggregateType = events.TryResolveAggregateType(reader.GetString(1));
         }
 

--- a/src/Polecat/Events/Storage/SqlServerEventStoreDialect.cs
+++ b/src/Polecat/Events/Storage/SqlServerEventStoreDialect.cs
@@ -131,7 +131,14 @@ internal sealed class SqlServerEventStoreDialect : IEventStoreSqlDialect
             dialect.SetParameterType(idParam, isGuid ? StorageColumnType.Guid : StorageColumnType.String);
 
             builder.Append(", ");
-            var typeParam = builder.AppendParameter((object?)stream.AggregateType?.Name ?? DBNull.Value);
+            // #373: go through AggregateAliasFor rather than reading .Name directly. The persisted value is
+            // identical — the alias IS the simple name — but the call also registers the alias→Type pair on
+            // the EventGraph, which is the only thing that populates its lookup map. JasperFx.Events would
+            // normally do that from StreamAction.PrepareEvents, a path this QuickAppend closed-shape writer
+            // never goes through, so without this the process that WROTE a stream could not resolve the type
+            // it had just stamped unless that type also happened to be registered as a projection.
+            var typeParam = builder.AppendParameter(
+                stream.AggregateType is null ? DBNull.Value : graph.AggregateAliasFor(stream.AggregateType));
             dialect.SetParameterType(typeParam, StorageColumnType.String);
 
             builder.Append(", ");


### PR DESCRIPTION
Closes #373. Follow-up to the `StreamState.AggregateType` fix that rode along with #370 (PR #372) — that change made the property resolvable at all; this closes the three gaps it left behind.

## 1. The write path now registers the alias it stamps

`SqlServerEventStoreDialect` wrote `stream.AggregateType?.Name` straight into `pc_streams.type` and never called `EventGraph.AggregateAliasFor`, which is the only thing that populates the alias registry. JasperFx.Events would normally call it from `StreamAction.PrepareEvents` — a path Polecat's QuickAppend closed-shape writer never goes through.

The consequence was a real gap rather than a cosmetic one: the registered projections were the *only* resolution source, so an aggregate tagged onto a stream with `StartStream<T>()` but not registered as a projection was unresolvable **even in the process that had just written it**. `StartStream<T>()` accepts any type, so that is not an exotic case.

The insert now goes through `AggregateAliasFor`. The persisted value is byte-identical — the alias *is* the simple name — but the call also registers the alias→Type pair. Cost is one `TryAdd` per stream insert.

## 2. `ReadStreamState`'s EventGraph parameter is required

It was `EventGraph? events = null`, and a null graph silently meant "no aggregate type". That is precisely the defect class this whole thread is about: a call site that forgets the argument gets a quietly null property instead of a compiler error. Now required.

## 3. One resolver instead of two

`DocumentStore.EventStoreExplorer.ResolveAggregateType` predated `EventGraph.TryResolveAggregateType` and did the same job — same projection walk, same fallback — but swallowed *every* exception with a bare `catch` where the shared helper catches only the `ArgumentOutOfRangeException` an unknown alias actually raises. The explorer now delegates, which also means it picks up the alias registry the writer populates.

## Also

The class-level trimming suppression on `EventGraph` credited `AggregateTypeFor` with using `Type.GetType(string)`. It does not — it is a pure dictionary lookup. The real `IL2057` trigger is `ResolveEventType` resolving each event row's `dotnet_type`. The justification now says what the code does, and states explicitly that aggregate types are *not* resolved by reflection over type names.

## The boundary, stated rather than papered over

Resolution draws on two sources: the alias registry (authoritative for anything this process wrote, now that the writer populates it) and the registered projections (everything else — another process, an earlier run). A reader with **neither** cannot resolve the type, and returns `null` rather than throwing: a stream tagged by a deployment that knew a type this one does not must still report its version and timestamps. There is a test asserting exactly that, not just the happy paths.

The alias is the simple name because that is what the column stores, so two aggregate types sharing a `Name` across namespaces share an alias and first-seen wins. That ambiguity lives in the persisted format; resolving it would mean changing what the column holds, which is not this issue.

## Tests

New `aggregate_type_resolution_tests`: the writing process resolving a non-projection type (the gap #373 closes), a fresh store falling through to its registered projections, an unresolvable alias yielding null rather than an exception, and the batched read agreeing with the standalone one.

The existing #370 test in `batch_event_fetching` **lost** its projection registration — it needed one before and does not now, which is itself the evidence the gap closed.

Full suite plus the explorer's rehydrate-by-name coverage green.
