### PR TITLE
chore: migrate the test suites to xUnit v3

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+
+    <!--
+      Turn the xUnit analyzers off for the duration of the v2 -> v3 migration.
+
+      They arrive transitively (xunit.v3 -> xunit.v3.mtp-v1 -> xunit.analyzers) and light up 10,212
+      warnings across the solution, against a previous whole-solution baseline of roughly 120. That
+      buries every real warning, which is a worse outcome than not having the analyzers at all.
+
+      This is done in MSBuild rather than through NuGet because NuGet cannot express it. Both
+      spellings that look like they should work are silently no-ops here:
+
+        <PackageReference Include="xunit.v3" ExcludeAssets="analyzers" />
+            asset exclusions do not propagate down the dependency graph, so this never reaches
+            xunit.analyzers two edges away;
+        <PackageReference Include="xunit.analyzers" ExcludeAssets="all" />
+            a direct reference does not override the assets already flowing along the transitive
+            edge either.
+
+      Both were measured at the full 10,212 warnings before settling on removing the Analyzer items
+      directly, which is unambiguous. Deliberately NOT a NoWarn list: xUnit1051 accounts for all
+      10,212, but xUnit3003 also fires, and pinning a list means the next new rule reintroduces the
+      noise silently.
+
+      Adopting the analyzers for real (mostly threading TestContext.Current.CancellationToken
+      through ~6,500 async database calls) is follow-up work with actual code changes behind it.
+      Delete this target when that lands.
+    -->
+    <Target Name="RemoveXunitAnalyzers" BeforeTargets="CoreCompile">
+        <ItemGroup>
+            <Analyzer Remove="@(Analyzer)"
+                      Condition="$([System.String]::Copy('%(Analyzer.Filename)').StartsWith('xunit.analyzers'))" />
+        </ItemGroup>
+    </Target>
+
+</Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -78,8 +78,18 @@
         <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
         <PackageVersion Include="NSubstitute" Version="5.3.0" />
         <PackageVersion Include="Shouldly" Version="4.3.0" />
-        <PackageVersion Include="xunit" Version="2.9.3" />
-        <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.4" />
+        <!-- xUnit v3. The test projects reference xunit.v3; Polecat.TestUtils, which is a plain
+             library that only authors custom [Fact]/[Theory] attributes, references
+             xunit.v3.extensibility.core instead — xunit.v3 forces OutputType=Exe onto whatever
+             references it, which is wrong for a library.
+
+             The xUnit analyzers ride in transitively (xunit.v3 -> xunit.v3.mtp-v1 ->
+             xunit.analyzers) and are switched off for now — see the RemoveXunitAnalyzers target in
+             Directory.Build.targets, which also records why this cannot be expressed as an
+             ExcludeAssets on any PackageReference here. -->
+        <PackageVersion Include="xunit.v3" Version="3.2.2" />
+        <PackageVersion Include="xunit.v3.extensibility.core" Version="3.2.2" />
+        <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
         <!-- Weasel 9.8.0/9.9.0 introduce Weasel.Storage: the dialect-neutral closed-shape
              storage contracts extracted from Marten (marten#4821/#4830, weasel#329/#331) —
              IStorageSession / IStorageDatabase / IStorageSerializer / IDocumentStorage /

--- a/src/Polecat.AspNetCore.Testing/HighWaterHealthCheckTests.cs
+++ b/src/Polecat.AspNetCore.Testing/HighWaterHealthCheckTests.cs
@@ -53,7 +53,7 @@ public class HighWaterHealthCheckTests: IAsyncLifetime
         _timeProvider = new MutableTimeProvider(_now);
     }
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         // Drop the schema for a clean slate.
         await using var conn = new SqlConnection(ConnectionString);
@@ -73,7 +73,7 @@ public class HighWaterHealthCheckTests: IAsyncLifetime
         await cmd.ExecuteNonQueryAsync();
     }
 
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         if (_store != null)
         {

--- a/src/Polecat.AspNetCore.Testing/Polecat.AspNetCore.Testing.csproj
+++ b/src/Polecat.AspNetCore.Testing/Polecat.AspNetCore.Testing.csproj
@@ -10,7 +10,7 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="NSubstitute" />
         <PackageReference Include="Shouldly" />
-        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.v3" />
         <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>

--- a/src/Polecat.AspNetCore.Testing/etag_streaming_tests.cs
+++ b/src/Polecat.AspNetCore.Testing/etag_streaming_tests.cs
@@ -13,7 +13,7 @@ public class etag_streaming_tests : IAsyncLifetime
 {
     private IAlbaHost _host = null!;
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         _host = await AlbaHost.For(TestApp.CreateBuilder(), TestApp.Configure);
 
@@ -22,7 +22,7 @@ public class etag_streaming_tests : IAsyncLifetime
         await store.Advanced.CleanAllDocumentsAsync();
     }
 
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         await _host.DisposeAsync();
     }

--- a/src/Polecat.AspNetCore.Testing/mcp_endpoint_tests.cs
+++ b/src/Polecat.AspNetCore.Testing/mcp_endpoint_tests.cs
@@ -9,12 +9,12 @@ public class mcp_endpoint_tests : IAsyncLifetime
 {
     private IAlbaHost _host = null!;
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         _host = await AlbaHost.For(TestApp.CreateBuilder(), TestApp.Configure);
     }
 
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         await _host.DisposeAsync();
     }

--- a/src/Polecat.AspNetCore.Testing/stream_event_result_types_tests.cs
+++ b/src/Polecat.AspNetCore.Testing/stream_event_result_types_tests.cs
@@ -14,7 +14,7 @@ public class stream_event_result_types_tests : IAsyncLifetime
 {
     private IAlbaHost _host = null!;
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         _host = await AlbaHost.For(TestApp.CreateBuilder(), TestApp.Configure);
 
@@ -22,7 +22,7 @@ public class stream_event_result_types_tests : IAsyncLifetime
         await store.Database.ApplyAllConfiguredChangesToDatabaseAsync();
     }
 
