### PR TITLE
fix: throw a lone DcbConcurrencyException unwrapped from SaveChangesAsync (#394)

### DIFF
--- a/docs/events/dcb.md
+++ b/docs/events/dcb.md
@@ -160,6 +160,14 @@ for SingleStreamProjection<CourseEnrollmentSummary, string>
 The consistency check only detects events that match the **same tag query**. Events appended to unrelated tags or streams will not cause a violation.
 :::
 
+::: warning
+A session can establish more than one consistency boundary. If **several** of them are violated in the
+same `SaveChangesAsync()`, Polecat throws an `AggregateException` carrying one
+`DcbConcurrencyException` per violated boundary rather than a single exception. A session with one
+boundary -- the common case, and what the sample above shows -- always throws the
+`DcbConcurrencyException` directly.
+:::
+
 ## Checking Event Existence
 
 If you only need to know whether any events matching a tag query exist -- without loading or deserializing them -- use `EventsExistAsync`. This is a lightweight existence check that avoids the overhead of fetching and materializing event data:

--- a/src/Polecat.Tests/Events/conjoined_tenancy_dcb_and_natural_key_tests.cs
+++ b/src/Polecat.Tests/Events/conjoined_tenancy_dcb_and_natural_key_tests.cs
@@ -218,16 +218,9 @@ public class conjoined_tenancy_dcb_and_natural_key_tests : OneOffConfigurationsC
         conflictEvent.WithTag(studentId, courseId);
         boundary.AppendOne(conflictEvent);
 
-        var ex = await Should.ThrowAsync<Exception>(() => session1.SaveChangesAsync());
-        // The DcbConcurrencyException may be wrapped in an AggregateException
-        if (ex is AggregateException agg)
-        {
-            agg.InnerExceptions.ShouldContain(e => e is DcbConcurrencyException);
-        }
-        else
-        {
-            ex.ShouldBeOfType<DcbConcurrencyException>();
-        }
+        // #394: one boundary in the session, so the DcbConcurrencyException comes through unwrapped
+        await Should.ThrowAsync<DcbConcurrencyException>(
+            () => session1.SaveChangesAsync(TestContext.Current.CancellationToken));
     }
 
     [Fact]

