### PR TITLE
Adopt JasperFx 2.37.0 + Weasel 9.23.0 and release 5.9.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>5.9.0</Version>
+        <Version>5.9.1</Version>
         <LangVersion>latest</LangVersion>
         <Authors>Jeremy D. Miller</Authors>
         <PackageIcon>logo.png</PackageIcon>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -52,9 +52,18 @@
                  unbindable [NaturalKeySource] (polecat#369).
              Also carries jasperfx#568/#572 daemon race fixes, picked up for free.
              JasperFx 2.36.3: the floor Weasel 9.21.0 depends on — bumped in lockstep with the
-             Weasel bump below so the matrix stays coherent rather than resolving transitively. -->
-        <PackageVersion Include="JasperFx" Version="2.36.3" />
-        <PackageVersion Include="JasperFx.Events" Version="2.36.3" />
+             Weasel bump below so the matrix stays coherent rather than resolving transitively.
+             JasperFx 2.37.0: jasperfx#590 — OptionsDescription no longer loses an entire diagnostic
+             description to one throwing property getter; set-only properties and indexers are
+             skipped, and a getter that throws is recorded as OptionsValue.Unreadable (exception
+             TYPE only, never the message, since descriptions ship to monitoring consoles). Polecat
+             is described this way by CritterWatch, so this is the store-side half of that fix.
+             Also carries the jasperfx#594 patch half (a timed-out blue/green side-effect gate
+             re-reads progression and succeeds when the replay had already reached the mark, plus a
+             configurable DaemonSettings.SideEffectGateTimeout), jasperfx#595 (BatchingChannel could
+             deliver its trailing batch twice on shutdown) and #597. Same lockstep rule as above. -->
+        <PackageVersion Include="JasperFx" Version="2.37.0" />
+        <PackageVersion Include="JasperFx.Events" Version="2.37.0" />
         <!-- Pin the sibling JasperFx packages for parity with Marten 9's matrix
              even though Polecat doesn't currently reference them directly —
              keeps the lockstep matrix coherent when transitive resolution
@@ -62,7 +71,7 @@
              RuntimeCompiler 5.x line is the active continuation of the 4.x
              lineage; do not pin against the parallel stale 2.0.x series. -->
         <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.36.3" />
+        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.37.0" />
         <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
@@ -135,16 +144,22 @@
              (PartitionOn(...).ByRollingRange(...)). Also rides along from the intervening line:
              weasel#391 (managed tenant bucketing actually shares one partition — #335's ordinal
              sharing) and weasel#399 (TableColumn.MatchesForDelta compares through the virtual
-             Equals, so a subclassed column no longer churns the delta). -->
-        <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.21.0" />
-        <PackageVersion Include="Weasel.SqlServer" Version="9.21.0" />
-        <PackageVersion Include="Weasel.Storage" Version="9.21.0" />
+             Equals, so a subclassed column no longer churns the delta).
+             Weasel 9.21.1 (weasel#416): partition bound VALUES are escaped — FormatSqlValue doubles
+             an embedded single quote and no longer returns an already-quote-wrapped string verbatim.
+             Weasel 9.22.0 (weasel#417): carries the JasperFx 2.37.0 floor.
+             Weasel 9.23.0: weasel#415 — EnsureDatabaseExistsAsync is safe under concurrent callers,
+             which is the SQL Server path Polecat provisions on; plus weasel#416, where
+             AssertValidIdentifier now rejects a quote or semicolon outright. -->
+        <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.23.0" />
+        <PackageVersion Include="Weasel.SqlServer" Version="9.23.0" />
+        <PackageVersion Include="Weasel.Storage" Version="9.23.0" />
 
         <!-- Strongly typed IDs -->
         <PackageVersion Include="StronglyTypedId" Version="1.0.0-beta08" />
 
         <!-- Source generators (matched to JasperFx.Events above) -->
-        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.36.3" />
+        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.37.0" />
 
         <!-- Build automation -->
         <PackageVersion Include="Nuke.Common" Version="9.0.4" />


### PR DESCRIPTION
Third link in the coordinated release train, alongside [marten#5097](https://github.com/JasperFx/marten/pull/5097), after JasperFx **2.37.0** and Weasel **9.23.0** went live on nuget.org. Dependency versions only — **no source changes**.

## What comes in

**JasperFx 2.37.0**
- jasperfx#590 — `OptionsDescription` no longer loses an entire diagnostic description to one throwing property getter; the getter is recorded as `OptionsValue.Unreadable`, reporting the exception **type** only (descriptions ship to monitoring consoles). **Polecat is described this way by CritterWatch, so this is the store-side half of that fix.**
- The #594 patch half (timed-out blue/green side-effect gate re-reads progression and succeeds when the replay had already reached the mark, plus a configurable `DaemonSettings.SideEffectGateTimeout`), #595 and #597.

**Weasel 9.23.0**
- weasel#415 — `EnsureDatabaseExistsAsync` is safe under concurrent callers. **This is the SQL Server provisioning path Polecat uses**, so it's the one that matters most here.
- weasel#416 — `AssertValidIdentifier` rejects a quote or semicolon outright.

## Version choice

`5.9.0` → **`5.9.1`**, per Jeremy. Note this is a **patch** that raises dependency floors (JasperFx 2.36.3 → 2.37.0, Weasel 9.21.0 → 9.23.0).

## Verification

Full solution builds with **0 errors** against the published packages.

⚠️ **The integration suite was not run locally and is left to CI.** It needs SQL Server, and the only image available here is amd64 running under QEMU emulation on an arm64 host — it was creating schemas steadily but was nowhere near finishing. Rather than report a partial run as if it were a pass, this leans on CI, which runs it natively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)