### PR TITLE
feat: EventStoreOptions.AddEventType / AddEventTypes (#395)

### DIFF
--- a/docs/events/storage.md
+++ b/docs/events/storage.md
@@ -54,6 +54,26 @@ Polecat converts .NET event type names to snake_case for storage:
 - `MembersJoined` → `members_joined`
 - `InvoiceLineItemAdded` → `invoice_line_item_added`
 
+## Pre-registering Event Types
+
+Event types are registered with the store on the fly the first time they are appended, so registering
+them up front is optional. It is worth doing when the *reading* side may meet an event type before the
+writing side does -- most commonly the async daemon in a separate process, which has to map an
+`event_type_name` back to a .NET type it has not yet seen appended:
+
+```cs
+var store = DocumentStore.For(opts =>
+{
+    opts.Connection(connectionString);
+
+    opts.Events.AddEventType<QuestStarted>();
+    opts.Events.AddEventType(typeof(MembersJoined));
+    opts.Events.AddEventTypes([typeof(MembersDeparted), typeof(QuestEnded)]);
+});
+```
+
+This mirrors Marten's `StoreOptions.Events.AddEventType<T>()` / `AddEventTypes(...)`.
+
 ## Sequence IDs
 
 Events are assigned a global, monotonically increasing sequence ID via SQL Server's `IDENTITY(1,1)`. This provides a total ordering of all events across all streams, which is critical for the async daemon's event processing.

--- a/src/Polecat.Tests/Compliance/PolecatComplianceFixture.cs
+++ b/src/Polecat.Tests/Compliance/PolecatComplianceFixture.cs
@@ -118,9 +118,7 @@ public class PolecatComplianceFixture : EventStoreComplianceFixture<IDocumentSes
             _options = options;
         }
 
-        // Straight to the registry: unlike Marten, Polecat's public EventStoreOptions facade has no
-        // AddEventType, so the shared IEventRegistry member on StoreOptions.EventGraph is the seam.
-        public void AddEventType(Type eventType) => _options.EventGraph.AddEventType(eventType);
+        public void AddEventType(Type eventType) => _options.Events.AddEventType(eventType);
 
         public ITagTypeRegistration RegisterTagType<TTag>(string tableSuffix) where TTag : notnull
             => _options.Events.RegisterTagType<TTag>(tableSuffix);

--- a/src/Polecat.Tests/StoreOptionsTests.cs
+++ b/src/Polecat.Tests/StoreOptionsTests.cs
@@ -108,4 +108,51 @@ public class StoreOptionsTests
         options.Events.EnableCausationId.ShouldBeTrue();
         options.Events.EnableHeaders.ShouldBeTrue();
     }
+
+    [Fact]
+    public void add_event_type_generic_registers_the_event_type()
+    {
+        var options = new StoreOptions();
+        options.Events.AddEventType<StoreOptionsEventTypeA>();
+
+        options.EventGraph.AllKnownEventTypes()
+            .ShouldContain(x => x.EventType == typeof(StoreOptionsEventTypeA));
+    }
+
+    [Fact]
+    public void add_event_type_by_type_registers_the_event_type()
+    {
+        var options = new StoreOptions();
+        options.Events.AddEventType(typeof(StoreOptionsEventTypeB));
+
+        options.EventGraph.AllKnownEventTypes()
+            .ShouldContain(x => x.EventType == typeof(StoreOptionsEventTypeB));
+    }
+
+    [Fact]
+    public void add_event_types_registers_all_of_them()
+    {
+        var options = new StoreOptions();
+        options.Events.AddEventTypes([typeof(StoreOptionsEventTypeA), typeof(StoreOptionsEventTypeB)]);
+
+        var known = options.EventGraph.AllKnownEventTypes();
+        known.ShouldContain(x => x.EventType == typeof(StoreOptionsEventTypeA));
+        known.ShouldContain(x => x.EventType == typeof(StoreOptionsEventTypeB));
+    }
+
+    [Fact]
+    public void add_event_type_is_idempotent()
+    {
+        var options = new StoreOptions();
+        options.Events.AddEventType<StoreOptionsEventTypeA>();
+        options.Events.AddEventType<StoreOptionsEventTypeA>();
+
+        options.EventGraph.AllKnownEventTypes()
+            .Count(x => x.EventType == typeof(StoreOptionsEventTypeA))
+            .ShouldBe(1);
+    }
 }
