### PR TITLE
fix: implement ClearResolvedDaemons — unblock Polecat on JasperFx.Events 2.36.2

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -51,8 +51,8 @@
                  land together — plus reachable NaturalKeyBuilder / NaturalKeyFor() and loud failure on an
                  unbindable [NaturalKeySource] (polecat#369).
              Also carries jasperfx#568/#572 daemon race fixes, picked up for free. -->
-        <PackageVersion Include="JasperFx" Version="2.36.1" />
-        <PackageVersion Include="JasperFx.Events" Version="2.36.1" />
+        <PackageVersion Include="JasperFx" Version="2.36.2" />
+        <PackageVersion Include="JasperFx.Events" Version="2.36.2" />
         <!-- Pin the sibling JasperFx packages for parity with Marten 9's matrix
              even though Polecat doesn't currently reference them directly —
              keeps the lockstep matrix coherent when transitive resolution
@@ -60,7 +60,7 @@
              RuntimeCompiler 5.x line is the active continuation of the 4.x
              lineage; do not pin against the parallel stale 2.0.x series. -->
         <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.36.1" />
+        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.36.2" />
         <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
@@ -105,7 +105,7 @@
         <PackageVersion Include="StronglyTypedId" Version="1.0.0-beta08" />
 
         <!-- Source generators (matched to JasperFx.Events above) -->
-        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.36.1" />
+        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.36.2" />
 
         <!-- Build automation -->
         <PackageVersion Include="Nuke.Common" Version="9.0.4" />

--- a/src/Polecat/Events/Daemon/Coordination/ProjectionCoordinator.cs
+++ b/src/Polecat/Events/Daemon/Coordination/ProjectionCoordinator.cs
@@ -65,6 +65,12 @@ internal class ProjectionCoordinator : ProjectionCoordinatorBase, IProjectionCoo
     protected override IReadOnlyList<IProjectionDaemon> ResolvedDaemons()
         => _daemons.Values.Cast<IProjectionDaemon>().ToList();
 
+    // marten#5055: StopAsync disposes everything ResolvedDaemons() hands back, so the cache must be
+    // purged too — otherwise a second Pause/Stop fans StopAllAsync out over disposed daemons and a
+    // later ResumeAsync hands back a dead instance instead of building a fresh one. No lock needed
+    // for the same reason the dictionary is unsynchronized (see the _daemons declaration above).
+    protected override void ClearResolvedDaemons() => _daemons.Clear();
+
     public override IProjectionDaemon DaemonForMainDatabase()
     {
         var main = _options.Tenancy?.AllDatabases().FirstOrDefault()


### PR DESCRIPTION
## Problem

JasperFx.Events 2.36.2 (jasperfx `24b5daa`, marten#5055) added a new member to `ProjectionCoordinatorBase`:

```csharp
protected abstract void ClearResolvedDaemons();
```

`StopAsync` calls it after disposing everything `ResolvedDaemons()` returned, so the subclass cache can't keep handing back disposed daemons.

Marten 9.20.1 implemented it. **Polecat 5.7.0 did not**, so it no longer satisfies the base class. Any app on Polecat + JasperFx.Events 2.36.2 fails at DI resolution:

```
System.TypeLoadException : Method 'ClearResolvedDaemons' in type
'Polecat.Events.Daemon.Coordination.ProjectionCoordinator' from assembly
'Polecat, Version=5.7.0.0, Culture=neutral, PublicKeyToken=null'
does not have an implementation.
```

## Why this is blocking

**Marten 9.20.1 and 9.20.2 both require JasperFx 2.36.2.** Downstream apps therefore cannot take current Marten and Polecat together — the graph resolves JasperFx.Events 2.36.2 and Polecat's coordinator fails to load. Marten 9.20.0 is the newest Marten a Polecat app can use today.

Found while bumping CritterWatch to Marten 9.20.2 / JasperFx 2.36.2.

## Change

- `Directory.Packages.props`: JasperFx pins 2.36.1 → 2.36.2
- `ProjectionCoordinator`: implement the new member

```csharp
protected override void ClearResolvedDaemons() => _daemons.Clear();
```

No lock, matching the existing contract on `_daemons` (the coordinator loop is single-threaded — see the comment on its declaration).

## Verification

- Polecat solution builds clean against 2.36.2 — this was the **only** break in the assembly
- Coordinator/daemon suites: **109/113 (net9.0)**, 108/113 (net10.0)
- The 1–2 failures (`vectorized_high_water_tests`, `per_tenant_rebuild_tests`) are **pre-existing**: stashing this change and running unmodified 5.7.0 fails those **3 of 4**, i.e. worse than with the fix. Unrelated to this change.
- End-to-end: packed `5.7.1-clearcache.1`, pinned CritterWatch to it alongside the full JasperFx 2.36.2 + Marten 9.20.2 upgrade — the `TypeLoadException` clears and CritterWatch's `EventStoreExplorerTests` goes **41/41**, including the coordinator-resolution regression guard for jasperfx#430.

## Follow-up

Needs a **5.7.1** release to unblock downstream apps on the current Marten line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U6rL8dGQMMh9xNYtP9R9jP