### PR TITLE
chore: drop the inert parallelizeAssembly from xunit.runner.json

### DIFF
--- a/src/Polecat.EntityFrameworkCore.Tests/xunit.runner.json
+++ b/src/Polecat.EntityFrameworkCore.Tests/xunit.runner.json
@@ -1,5 +1,4 @@
 {
   "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
-  "parallelizeAssembly": false,
   "parallelizeTestCollections": false
 }

--- a/src/Polecat.Tests/xunit.runner.json
+++ b/src/Polecat.Tests/xunit.runner.json
@@ -1,5 +1,4 @@
 {
   "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
-  "parallelizeAssembly": false,
   "parallelizeTestCollections": false
 }


### PR DESCRIPTION
Follow-up to #381, which flagged this but left it alone to keep that PR's blast radius down.

`parallelizeAssembly` is still a *recognized* key in xUnit v3 — it was not producing a warning — but it can only affect a runner that hosts several test assemblies **in one process**. Under Microsoft Testing Platform each assembly is its own executable, so there is no assembly-level parallelism for it to switch off. Both suites also run one project per CI job.

It reads like a live setting protecting these database-backed suites from each other, and it isn't one.

`parallelizeTestCollections` stays — *that* one is load-bearing: these suites share a single SQL Server database, and collections running concurrently would collide.

## Verification

Verified rather than assumed, since a silent loss of serialization would look exactly like flakiness weeks later:

- Polecat.Tests **1601 total / 1598 passed / 3 skipped** in **15m44s**
- EntityFrameworkCore.Tests **37**
- both exit 0

A run that had quietly gone parallel would be both markedly faster *and* failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)