-    public async Task DisposeAsync() => await _host.DisposeAsync();
+    public async ValueTask DisposeAsync() => await _host.DisposeAsync();
 
     [Fact]
     public async Task stream_event_state_returns_200_with_the_metadata()

--- a/src/Polecat.AspNetCore.Testing/stream_paged_by_cursor_tests.cs
+++ b/src/Polecat.AspNetCore.Testing/stream_paged_by_cursor_tests.cs
@@ -14,7 +14,7 @@ public class stream_paged_by_cursor_tests : IAsyncLifetime
 {
     private IAlbaHost _host = null!;
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         _host = await AlbaHost.For(TestApp.CreateBuilder(), TestApp.Configure);
 
@@ -31,7 +31,7 @@ public class stream_paged_by_cursor_tests : IAsyncLifetime
         await session.SaveChangesAsync();
     }
 
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         await _host.DisposeAsync();
     }

--- a/src/Polecat.AspNetCore.Testing/stream_paged_tests.cs
+++ b/src/Polecat.AspNetCore.Testing/stream_paged_tests.cs
@@ -15,7 +15,7 @@ public class stream_paged_tests : IAsyncLifetime
 {
     private IAlbaHost _host = null!;
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         _host = await AlbaHost.For(TestApp.CreateBuilder(), TestApp.Configure);
 
@@ -32,7 +32,7 @@ public class stream_paged_tests : IAsyncLifetime
         await session.SaveChangesAsync();
     }
 
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         await _host.DisposeAsync();
     }

--- a/src/Polecat.AspNetCore.Testing/streaming_result_types_tests.cs
+++ b/src/Polecat.AspNetCore.Testing/streaming_result_types_tests.cs
@@ -9,7 +9,7 @@ public class streaming_result_types_tests : IAsyncLifetime
 {
     private IAlbaHost _host = null!;
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         _host = await AlbaHost.For(TestApp.CreateBuilder(), TestApp.Configure);
 
@@ -19,7 +19,7 @@ public class streaming_result_types_tests : IAsyncLifetime
         await store.Advanced.CleanAllDocumentsAsync();
     }
 
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         await _host.DisposeAsync();
     }

--- a/src/Polecat.EntityFrameworkCore.Tests/EfCoreEventProjectionTests.cs
+++ b/src/Polecat.EntityFrameworkCore.Tests/EfCoreEventProjectionTests.cs
@@ -6,15 +6,15 @@ public class ef_core_event_projection_tests : IAsyncLifetime
 {
     private DocumentStore _store = null!;
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         _store = await EfCoreTestHelper.CreateStoreWithEventProjection(ProjectionLifecycle.Inline);
     }
 
-    public Task DisposeAsync()
+    public ValueTask DisposeAsync()
     {
         _store?.Dispose();
-        return Task.CompletedTask;
+        return ValueTask.CompletedTask;
     }
 
     [RequiresNativeJsonFact(true)]

--- a/src/Polecat.EntityFrameworkCore.Tests/EfCoreMultiStreamProjectionTests.cs
+++ b/src/Polecat.EntityFrameworkCore.Tests/EfCoreMultiStreamProjectionTests.cs
@@ -7,12 +7,12 @@ public abstract class ef_core_multi_stream_projection_tests_base : IAsyncLifetim
     protected DocumentStore Store = null!;
     protected abstract ProjectionLifecycle Lifecycle { get; }
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         Store = await EfCoreTestHelper.CreateStoreWithMultiStreamProjection(Lifecycle);
     }
 
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         Store?.Dispose();
     }
@@ -123,15 +123,15 @@ public class ef_core_multi_stream_live_tests : IAsyncLifetime
 {
     private DocumentStore _store = null!;
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         _store = await EfCoreTestHelper.CreateStoreWithMultiStreamProjection(ProjectionLifecycle.Inline);
     }
 
-    public Task DisposeAsync()
+    public ValueTask DisposeAsync()
     {
         _store?.Dispose();
-        return Task.CompletedTask;
+        return ValueTask.CompletedTask;
     }
 
     [RequiresNativeJsonFact(true)]

--- a/src/Polecat.EntityFrameworkCore.Tests/EfCoreSingleStreamProjectionTests.cs
+++ b/src/Polecat.EntityFrameworkCore.Tests/EfCoreSingleStreamProjectionTests.cs
@@ -9,12 +9,12 @@ public abstract class ef_core_single_stream_projection_tests_base : IAsyncLifeti
     protected DocumentStore Store = null!;
     protected abstract ProjectionLifecycle Lifecycle { get; }
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         Store = await EfCoreTestHelper.CreateStoreWithSingleStreamProjection(Lifecycle);
     }
 
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         Store?.Dispose();
     }
@@ -129,15 +129,15 @@ public class ef_core_single_stream_live_tests : IAsyncLifetime
 {
     private DocumentStore _store = null!;
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         _store = await EfCoreTestHelper.CreateStoreWithSingleStreamProjection(ProjectionLifecycle.Inline);
     }
 
-    public Task DisposeAsync()
+    public ValueTask DisposeAsync()
     {
         _store?.Dispose();
-        return Task.CompletedTask;
+        return ValueTask.CompletedTask;
     }
 
     [RequiresNativeJsonFact(true)]