--- a/src/Polecat.Tests/Events/dcb_concurrency_exception_shape_tests.cs
+++ b/src/Polecat.Tests/Events/dcb_concurrency_exception_shape_tests.cs
@@ -1,0 +1,124 @@
+#nullable enable
+using JasperFx.Events;
+using JasperFx.Events.Tags;
+using Polecat.Events.Dcb;
+using Polecat.Tests.Harness;
+
+namespace Polecat.Tests.Events;
+
+/// <summary>
+///     #394: the exception shape <c>SaveChangesAsync</c> throws when DCB consistency boundaries lose a
+///     concurrency race. A session with a single boundary — overwhelmingly the common case — throws the
+///     <see cref="DcbConcurrencyException" /> directly, matching Marten, so the documented
+///     <c>catch (DcbConcurrencyException)</c> retry pattern ports between the two stores. Only a
+///     session that violates several boundaries at once still wraps them in an
+///     <see cref="AggregateException" />, since there is more than one failure to carry.
+/// </summary>
+[Collection("integration")]
+public class dcb_concurrency_exception_shape_tests : IntegrationContext
+{
+    public dcb_concurrency_exception_shape_tests(DefaultStoreFixture fixture) : base(fixture)
+    {
+    }
+
+    public override async ValueTask InitializeAsync()
+    {
+        await StoreOptions(opts =>
+        {
+            opts.Events.RegisterTagType<StudentId>("student")
+                .ForAggregate<StudentCourseEnrollment>();
+            opts.Events.RegisterTagType<CourseId>("course")
+                .ForAggregate<StudentCourseEnrollment>();
+        });
+    }
+
+    [Fact]
+    public async Task single_violated_boundary_throws_the_concurrency_exception_directly()
+    {
+        var studentId = new StudentId(Guid.NewGuid());
+        var courseId = new CourseId(Guid.NewGuid());
+        var streamId = Guid.NewGuid();
+
+        var enrolled = theSession.Events.BuildEvent(new StudentEnrolled("Alice", "Math"));
+        enrolled.WithTag(studentId, courseId);
+        theSession.Events.Append(streamId, enrolled);
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        await using var session1 = theStore.LightweightSession();
+        var query = new EventTagQuery().Or<StudentId>(studentId);
+        var boundary =
+            await session1.Events.FetchForWritingByTags<StudentCourseEnrollment>(query,
+                TestContext.Current.CancellationToken);
+
+        // Another session slips a matching event in before session1 saves
+        await using var session2 = theStore.LightweightSession();
+        var conflicting = session2.Events.BuildEvent(new AssignmentSubmitted("HW-conflict", 50));
+        conflicting.WithTag(studentId, courseId);
+        session2.Events.Append(streamId, conflicting);
+        await session2.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var assignment = session1.Events.BuildEvent(new AssignmentSubmitted("HW1", 95));
+        assignment.WithTag(studentId, courseId);
+        boundary.AppendOne(assignment);
+
+        // Not an AggregateException -- Should.ThrowAsync<T> is exact-type, so this also asserts the
+        // absence of the wrapper the pre-#394 behavior added.
+        var violation = await Should.ThrowAsync<DcbConcurrencyException>(
+            () => session1.SaveChangesAsync(TestContext.Current.CancellationToken));
+
+        violation.Query.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task several_violated_boundaries_are_still_wrapped_in_an_aggregate_exception()
+    {
+        var student1 = new StudentId(Guid.NewGuid());
+        var student2 = new StudentId(Guid.NewGuid());
+        var courseId = new CourseId(Guid.NewGuid());
+        var stream1 = Guid.NewGuid();
+        var stream2 = Guid.NewGuid();
+
+        var first = theSession.Events.BuildEvent(new StudentEnrolled("Alice", "Math"));
+        first.WithTag(student1, courseId);
+        theSession.Events.Append(stream1, first);
+
+        var second = theSession.Events.BuildEvent(new StudentEnrolled("Bob", "Math"));
+        second.WithTag(student2, courseId);
+        theSession.Events.Append(stream2, second);
+
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        // One session, two independent consistency boundaries
+        await using var session1 = theStore.LightweightSession();
+        var boundary1 = await session1.Events.FetchForWritingByTags<StudentCourseEnrollment>(
+            new EventTagQuery().Or<StudentId>(student1), TestContext.Current.CancellationToken);
+        var boundary2 = await session1.Events.FetchForWritingByTags<StudentCourseEnrollment>(
+            new EventTagQuery().Or<StudentId>(student2), TestContext.Current.CancellationToken);
+
+        // Another session invalidates both of them
+        await using var session2 = theStore.LightweightSession();
+        var conflict1 = session2.Events.BuildEvent(new AssignmentSubmitted("HW-conflict-1", 50));
+        conflict1.WithTag(student1, courseId);
+        session2.Events.Append(stream1, conflict1);
+
+        var conflict2 = session2.Events.BuildEvent(new AssignmentSubmitted("HW-conflict-2", 60));
+        conflict2.WithTag(student2, courseId);
+        session2.Events.Append(stream2, conflict2);
+
+        await session2.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var append1 = session1.Events.BuildEvent(new AssignmentSubmitted("HW1", 95));
+        append1.WithTag(student1, courseId);
+        boundary1.AppendOne(append1);
+
+        var append2 = session1.Events.BuildEvent(new AssignmentSubmitted("HW2", 85));
+        append2.WithTag(student2, courseId);
+        boundary2.AppendOne(append2);
+
+        var aggregate = await Should.ThrowAsync<AggregateException>(
+            () => session1.SaveChangesAsync(TestContext.Current.CancellationToken));
+
+        aggregate.InnerExceptions.Count.ShouldBe(2);
+        aggregate.InnerExceptions.ShouldAllBe(x => x is DcbConcurrencyException);
+    }
+}

--- a/src/Polecat.Tests/Events/dcb_documentation_samples.cs
+++ b/src/Polecat.Tests/Events/dcb_documentation_samples.cs
@@ -264,20 +264,29 @@ public class dcb_documentation_samples : IntegrationContext
         assignment.WithTag(studentId, courseId);
         boundary.AppendOne(assignment);
 
-        #region sample_polecat_dcb_handling_concurrency
+        // A session with a single DCB boundary throws the DcbConcurrencyException directly (#394),
+        // so the Marten-documented retry pattern below ports unchanged.
+        var violation = await Should.ThrowAsync<DcbConcurrencyException>(
+            () => session1.SaveChangesAsync(TestContext.Current.CancellationToken));
+        violation.Query.ShouldNotBeNull();
+    }
+
+    #region sample_polecat_dcb_handling_concurrency
+    public static async Task handling_a_concurrency_violation(IDocumentSession session)
+    {
         try
         {
-            await session1.SaveChangesAsync(TestContext.Current.CancellationToken);
+            await session.SaveChangesAsync();
         }
-        catch (AggregateException ex) when (ex.InnerExceptions.OfType<DcbConcurrencyException>().Any())
+        catch (DcbConcurrencyException violation)
         {
-            // Reload and retry -- the boundary's tag query had new matching events
-            var violation = ex.InnerExceptions.OfType<DcbConcurrencyException>().First();
-            // violation.Query -- the original tag query
-            // violation.LastSeenSequence -- the sequence at time of read
+            // Reload and retry -- the boundary's tag query had new matching events since the read.
+            // violation.Query is the original tag query, violation.LastSeenSequence the sequence
+            // the boundary was read at.
+            Console.WriteLine($"DCB violation on {violation.Query} at {violation.LastSeenSequence}");
         }
-        #endregion
     }
