### PR TITLE
build: move the test suites to Microsoft Testing Platform

### DIFF
--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -10,10 +10,11 @@ on:
         required: false
         type: string
         default: "default"
-      TEST_FILTERS:
-        required: false
-        type: string
-        default: "Category!=Flaky"
+      # TEST_FILTERS is gone. It defaulted to "Category!=Flaky" and no caller ever overrode it,
+      # but there is not a single [Trait] attribute anywhere in the repo — so the filter matched
+      # every test and had never excluded anything. Under Microsoft Testing Platform the equivalent
+      # would be `--filter-not-trait "Category=Flaky"`; add it back with real traits behind it if
+      # a flaky-test quarantine is ever actually wanted.
 
 jobs:
   test:
@@ -57,8 +58,32 @@ jobs:
           echo "SQL Server failed to become healthy"
           exit 1
 
+      # Runs the Microsoft Testing Platform executable directly rather than going through
+      # `dotnet test`. An xUnit v3 test project builds as its own MTP executable, and invoking it is
+      # the only way to get the TRX report out on every SDK.
+      #
+      # `dotnet test` does not work here, which is worth recording because two of the three failure
+      # modes are silent:
+      #   dotnet test ... --logger "trx;..."        VSTest-only. MTP warns MTP0001 that the property
+      #                                             is ignored, runs the tests, exits 0 — and writes
+      #                                             no TRX at all, so the reporter step below finds
+      #                                             nothing and the build goes red for the wrong
+      #                                             reason.
+      #   dotnet test ... -- --report-trx           arguments are swallowed. Tests run, exit 0, no TRX.
+      #   dotnet test ... --report-trx              MSBuild rejects it outright: MSB1001 Unknown switch.
+      # All three were measured on SDK 10.0.101 before settling on this.
+      #
+      # Verified that a failing test still fails the build: a deliberately failing probe produced
+      # "failed: 1, succeeded: 37", printed the assertion and a file:line stack trace inline, and
+      # exited 2. A runner swap that quietly stopped failing builds would be the worst outcome here.
+      #
+      # The TRX lands in <project>/bin/Release/net9.0/TestResults/, which the reporter's
+      # **/TestResults/*.trx glob already matches.
       - name: Test
-        run: dotnet test ${{ env.TEST_PROJECT_PATH }} -c Release --no-build --framework net9.0 --logger "trx;LogFileName=test-results.trx" --filter "${{ inputs.TEST_FILTERS }}"  
+        run: |
+          PROJECT_DIR=$(dirname "${{ env.TEST_PROJECT_PATH }}")
+          ASSEMBLY=$(basename "${{ env.TEST_PROJECT_PATH }}" .csproj)
+          "$PROJECT_DIR/bin/Release/net9.0/$ASSEMBLY" --report-trx --report-trx-filename test-results.trx
 
       - name: Report results
         uses: dorny/test-reporter@v3

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,6 +14,41 @@
         <RepositoryUrl>https://github.com/JasperFx/polecat</RepositoryUrl>
     </PropertyGroup>
 
+    <!--
+      Microsoft Testing Platform. These are repo-wide rather than per-test-project on purpose:
+      TestingPlatformDotnetTestSupport changes how `dotnet test` invokes a project, so a solution
+      where only some projects answered to MTP would leave `dotnet test polecat.slnx` in a mixed
+      mode. They are inert in projects that don't reference xunit.v3.
+
+      UseMicrosoftTestingPlatformRunner makes xunit v3 build its MTP entry point instead of the
+      VSTest bridge; TestingPlatformDotnetTestSupport makes `dotnet test` run that executable
+      directly rather than going through testhost. Neither Microsoft.NET.Test.Sdk nor
+      xunit.runner.visualstudio is referenced anymore.
+    -->
+    <PropertyGroup>
+        <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
+        <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+        <!--
+          Without this, a failing test prints only
+
+            error run failed: Tests failed: '.../TestResults/Polecat.Tests_net9.0_x64.log'
+
+          and the test name, assertion and stack trace go to that file. CI never publishes it, so a
+          red build would carry no indication of what broke — strictly worse than the VSTest bridge,
+          which printed failures inline. This restores that.
+        -->
+        <TestingPlatformShowTestsFailure>true</TestingPlatformShowTestsFailure>
+        <!--
+          Every database-backed suite here shares schemas between target frameworks, so running the
+          net9.0 and net10.0 suites concurrently makes them drop each other's schemas mid-test. This
+          repo has long documented that as unexplained local flakiness on a bare `dotnet test`
+          (duplicate-object and deadlock errors that look like real failures); CI never hit it
+          because each job names a single framework explicitly. Serializing the frameworks fixes it
+          at the source.
+        -->
+        <TestTfmsInParallel>false</TestTfmsInParallel>
+    </PropertyGroup>
+
     <ItemGroup>
         <None Include="$(MSBuildThisFileDirectory)logo.png" Pack="true" PackagePath="" Visible="false" />
     </ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -74,8 +74,27 @@
 
         <!-- Testing -->
         <PackageVersion Include="Alba" Version="8.5.2" />