--- a/src/Polecat.EntityFrameworkCore.Tests/EfCoreTenantedSingleStreamProjectionTests.cs
+++ b/src/Polecat.EntityFrameworkCore.Tests/EfCoreTenantedSingleStreamProjectionTests.cs
@@ -7,7 +7,7 @@ public abstract class ef_core_tenanted_single_stream_tests_base : IAsyncLifetime
     protected DocumentStore Store = null!;
     protected abstract ProjectionLifecycle Lifecycle { get; }
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         Store = DocumentStore.For(opts =>
         {
@@ -25,10 +25,10 @@ public abstract class ef_core_tenanted_single_stream_tests_base : IAsyncLifetime
         await EfCoreTestHelper.CleanEfCoreTablesAsync(ConnectionSource.ConnectionString, "ef_tenanted_orders");
     }
 
-    public Task DisposeAsync()
+    public ValueTask DisposeAsync()
     {
         Store?.Dispose();
-        return Task.CompletedTask;
+        return ValueTask.CompletedTask;
     }
 
     protected virtual Task WaitForProjectionAsync() => Task.CompletedTask;

--- a/src/Polecat.EntityFrameworkCore.Tests/Polecat.EntityFrameworkCore.Tests.csproj
+++ b/src/Polecat.EntityFrameworkCore.Tests/Polecat.EntityFrameworkCore.Tests.csproj
@@ -9,7 +9,7 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="Shouldly" />
         <PackageReference Include="Weasel.SqlServer" />
-        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.v3" />
         <PackageReference Include="xunit.runner.visualstudio" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
     </ItemGroup>

--- a/src/Polecat.TestUtils/Polecat.TestUtils.csproj
+++ b/src/Polecat.TestUtils/Polecat.TestUtils.csproj
@@ -7,7 +7,10 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Data.SqlClient" />
-        <PackageReference Include="xunit" />
+        <!-- NOT xunit.v3: that package forces OutputType=Exe on anything referencing it, and this
+             is a library. extensibility.core is the supported way to author custom xunit attributes
+             (RepeatAttribute, RequiresNativeJsonFactAttribute) outside a test assembly. -->
+        <PackageReference Include="xunit.v3.extensibility.core" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Polecat.TestUtils/RepeatAttribute.cs
+++ b/src/Polecat.TestUtils/RepeatAttribute.cs
@@ -1,12 +1,30 @@
 using System.Reflection;
+using Xunit;
 using Xunit.Sdk;
+using Xunit.v3;
 
 namespace Polecat.TestUtils;
 
+/// <summary>
+///     Runs a [Theory] <paramref name="count" /> times, passing the 1-based iteration number.
+///     Used by the concurrency suites (HiLo, async daemon) where a single pass proves nothing.
+/// </summary>
+/// <remarks>
+///     xUnit v3 moved <c>DataAttribute</c> from <c>Xunit.Sdk</c> to <c>Xunit.v3</c> and reshaped both
+///     of its abstract members: <c>GetData</c> now returns theory data rows asynchronously and takes
+///     a <see cref="DisposalTracker" />, and <c>SupportsDiscoveryEnumeration</c> is required. The
+///     data here is constant and cheap, so it enumerates at discovery time — which is what keeps
+///     each iteration a test case of its own rather than collapsing them into a single one.
+/// </remarks>
 public class RepeatAttribute(int count) : DataAttribute
 {
-    public override IEnumerable<object[]> GetData(MethodInfo testMethod)
+    public override ValueTask<IReadOnlyCollection<ITheoryDataRow>> GetData(
+        MethodInfo testMethod,
+        DisposalTracker disposalTracker)
     {
-        return Enumerable.Range(1, count).Select(i => new object[] { i });
+        return new ValueTask<IReadOnlyCollection<ITheoryDataRow>>(
+            Enumerable.Range(1, count).Select(i => (ITheoryDataRow)new TheoryDataRow(i)).ToArray());
     }
+
+    public override bool SupportsDiscoveryEnumeration() => true;
 }

--- a/src/Polecat.Tests/BulkInsert/bulk_insert_edge_cases.cs
+++ b/src/Polecat.Tests/BulkInsert/bulk_insert_edge_cases.cs
@@ -13,7 +13,7 @@ public class bulk_insert_edge_cases : IntegrationContext
     {
     }
 
-    public override async Task InitializeAsync()
+    public override async ValueTask InitializeAsync()
     {
         await StoreOptions(opts => { opts.DatabaseSchemaName = "bulk_edge"; });
     }

--- a/src/Polecat.Tests/BulkInsert/bulk_insert_operations.cs
+++ b/src/Polecat.Tests/BulkInsert/bulk_insert_operations.cs
@@ -13,7 +13,7 @@ public class bulk_insert_operations : IntegrationContext
     {
     }
 
-    public override async Task InitializeAsync()
+    public override async ValueTask InitializeAsync()
     {
         await StoreOptions(opts => { opts.DatabaseSchemaName = "bulk_insert"; });
     }

--- a/src/Polecat.Tests/BulkInsert/bulk_insert_with_version_check.cs
+++ b/src/Polecat.Tests/BulkInsert/bulk_insert_with_version_check.cs
@@ -18,7 +18,7 @@ public class bulk_insert_with_version_check : IntegrationContext
     {
     }
 
-    public override async Task InitializeAsync()
+    public override async ValueTask InitializeAsync()
     {
         await StoreOptions(opts => { opts.DatabaseSchemaName = "bulk_insert_version"; });
     }

--- a/src/Polecat.Tests/Daemon/bluegreen_side_effect_gate_tests.cs
+++ b/src/Polecat.Tests/Daemon/bluegreen_side_effect_gate_tests.cs
@@ -23,9 +23,9 @@ public partial class bluegreen_side_effect_gate_tests : IAsyncLifetime
 {
     private const string Schema = "bluegreen_gate";
 
-    public async Task InitializeAsync() => await DropSchemaTablesAsync(Schema);
+    public async ValueTask InitializeAsync() => await DropSchemaTablesAsync(Schema);
 
-    public Task DisposeAsync() => Task.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
     private static DocumentStore CreateStore(uint version, GateOutbox outbox, bool gate)
     {

--- a/src/Polecat.Tests/Daemon/delete_projection_progress_by_shard_name_tests.cs
+++ b/src/Polecat.Tests/Daemon/delete_projection_progress_by_shard_name_tests.cs
@@ -28,7 +28,7 @@ public class delete_projection_progress_by_shard_name_tests : IntegrationContext
     {
     }
 
-    public override async Task InitializeAsync()
+    public override async ValueTask InitializeAsync()
     {
         await base.InitializeAsync();
         // Clean progression table for each test

--- a/src/Polecat.Tests/Daemon/event_database_tests.cs
+++ b/src/Polecat.Tests/Daemon/event_database_tests.cs
@@ -10,7 +10,7 @@ public class event_database_tests : IntegrationContext
     {
     }
 
-    public override async Task InitializeAsync()
+    public override async ValueTask InitializeAsync()
     {
         await base.InitializeAsync();
         // Clean slate for each test

--- a/src/Polecat.Tests/Daemon/event_loader_resiliency_tests.cs
+++ b/src/Polecat.Tests/Daemon/event_loader_resiliency_tests.cs
@@ -19,7 +19,7 @@ public class event_loader_resiliency_tests : IntegrationContext
     {
     }
 
-    public override async Task InitializeAsync()
+    public override async ValueTask InitializeAsync()
     {
         await base.InitializeAsync();
         // Clean slate for each test

--- a/src/Polecat.Tests/Daemon/event_loader_tests.cs
+++ b/src/Polecat.Tests/Daemon/event_loader_tests.cs
@@ -14,7 +14,7 @@ public class event_loader_tests : IntegrationContext
     {
     }
 
-    public override async Task InitializeAsync()
+    public override async ValueTask InitializeAsync()
     {
         await base.InitializeAsync();
         // Clean slate for each test

--- a/src/Polecat.Tests/Daemon/high_water_detector_tests.cs
+++ b/src/Polecat.Tests/Daemon/high_water_detector_tests.cs
@@ -12,7 +12,7 @@ public class high_water_detector_tests : IntegrationContext
     {
     }
 
-    public override async Task InitializeAsync()
+    public override async ValueTask InitializeAsync()
     {
         await base.InitializeAsync();
         // Clean slate for each test

--- a/src/Polecat.Tests/Daemon/per_tenant_rebuild_tests.cs
+++ b/src/Polecat.Tests/Daemon/per_tenant_rebuild_tests.cs
@@ -21,14 +21,14 @@ public class per_tenant_rebuild_tests : IAsyncLifetime
     private const string Schema = "pt_rebuild";
     private static readonly string[] Tenants = ["Red", "Blue", "Green"];
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         await DropSchemaTablesAsync(Schema);
         await PartitionTestCleanup.DropEventsPartitionObjectsAsync();
         await DropSequencesAsync(Schema);
     }
 
-    public Task DisposeAsync() => Task.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
     private static DocumentStore CreateStore()
     {

--- a/src/Polecat.Tests/Daemon/projection_progression_tests.cs
+++ b/src/Polecat.Tests/Daemon/projection_progression_tests.cs
@@ -17,7 +17,7 @@ public class projection_progression_tests : IntegrationContext
     {
     }
 
-    public override async Task InitializeAsync()
+    public override async ValueTask InitializeAsync()
     {
         await base.InitializeAsync();
         // Clean progression table for each test

--- a/src/Polecat.Tests/Daemon/vectorized_high_water_tests.cs
+++ b/src/Polecat.Tests/Daemon/vectorized_high_water_tests.cs
@@ -18,14 +18,14 @@ public class vectorized_high_water_tests : IAsyncLifetime
 {
     private const string Schema = "pt_hw";
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         await DropSchemaTablesAsync(Schema);
         await PartitionTestCleanup.DropEventsPartitionObjectsAsync();
         await DropSequencesAsync(Schema);
     }
 
-    public Task DisposeAsync() => Task.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
     private static DocumentStore CreateStore(bool partitioned)
     {

--- a/src/Polecat.Tests/Documents/plain_guid_id_assignment_tests.cs
+++ b/src/Polecat.Tests/Documents/plain_guid_id_assignment_tests.cs
@@ -17,7 +17,7 @@ public class plain_guid_id_assignment_tests : IntegrationContext
     {
     }
 
-    public override async Task InitializeAsync()
+    public override async ValueTask InitializeAsync()
     {
         await StoreOptions(opts => { opts.DatabaseSchemaName = "plain_guid_id"; });
     }

--- a/src/Polecat.Tests/Events/Bug_259_natural_key_rebuild.cs
+++ b/src/Polecat.Tests/Events/Bug_259_natural_key_rebuild.cs
@@ -22,9 +22,9 @@ public class Bug_259_natural_key_rebuild : IAsyncLifetime
     private const string Schema = "natural_key_rebuild";
     private const string Table = "pc_natural_key_orderaggregate";
 
-    public async Task InitializeAsync() => await DropSchemaTablesAsync(Schema);
+    public async ValueTask InitializeAsync() => await DropSchemaTablesAsync(Schema);
 
-    public Task DisposeAsync() => Task.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
     private static DocumentStore CreateStore()
     {

--- a/src/Polecat.Tests/Events/Bug_369_natural_key_source_discovery.cs
+++ b/src/Polecat.Tests/Events/Bug_369_natural_key_source_discovery.cs
@@ -27,9 +27,9 @@ public class Bug_369_natural_key_source_discovery : IAsyncLifetime
     private const string Schema = "bug_369_natural_key";
     private const string Table = "pc_natural_key_nkproduct";
 
-    public async Task InitializeAsync() => await DropSchemaTablesAsync(Schema);
+    public async ValueTask InitializeAsync() => await DropSchemaTablesAsync(Schema);
 
-    public Task DisposeAsync() => Task.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
     private static DocumentStore CreateStore(Action<SingleStreamProjection<NkProduct, Guid>>? configure = null)
     {

--- a/src/Polecat.Tests/Events/aggregate_type_resolution_tests.cs
+++ b/src/Polecat.Tests/Events/aggregate_type_resolution_tests.cs
@@ -16,9 +16,9 @@ public class aggregate_type_resolution_tests : IAsyncLifetime
 {
     private const string Schema = "aggregate_type_resolution";
 
-    public async Task InitializeAsync() => await DropSchemaTablesAsync(Schema);
+    public async ValueTask InitializeAsync() => await DropSchemaTablesAsync(Schema);
 
-    public Task DisposeAsync() => Task.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
     private static DocumentStore CreateStore(bool registerProjection = false)
     {

--- a/src/Polecat.Tests/Events/archived_partitioning_dcb_tag_tests.cs
+++ b/src/Polecat.Tests/Events/archived_partitioning_dcb_tag_tests.cs
@@ -17,7 +17,7 @@ public class archived_partitioning_dcb_tag_tests : IntegrationContext
     {
     }
 
-    public override async Task InitializeAsync()
+    public override async ValueTask InitializeAsync()
     {
         var conn = await OpenConnectionAsync();
 

--- a/src/Polecat.Tests/Events/archived_stream_partitioning.cs
+++ b/src/Polecat.Tests/Events/archived_stream_partitioning.cs
@@ -10,7 +10,7 @@ public class archived_stream_partitioning : IntegrationContext
     {
     }
 
-    public override async Task InitializeAsync()
+    public override async ValueTask InitializeAsync()
     {
         // The partition scheme/function ps_pc_events_is_archived /
         // pf_pc_events_is_archived are global SQL Server objects (Weasel does not

--- a/src/Polecat.Tests/Events/closed_shape_partitioned_event_tests.cs
+++ b/src/Polecat.Tests/Events/closed_shape_partitioned_event_tests.cs
@@ -17,14 +17,14 @@ public class closed_shape_partitioned_event_tests : IAsyncLifetime
 {
     private const string Schema = "closed_pt";
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         await DropSchemaTablesAsync(Schema);
         await PartitionTestCleanup.DropEventsPartitionObjectsAsync();
         await DropSequencesAsync(Schema);
     }
 
-    public Task DisposeAsync() => Task.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
     private static DocumentStore CreateStore()
     {

--- a/src/Polecat.Tests/Events/dcb_tag_query_and_consistency_tests.cs
+++ b/src/Polecat.Tests/Events/dcb_tag_query_and_consistency_tests.cs
@@ -63,7 +63,7 @@ public class dcb_tag_query_and_consistency_tests : IntegrationContext
     }
 
     #region sample_polecat_dcb_registering_tag_types
-    public override async Task InitializeAsync()
+    public override async ValueTask InitializeAsync()
     {
         await StoreOptions(opts =>
         {

--- a/src/Polecat.Tests/Events/event_append_counter_tests.cs
+++ b/src/Polecat.Tests/Events/event_append_counter_tests.cs
@@ -13,8 +13,8 @@ namespace Polecat.Tests.Events;
 /// </summary>
 public class event_append_counter_tests : IAsyncLifetime
 {
-    public Task InitializeAsync() => Task.CompletedTask;
-    public Task DisposeAsync() => Task.CompletedTask;
+    public ValueTask InitializeAsync() => ValueTask.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
     private static DocumentStore CreateStore(string schema, bool trackCounters)
     {

--- a/src/Polecat.Tests/Events/event_store_instrumentation_tests.cs
+++ b/src/Polecat.Tests/Events/event_store_instrumentation_tests.cs
@@ -27,13 +27,13 @@ public class event_store_instrumentation_tests : IAsyncLifetime
         "failure_category", "failure_event_sequence", "failure_event_type", "failure_event_tenant_id"
     ];
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         await DropSchemaTablesAsync(OnSchema);
         await DropSchemaTablesAsync(OffSchema);
     }
 
-    public Task DisposeAsync() => Task.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
     private static DocumentStore CreateStore(string schema, bool extended)
     {

--- a/src/Polecat.Tests/Events/per_tenant_event_sequence_tests.cs
+++ b/src/Polecat.Tests/Events/per_tenant_event_sequence_tests.cs
@@ -17,7 +17,7 @@ public class per_tenant_event_sequence_tests : IAsyncLifetime
     private const string PartitionedSchema = "pt_on";
     private const string DefaultSchema = "pt_off";
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         await DropSchemaTablesAsync(PartitionedSchema);
         await DropSchemaTablesAsync(DefaultSchema);
@@ -25,7 +25,7 @@ public class per_tenant_event_sequence_tests : IAsyncLifetime
         await DropSequencesAsync(PartitionedSchema);
     }
 
-    public Task DisposeAsync() => Task.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
     private static DocumentStore CreatePartitionedStore(string schema = PartitionedSchema)
     {

--- a/src/Polecat.Tests/Events/tenant_partitioned_streams_tests.cs
+++ b/src/Polecat.Tests/Events/tenant_partitioned_streams_tests.cs
@@ -16,14 +16,14 @@ public class tenant_partitioned_streams_tests : IAsyncLifetime
 {
     private const string Schema = "pt_streams";
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         await TestSchema.DropSchemaTablesAsync(Schema);
         await PartitionTestCleanup.DropEventsPartitionObjectsAsync();
         await TestSchema.DropSequencesAsync(Schema);
     }
 
-    public Task DisposeAsync() => Task.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
     private static DocumentStore CreateStore()
     {

--- a/src/Polecat.Tests/Events/use_identity_map_for_aggregates.cs
+++ b/src/Polecat.Tests/Events/use_identity_map_for_aggregates.cs
@@ -9,7 +9,7 @@ public class use_identity_map_for_aggregates : IntegrationContext
     {
     }
 
-    public override async Task InitializeAsync()
+    public override async ValueTask InitializeAsync()
     {
         await StoreOptions(opts =>
         {

--- a/src/Polecat.Tests/Harness/DefaultStoreFixture.cs
+++ b/src/Polecat.Tests/Harness/DefaultStoreFixture.cs
@@ -14,7 +14,7 @@ public class DefaultStoreFixture : IAsyncLifetime
     public StoreOptions Options { get; private set; } = null!;
     public DocumentStore Store { get; private set; } = null!;
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         Options = new StoreOptions
         {
@@ -31,10 +31,10 @@ public class DefaultStoreFixture : IAsyncLifetime
         await Database.ApplyAllConfiguredChangesToDatabaseAsync();
     }
 
-    public Task DisposeAsync()
+    public ValueTask DisposeAsync()
     {
         Store?.Dispose();
-        return Task.CompletedTask;
+        return ValueTask.CompletedTask;
     }
 
     internal async Task DropAllEventStoreTablesAsync()

--- a/src/Polecat.Tests/Harness/IntegrationContext.cs
+++ b/src/Polecat.Tests/Harness/IntegrationContext.cs
@@ -86,9 +86,9 @@ public abstract class IntegrationContext : IAsyncLifetime
         return conn;
     }
 
-    public virtual Task InitializeAsync() => Task.CompletedTask;
+    public virtual ValueTask InitializeAsync() => ValueTask.CompletedTask;
 
-    public virtual async Task DisposeAsync()
+    public virtual async ValueTask DisposeAsync()
     {
         foreach (var disposable in AsyncDisposables)
         {

--- a/src/Polecat.Tests/Harness/OneOffConfigurationsContext.cs
+++ b/src/Polecat.Tests/Harness/OneOffConfigurationsContext.cs
@@ -78,7 +78,7 @@ public abstract class OneOffConfigurationsContext : IAsyncLifetime
         return conn;
     }
 
-    public virtual async Task InitializeAsync()
+    public virtual async ValueTask InitializeAsync()
     {
         // Drop the schema if it exists for a clean slate
         await using var conn = new SqlConnection(ConnectionSource.ConnectionString);
@@ -113,7 +113,7 @@ public abstract class OneOffConfigurationsContext : IAsyncLifetime
         }
     }
 
-    public virtual async Task DisposeAsync()
+    public virtual async ValueTask DisposeAsync()
     {
         foreach (var disposable in AsyncDisposables)
         {

--- a/src/Polecat.Tests/HiLo/hilo_reset_floor_tests.cs
+++ b/src/Polecat.Tests/HiLo/hilo_reset_floor_tests.cs
@@ -10,7 +10,7 @@ public class hilo_reset_floor_tests : IntegrationContext
     {
     }
 
-    public override async Task InitializeAsync()
+    public override async ValueTask InitializeAsync()
     {
         await StoreOptions(opts => { opts.DatabaseSchemaName = "hilo_reset"; });
     }

--- a/src/Polecat.Tests/MultiTenancy/master_table_tenancy_tests.cs
+++ b/src/Polecat.Tests/MultiTenancy/master_table_tenancy_tests.cs
@@ -21,7 +21,7 @@ public class master_table_tenancy_tests : IAsyncLifetime
     private static string Db(string name) =>
         ConnectionSource.ConnectionString.Replace("Initial Catalog=master", $"Database={name}");
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         await using var conn = new SqlConnection(MasterConnectionString);
         await conn.OpenAsync();
@@ -34,7 +34,7 @@ public class master_table_tenancy_tests : IAsyncLifetime
         }
     }
 
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         await using var conn = new SqlConnection(MasterConnectionString);
         await conn.OpenAsync();

--- a/src/Polecat.Tests/MultiTenancy/separate_database_tenancy_tests.cs
+++ b/src/Polecat.Tests/MultiTenancy/separate_database_tenancy_tests.cs
@@ -21,7 +21,7 @@ public class separate_database_tenancy_tests : IAsyncLifetime
     private static string TenantConnectionString(string dbName) =>
         ConnectionSource.ConnectionString.Replace("Initial Catalog=master", $"Database={dbName}");
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         // Create tenant databases if they don't exist
         await using var conn = new SqlConnection(MasterConnectionString);
@@ -35,7 +35,7 @@ public class separate_database_tenancy_tests : IAsyncLifetime
         }
     }
 
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         // Drop tenant databases
         await using var conn = new SqlConnection(MasterConnectionString);

--- a/src/Polecat.Tests/Pagination/paged_list_tests.cs
+++ b/src/Polecat.Tests/Pagination/paged_list_tests.cs
@@ -12,7 +12,7 @@ public class paged_list_tests : IntegrationContext
     {
     }
 
-    public override async Task InitializeAsync()
+    public override async ValueTask InitializeAsync()
     {
         await StoreOptions(opts => { opts.DatabaseSchemaName = "pagination"; });
 

--- a/src/Polecat.Tests/Patching/patching_api.cs
+++ b/src/Polecat.Tests/Patching/patching_api.cs
@@ -11,7 +11,7 @@ public class patching_api : IntegrationContext
     {
     }
 
-    public override async Task InitializeAsync()
+    public override async ValueTask InitializeAsync()
     {
         await StoreOptions(opts => { opts.DatabaseSchemaName = "patching"; });
     }

--- a/src/Polecat.Tests/Patching/patching_datetime.cs
+++ b/src/Polecat.Tests/Patching/patching_datetime.cs
@@ -18,7 +18,7 @@ public class patching_datetime : IntegrationContext
     {
     }
 
-    public override async Task InitializeAsync()
+    public override async ValueTask InitializeAsync()
     {
         await StoreOptions(opts => { opts.DatabaseSchemaName = "patching_dates"; });
     }

--- a/src/Polecat.Tests/Polecat.Tests.csproj
+++ b/src/Polecat.Tests/Polecat.Tests.csproj
@@ -8,7 +8,7 @@
         <PackageReference Include="coverlet.collector" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="Shouldly" />
-        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.v3" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
         <PackageReference Include="Microsoft.Extensions.Hosting" />
         <PackageReference Include="xunit.runner.visualstudio" />

--- a/src/Polecat.Tests/Querying/fetching_stream_query_plans.cs
+++ b/src/Polecat.Tests/Querying/fetching_stream_query_plans.cs
@@ -181,7 +181,7 @@ public class fetching_stream_query_plans_by_string_key : IAsyncLifetime
     private const string Schema = "fetch_stream_plans_str";
     private DocumentStore _store = null!;
 
-    public Task InitializeAsync()
+    public ValueTask InitializeAsync()
     {
         _store = DocumentStore.For(opts =>
         {
@@ -192,13 +192,13 @@ public class fetching_stream_query_plans_by_string_key : IAsyncLifetime
             opts.Events.StreamIdentity = StreamIdentity.AsString;
         });
 
-        return Task.CompletedTask;
+        return ValueTask.CompletedTask;
     }
 
-    public Task DisposeAsync()
+    public ValueTask DisposeAsync()
     {
         _store.Dispose();
-        return Task.CompletedTask;
+        return ValueTask.CompletedTask;
     }
 
     [Fact]

--- a/src/Polecat.Tests/Schema/SchemaCreationTests.cs
+++ b/src/Polecat.Tests/Schema/SchemaCreationTests.cs
@@ -11,9 +11,9 @@ namespace Polecat.Tests.Schema;
 /// </summary>
 public class SchemaCreationTests : IAsyncLifetime
 {
-    public Task InitializeAsync() => SchemaInspector.DropEventStoreTablesAsync();
+    public async ValueTask InitializeAsync() => await SchemaInspector.DropEventStoreTablesAsync();
 
-    public Task DisposeAsync() => Task.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
     private static PolecatDatabase CreateDatabase(Action<StoreOptions>? configure = null)
     {

--- a/src/Polecat.Tests/SoftDeletes/soft_delete_operations.cs
+++ b/src/Polecat.Tests/SoftDeletes/soft_delete_operations.cs
@@ -11,7 +11,7 @@ public class soft_delete_operations : IntegrationContext
     {
     }
 
-    public override async Task InitializeAsync()
+    public override async ValueTask InitializeAsync()
     {
         await StoreOptions(opts =>
         {

--- a/src/Polecat.Tests/SoftDeletes/soft_delete_querying.cs
+++ b/src/Polecat.Tests/SoftDeletes/soft_delete_querying.cs
@@ -11,7 +11,7 @@ public class soft_delete_querying : IntegrationContext
     {
     }
 
-    public override async Task InitializeAsync()
+    public override async ValueTask InitializeAsync()
     {
         // Use a custom schema so the table is created fresh with soft delete columns
         await StoreOptions(opts =>

--- a/src/Polecat.Tests/Storage/tenant_partitioned_documents_tests.cs
+++ b/src/Polecat.Tests/Storage/tenant_partitioned_documents_tests.cs
@@ -32,14 +32,14 @@ public class tenant_partitioned_documents_tests : IAsyncLifetime
 {
     private const string Schema = "pt_docs";
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         await TestSchema.DropSchemaTablesAsync(Schema);
         await PartitionTestCleanup.DropEventsPartitionObjectsAsync();
         await TestSchema.DropSequencesAsync(Schema);
     }
 
-    public Task DisposeAsync() => Task.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
     private static DocumentStore CreateStore(Action<StoreOptions>? configure = null)
     {

--- a/src/Polecat.Tests/StrongTypedId/guid_based_document_operations.cs
+++ b/src/Polecat.Tests/StrongTypedId/guid_based_document_operations.cs
@@ -19,7 +19,7 @@ public class guid_based_document_operations : IntegrationContext
     {
     }
 
-    public override async Task InitializeAsync()
+    public override async ValueTask InitializeAsync()
     {
         await StoreOptions(opts => { opts.DatabaseSchemaName = "strong_guid"; });
     }

--- a/src/Polecat.Tests/StrongTypedId/int_based_document_operations.cs
+++ b/src/Polecat.Tests/StrongTypedId/int_based_document_operations.cs
@@ -19,7 +19,7 @@ public class int_based_document_operations : IntegrationContext
     {
     }
 
-    public override async Task InitializeAsync()
+    public override async ValueTask InitializeAsync()
     {
         await StoreOptions(opts => { opts.DatabaseSchemaName = "strong_int"; });
     }

--- a/src/Polecat.Tests/StrongTypedId/long_based_document_operations.cs
+++ b/src/Polecat.Tests/StrongTypedId/long_based_document_operations.cs
@@ -19,7 +19,7 @@ public class long_based_document_operations : IntegrationContext
     {
     }
 
-    public override async Task InitializeAsync()
+    public override async ValueTask InitializeAsync()
     {
         await StoreOptions(opts => { opts.DatabaseSchemaName = "strong_long"; });
     }

--- a/src/Polecat.Tests/StrongTypedId/string_based_document_operations.cs
+++ b/src/Polecat.Tests/StrongTypedId/string_based_document_operations.cs
@@ -19,7 +19,7 @@ public class string_based_document_operations : IntegrationContext
     {
     }
 
-    public override async Task InitializeAsync()
+    public override async ValueTask InitializeAsync()
     {
         await StoreOptions(opts => { opts.DatabaseSchemaName = "strong_string"; });
     }

--- a/src/Polecat.Tests/StrongTypedId/strong_typed_id_column_type_tests.cs
+++ b/src/Polecat.Tests/StrongTypedId/strong_typed_id_column_type_tests.cs
@@ -18,7 +18,7 @@ public class strong_typed_id_column_type_tests : IntegrationContext
     {
     }
 
-    public override async Task InitializeAsync()
+    public override async ValueTask InitializeAsync()
     {
         await StoreOptions(opts => { opts.DatabaseSchemaName = "strong_id_column"; });
     }

--- a/src/Polecat.Tests/StrongTypedId/strong_typed_id_tests.cs
+++ b/src/Polecat.Tests/StrongTypedId/strong_typed_id_tests.cs
@@ -42,7 +42,7 @@ public class strong_typed_id_tests : IntegrationContext
     {
     }
 
-    public override async Task InitializeAsync()
+    public override async ValueTask InitializeAsync()
     {
         await StoreOptions(opts => { opts.DatabaseSchemaName = "strong_typed_id"; });
     }

--- a/src/Polecat.Tests/Versioning/long_versioned_operations.cs
+++ b/src/Polecat.Tests/Versioning/long_versioned_operations.cs
@@ -14,7 +14,7 @@ public class long_versioned_operations : IntegrationContext
     {
     }
 
-    public override async Task InitializeAsync()
+    public override async ValueTask InitializeAsync()
     {
         await StoreOptions(opts =>
         {

--- a/src/Polecat.Tests/Versioning/revisioned_operations.cs
+++ b/src/Polecat.Tests/Versioning/revisioned_operations.cs
@@ -11,7 +11,7 @@ public class revisioned_operations : IntegrationContext
     {
     }
 
-    public override async Task InitializeAsync()
+    public override async ValueTask InitializeAsync()
     {
         await StoreOptions(opts =>
         {

--- a/src/Polecat.Tests/Versioning/version_column_widening_migration.cs
+++ b/src/Polecat.Tests/Versioning/version_column_widening_migration.cs
@@ -20,7 +20,7 @@ public class version_column_widening_migration : IntegrationContext
     {
     }
 
-    public override async Task InitializeAsync()
+    public override async ValueTask InitializeAsync()
     {
         await StoreOptions(opts => opts.DatabaseSchemaName = Schema);
     }

--- a/src/Polecat.Tests/Versioning/versioned_operations.cs
+++ b/src/Polecat.Tests/Versioning/versioned_operations.cs
@@ -11,7 +11,7 @@ public class versioned_operations : IntegrationContext
     {
     }
 
-    public override async Task InitializeAsync()
+    public override async ValueTask InitializeAsync()
     {
         await StoreOptions(opts =>
         {

--- a/src/Polecat.Tests/event_store_usage_integration_tests.cs
+++ b/src/Polecat.Tests/event_store_usage_integration_tests.cs
@@ -21,7 +21,7 @@ public class event_store_usage_integration_tests : IntegrationContext
     {
     }
 
-    public override async Task InitializeAsync()
+    public override async ValueTask InitializeAsync()
     {
         await base.InitializeAsync();
         await using var conn = await OpenConnectionAsync();


### PR DESCRIPTION
Second of four PRs moving to xUnit v3 + Microsoft Testing Platform (follows #379). This is the version bump itself, and it deliberately **stays on the VSTest bridge** so `dotnet test`, the Nuke `DotNetTest` targets and CI all keep working untouched. MTP is the next PR.

## Packages

`xunit 2.9.3` → `xunit.v3 3.2.2`, `xunit.runner.visualstudio 3.1.4` → `3.1.5`. `Microsoft.NET.Test.Sdk` and `coverlet.collector` stay for now.

`Polecat.TestUtils` references `xunit.v3.extensibility.core` rather than `xunit.v3` — it's a library that only authors custom attributes, and `xunit.v3` forces `OutputType=Exe` onto anything referencing it.

## Three real changes; everything else is mechanical

**1. `IAsyncLifetime` is now ValueTask-based** and inherits `IAsyncDisposable` — 96 `InitializeAsync`/`DisposeAsync` declarations across 61 files change return type. Most funnel through `IntegrationContext`, `OneOffConfigurationsContext`, `DefaultStoreFixture`.

I checked for the trap Weasel hit — v3 calls `DisposeAsync` *only* when a class implements both `IAsyncDisposable` and `IDisposable`, silently skipping cleanup held in `Dispose()`. No test class here implements `IDisposable`, so nothing was affected.

**2. `RepeatAttribute` rewritten.** `DataAttribute` moved namespace (`Xunit.Sdk` → `Xunit.v3`) and both abstract members changed shape: `GetData` now returns `ValueTask<IReadOnlyCollection<ITheoryDataRow>>` and takes a `DisposalTracker`, and `SupportsDiscoveryEnumeration` is required. Returning `true` there is what keeps each `[Repeat]` iteration its own test case — the discovery diff below proves it matches v2 exactly.

**3. xUnit analyzers turned off**, in `Directory.Build.targets` rather than through NuGet. They arrive transitively and light up **10,212 warnings** against a whole-solution baseline of 68, which buries every real warning.

Both NuGet spellings that *look* like they should work are silently no-ops, and I measured both at the full 10,212 before moving on:

| Attempt | Result |
|---|---|
| `ExcludeAssets="analyzers"` on `xunit.v3` | no-op — exclusions don't propagate two edges down the graph |
| `ExcludeAssets="all"` on a direct `xunit.analyzers` | no-op — doesn't override the transitive edge |
| Remove `Analyzer` items in MSBuild | works |

Deliberately **not** a `NoWarn` list, so a future new rule can't quietly reintroduce the noise. (`xUnit1051` accounts for all 10,212, but `xUnit3003` also fires.) Adopting the analyzers for real — mostly threading `TestContext.Current.CancellationToken` through ~6,500 async DB calls — is follow-up work.

`RequiresNativeJsonFactAttribute` needed no change: `FactAttribute` is still unsealed with a virtual settable `Skip`.

## Verification

- **Discovery lists are byte-identical to v2** on both TFMs — `diff` of sorted `dotnet test --list-tests` output is empty. 1565 / 37 / 65.
- **Full runs green**: Polecat.Tests 1598 passed / 3 skipped / 1601 total; EntityFrameworkCore.Tests 37; AspNetCore.Testing 65.
- The 1601-vs-1565 gap is three `MemberData` theories that discovery reports as one entry each and execution expands — equally true on v2.
- **Whole-solution warning count: 68 on this branch, 68 on main.**

One caveat, stated plainly: an earlier full run showed 2 failures in `strong_typed_id_tests`. They did not reproduce on a second full run, pass in isolation, and touch the shared local database this repo already documents as a source of cross-test flakiness. CI runs against a fresh database and is the referee here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)