+
+public record StoreOptionsEventTypeA(string Name);
+
+public record StoreOptionsEventTypeB(int Count);

--- a/src/Polecat/StoreOptions.cs
+++ b/src/Polecat/StoreOptions.cs
@@ -461,6 +461,36 @@ public class EventStoreOptions : IEventStoreInstrumentation
         = Polecat.Events.Aggregation.NulloMessageOutbox.Instance;
 
     /// <summary>
+    ///     Pre-register an event type with the event store. Mirrors Marten's
+    ///     <c>StoreOptions.Events.AddEventType&lt;TEvent&gt;()</c>. Not strictly necessary — event types are
+    ///     registered on the fly as they are appended — but pre-registration can help with asynchronous
+    ///     projections where the daemon process hasn't yet encountered the event type, and lets the
+    ///     event type name alias be resolved before the first append.
+    /// </summary>
+    public void AddEventType<TEvent>() where TEvent : notnull
+    {
+        EventGraph!.AddEventType(typeof(TEvent));
+    }
+
+    /// <summary>
+    ///     Pre-register an event type with the event store. Mirrors Marten's
+    ///     <c>StoreOptions.Events.AddEventType(Type)</c>.
+    /// </summary>
+    public void AddEventType(Type eventType)
+    {
+        EventGraph!.AddEventType(eventType);
+    }
+
+    /// <summary>
+    ///     Pre-register several event types with the event store in one call. Mirrors Marten's
+    ///     <c>StoreOptions.Events.AddEventTypes(IEnumerable&lt;Type&gt;)</c>.
+    /// </summary>
+    public void AddEventTypes(IEnumerable<Type> eventTypes)
+    {
+        foreach (var eventType in eventTypes) EventGraph!.AddEventType(eventType);
+    }
+
+    /// <summary>
     ///     Register a tag type for Dynamic Consistency Boundary (DCB) support.
     ///     Creates a tag table with an auto-generated suffix.
     /// </summary>


### PR DESCRIPTION
Closes #395.

## The gap

`StoreOptions.Events` is an `EventStoreOptions` facade exposing `RegisterTagType<TTag>()` and a pile of flags — but no `AddEventType`. A user following Marten's documented pattern:

```cs
opts.Events.AddEventType<StudentEnrolled>();   // did not compile on Polecat
```

had to go around the facade to `opts.EventGraph.AddEventType(typeof(StudentEnrolled))`. That works (`StoreOptions.EventGraph` is public and `EventGraph` implements `IEventRegistry`) but is undiscoverable and matches no Marten-derived docs or samples. It also matters beyond ergonomics: pre-registration is the documented mitigation for the async daemon meeting an event type it has not yet seen appended, and that mitigation was unreachable from the options facade.

## The change

Three `void` delegations on `EventStoreOptions`, mirroring the existing `RegisterTagType` delegation pattern (`EventGraph!` — assigned in the `StoreOptions` constructor, so non-null at configure time):

- `AddEventType<TEvent>()`
- `AddEventType(Type)`
- `AddEventTypes(IEnumerable<Type>)`

Deliberately **not** returning `IEventStoreOptions` for fluent chaining. Marten's `AddEventType<T>()` does, and that return type is precisely what makes marten#5114 (a generic DIM on `IEventRegistry`) impossible to land there without a source-breaking change. Keeping these `void` matches the shared interface and leaves the door open.

Also:
- `PolecatComplianceFixture.PolecatComplianceRegistrar.AddEventType` now goes through the facade; its comment explaining the detour is gone with the detour.
- New "Pre-registering Event Types" section in `docs/events/storage.md`.

## Tests

Four unit tests in `StoreOptionsTests` covering the generic overload, the `Type` overload, the batch overload, and idempotency (re-registering the same type does not duplicate it).

Locally on net10.0: `StoreOptionsTests` 16/16, `Polecat.Tests.Compliance` 42/42.

🤖 Generated with [Claude Code](https://claude.com/claude-code)