-        <PackageVersion Include="coverlet.collector" Version="6.0.4" />
-        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+        <!--
+          Microsoft Testing Platform extensions, replacing coverlet.collector and the TRX logger,
+          both of which are VSTest-only. CodeCoverage is capability parity — no build target asks
+          for coverage today — while TrxReport is what CI's TRX report option and the
+          dorny/test-reporter step depend on.
+
+          BOTH ARE PINNED TO THE MTP 1.x LINE, NOT THE LATEST. xunit.v3 3.2.2 is built against
+          Microsoft.Testing.Platform 1.x — its packages are literally named xunit.v3.core.mtp-v1.
+          The 2.x releases of these extensions (TrxReport 2.x, CodeCoverage 18.1.0+) drag the
+          platform assembly up to 2.x while Microsoft.Testing.Platform.MSBuild stays behind, and
+          every test run then dies at startup with
+
+            TypeLoadException: Could not load type
+            'Microsoft.Testing.Platform.Extensions.TestHost.IDataConsumer'
+            from assembly 'Microsoft.Testing.Platform, Version=2.3.0.0'
+
+          1.9.1 and 18.0.6 are the last releases on MTP 1.x. Move these forward together when
+          xunit.v3 ships an mtp-v2 build, and not before.
+        -->
+        <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.0.6" />
+        <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="1.9.1" />
         <PackageVersion Include="NSubstitute" Version="5.3.0" />
         <PackageVersion Include="Shouldly" Version="4.3.0" />
         <!-- xUnit v3. The test projects reference xunit.v3; Polecat.TestUtils, which is a plain
@@ -89,7 +108,6 @@
              ExcludeAssets on any PackageReference here. -->
         <PackageVersion Include="xunit.v3" Version="3.2.2" />
         <PackageVersion Include="xunit.v3.extensibility.core" Version="3.2.2" />
