### PR TITLE
feat: MasterTableTenancy implements IDynamicTenantSource<string> (#377)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>5.7.1</Version>
+        <Version>5.8.0</Version>
         <LangVersion>latest</LangVersion>
         <Authors>Jeremy D. Miller</Authors>
         <PackageIcon>logo.png</PackageIcon>

--- a/docs/configuration/multitenancy.md
+++ b/docs/configuration/multitenancy.md
@@ -149,6 +149,91 @@ Notes:
 This is the Polecat (SQL Server) equivalent of Marten's `MultiTenantedDatabasesViaMasterTable` /
 `MasterTableTenancy`.
 
+### Store-Agnostic Runtime Tenant Management <Badge type="tip" text="5.8" />
+
+The `MasterTableTenancy` methods above are Polecat-specific. `MasterTableTenancy` also implements
+`JasperFx.MultiTenancy.IDynamicTenantSource<string>` — the same store-agnostic abstraction Marten's
+`MasterTableTenancy` and `ShardedTenancy` implement — so tooling can drive the runtime tenant
+lifecycle without taking a dependency on Polecat's concrete tenancy types:
+
+```cs
+var source = (IDynamicTenantSource<string>)store.Options.Tenancy!;
+
+// Always DatabaseCardinality.DynamicMultiple -- the tenant list is read from the
+// master table and free to change while the store is running
+var cardinality = source.Cardinality;
+
+// Add a tenant with a caller-supplied connection string
+await source.AddTenantAsync("tenant-a", "Server=localhost;Database=tenant_a;...");
+
+// Resolve a tenant's connection string; throws UnknownTenantIdException for an
+// unknown *or* disabled tenant
+var connectionString = await source.FindAsync("tenant-a");
+
+// Soft delete / restore
+await source.DisableTenantAsync("tenant-a");
+IReadOnlyList<string> disabled = await source.AllDisabledAsync();
+await source.EnableTenantAsync("tenant-a");
+
+// Re-read the master table, dropping cached entries for tenants that have since
+// been removed or disabled elsewhere
+await source.RefreshAsync();
+
+// The currently active tenants. AllActive() returns the tenant *database
+// identifiers* rather than raw connection strings, so credentials never reach an
+// admin dashboard
+IReadOnlyList<string> databases = source.AllActive();
+IReadOnlyList<Assignment<string>> byTenant = source.AllActiveByTenant();
+
+// Remove the registry record entirely. The tenant database itself is untouched
+await source.RemoveTenantAsync("tenant-a");
+```
+
+When the store is configured with `MultiTenantedMasterTable()`, `AddPolecat()` also registers the
+tenancy in the container as `IDynamicTenantSource<string>`:
+
+```cs
+builder.Services.AddPolecat(opts =>
+{
+    opts.Connection(connectionString);
+    opts.MultiTenantedMasterTable(controlPlaneConnectionString);
+});
+
+// ...elsewhere
+var source = provider.GetServices<IDynamicTenantSource<string>>().Single();
+```
+
+This is what makes a Polecat-backed service's **Tenants** tab editable in CritterWatch — add,
+disable, enable, and remove all round-trip against SQL Server with no CritterWatch release required.
+Consumers resolve the source with `GetServices<IDynamicTenantSource<string>>()` and degrade to a
+read-only tenant list when the collection is empty.
+
+::: tip
+The registration is deliberately **conditional**: it happens only when the configured tenancy is a
+dynamic source. Single-database stores and static `MultiTenantedDatabases()` stores leave
+`GetServices<IDynamicTenantSource<string>>()` empty, which is the signal consumers use to fall back
+to a read-only tenant list.
+:::
+
+Two caveats:
+
+- The auto-assign overload, `Task<string> AddTenantAsync(string tenantId, CancellationToken)`, throws
+  `NotSupportedException`. Database-per-tenant has no pool for Polecat to assign from, so the caller
+  must supply a connection string via `AddTenantAsync(tenantId, connectionValue)`. CritterWatch treats
+  an empty connection string as "auto-assign" and skips sources that throw.
+- The `AddPolecat(Func<IServiceProvider, StoreOptions>)` overload cannot inspect the tenancy while the
+  container is still being assembled, so it does not auto-register the source. Configure the store with
+  one of the other `AddPolecat` overloads, or register it yourself:
+
+  ```cs
+  services.AddSingleton<IDynamicTenantSource<string>>(sp =>
+      (IDynamicTenantSource<string>)((DocumentStore)sp.GetRequiredService<IDocumentStore>()).Options.Tenancy!);
+  ```
+
+Hard-deleting the physical tenant database is out of scope for this abstraction — SQL Server needs
+`ALTER DATABASE ... SET SINGLE_USER WITH ROLLBACK IMMEDIATE` before `DROP DATABASE`, and that is the
+consumer's job. Add, disable, enable, and remove all work without it.
+
 ## Setting the Tenant ID
 
 The tenant ID is set when opening a session:

--- a/src/Polecat.Tests/DependencyInjection/dynamic_tenant_source_registration_tests.cs
+++ b/src/Polecat.Tests/DependencyInjection/dynamic_tenant_source_registration_tests.cs
@@ -1,0 +1,85 @@
+using JasperFx.MultiTenancy;
+using Microsoft.Extensions.DependencyInjection;
+using Polecat.Storage;
+using Polecat.TestUtils;
+
+namespace Polecat.Tests.DependencyInjection;
+
+/// <summary>
+///     #377: implementing IDynamicTenantSource&lt;string&gt; is only half the story — CritterWatch
+///     resolves it with GetServices&lt;IDynamicTenantSource&lt;string&gt;&gt;() and degrades to a
+///     read-only tenant list when the collection is empty. So the registration has to exist for a
+///     dynamic tenancy and must *not* exist for every other tenancy model.
+/// </summary>
+public class dynamic_tenant_source_registration_tests
+{
+    [Fact]
+    public void master_table_tenancy_registers_the_dynamic_source()
+    {
+        var services = new ServiceCollection();
+        services.AddPolecat(opts =>
+        {
+            opts.ConnectionString = ConnectionSource.ConnectionString;
+            opts.UseNativeJsonType = ConnectionSource.SupportsNativeJson;
+            opts.MultiTenantedMasterTable(ConnectionSource.ConnectionString);
+        });
+
+        using var provider = services.BuildServiceProvider();
+
+        var sources = provider.GetServices<IDynamicTenantSource<string>>().ToList();
+        sources.Count.ShouldBe(1);
+        var store = (DocumentStore)provider.GetRequiredService<IDocumentStore>();
+        sources[0].ShouldBeOfType<MasterTableTenancy>().ShouldBeSameAs(store.Options.Tenancy);
+    }
+
+    [Fact]
+    public void master_table_tenancy_registers_the_dynamic_source_from_prebuilt_options()
+    {
+        var options = new StoreOptions
+        {
+            ConnectionString = ConnectionSource.ConnectionString,
+            UseNativeJsonType = ConnectionSource.SupportsNativeJson
+        };
+        options.MultiTenantedMasterTable(ConnectionSource.ConnectionString);
+
+        var services = new ServiceCollection();
+        services.AddPolecat(options);
+
+        using var provider = services.BuildServiceProvider();
+
+        provider.GetServices<IDynamicTenantSource<string>>().ShouldHaveSingleItem();
+    }
+
+    [Fact]
+    public void single_database_store_registers_no_dynamic_source()
+    {
+        var services = new ServiceCollection();
+        services.AddPolecat(opts =>
+        {
+            opts.ConnectionString = ConnectionSource.ConnectionString;
+            opts.UseNativeJsonType = ConnectionSource.SupportsNativeJson;
+        });
+
+        using var provider = services.BuildServiceProvider();
+
+        provider.GetServices<IDynamicTenantSource<string>>().ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void static_separate_database_tenancy_registers_no_dynamic_source()
+    {
+        var services = new ServiceCollection();
+        services.AddPolecat(opts =>
+        {
+            opts.ConnectionString = ConnectionSource.ConnectionString;
+            opts.UseNativeJsonType = ConnectionSource.SupportsNativeJson;
+            opts.MultiTenantedDatabases(x => x.AddTenant("one", ConnectionSource.ConnectionString));
+        });
+
+        using var provider = services.BuildServiceProvider();
+
+        // Static tenancy has no runtime lifecycle, so the collection stays empty and consumers
+        // correctly show a read-only tenant list.
+        provider.GetServices<IDynamicTenantSource<string>>().ShouldBeEmpty();
+    }
+}

--- a/src/Polecat.Tests/MultiTenancy/dynamic_tenant_source_tests.cs
+++ b/src/Polecat.Tests/MultiTenancy/dynamic_tenant_source_tests.cs
@@ -1,0 +1,191 @@
+using JasperFx;
+using JasperFx.Descriptors;
+using JasperFx.MultiTenancy;
+using Microsoft.Data.SqlClient;
+using Polecat.Storage;
+using Polecat.TestUtils;
+
+namespace Polecat.Tests.MultiTenancy;
+
+/// <summary>
+///     #377: MasterTableTenancy declares JasperFx.MultiTenancy.IDynamicTenantSource&lt;string&gt; so
+///     store-agnostic admin tooling (CritterWatch) can drive the runtime tenant lifecycle without
+///     referencing Polecat's concrete tenancy types. These tests exercise the tenancy *only* through
+///     that abstraction — every call goes through the interface reference, never the concrete type.
+/// </summary>
+public class dynamic_tenant_source_tests : IAsyncLifetime
+{
+    private const string TenantA = "tenant_a";
+    private const string TenantB = "tenant_b";
+    private const string ControlDb = "polecat_dts_control";
+    private const string DbA = "polecat_dts_tenant_a";
+    private const string DbB = "polecat_dts_tenant_b";
+
+    private static readonly string MasterConnectionString =
+        ConnectionSource.ConnectionString.Replace("Initial Catalog=master", "Database=master");
+
+    private static string Db(string name) =>
+        ConnectionSource.ConnectionString.Replace("Initial Catalog=master", $"Database={name}");
+
+    public async ValueTask InitializeAsync()
+    {
+        await using var conn = new SqlConnection(MasterConnectionString);
+        await conn.OpenAsync();
+
+        foreach (var db in new[] { ControlDb, DbA, DbB })
+        {
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = $"IF DB_ID('{db}') IS NULL CREATE DATABASE [{db}];";
+            await cmd.ExecuteNonQueryAsync();
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await using var conn = new SqlConnection(MasterConnectionString);
+        await conn.OpenAsync();
+
+        foreach (var db in new[] { ControlDb, DbA, DbB })
+        {
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = $"""
+                IF DB_ID('{db}') IS NOT NULL
+                BEGIN
+                    ALTER DATABASE [{db}] SET SINGLE_USER WITH ROLLBACK IMMEDIATE;
+                    DROP DATABASE [{db}];
+                END
+                """;
+            await cmd.ExecuteNonQueryAsync();
+        }
+    }
+
+    private (DocumentStore Store, IDynamicTenantSource<string> Source) CreateStore()
+    {
+        MasterTableTenancy? tenancy = null;
+        var store = DocumentStore.For(opts =>
+        {
+            opts.ConnectionString = Db(ControlDb);
+            opts.AutoCreateSchemaObjects = AutoCreate.All;
+            opts.UseNativeJsonType = ConnectionSource.SupportsNativeJson;
+
+            tenancy = opts.MultiTenantedMasterTable(Db(ControlDb));
+        });
+
+        // The whole point of #377: the concrete tenancy *is* the abstraction.
+        return (store, tenancy!.ShouldBeAssignableTo<IDynamicTenantSource<string>>()!);
+    }
+
+    [Fact]
+    public void master_table_tenancy_is_a_dynamic_tenant_source()
+    {
+        var (store, source) = CreateStore();
+        using (store)
+        {
+            store.Options.Tenancy.ShouldBeAssignableTo<IDynamicTenantSource<string>>();
+            source.Cardinality.ShouldBe(DatabaseCardinality.DynamicMultiple);
+        }
+    }
+
+    [Fact]
+    public async Task add_tenant_then_find_returns_the_connection_string()
+    {
+        var (store, source) = CreateStore();
+        using (store)
+        {
+            await source.AddTenantAsync(TenantA, Db(DbA));
+
+            (await source.FindAsync(TenantA)).ShouldBe(Db(DbA));
+        }
+    }
+
+    [Fact]
+    public async Task find_unknown_tenant_throws()
+    {
+        var (store, source) = CreateStore();
+        using (store)
+        {
+            await Should.ThrowAsync<UnknownTenantIdException>(async () => await source.FindAsync("nope"));
+        }
+    }
+
+    [Fact]
+    public async Task disable_and_enable_round_trip_through_the_abstraction()
+    {
+        var (store, source) = CreateStore();
+        using (store)
+        {
+            await source.AddTenantAsync(TenantA, Db(DbA));
+
+            await source.DisableTenantAsync(TenantA);
+
+            (await source.AllDisabledAsync()).ShouldContain(TenantA);
+            await Should.ThrowAsync<UnknownTenantIdException>(async () => await source.FindAsync(TenantA));
+
+            await source.EnableTenantAsync(TenantA);
+
+            (await source.AllDisabledAsync()).ShouldNotContain(TenantA);
+            (await source.FindAsync(TenantA)).ShouldBe(Db(DbA));
+        }
+    }
+
+    [Fact]
+    public async Task remove_tenant_deletes_the_registry_record()
+    {
+        var (store, source) = CreateStore();
+        using (store)
+        {
+            await source.AddTenantAsync(TenantA, Db(DbA));
+
+            await source.RemoveTenantAsync(TenantA);
+
+            await Should.ThrowAsync<UnknownTenantIdException>(async () => await source.FindAsync(TenantA));
+            (await source.AllDisabledAsync()).ShouldNotContain(TenantA);
+
+            // A fresh tenancy reading purely from the master table agrees — the row is gone, not
+            // merely evicted from the in-memory cache.
+            var (store2, source2) = CreateStore();
+            using (store2)
+            {
+                await Should.ThrowAsync<UnknownTenantIdException>(async () => await source2.FindAsync(TenantA));
+            }
+        }
+    }
+
+    [Fact]
+    public async Task refresh_reloads_the_active_tenants()
+    {
+        var (store, source) = CreateStore();
+        using (store)
+        {
+            await source.AddTenantAsync(TenantA, Db(DbA));
+            await source.AddTenantAsync(TenantB, Db(DbB));
+
+            await source.RefreshAsync();
+
+            source.AllActiveByTenant().Select(x => x.TenantId)
+                .OrderBy(x => x, StringComparer.Ordinal)
+                .ShouldBe([TenantA, TenantB]);
+            source.AllActive().Count.ShouldBe(2);
+
+            // A disabled tenant drops out of the active set on the next refresh.
+            await source.DisableTenantAsync(TenantB);
+            await source.RefreshAsync();
+
+            source.AllActiveByTenant().Select(x => x.TenantId).ShouldBe([TenantA]);
+        }
+    }
+
+    [Fact]
+    public async Task auto_assign_overload_is_not_supported()
+    {
+        var (store, source) = CreateStore();
+        using (store)
+        {
+            // Database-per-tenant has no pool to assign from, so the jasperfx#413 auto-assign
+            // overload keeps its default NotSupportedException. CritterWatch relies on that to
+            // require a caller-supplied connection string for this tenancy model.
+            await Should.ThrowAsync<NotSupportedException>(async () =>
+                await source.AddTenantAsync(TenantA, TestContext.Current.CancellationToken));
+        }
+    }
+}

--- a/src/Polecat/PolecatServiceCollectionExtensions.cs
+++ b/src/Polecat/PolecatServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using JasperFx.CommandLine.Descriptions;
 using JasperFx.Events;
+using JasperFx.MultiTenancy;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Polecat.Internal;
@@ -17,12 +18,15 @@ public static class PolecatServiceCollectionExtensions
     public static PolecatConfigurationExpression AddPolecat(
         this IServiceCollection services, Action<StoreOptions> configure)
     {
-        return services.AddPolecat(sp =>
-        {
-            var options = new StoreOptions();
-            configure(options);
-            return options;
-        });
+        // The StoreOptions is built here rather than inside the resolution factory so that
+        // AddPolecat(StoreOptions) below can inspect the configured tenancy while the container is
+        // still being assembled (#377). Mirrors Marten's AddMarten(Action<StoreOptions>), which does
+        // the same eager build and then delegates to AddMarten(StoreOptions). The IConfigurePolecat
+        // chain still runs later, on first IDocumentStore resolution.
+        var options = new StoreOptions();
+        configure(options);
+
+        return services.AddPolecat(options);
     }
 
     /// <summary>
@@ -40,12 +44,42 @@ public static class PolecatServiceCollectionExtensions
     public static PolecatConfigurationExpression AddPolecat(
         this IServiceCollection services, StoreOptions options)
     {
-        return services.AddPolecat(_ => options);
+        var expression = services.AddPolecat(_ => options);
+
+        // #377 / jasperfx#413: when the configured tenancy is a dynamic source (today only
+        // MasterTableTenancy), also register it as IDynamicTenantSource<string> so store-agnostic
+        // admin tooling (CritterWatch) can resolve it through GetServices without referencing
+        // Polecat's concrete tenancy types. Conditional on purpose: non-dynamic stores
+        // (DefaultTenancy / SeparateDatabaseTenancy) must keep GetServices empty, which is the
+        // signal consumers use to fall back to a read-only tenant list.
+        //
+        // The factory resolves IDocumentStore first so the IConfigurePolecat chain has run and
+        // Options.Tenancy is final before it is handed out.
+        if (options.Tenancy is IDynamicTenantSource<string>)
+        {
+            services.AddSingleton<IDynamicTenantSource<string>>(sp =>
+            {
+                var store = (DocumentStore)sp.GetRequiredService<IDocumentStore>();
+                return (IDynamicTenantSource<string>)store.Options.Tenancy!;
+            });
+        }
+
+        return expression;
     }
 
     /// <summary>
     ///     Add Polecat with a factory function that receives the IServiceProvider.
     /// </summary>
+    /// <remarks>
+    ///     The StoreOptions is not available until the container is built, so this overload cannot
+    ///     auto-register <c>IDynamicTenantSource&lt;string&gt;</c> for a dynamic tenancy the way the
+    ///     other overloads do (#377). If you configure <c>MultiTenantedMasterTable()</c> from here and
+    ///     want CritterWatch's runtime tenant management, register it yourself:
+    ///     <code>
+    ///     services.AddSingleton&lt;IDynamicTenantSource&lt;string&gt;&gt;(sp =&gt;
+    ///         (IDynamicTenantSource&lt;string&gt;)((DocumentStore)sp.GetRequiredService&lt;IDocumentStore&gt;()).Options.Tenancy!);
+    ///     </code>
+    /// </remarks>
     public static PolecatConfigurationExpression AddPolecat(
         this IServiceCollection services, Func<IServiceProvider, StoreOptions> optionSource)
     {

--- a/src/Polecat/Storage/MasterTableTenancy.cs
+++ b/src/Polecat/Storage/MasterTableTenancy.cs
@@ -16,7 +16,13 @@ namespace Polecat.Storage;
 ///     Marten's <c>MasterTableTenancy</c> and the surface CritterWatch uses for dynamic tenant
 ///     management.
 /// </summary>
-public class MasterTableTenancy : ITenancy
+/// <remarks>
+///     #377: this type also declares <see cref="IDynamicTenantSource{T}" /> so store-agnostic admin
+///     tooling (CritterWatch) can drive the add / disable / enable / remove lifecycle without taking a
+///     reference to Polecat's concrete tenancy types. Mirrors Marten's
+///     <c>MasterTableTenancy: ITenancy, ITenancyWithMasterDatabase, IDynamicTenantSource&lt;string&gt;</c>.
+/// </remarks>
+public class MasterTableTenancy : ITenancy, IDynamicTenantSource<string>
 {
     /// <summary>
     ///     The master tenant-registry table name (unqualified).
@@ -48,7 +54,13 @@ public class MasterTableTenancy : ITenancy
     /// </summary>
     public string QualifiedTableName => $"[{_schemaName}].[{TableName}]";
 
-    DatabaseCardinality ITenancy.Cardinality => DatabaseCardinality.DynamicMultiple;
+    /// <summary>
+    ///     Always <see cref="DatabaseCardinality.DynamicMultiple" /> — the tenant database set is read
+    ///     from the master table and can change while the store is running. Declared publicly so it
+    ///     satisfies both <see cref="ITenancy" /> and <see cref="ITenantedSource{T}" />.
+    /// </summary>
+    public DatabaseCardinality Cardinality => DatabaseCardinality.DynamicMultiple;
+
     string ITenancy.DefaultTenantId => StorageConstants.DefaultTenantId;
 
     ConnectionFactory ITenancy.GetConnectionFactory(string tenantId)
@@ -244,6 +256,86 @@ public class MasterTableTenancy : ITenancy
             return (IReadOnlyList<string>)list;
         }, (_masterConnectionString, QualifiedTableName), token).ConfigureAwait(false);
     }
+
+    #region IDynamicTenantSource<string>
+
+    // #377: the store-agnostic dynamic-tenancy surface. Every one of these is a thin adapter over the
+    // Polecat-native methods above, which carry an optional CancellationToken and therefore cannot
+    // implement the token-less interface signatures implicitly. Implemented explicitly so the concrete
+    // MasterTableTenancy API stays the (cancellable) one, with no overload ambiguity for callers.
+
+    /// <summary>
+    ///     Resolve the connection string for a tenant. Throws <see cref="UnknownTenantIdException" />
+    ///     for an unknown or disabled tenant, matching the behavior of opening a session for it.
+    /// </summary>
+    async ValueTask<string> ITenantedSource<string>.FindAsync(string tenantId)
+    {
+        var connectionString = await LookupConnectionStringAsync(tenantId).ConfigureAwait(false);
+        if (string.IsNullOrEmpty(connectionString))
+        {
+            throw new UnknownTenantIdException(tenantId);
+        }
+
+        return connectionString;
+    }
+
+    /// <summary>
+    ///     Re-read the master table, discarding cached entries for tenants that have since been
+    ///     removed or disabled.
+    /// </summary>
+    async Task ITenantedSource<string>.RefreshAsync()
+    {
+        _cache.Clear();
+        await BuildDatabasesAsync().ConfigureAwait(false);
+    }
+
+    /// <summary>
+    ///     The identifiers of the tenant databases currently known to this tenancy. Deliberately the
+    ///     database identifiers rather than the raw connection strings so credentials never reach an
+    ///     admin dashboard; mirrors Marten, which returns <c>MartenDatabase.Identifier</c> here.
+    /// </summary>
+    IReadOnlyList<string> ITenantedSource<string>.AllActive()
+    {
+        return _cache.Values.Select(x => x.Database.Identifier).Distinct().ToList();
+    }
+
+    IReadOnlyList<Assignment<string>> ITenantedSource<string>.AllActiveByTenant()
+    {
+        return _cache.Keys.Select(tenantId => new Assignment<string>(tenantId, tenantId)).ToList();
+    }
+
+    Task IDynamicTenantSource<string>.AddTenantAsync(string tenantId, string connectionValue)
+    {
+        return AddDatabaseRecordAsync(tenantId, connectionValue);
+    }
+
+    // NOTE: the auto-assign overload -- Task<string> AddTenantAsync(string, CancellationToken) -- is
+    // deliberately left on its default interface implementation, which throws NotSupportedException.
+    // That is the correct answer for database-per-tenant: there is no pool for Polecat to assign from,
+    // so the caller must supply a connection string. CritterWatch treats an empty connection value as
+    // "auto-assign" and skips sources that throw.
+
+    Task IDynamicTenantSource<string>.DisableTenantAsync(string tenantId)
+    {
+        return DisableTenantAsync(tenantId, CancellationToken.None);
+    }
+
+    Task IDynamicTenantSource<string>.EnableTenantAsync(string tenantId)
+    {
+        return EnableTenantAsync(tenantId, CancellationToken.None);
+    }
+
+    Task IDynamicTenantSource<string>.RemoveTenantAsync(string tenantId)
+    {
+        return DeleteDatabaseRecordAsync(tenantId, CancellationToken.None);
+    }
+
+    Task<IReadOnlyList<string>> IDynamicTenantSource<string>.AllDisabledAsync()
+    {
+        return AllDisabledAsync(CancellationToken.None);
+    }
+
+    #endregion
 
     private async Task<string?> LookupConnectionStringAsync(string tenantId, CancellationToken token = default)
     {


### PR DESCRIPTION
Closes #377. Marks the NuGet packages as **5.8.0**.

## What

`MasterTableTenancy` already had the full dynamic-tenancy *behavior* (shipped in #165) but did not **declare** `JasperFx.MultiTenancy.IDynamicTenantSource<string>` — the abstraction store-agnostic admin tooling resolves through. Polecat-backed services therefore showed their tenants read-only in CritterWatch: no runtime add / disable / enable / remove.

Modeled directly on Marten's `MasterTableTenancy: ITenancy, ITenancyWithMasterDatabase, IDynamicTenantSource<string>` and `MartenServiceCollectionExtensions`.

### `MasterTableTenancy`

- Now `: ITenancy, IDynamicTenantSource<string>`, reporting `Cardinality == DatabaseCardinality.DynamicMultiple`. `Cardinality` became a public member so it satisfies both `ITenancy` and `ITenantedSource<string>`.
- The interface members are **explicit** implementations adapting to the existing cancellable Polecat-native methods. Those carry an optional `CancellationToken` and therefore cannot implement the token-less interface signatures implicitly; explicit implementation also keeps the concrete API unambiguous for existing callers.

  | `IDynamicTenantSource<string>` | Polecat-native method |
  |---|---|
  | `AddTenantAsync(tenantId, connectionValue)` | `AddDatabaseRecordAsync` |
  | `RemoveTenantAsync(tenantId)` | `DeleteDatabaseRecordAsync` |
  | `DisableTenantAsync(tenantId)` | `DisableTenantAsync(tenantId, token)` |
  | `EnableTenantAsync(tenantId)` | `EnableTenantAsync(tenantId, token)` |
  | `AllDisabledAsync()` | `AllDisabledAsync(token)` |

- `FindAsync` throws `UnknownTenantIdException` for an unknown **or** disabled tenant — same as opening a session for it.
- `RefreshAsync` clears the cache and re-reads the master table.
- `AllActive()` returns the tenant **database identifiers**, not raw connection strings, so credentials never reach an admin dashboard. This is the same choice Marten makes (it returns `MartenDatabase.Identifier`). `AllActiveByTenant()` returns `Assignment<string>(tenantId, tenantId)`, matching Marten.
- The jasperfx#413 auto-assign overload `Task<string> AddTenantAsync(string, CancellationToken)` is deliberately left on its default interface implementation, which throws `NotSupportedException`. Database-per-tenant has no pool for Polecat to assign from, and CritterWatch skips sources that throw.

### DI registration

`AddPolecat` registers the tenancy as `IDynamicTenantSource<string>` — but **only** when the configured tenancy is a dynamic source. Non-dynamic stores must keep `GetServices` empty; that emptiness is the signal consumers use to fall back to a read-only tenant list.

To make that probe possible while the container is still being assembled, `AddPolecat(Action<StoreOptions>)` now builds the `StoreOptions` eagerly and delegates to `AddPolecat(StoreOptions)` — exactly what Marten's `AddMarten(Action<StoreOptions>)` does. **This is the one behavior change in the PR:** the configure lambda now runs at registration time rather than on first `IDocumentStore` resolution. The lambda takes no `IServiceProvider`, so nothing it can legally reach has changed; the `IConfigurePolecat` chain and `ReadJasperFxOptions` still run later, at store construction, unchanged.

`AddPolecat(Func<IServiceProvider, StoreOptions>)` cannot probe (the options do not exist until the container is built) and is documented as such, with the one-liner for registering it manually.

## Tests

- `src/Polecat.Tests/MultiTenancy/dynamic_tenant_source_tests.cs` — 7 tests driving the tenancy **only** through the `IDynamicTenantSource<string>` reference against real SQL Server databases: cardinality, add→find, unknown-tenant throw, disable/enable round-trip, remove, refresh/active-set, and the `NotSupportedException` on auto-assign.
- `src/Polecat.Tests/DependencyInjection/dynamic_tenant_source_registration_tests.cs` — 4 tests: registered (and same instance as `Options.Tenancy`) for master-table tenancy via both the lambda and pre-built-options overloads; **empty** for single-database and static `MultiTenantedDatabases()` stores.

## Docs

New `### Store-Agnostic Runtime Tenant Management` section in `docs/configuration/multitenancy.md` (badged 5.8), based on Marten's master-table docs: the full lifecycle through the abstraction, the DI registration, why the registration is conditional, and both caveats (auto-assign `NotSupportedException`; the SP-factory overload). Also notes that hard-deleting the physical database is out of scope — SQL Server needs `ALTER DATABASE ... SET SINGLE_USER WITH ROLLBACK IMMEDIATE` before `DROP DATABASE`, and that is the consumer's job (tracked on the CritterWatch side).

🤖 Generated with [Claude Code](https://claude.com/claude-code)