+    #endregion
 
     #region sample_polecat_dcb_events_exist_async
     [Fact]

--- a/src/Polecat/Internal/DocumentSessionBase.cs
+++ b/src/Polecat/Internal/DocumentSessionBase.cs
@@ -485,6 +485,16 @@ internal abstract class DocumentSessionBase : QuerySession, IDocumentSession
                     }
                 }
 
+                // #394: a session with a single DCB boundary — overwhelmingly the common case —
+                // throws its DcbConcurrencyException directly, matching Marten, so the documented
+                // `catch (DcbConcurrencyException)` retry pattern ports between the two stores.
+                // Only a session with several boundaries failing at once still needs the
+                // AggregateException to carry all of them.
+                if (dcbExceptions.Count == 1)
+                {
+                    throw dcbExceptions[0];
+                }
+
                 if (dcbExceptions.Count > 0)
                 {
                     throw new AggregateException(dcbExceptions);


### PR DESCRIPTION
Closes #394. Takes **option 1** from the issue — unwrap the single case for Marten parity.

## The behavior

`DocumentSessionBase.SaveChangesAsync` batched the DCB assertions, postprocessed them into a failure list, and then threw `new AggregateException(dcbExceptions)` unconditionally. A session with **one** `FetchForWritingByTags` boundary that lost a concurrency race therefore threw an `AggregateException` wrapping a single `DcbConcurrencyException`; Marten throws it directly.

The consequence was not cosmetic: the documented retry pattern — the shape our own DCB docs sample showed — silently did not catch on Polecat.

```cs
try { await session.SaveChangesAsync(); }
catch (DcbConcurrencyException ex) { /* reload and retry */ }
```

## The change

```cs
if (dcbExceptions.Count == 1)
{
    throw dcbExceptions[0];
}

if (dcbExceptions.Count > 0)
{
    throw new AggregateException(dcbExceptions);
}
```

A session with several violated boundaries still throws an `AggregateException` — there is genuinely more than one failure to carry, and nothing to unwrap to.

This is a **behavioral change** for anyone currently catching `AggregateException` around a single-boundary save, which is why it is called out here rather than buried: the fix for such code is to catch `DcbConcurrencyException`, which then works on both stores.

## Tests

New `dcb_concurrency_exception_shape_tests` pins both shapes:

- `single_violated_boundary_throws_the_concurrency_exception_directly` — `Should.ThrowAsync<T>` is exact-type, so this asserts the absence of the old wrapper as well as the presence of the right exception.
- `several_violated_boundaries_are_still_wrapped_in_an_aggregate_exception` — two independent boundaries in one session, both invalidated; asserts `InnerExceptions.Count == 2` and that all of them are `DcbConcurrencyException`.

Also updated:
- The `sample_polecat_dcb_handling_concurrency` snippet is now the Marten-parity `catch (DcbConcurrencyException)`, hoisted out of the test body into a small self-contained method so the published snippet has balanced braces and no test scaffolding in it. The test it came from now asserts the throw explicitly instead of relying on a `catch` that passed silently when nothing was thrown.
- `conjoined_tenancy_dcb_and_natural_key_tests` dropped its `if (ex is AggregateException) … else …` branch.
- `docs/events/dcb.md` gains a warning documenting the multi-boundary `AggregateException`.

The shared compliance suites are unaffected — `EventStoreComplianceSuite.ShouldFailWithAsync<T>` already accepts the exception directly or flattened out of an `AggregateException`, exactly as the issue anticipated.

Locally on net10.0: new tests 2/2, `dcb_documentation_samples` + `conjoined_tenancy_dcb_and_natural_key_tests` 20/20, `Polecat.Tests.Compliance` 42/42.

🤖 Generated with [Claude Code](https://claude.com/claude-code)