-        <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
         <!-- Weasel 9.8.0/9.9.0 introduce Weasel.Storage: the dialect-neutral closed-shape
              storage contracts extracted from Marten (marten#4821/#4830, weasel#329/#331) —
              IStorageSession / IStorageDatabase / IStorageSerializer / IDocumentStorage /

--- a/src/Polecat.AspNetCore.Testing/Polecat.AspNetCore.Testing.csproj
+++ b/src/Polecat.AspNetCore.Testing/Polecat.AspNetCore.Testing.csproj
@@ -7,14 +7,11 @@
 
     <ItemGroup>
         <PackageReference Include="Alba" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="NSubstitute" />
         <PackageReference Include="Shouldly" />
+        <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
+        <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
         <PackageReference Include="xunit.v3" />
-        <PackageReference Include="xunit.runner.visualstudio">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Polecat.EntityFrameworkCore.Tests/Polecat.EntityFrameworkCore.Tests.csproj
+++ b/src/Polecat.EntityFrameworkCore.Tests/Polecat.EntityFrameworkCore.Tests.csproj
@@ -2,15 +2,17 @@
 
     <PropertyGroup>
         <IsPackable>false</IsPackable>
+        <!-- Explicit now that Microsoft.NET.Test.Sdk is gone: it used to set this. An xunit v3
+             test project is its own MTP executable and will not build without it. -->
+        <OutputType>Exe</OutputType>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.collector" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="Shouldly" />
         <PackageReference Include="Weasel.SqlServer" />
+        <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
+        <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
         <PackageReference Include="xunit.v3" />
-        <PackageReference Include="xunit.runner.visualstudio" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
     </ItemGroup>
 

--- a/src/Polecat.Tests/Polecat.Tests.csproj
+++ b/src/Polecat.Tests/Polecat.Tests.csproj
@@ -2,16 +2,18 @@
 
     <PropertyGroup>
         <IsPackable>false</IsPackable>
+        <!-- Explicit now that Microsoft.NET.Test.Sdk is gone: it used to set this. An xunit v3
+             test project is its own MTP executable and will not build without it. -->
+        <OutputType>Exe</OutputType>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.collector" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="Shouldly" />
+        <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
+        <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
         <PackageReference Include="xunit.v3" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
         <PackageReference Include="Microsoft.Extensions.Hosting" />
-        <PackageReference Include="xunit.runner.visualstudio" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
         <PackageReference Include="StronglyTypedId" />
     </ItemGroup>


### PR DESCRIPTION
Final PR of the xUnit v3 arc, following #379 and #380. All three test projects drop the VSTest bridge and run as their own MTP executables — no testhost indirection, faster startup, xUnit v3's own reporting.

## Why this includes the CI change

The plan had CI as a separate fourth PR. It can't be: switching the runner and leaving `--logger "trx;..."` in place does **not** fail the tests — it warns `MTP0001`, runs, exits 0, and silently writes no TRX. `dorny/test-reporter` then finds no report and turns the build red for the wrong reason. Splitting would knowingly put main in that state, so the CI change lands here.

## Packages

`Microsoft.NET.Test.Sdk`, `xunit.runner.visualstudio` and `coverlet.collector` are gone. `Microsoft.Testing.Extensions.TrxReport` and `Microsoft.Testing.Extensions.CodeCoverage` replace the last two.

## Four things worth recording, three of them silent failures

**1. Both MTP extensions are pinned to 1.x, not latest.** xunit.v3 3.2.2 is built against Microsoft.Testing.Platform **1.x** — its packages are literally named `xunit.v3.core.mtp-v1`. TrxReport 2.x and CodeCoverage 18.1.0+ moved to MTP 2.x, and the mixed graph dies at startup on *every* test run:

```
TypeLoadException: Could not load type
'Microsoft.Testing.Platform.Extensions.TestHost.IDataConsumer'
from assembly 'Microsoft.Testing.Platform, Version=2.3.0.0'
```

`1.9.1` and `18.0.6` are the last releases on MTP 1.x.

**2. `dotnet test` cannot emit TRX under MTP on SDK 10.0.101.** All four forms measured before settling:

| Invocation | Result |
|---|---|
| `--logger "trx;..."` | `MTP0001` warning, exit 0, **no TRX** |
| `-- --report-trx` | arguments swallowed, exit 0, **no TRX** |
| `--report-trx` | `MSB1001 Unknown switch` |
| **direct executable** | ✅ TRX written, correct exit code |

Only the last is reliable across SDKs, so that is what CI runs.

**3. `OutputType=Exe` is now explicit.** `Microsoft.NET.Test.Sdk` used to set it; without it xunit.v3's targets fail the build outright.

**4. `TestingPlatformShowTestsFailure` is required**, and its absence is a trap: by default MTP sends the failing test name, assertion and stack trace to a log file under `TestResults` that CI never publishes, leaving a red build with no indication of what broke.

## Bonus: fixes a long-standing local flake

`TestTfmsInParallel=false` lands here too. Every database-backed suite shares schemas between target frameworks, so a bare `dotnet test` ran net9.0 and net10.0 concurrently against the same schemas and they dropped each other's tables mid-test. That has been carried as "unexplained local flakiness" (duplicate-object / deadlock errors that look like real failures). CI never saw it because each job names one framework.

CI also loses the `TEST_FILTERS` input — it defaulted to `Category!=Flaky`, no caller overrode it, and there is not one `[Trait]` attribute in the repo, so it matched every test and had never excluded anything.

`build/build.cs` needed no changes; its `DotNetTest` targets work as-is under MTP.

## Verification

- **Polecat.Tests 1601 total, 1598 passed, 3 skipped, exit 0** — identical to the VSTest-bridge numbers in #380. EntityFrameworkCore.Tests 37, AspNetCore.Testing 65, both exit 0.
- Emitted TRX parses with `Counters total=1601 executed=1598 passed=1598 failed=0`, which is what `dorny/test-reporter` consumes.
- **A failing test still fails the build** — the thing a silent runner swap could quietly break. A deliberately failing probe produced `failed: 1, succeeded: 37`, printed the Shouldly assertion and a `file:line` stack trace inline, and exited **2**.
- Whole-solution warning count stays at **68**, matching main.

**Known leftover:** `xunit.runner.json` still carries `parallelizeAssembly`, inert under v3 (each assembly is its own process). `parallelizeTestCollections` still matters and is doing real work. Left alone to keep this PR's blast radius down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)