### PR TITLE
feat: pluggable binary event serialization (IEventBinarySerializer) (#388)

### DIFF
--- a/src/Polecat.Tests/Events/binary_event_serialization_tests.cs
+++ b/src/Polecat.Tests/Events/binary_event_serialization_tests.cs
@@ -1,0 +1,421 @@
+using System.Text;
+using System.Text.Json;
+using JasperFx.Events;
+using JasperFx.Events.Projections;
+using Polecat.Events;
+using Polecat.Linq;
+using Polecat.Projections;
+using Polecat.Tests.Harness;
+using Shouldly;
+
+namespace Polecat.Tests.Events;
+
+#region sample_polecat_binary_event_serializer
+
+/// <summary>
+///     A deliberately non-JSON binary format, so a test can prove a row really did travel through the
+///     binary path: the bytes are a length-prefixed UTF-8 blob that no JSON parser would accept, and a
+///     four-byte magic header lets the assertions recognize it on the wire.
+/// </summary>
+public sealed class TestBinaryEventSerializer : IEventBinarySerializer
+{
+    public static readonly byte[] Magic = "PCB1"u8.ToArray();
+
+    /// <summary>How many times Serialize/Deserialize were called — proves the path was taken.</summary>
+    public int SerializeCount;
+
+    public int DeserializeCount;
+
+    public byte[] Serialize(Type type, object data)
+    {
+        Interlocked.Increment(ref SerializeCount);
+        var payload = JsonSerializer.SerializeToUtf8Bytes(data, type);
+        var buffer = new byte[Magic.Length + payload.Length];
+        Magic.CopyTo(buffer, 0);
+        payload.CopyTo(buffer, Magic.Length);
+        return buffer;
+    }
+
+    public object Deserialize(Type type, byte[] data)
+    {
+        Interlocked.Increment(ref DeserializeCount);
+        if (data.Length < Magic.Length || !data.AsSpan(0, Magic.Length).SequenceEqual(Magic))
+        {
+            throw new InvalidOperationException("Not a payload written by this serializer.");
+        }
+
+        return JsonSerializer.Deserialize(data.AsSpan(Magic.Length), type)!;
+    }
+}
+
+#endregion
+
+public record BinaryPayloadRecorded(string Name, int Amount);
+
+public record JsonPayloadRecorded(string Name, int Amount);
+
+[BinaryEvent]
+public record AttributeMarkedRecorded(string Name);
+
+public class BinaryLedger
+{
+    public Guid Id { get; set; }
+    public int Total { get; set; }
+    public List<string> Names { get; set; } = new();
+}
+
+public partial class BinaryLedgerProjection : SingleStreamProjection<BinaryLedger, Guid>
+{
+    public void Apply(BinaryLedger ledger, BinaryPayloadRecorded e)
+    {
+        ledger.Total += e.Amount;
+        ledger.Names.Add(e.Name);
+    }
+
+    public void Apply(BinaryLedger ledger, JsonPayloadRecorded e)
+    {
+        ledger.Total += e.Amount;
+        ledger.Names.Add(e.Name);
+    }
+}
+
+/// <summary>
+///     polecat#388: pluggable binary event serialization at parity with Marten's
+///     <c>IEventBinarySerializer</c> (marten#4515). The design point under test throughout is the
+///     <b>coexistence</b> one: an additive nullable <c>bdata</c> column with <c>bdata IS NULL</c> as
+///     the per-row discriminator, so JSON and binary events live in the same <c>pc_events</c> table
+///     and the feature is switchable on an existing store with no data migration.
+/// </summary>
+public class binary_event_serialization_tests : OneOffConfigurationsContext
+{
+    private readonly TestBinaryEventSerializer _serializer = new();
+
+    private async Task ConfigureAndApply(Action<StoreOptions> configure)
+    {
+        ConfigureStore(configure);
+        await theDatabase.ApplyAllConfiguredChangesToDatabaseAsync();
+    }
+
+    private Task ConfigureBinaryStore(Action<StoreOptions>? extra = null) => ConfigureAndApply(opts =>
+    {
+        opts.Events.UseBinarySerializer<BinaryPayloadRecorded>(_serializer);
+        extra?.Invoke(opts);
+    });
+
+    private async Task<(string data, byte[]? bdata)> ReadRawRowAsync(long sequence)
+    {
+        await using var conn = await OpenConnectionAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"SELECT CONVERT(nvarchar(max), data), bdata FROM {theStore.Options.EventGraph.EventsTableName} WHERE seq_id = @seq";
+        var p = cmd.CreateParameter();
+        p.ParameterName = "@seq";
+        p.Value = sequence;
+        cmd.Parameters.Add(p);
+
+        await using var reader = await cmd.ExecuteReaderAsync(TestContext.Current.CancellationToken);
+        (await reader.ReadAsync(TestContext.Current.CancellationToken)).ShouldBeTrue();
+        var data = reader.GetString(0);
+        var bdata = reader.IsDBNull(1) ? null : (byte[])reader.GetValue(1);
+        return (data, bdata);
+    }
+
+    [Fact]
+    public async Task pc_events_carries_a_nullable_bdata_column()
+    {
+        await ConfigureAndApply(_ => { });
+
+        await using var conn = await OpenConnectionAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = """
+            SELECT c.is_nullable, TYPE_NAME(c.system_type_id), c.max_length
+            FROM sys.columns c
+            WHERE c.object_id = OBJECT_ID(@table) AND c.name = 'bdata'
+            """;
+        var p = cmd.CreateParameter();
+        p.ParameterName = "@table";
+        p.Value = theStore.Options.EventGraph.EventsTableName;
+        cmd.Parameters.Add(p);
+
+        await using var reader = await cmd.ExecuteReaderAsync(TestContext.Current.CancellationToken);
+        (await reader.ReadAsync(TestContext.Current.CancellationToken))
+            .ShouldBeTrue("pc_events should carry the bdata column even with no serializer configured");
+        reader.GetBoolean(0).ShouldBeTrue("bdata must be nullable — NULL is the JSON-row discriminator");
+        reader.GetString(1).ShouldBe("varbinary");
+        reader.GetInt16(2).ShouldBe((short)-1); // varbinary(max)
+    }
+
+    [Fact]
+    public async Task an_unconfigured_store_writes_json_and_leaves_bdata_null()
+    {
+        await ConfigureAndApply(_ => { });
+
+        await using var session = theStore.LightweightSession();
+        var streamId = session.Events.StartStream(new JsonPayloadRecorded("plain", 3)).Id;
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var events = await session.Events.FetchStreamAsync(streamId, token: TestContext.Current.CancellationToken);
+        var (data, bdata) = await ReadRawRowAsync(events[0].Sequence);
+
+        bdata.ShouldBeNull();
+        data.ShouldContain("plain");
+    }
+
+    [Fact]
+    public async Task a_binary_event_round_trips_through_bdata_and_leaves_data_as_a_placeholder()
+    {
+        await ConfigureBinaryStore();
+
+        Guid streamId;
+        await using (var session = theStore.LightweightSession())
+        {
+            streamId = session.Events.StartStream(new BinaryPayloadRecorded("binary", 7)).Id;
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        _serializer.SerializeCount.ShouldBe(1);
+
+        await using var query = theStore.QuerySession();
+        var events = await query.Events.FetchStreamAsync(streamId, token: TestContext.Current.CancellationToken);
+        events.Count.ShouldBe(1);
+        events[0].Data.ShouldBeOfType<BinaryPayloadRecorded>().ShouldBe(new BinaryPayloadRecorded("binary", 7));
+        _serializer.DeserializeCount.ShouldBeGreaterThan(0);
+
+        // On the wire: the payload is in bdata, and `data` holds only the placeholder — so the
+        // saving the feature exists for is real, not just a round trip that happens to work.
+        var (data, bdata) = await ReadRawRowAsync(events[0].Sequence);
+        bdata.ShouldNotBeNull();
+        bdata!.AsSpan(0, TestBinaryEventSerializer.Magic.Length).SequenceEqual(TestBinaryEventSerializer.Magic)
+            .ShouldBeTrue();
+        Encoding.UTF8.GetString(bdata).ShouldContain("binary");
+        data.ShouldBe("{}");
+        data.ShouldNotContain("binary");
+    }
+
+    [Fact]
+    public async Task json_and_binary_events_coexist_in_one_stream()
+    {
+        // The coexistence property is the whole reason this design is low-risk to adopt: only the
+        // opted-in type changes format, and per-ROW dispatch means one stream can hold both.
+        await ConfigureBinaryStore();
+
+        Guid streamId;
+        await using (var session = theStore.LightweightSession())
+        {
+            streamId = session.Events.StartStream(
+                new JsonPayloadRecorded("first", 1),
+                new BinaryPayloadRecorded("second", 2),
+                new JsonPayloadRecorded("third", 3)).Id;
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using var query = theStore.QuerySession();
+        var events = await query.Events.FetchStreamAsync(streamId, token: TestContext.Current.CancellationToken);
+        events.Count.ShouldBe(3);
+        events.Select(x => x.Data).ShouldBe([
+            new JsonPayloadRecorded("first", 1),
+            new BinaryPayloadRecorded("second", 2),
+            new JsonPayloadRecorded("third", 3)
+        ]);
+
+        (await ReadRawRowAsync(events[0].Sequence)).bdata.ShouldBeNull();
+        (await ReadRawRowAsync(events[1].Sequence)).bdata.ShouldNotBeNull();
+        (await ReadRawRowAsync(events[2].Sequence)).bdata.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task rows_written_before_the_serializer_was_configured_still_read_as_json()
+    {
+        // The "switch it on for an existing store with no migration" claim, exercised directly:
+        // append as JSON, then reconfigure the same schema with the serializer registered and read
+        // the pre-existing row back.
+        await ConfigureAndApply(_ => { });
+
+        Guid streamId;
+        await using (var session = theStore.LightweightSession())
+        {
+            streamId = session.Events.StartStream(new BinaryPayloadRecorded("legacy-json", 5)).Id;
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        // Reconfigure WITHOUT dropping the schema — same tables, now with binary registered.
+        ConfigureStore(opts => opts.Events.UseBinarySerializer<BinaryPayloadRecorded>(_serializer));
+
+        await using var query = theStore.QuerySession();
+        var events = await query.Events.FetchStreamAsync(streamId, token: TestContext.Current.CancellationToken);
+        events[0].Data.ShouldBe(new BinaryPayloadRecorded("legacy-json", 5));
+        _serializer.DeserializeCount.ShouldBe(0, "a bdata IS NULL row must not go through the binary path");
+
+        // And the next append for that type does use binary — the two formats sit side by side.
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Events.Append(streamId, new BinaryPayloadRecorded("now-binary", 6));
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using var query2 = theStore.QuerySession();
+        var after = await query2.Events.FetchStreamAsync(streamId, token: TestContext.Current.CancellationToken);
+        after.Count.ShouldBe(2);
+        after.Select(x => ((BinaryPayloadRecorded)x.Data).Name).ShouldBe(["legacy-json", "now-binary"]);
+        (await ReadRawRowAsync(after[0].Sequence)).bdata.ShouldBeNull();
+        (await ReadRawRowAsync(after[1].Sequence)).bdata.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task the_binary_event_attribute_resolves_against_the_default_serializer()
+    {
+        await ConfigureAndApply(opts => opts.Events.DefaultBinarySerializer = _serializer);
+
+        Guid streamId;
+        await using (var session = theStore.LightweightSession())
+        {
+            streamId = session.Events.StartStream(
+                new AttributeMarkedRecorded("attributed"),
+                new JsonPayloadRecorded("not-attributed", 1)).Id;
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using var query = theStore.QuerySession();
+        var events = await query.Events.FetchStreamAsync(streamId, token: TestContext.Current.CancellationToken);
+        events[0].Data.ShouldBe(new AttributeMarkedRecorded("attributed"));
+        events[1].Data.ShouldBe(new JsonPayloadRecorded("not-attributed", 1));
+
+        (await ReadRawRowAsync(events[0].Sequence)).bdata.ShouldNotBeNull();
+        (await ReadRawRowAsync(events[1].Sequence)).bdata
+            .ShouldBeNull("[BinaryEvent] is per type — an unmarked type stays on the JSON path");
+    }
+
+    [Fact]
+    public async Task an_explicit_registration_wins_over_the_attribute_and_the_default()
+    {
+        var explicitSerializer = new TestBinaryEventSerializer();
+        await ConfigureAndApply(opts =>
+        {
+            opts.Events.DefaultBinarySerializer = _serializer;
+            opts.Events.UseBinarySerializer<AttributeMarkedRecorded>(explicitSerializer);
+        });
+
+        await using var session = theStore.LightweightSession();
+        session.Events.StartStream(new AttributeMarkedRecorded("explicit"));
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        explicitSerializer.SerializeCount.ShouldBe(1);
+        _serializer.SerializeCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task a_marked_type_with_no_serializer_configured_throws_rather_than_silently_writing_json()
+    {
+        // A silent fallback would leave a store whose write amplification does not match its
+        // configuration — which is exactly the problem the feature exists to fix.
+        await ConfigureAndApply(_ => { });
+
+        await using var session = theStore.LightweightSession();
+        session.Events.StartStream(new AttributeMarkedRecorded("unconfigured"));
+
+        var ex = await Should.ThrowAsync<InvalidOperationException>(
+            async () => await session.SaveChangesAsync(TestContext.Current.CancellationToken));
+        ex.Message.ShouldContain("[BinaryEvent]");
+        ex.Message.ShouldContain("DefaultBinarySerializer");
+    }
+
+    [Fact]
+    public async Task binary_events_flow_through_an_inline_projection()
+    {
+        await ConfigureBinaryStore(opts =>
+            opts.Projections.Add<BinaryLedgerProjection>(ProjectionLifecycle.Inline));
+
+        Guid streamId;
+        await using (var session = theStore.LightweightSession())
+        {
+            streamId = session.Events.StartStream(
+                new BinaryPayloadRecorded("b", 10),
+                new JsonPayloadRecorded("j", 5)).Id;
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using var query = theStore.QuerySession();
+        var ledger = await query.LoadAsync<BinaryLedger>(streamId, TestContext.Current.CancellationToken);
+        ledger.ShouldNotBeNull();
+        ledger!.Total.ShouldBe(15);
+        ledger.Names.ShouldBe(["b", "j"]);
+    }
+
+    [Fact]
+    public async Task binary_events_flow_through_an_async_projection_via_the_daemon()
+    {
+        // The daemon's event loader is a separate reader from FetchStreamAsync, with its own SELECT
+        // and its own deserialization — so it needs its own coverage for the bdata dispatch.
+        await ConfigureBinaryStore(opts =>
+            opts.Projections.Add<BinaryLedgerProjection>(ProjectionLifecycle.Async));
+
+        Guid streamId;
+        await using (var session = theStore.LightweightSession())
+        {
+            streamId = session.Events.StartStream(
+                new BinaryPayloadRecorded("b1", 4),
+                new BinaryPayloadRecorded("b2", 6),
+                new JsonPayloadRecorded("j1", 1)).Id;
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        using var daemon = await theStore.BuildProjectionDaemonAsync();
+        await daemon.StartAllAsync();
+        await daemon.WaitForNonStaleData(TimeSpan.FromSeconds(30));
+
+        await using var query = theStore.QuerySession();
+        var ledger = await query.LoadAsync<BinaryLedger>(streamId, TestContext.Current.CancellationToken);
+        ledger.ShouldNotBeNull();
+        ledger!.Total.ShouldBe(11);
+        ledger.Names.ShouldBe(["b1", "b2", "j1"]);
+    }
+
+    [Fact]
+    public async Task binary_events_hydrate_through_the_event_linq_provider()
+    {
+        // A third distinct reader (EventListHandler) — same dispatch, separately covered.
+        await ConfigureBinaryStore();
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Events.StartStream(new BinaryPayloadRecorded("via-linq", 42));
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using var query = theStore.QuerySession();
+        var events = await query.Events.QueryAllRawEvents()
+            .Where(e => e.EventTypeName == "binary_payload_recorded")
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        events.Count.ShouldBe(1);
+        events[0].Data.ShouldBe(new BinaryPayloadRecorded("via-linq", 42));
+    }
+
+    [Fact]
+    public async Task masking_a_binary_event_rewrites_bdata_not_just_the_json_column()
+    {
+        // If masking only rewrote `data`, the original payload would stay readable in bdata — for a
+        // GDPR masking operation that is the entire point missed.
+        await ConfigureBinaryStore();
+        theStore.Events.AddMaskingRuleForProtectedInformation<BinaryPayloadRecorded>(
+            e => e with { Name = "****" });
+
+        Guid streamId;
+        await using (var session = theStore.LightweightSession())
+        {
+            streamId = session.Events.StartStream(new BinaryPayloadRecorded("secret", 9)).Id;
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await theStore.Advanced.ApplyEventDataMasking(x => x.IncludeStream(streamId),
+            TestContext.Current.CancellationToken);
+
+        await using var query = theStore.QuerySession();
+        var events = await query.Events.FetchStreamAsync(streamId, token: TestContext.Current.CancellationToken);
+        events[0].Data.ShouldBeOfType<BinaryPayloadRecorded>().Name.ShouldBe("****");
+
+        var (data, bdata) = await ReadRawRowAsync(events[0].Sequence);
+        bdata.ShouldNotBeNull("the masked row must stay binary");
+        Encoding.UTF8.GetString(bdata!).ShouldNotContain("secret");
+        data.ShouldBe("{}");
+    }
+}

--- a/src/Polecat/Events/BinaryEventAttribute.cs
+++ b/src/Polecat/Events/BinaryEventAttribute.cs
@@ -1,0 +1,28 @@
+namespace Polecat.Events;
+
+/// <summary>
+///     Marks an event type as binary-serialized: its <c>pc_events.data</c> column holds the
+///     <c>'{}'</c> placeholder and the real payload lives in <c>bdata</c>, written and read by an
+///     <see cref="IEventBinarySerializer" />. Mirrors Marten's <c>[BinaryEvent]</c>
+///     (<see href="https://github.com/JasperFx/marten/issues/4515" />); tracked as
+///     <see href="https://github.com/JasperFx/polecat/issues/388">polecat#388</see>.
+/// </summary>
+/// <remarks>
+///     <para>
+///         The serializer for an attribute-marked type is the store-wide
+///         <c>opts.Events.DefaultBinarySerializer</c>. An explicit
+///         <c>opts.Events.UseBinarySerializer&lt;TEvent&gt;(serializer)</c> registration takes
+///         precedence. If a type is attribute-marked but neither is configured, the store throws when
+///         it first resolves that event type rather than silently writing JSON — a silent fallback
+///         would produce a store whose write amplification quietly does not match its configuration.
+///     </para>
+///     <para>
+///         JSON and binary events coexist per event type in the same table, so applying this to a
+///         single event type is a safe in-place change: existing JSON rows keep <c>bdata = NULL</c>
+///         and keep reading through the JSON path.
+///     </para>
+/// </remarks>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, Inherited = false)]
+public sealed class BinaryEventAttribute : Attribute
+{
+}

--- a/src/Polecat/Events/Daemon/PolecatEventLoader.cs
+++ b/src/Polecat/Events/Daemon/PolecatEventLoader.cs
@@ -80,7 +80,7 @@ internal class PolecatEventLoader : IEventLoader
         await using var cmd = conn.CreateCommand();
         cmd.CommandText = $"""
             SELECT TOP(@batchSize) seq_id, id, stream_id, version, data, type, timestamp,
-                tenant_id, dotnet_type, is_archived
+                tenant_id, dotnet_type, is_archived, bdata
             FROM {_events.EventsTableName}
             WHERE seq_id > @floor AND seq_id <= @ceiling AND is_archived = 0{tenantPredicate}
             ORDER BY seq_id;
@@ -106,6 +106,8 @@ internal class PolecatEventLoader : IEventLoader
             var tenantId = reader.GetString(7);
             var dotNetTypeName = reader.IsDBNull(8) ? null : reader.GetString(8);
             var isArchived = reader.GetBoolean(9);
+            // #388: non-null bdata means this row's payload is binary, not JSON.
+            var bdata = reader.IsDBNull(10) ? null : reader.GetFieldValue<byte[]>(10);
 
             // Apply event type allow-list filter (skip events not in the subscription's filter)
             if (_allowedDotNetTypes != null && dotNetTypeName != null &&
@@ -133,7 +135,7 @@ internal class PolecatEventLoader : IEventLoader
             object data;
             try
             {
-                data = _options.Serializer.FromJson(resolvedType, json);
+                data = _events.DeserializeEventData(resolvedType, json, bdata, _options.Serializer);
             }
             catch (Exception ex)
             {

--- a/src/Polecat/Events/EventGraph.cs
+++ b/src/Polecat/Events/EventGraph.cs
@@ -440,6 +440,118 @@ public class EventGraph : EventRegistry, IAggregationSourceFactory<IQuerySession
 
     public IReadOnlyList<ITagTypeRegistration> TagTypes => _tagTypes;
 
+    // ---- #388: pluggable binary event serialization ------------------------------------------
+    //
+    // Explicit per-type registrations from UseBinarySerializer<TEvent>(...). Types marked with
+    // [BinaryEvent] but not registered explicitly fall back to DefaultBinarySerializer; that
+    // resolution is cached in _binarySerializerResolution so the attribute probe (and the throw for a
+    // misconfigured type) happens once per event type rather than once per row.
+    private readonly ConcurrentDictionary<Type, IEventBinarySerializer> _binarySerializerByType = new();
+    private readonly ConcurrentDictionary<Type, IEventBinarySerializer?> _binarySerializerResolution = new();
+
+    /// <summary>
+    ///     Store-wide fallback <see cref="IEventBinarySerializer" /> used for event types marked with
+    ///     <see cref="BinaryEventAttribute" /> that have no explicit per-type registration. Null by
+    ///     default, which leaves every event type on the JSON path.
+    /// </summary>
+    public IEventBinarySerializer? DefaultBinarySerializer
+    {
+        get => _defaultBinarySerializer;
+        set
+        {
+            _defaultBinarySerializer = value;
+            _binarySerializerResolution.Clear();
+        }
+    }
+
+    private IEventBinarySerializer? _defaultBinarySerializer;
+
+    /// <summary>
+    ///     Opt <typeparamref name="TEvent" /> into binary serialization (#388): its payload is written
+    ///     to the <c>bdata</c> column instead of <c>data</c>, and read back through the same
+    ///     serializer. Wins over <see cref="BinaryEventAttribute" /> + <see cref="DefaultBinarySerializer" />.
+    /// </summary>
+    public EventGraph UseBinarySerializer<TEvent>(IEventBinarySerializer serializer) where TEvent : notnull
+    {
+        ArgumentNullException.ThrowIfNull(serializer);
+        _binarySerializerByType[typeof(TEvent)] = serializer;
+        _binarySerializerResolution.Clear();
+        return this;
+    }
+
+    /// <summary>
+    ///     The <see cref="IEventBinarySerializer" /> governing <paramref name="eventType" />, or null
+    ///     when that type stays on the JSON path. Explicit registration beats
+    ///     <see cref="BinaryEventAttribute" /> + <see cref="DefaultBinarySerializer" />.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    ///     The type carries <see cref="BinaryEventAttribute" /> but no serializer is configured for it.
+    ///     Deliberately a throw rather than a silent fall back to JSON: a store that quietly ignored
+    ///     the attribute would have write-amplification characteristics that do not match its
+    ///     configuration, which is the whole reason the feature exists.
+    /// </exception>
+    internal IEventBinarySerializer? ResolveBinarySerializerFor(Type eventType)
+        => _binarySerializerResolution.GetOrAdd(eventType, static (type, graph) =>
+        {
+            if (graph._binarySerializerByType.TryGetValue(type, out var explicitSerializer))
+            {
+                return explicitSerializer;
+            }
+
+            if (!type.IsDefined(typeof(BinaryEventAttribute), inherit: false))
+            {
+                return null;
+            }
+
+            return graph._defaultBinarySerializer ?? throw new InvalidOperationException(
+                $"Event type '{type.FullName}' is marked with [BinaryEvent] but no IEventBinarySerializer "
+                + $"is registered. Either call opts.Events.UseBinarySerializer<{type.Name}>(...) explicitly, "
+                + "or set opts.Events.DefaultBinarySerializer to a store-wide fallback.");
+        }, this);
+
+    /// <summary>
+    ///     The <c>bdata</c> bytes for an event on the write path, or null when the event's type stays
+    ///     on the JSON path. The two are mutually exclusive per row — see
+    ///     <see cref="JsonPlaceholderForBinaryEvent" />.
+    /// </summary>
+    internal byte[]? SerializeEventBdata(IEvent @event)
+    {
+        // Deliberately NOT short-circuited on UsesBinaryEventSerialization: a type marked
+        // [BinaryEvent] in a store with no serializer configured has to throw here, and skipping the
+        // resolve for "performance" would turn that into a silent write of JSON. The resolve is a
+        // ConcurrentDictionary hit cached per event type, so a JSON-only store pays one lookup per
+        // appended event and nothing more.
+        var eventType = @event.EventType ?? @event.Data.GetType();
+        var serializer = ResolveBinarySerializerFor(eventType);
+        return serializer?.Serialize(eventType, @event.Data);
+    }
+
+    /// <summary>
+    ///     What goes in the <c>data</c> column of a binary event's row. An empty JSON object rather
+    ///     than NULL, because <c>data</c> is NOT NULL and typed <c>json</c> on SQL Server 2025 — a
+    ///     row still has to hold something the engine will parse.
+    /// </summary>
+    internal const string JsonPlaceholderForBinaryEvent = "{}";
+
+    /// <summary>
+    ///     The per-row read counterpart of <see cref="SerializeEventBdata" />: <paramref name="bdata" />
+    ///     being non-null is the on-row discriminator, so JSON rows written before the feature was
+    ///     switched on keep deserializing through <paramref name="serializer" /> unchanged.
+    /// </summary>
+    internal object DeserializeEventData(Type resolvedType, string json, byte[]? bdata, ISerializer serializer)
+    {
+        if (bdata is null) return serializer.FromJson(resolvedType, json);
+
+        var binary = ResolveBinarySerializerFor(resolvedType)
+                     ?? throw new InvalidOperationException(
+                         $"A pc_events row for '{resolvedType.FullName}' has a non-null bdata column but no "
+                         + "IEventBinarySerializer is registered for that type. Configure it with "
+                         + $"opts.Events.UseBinarySerializer<{resolvedType.Name}>(...) or set "
+                         + "opts.Events.DefaultBinarySerializer — the event cannot be read without it.");
+
+        return binary.Deserialize(resolvedType, bdata);
+    }
+
     /// <summary>
     ///     All currently registered event types.
     /// </summary>

--- a/src/Polecat/Events/EventOperations.cs
+++ b/src/Polecat/Events/EventOperations.cs
@@ -512,11 +512,17 @@ internal class EventOperations : QueryEventStore, IEventOperations
 
     public void OverwriteEvent(IEvent @event)
     {
-        var serializedData = _sessionBase.Serializer.ToJson(@event.Data);
+        // #388: same data/bdata split as the append path — a binary event's masked payload has to go
+        // back through its IEventBinarySerializer, not into the JSON column.
+        var serializedBdata = _events.SerializeEventBdata(@event);
+        var serializedData = serializedBdata is null
+            ? _sessionBase.Serializer.ToJson(@event.Data)
+            : EventGraph.JsonPlaceholderForBinaryEvent;
         var serializedHeaders = @event.Headers != null
             ? _sessionBase.Serializer.ToJson(@event.Headers)
             : null;
-        _workTracker.Add(new Protected.OverwriteEventOperation(_events, @event, serializedData, serializedHeaders));
+        _workTracker.Add(new Protected.OverwriteEventOperation(
+            _events, @event, serializedData, serializedBdata, serializedHeaders));
     }
 
     public Guid CompletelyReplaceEvent<T>(long sequence, T eventBody) where T : class
@@ -527,9 +533,14 @@ internal class EventOperations : QueryEventStore, IEventOperations
         _events.AddEventType(typeof(T));
         var mapping = _events.EventMappingFor(typeof(T));
 
-        var serializedData = _sessionBase.Serializer.ToJson(eventBody);
+        // #388: the REPLACEMENT body's type decides the row's format, not the replaced row's.
+        var binary = _events.ResolveBinarySerializerFor(typeof(T));
+        var serializedBdata = binary?.Serialize(typeof(T), eventBody);
+        var serializedData = serializedBdata is null
+            ? _sessionBase.Serializer.ToJson(eventBody)
+            : EventGraph.JsonPlaceholderForBinaryEvent;
         var op = new Protected.ReplaceEventOperation(
-            _events, sequence, serializedData, mapping.EventTypeName, mapping.DotNetTypeName);
+            _events, sequence, serializedData, serializedBdata, mapping.EventTypeName, mapping.DotNetTypeName);
 
         _workTracker.Add(op);
         return op.Id;
@@ -868,10 +879,10 @@ internal class EventOperations : QueryEventStore, IEventOperations
         var eventOptions = _events.EventOptions;
 
         // Build SELECT columns matching the event reader format
-        var selectColumns = "e.seq_id, e.id, e.stream_id, e.version, e.data, e.type, e.timestamp, e.tenant_id, e.dotnet_type, e.is_archived";
-        if (eventOptions.EnableCorrelationId) selectColumns += ", e.correlation_id";
-        if (eventOptions.EnableCausationId) selectColumns += ", e.causation_id";
-        if (eventOptions.EnableHeaders) selectColumns += ", e.headers";
+        // #388: composed by PcEventsRowReader rather than spelled out here — this projection has to
+        // stay in lockstep with the canonical one (which now carries bdata at ordinal 10), and two
+        // hand-written copies of the same column list is exactly how that stops being true.
+        var selectColumns = Internal.PcEventsRowReader.ComposeSelectColumnsWithAlias(eventOptions, "e");
 
         var sb = new StringBuilder();
         sb.Append($"SELECT {selectColumns} FROM [{schema}].[pc_events] e");
@@ -949,11 +960,12 @@ internal class EventOperations : QueryEventStore, IEventOperations
             var tenantId = reader.GetString(7);
             var dotNetTypeName = reader.IsDBNull(8) ? null : reader.GetString(8);
             var isArchived = reader.GetBoolean(9);
+            var bdata = reader.IsDBNull(10) ? null : reader.GetFieldValue<byte[]>(10); // #388
 
             var resolvedType = _events.ResolveEventType(dotNetTypeName);
             if (resolvedType == null) continue;
 
-            var data = _sessionBase.Serializer.FromJson(resolvedType, json);
+            var data = _events.DeserializeEventData(resolvedType, json, bdata, _sessionBase.Serializer);
             var mapping = _events.EventMappingFor(resolvedType);
             var @event = mapping.Wrap(data);
 
@@ -978,7 +990,7 @@ internal class EventOperations : QueryEventStore, IEventOperations
                 @event.StreamKey = rawStreamId.ToString();
             }
 
-            var metaIndex = 10;
+            var metaIndex = 11; // #388: ordinal 10 is bdata
             if (eventOptions.EnableCorrelationId)
             {
                 @event.CorrelationId = reader.IsDBNull(metaIndex) ? null : reader.GetString(metaIndex);
@@ -1075,10 +1087,10 @@ internal class EventOperations : QueryEventStore, IEventOperations
         var schema = eventGraph.DatabaseSchemaName;
         var eventOptions = eventGraph.EventOptions;
 
-        var selectColumns = "e.seq_id, e.id, e.stream_id, e.version, e.data, e.type, e.timestamp, e.tenant_id, e.dotnet_type, e.is_archived";
-        if (eventOptions.EnableCorrelationId) selectColumns += ", e.correlation_id";
-        if (eventOptions.EnableCausationId) selectColumns += ", e.causation_id";
-        if (eventOptions.EnableHeaders) selectColumns += ", e.headers";
+        // #388: composed by PcEventsRowReader rather than spelled out here — this projection has to
+        // stay in lockstep with the canonical one (which now carries bdata at ordinal 10), and two
+        // hand-written copies of the same column list is exactly how that stops being true.
+        var selectColumns = Internal.PcEventsRowReader.ComposeSelectColumnsWithAlias(eventOptions, "e");
 
         builder.Append($"SELECT {selectColumns} FROM [{schema}].[pc_events] e");
 
@@ -1148,11 +1160,12 @@ internal class EventOperations : QueryEventStore, IEventOperations
         var tenantId = reader.GetString(7);
         var dotNetTypeName = reader.IsDBNull(8) ? null : reader.GetString(8);
         var isArchived = reader.GetBoolean(9);
+        var bdata = reader.IsDBNull(10) ? null : reader.GetFieldValue<byte[]>(10); // #388
 
         var resolvedType = eventGraph.ResolveEventType(dotNetTypeName);
         if (resolvedType == null) return null;
 
-        var data = serializer.FromJson(resolvedType, json);
+        var data = eventGraph.DeserializeEventData(resolvedType, json, bdata, serializer);
         var mapping = eventGraph.EventMappingFor(resolvedType);
         var @event = mapping.Wrap(data);
 
@@ -1165,7 +1178,7 @@ internal class EventOperations : QueryEventStore, IEventOperations
         @event.DotNetTypeName = dotNetTypeName!;
         @event.IsArchived = isArchived;
 
-        var metaIndex = 10;
+        var metaIndex = 11; // #388: ordinal 10 is bdata
         if (eventOptions.EnableCorrelationId)
         {
             @event.CorrelationId = reader.IsDBNull(metaIndex) ? null : reader.GetString(metaIndex);

--- a/src/Polecat/Events/IEventBinarySerializer.cs
+++ b/src/Polecat/Events/IEventBinarySerializer.cs
@@ -1,0 +1,42 @@
+namespace Polecat.Events;
+
+/// <summary>
+///     Pluggable binary serializer for event data — Polecat's counterpart of Marten's
+///     <c>IEventBinarySerializer</c> (<see href="https://github.com/JasperFx/marten/issues/4515" />,
+///     shipped in Marten 9.20.2), at parity so a store-agnostic consumer can wire either flavor.
+///     Tracked as <see href="https://github.com/JasperFx/polecat/issues/388">polecat#388</see>.
+/// </summary>
+/// <remarks>
+///     <para>
+///         Binary serialization is enabled <strong>per event type</strong>, not store-wide. A store
+///         can have JSON events and binary events mixed in the same <c>pc_events</c> table; a row's
+///         format is determined by whether its <c>bdata</c> column is <c>NULL</c> (JSON) or not
+///         (binary). That is what makes the feature safe to switch on for an existing store with no
+///         migration of existing event data — and just as safe to switch back off.
+///     </para>
+///     <para>
+///         Opt in by marking an event type with <see cref="BinaryEventAttribute" /> (resolved against
+///         the store-wide <c>opts.Events.DefaultBinarySerializer</c>) or by registering it explicitly
+///         with <c>opts.Events.UseBinarySerializer&lt;TEvent&gt;(serializer)</c>. An explicit per-type
+///         registration wins over the attribute.
+///     </para>
+///     <para>
+///         Implementations must be thread-safe: one instance serves every session in the store.
+///     </para>
+/// </remarks>
+public interface IEventBinarySerializer
+{
+    /// <summary>
+    ///     Serialize an event data instance to bytes.
+    /// </summary>
+    /// <param name="type">The runtime CLR type of the event data.</param>
+    /// <param name="data">The event data to serialize.</param>
+    byte[] Serialize(Type type, object data);
+
+    /// <summary>
+    ///     Deserialize bytes back into an event data instance.
+    /// </summary>
+    /// <param name="type">The target CLR type to deserialize into.</param>
+    /// <param name="data">The bytes previously produced by <see cref="Serialize" />.</param>
+    object Deserialize(Type type, byte[] data);
+}

--- a/src/Polecat/Events/Internal/PcEventsRowReader.cs
+++ b/src/Polecat/Events/Internal/PcEventsRowReader.cs
@@ -61,10 +61,16 @@ namespace Polecat.Events.Internal;
 internal static class PcEventsRowReader
 {
     /// <summary>
-    ///     Mandatory columns, always projected. Ordinals 0–9.
+    ///     Mandatory columns, always projected. Ordinals 0–10.
     /// </summary>
+    /// <remarks>
+    ///     #388 pins <c>bdata</c> at ordinal 10, after the previously-locked 0–9 block and before the
+    ///     optional metadata columns, so the per-row JSON-vs-binary dispatch reads a stable ordinal
+    ///     without disturbing any of the existing ones. The optional metadata slots shift from 10 to 11
+    ///     — see <see cref="MetadataSlots.Compute" />.
+    /// </remarks>
     internal const string CoreSelectColumns =
-        "seq_id, id, stream_id, version, data, type, timestamp, tenant_id, dotnet_type, is_archived";
+        "seq_id, id, stream_id, version, data, type, timestamp, tenant_id, dotnet_type, is_archived, bdata";
 
     /// <summary>
     ///     Compose <see cref="CoreSelectColumns"/> plus any optional metadata
@@ -93,7 +99,7 @@ internal static class PcEventsRowReader
     internal static string ComposeSelectColumnsWithAlias(EventStoreOptions options, string alias)
     {
         var sb = new StringBuilder(
-            $"{alias}.seq_id, {alias}.id, {alias}.stream_id, {alias}.version, {alias}.data, {alias}.type, {alias}.timestamp, {alias}.tenant_id, {alias}.dotnet_type, {alias}.is_archived");
+            $"{alias}.seq_id, {alias}.id, {alias}.stream_id, {alias}.version, {alias}.data, {alias}.type, {alias}.timestamp, {alias}.tenant_id, {alias}.dotnet_type, {alias}.is_archived, {alias}.bdata");
         if (options.EnableCorrelationId) sb.Append($", {alias}.correlation_id");
         if (options.EnableCausationId) sb.Append($", {alias}.causation_id");
         if (options.EnableHeaders) sb.Append($", {alias}.headers");
@@ -162,6 +168,10 @@ internal static class PcEventsRowReader
         var tenantId = reader.IsDBNull(7) ? ctx.DefaultTenantId : reader.GetString(7);
         var dotNetTypeName = reader.IsDBNull(8) ? null : reader.GetString(8);
         var isArchived = reader.GetBoolean(9);
+        // #388: non-null bdata is the per-row discriminator. Reading it here (rather than inside the
+        // optional-metadata slot loop) keeps the dispatch on a fixed ordinal and off the JSON path's
+        // hot loop — a store with no binary events pays one IsDBNull per row.
+        var bdata = reader.IsDBNull(10) ? null : reader.GetFieldValue<byte[]>(10);
 
         var resolvedType = ctx.EventGraph.ResolveEventType(dotNetTypeName);
         if (resolvedType == null) return null;
@@ -171,7 +181,7 @@ internal static class PcEventsRowReader
         // this collapses N dictionary lookups into 1 per distinct type.
         var mapping = cache.LookupOrAdd(ctx.EventGraph, resolvedType);
 
-        var data = ctx.Serializer.FromJson(resolvedType, json);
+        var data = ctx.EventGraph.DeserializeEventData(resolvedType, json, bdata, ctx.Serializer);
         var @event = mapping.Wrap(data);
 
         @event.Id = eventId;
@@ -253,6 +263,10 @@ internal static class PcEventsRowReader
             metadata = headerDoc.RootElement.Clone();
         }
 
+        // #388: a binary event's `data` column holds only the '{}' placeholder, so the explorer's
+        // JsonElement view of a binary row is that empty object. The explorer is a diagnostic surface
+        // that deliberately does not deserialize (no ISerializer, no IEventBinarySerializer), so it
+        // reports what is in the JSON column rather than pretending to decode the bytes.
         using var doc = JsonDocument.Parse(rawData);
         var data = doc.RootElement.Clone();
 
@@ -294,7 +308,8 @@ internal readonly record struct MetadataSlots(int CorrelationIdx, int CausationI
 
     public static MetadataSlots Compute(EventStoreOptions options)
     {
-        var ordinal = 10;
+        // #388: ordinal 10 is bdata; the optional metadata block starts at 11.
+        var ordinal = 11;
         var correlation = options.EnableCorrelationId ? ordinal++ : Disabled;
         var causation = options.EnableCausationId ? ordinal++ : Disabled;
         var headers = options.EnableHeaders ? ordinal++ : Disabled;

--- a/src/Polecat/Events/Linq/EventLinqQueryProvider.cs
+++ b/src/Polecat/Events/Linq/EventLinqQueryProvider.cs
@@ -143,7 +143,7 @@ internal class EventLinqQueryProvider : IPolecatAsyncQueryProvider
                 // Full IEvent result set. #256: append the opt-in metadata columns (when enabled) so
                 // hydrated events carry correlation/causation/user_name — EventListHandler reads them
                 // at the trailing ordinals in this same enable order.
-                var columns = "seq_id, id, stream_id, version, data, type, timestamp, tenant_id, dotnet_type, is_archived";
+                var columns = Internal.PcEventsRowReader.CoreSelectColumns;
                 var eventOptions = _events.EventOptions;
                 if (eventOptions.EnableCorrelationId) columns += ", correlation_id";
                 if (eventOptions.EnableCausationId) columns += ", causation_id";

--- a/src/Polecat/Events/Linq/EventListHandler.cs
+++ b/src/Polecat/Events/Linq/EventListHandler.cs
@@ -8,7 +8,8 @@ namespace Polecat.Events.Linq;
 
 /// <summary>
 ///     Reads IEvent objects from a multi-column result set on pc_events.
-///     Column layout: seq_id, id, stream_id, version, data, type, timestamp, tenant_id, dotnet_type, is_archived
+///     Column layout: seq_id, id, stream_id, version, data, type, timestamp, tenant_id, dotnet_type,
+///     is_archived, bdata (#388), then the optional metadata columns.
 /// </summary>
 [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
     Justification = "Class-level: hydrates IEvent via EventGraph.Wrap (which routes through ISerializer.FromJson). Event types are preserved by EventGraph registration on the caller side per the AOT publishing guide.")]
@@ -42,11 +43,13 @@ internal class EventListHandler
             var tenantId = sqlReader.GetString(7);
             var dotNetTypeName = sqlReader.IsDBNull(8) ? null : sqlReader.GetString(8);
             var isArchived = sqlReader.GetBoolean(9);
+            // #388: non-null bdata means the payload is binary, not in the JSON `data` column.
+            var bdata = sqlReader.IsDBNull(10) ? null : sqlReader.GetFieldValue<byte[]>(10);
 
             var resolvedType = _events.ResolveEventType(dotNetTypeName);
             if (resolvedType == null) continue;
 
-            var data = _serializer.FromJson(resolvedType, json);
+            var data = _events.DeserializeEventData(resolvedType, json, bdata, _serializer);
             var mapping = _events.EventMappingFor(resolvedType);
             var @event = mapping.Wrap(data);
 
@@ -71,7 +74,7 @@ internal class EventListHandler
             // #256: read the opt-in metadata columns appended to the full-event SELECT (when enabled),
             // in the same enable order the query provider emitted them.
             var options = _events.EventOptions;
-            var ordinal = 10;
+            var ordinal = 11; // #388: ordinal 10 is bdata
             if (options.EnableCorrelationId)
             {
                 @event.CorrelationId = sqlReader.IsDBNull(ordinal) ? null : sqlReader.GetString(ordinal);

--- a/src/Polecat/Events/Protected/OverwriteEventOperation.cs
+++ b/src/Polecat/Events/Protected/OverwriteEventOperation.cs
@@ -11,13 +11,16 @@ internal class OverwriteEventOperation : Polecat.Internal.IStorageOperation
     private readonly EventGraph _events;
     private readonly IEvent _event;
     private readonly string _serializedData;
+    private readonly byte[]? _serializedBdata;
     private readonly string? _serializedHeaders;
 
-    public OverwriteEventOperation(EventGraph events, IEvent @event, string serializedData, string? serializedHeaders)
+    public OverwriteEventOperation(EventGraph events, IEvent @event, string serializedData,
+        byte[]? serializedBdata, string? serializedHeaders)
     {
         _events = events;
         _event = @event;
         _serializedData = serializedData;
+        _serializedBdata = serializedBdata;
         _serializedHeaders = serializedHeaders;
     }
 
@@ -26,24 +29,32 @@ internal class OverwriteEventOperation : Polecat.Internal.IStorageOperation
 
     public void ConfigureCommand(ICommandBuilder builder)
     {
-        if (_serializedHeaders != null)
+        builder.Append($"UPDATE {_events.EventsTableName} SET data = ");
+        builder.AppendParameter(_serializedData);
+
+        // #388: a binary event's payload lives in bdata, so masking has to rewrite THAT — rewriting
+        // only `data` would leave the original, unmasked payload readable in bdata, which for a GDPR
+        // masking operation is the whole point missed. The row keeps its own format either way:
+        // binary events stay binary (data holds the '{}' placeholder), JSON events stay JSON.
+        builder.Append(", bdata = ");
+        if (_serializedBdata is null)
         {
-            builder.Append($"UPDATE {_events.EventsTableName} SET data = ");
-            builder.AppendParameter(_serializedData);
-            builder.Append(", headers = ");
-            builder.AppendParameter(_serializedHeaders);
-            builder.Append(" WHERE seq_id = ");
-            builder.AppendParameter(_event.Sequence);
-            builder.Append(";");
+            builder.Append("NULL");
         }
         else
         {
-            builder.Append($"UPDATE {_events.EventsTableName} SET data = ");
-            builder.AppendParameter(_serializedData);
-            builder.Append(" WHERE seq_id = ");
-            builder.AppendParameter(_event.Sequence);
-            builder.Append(";");
+            builder.AppendParameter(_serializedBdata);
         }
+
+        if (_serializedHeaders != null)
+        {
+            builder.Append(", headers = ");
+            builder.AppendParameter(_serializedHeaders);
+        }
+
+        builder.Append(" WHERE seq_id = ");
+        builder.AppendParameter(_event.Sequence);
+        builder.Append(";");
     }
 
     public Task PostprocessAsync(DbDataReader reader, IList<Exception> exceptions, CancellationToken token)

--- a/src/Polecat/Events/Protected/ReplaceEventOperation.cs
+++ b/src/Polecat/Events/Protected/ReplaceEventOperation.cs
@@ -11,16 +11,18 @@ internal class ReplaceEventOperation : Polecat.Internal.IStorageOperation
     private readonly EventGraph _events;
     private readonly long _sequence;
     private readonly string _serializedData;
+    private readonly byte[]? _serializedBdata;
     private readonly string _eventTypeName;
     private readonly string _dotNetTypeName;
     private readonly Guid _newId;
 
     public ReplaceEventOperation(EventGraph events, long sequence, string serializedData,
-        string eventTypeName, string dotNetTypeName)
+        byte[]? serializedBdata, string eventTypeName, string dotNetTypeName)
     {
         _events = events;
         _sequence = sequence;
         _serializedData = serializedData;
+        _serializedBdata = serializedBdata;
         _eventTypeName = eventTypeName;
         _dotNetTypeName = dotNetTypeName;
         _newId = Guid.NewGuid();
@@ -34,6 +36,20 @@ internal class ReplaceEventOperation : Polecat.Internal.IStorageOperation
     {
         builder.Append($"UPDATE {_events.EventsTableName} SET data = ");
         builder.AppendParameter(_serializedData);
+
+        // #388: the replacement body's own event type decides the row's format, so bdata is set (or
+        // cleared) in the same statement — a replacement that switched a row from binary to JSON
+        // without clearing bdata would keep reading the OLD payload.
+        builder.Append(", bdata = ");
+        if (_serializedBdata is null)
+        {
+            builder.Append("NULL");
+        }
+        else
+        {
+            builder.AppendParameter(_serializedBdata);
+        }
+
         builder.Append(", timestamp = SYSDATETIMEOFFSET(), type = ");
         builder.AppendParameter(_eventTypeName);
         builder.Append(", dotnet_type = ");

--- a/src/Polecat/Events/Protected/StreamCompacting.cs
+++ b/src/Polecat/Events/Protected/StreamCompacting.cs
@@ -70,11 +70,21 @@ internal static class StreamCompactingExecution
         var compacted = new Compacted<T>(aggregate!,
             request.StreamId ?? Guid.Empty, request.StreamKey ?? string.Empty);
 
-        var serializedData = session.Serializer.ToJson(compacted);
-        var mapping = session.Options.EventGraph.EventMappingFor(typeof(Compacted<T>));
+        var graph = session.Options.EventGraph;
+
+        // #388: the Compacted<T> snapshot follows the same data/bdata rule as any other event —
+        // binary if Compacted<T> itself is opted in, JSON otherwise. The event being REPLACED may
+        // have been the other format; ReplaceEventOperation writes both columns so the row ends up
+        // consistent either way.
+        var binary = graph.ResolveBinarySerializerFor(typeof(Compacted<T>));
+        var serializedBdata = binary?.Serialize(typeof(Compacted<T>), compacted);
+        var serializedData = serializedBdata is null
+            ? session.Serializer.ToJson(compacted)
+            : EventGraph.JsonPlaceholderForBinaryEvent;
+        var mapping = graph.EventMappingFor(typeof(Compacted<T>));
 
         var replaceOp = new ReplaceEventOperation(
-            session.Options.EventGraph, request.Sequence, serializedData,
+            graph, request.Sequence, serializedData, serializedBdata,
             mapping.EventTypeName, mapping.DotNetTypeName);
 
         session.WorkTracker.Add(replaceOp);

--- a/src/Polecat/Events/Schema/EventsTable.cs
+++ b/src/Polecat/Events/Schema/EventsTable.cs
@@ -44,6 +44,17 @@ internal class EventsTable : Table
         // Event data — SQL Server 2025 native JSON type by default
         AddColumn("data", events.JsonColumnType).NotNull();
 
+        // #388: binary event payload, the SQL Server counterpart of Marten's bytea `bdata`
+        // (marten#4515). Nullable and unconditional on purpose: `bdata IS NULL` is the per-ROW
+        // discriminator between a JSON event and a binary one, so JSON and binary events coexist in
+        // this table per event type. That is what makes the feature switchable on an existing store
+        // with no migration of existing event data — rows written before the column existed simply
+        // have bdata = NULL and keep reading through the JSON path — and just as safely switchable
+        // back off. Adding it always (rather than only when a serializer is configured) keeps the
+        // read projection one fixed shape; Weasel's additive delta adds the column on the next
+        // schema apply.
+        AddColumn("bdata", "varbinary(max)").AllowNulls();
+
         // Event type name for deserialization
         AddColumn("type", "varchar(500)").NotNull();
 

--- a/src/Polecat/Events/Storage/PolecatQuickAppendEventsOperation.cs
+++ b/src/Polecat/Events/Storage/PolecatQuickAppendEventsOperation.cs
@@ -135,7 +135,7 @@ internal sealed class PolecatQuickAppendEventsOperation
                 builder.Append(", ");
             }
 
-            builder.Append("id, stream_id, version, data, type, timestamp, tenant_id, dotnet_type");
+            builder.Append("id, stream_id, version, data, bdata, type, timestamp, tenant_id, dotnet_type");
             if (options.EnableCorrelationId) builder.Append(", correlation_id");
             if (options.EnableCausationId) builder.Append(", causation_id");
             if (options.EnableHeaders) builder.Append(", headers");
@@ -164,8 +164,18 @@ internal sealed class PolecatQuickAppendEventsOperation
             builder.Append(", ");
             Bind(builder, @event.Version, StorageColumnType.Long);
 
+            // #388: a binary event writes the '{}' placeholder to `data` and its payload to `bdata`;
+            // a JSON event writes the payload to `data` and NULL to `bdata`. Exactly one of the two
+            // is populated per row, and `bdata IS NULL` is what the read path dispatches on.
+            var bdata = _graph.SerializeEventBdata(@event);
+
             builder.Append(", ");
-            Bind(builder, session.Serializer.ToJson(@event.Data), StorageColumnType.Json);
+            Bind(builder,
+                bdata is null ? session.Serializer.ToJson(@event.Data) : EventGraph.JsonPlaceholderForBinaryEvent,
+                StorageColumnType.Json);
+
+            builder.Append(", ");
+            Bind(builder, (object?)bdata ?? DBNull.Value, StorageColumnType.Binary);
 
             builder.Append(", ");
             Bind(builder, @event.EventTypeName, StorageColumnType.String);

--- a/src/Polecat/Events/Storage/SqlServerEventStoreDialect.cs
+++ b/src/Polecat/Events/Storage/SqlServerEventStoreDialect.cs
@@ -50,11 +50,14 @@ internal sealed class SqlServerEventStoreDialect : IEventStoreSqlDialect
             quickAppendEventsSql: $"insert into {graph.EventsTableName} ",
             insertStreamSql: $"insert into {graph.StreamsTableName} (...) values (...)",
             updateStreamVersionSql: $"update {graph.StreamsTableName} set version = ... where ...",
-            // Polecat is STJ/JSON-only — no binary event serialization. Data is always JSON; bdata is
-            // always null. Serialize through the session serializer at write time (see the append op);
-            // the descriptor closure below covers any shared-op path that reaches for it.
-            serializeEventData: e => serializer.ToJson(e.Data),
-            serializeEventBdata: _ => null)
+            // #388: event data is JSON unless the event's type is opted into binary serialization, in
+            // which case `data` carries the '{}' placeholder and the payload goes to `bdata`. Exactly
+            // one of the two closures produces a payload for any given event. These cover any shared-op
+            // path that reaches for them; the SQL Server append operation binds both directly.
+            serializeEventData: e => graph.SerializeEventBdata(e) is null
+                ? serializer.ToJson(e.Data)
+                : EventGraph.JsonPlaceholderForBinaryEvent,
+            serializeEventBdata: graph.SerializeEventBdata)
         {
             IsGuidStreamIdentity = isGuid,
             Dialect = dialect,

--- a/src/Polecat/Storage/SqlServerStorageDialect.cs
+++ b/src/Polecat/Storage/SqlServerStorageDialect.cs
@@ -95,6 +95,8 @@ internal sealed class SqlServerStorageDialect<TId> : IStorageDialect
             // Polecat binds JSON as string values throughout; SQL Server 2025's native JSON
             // column type (and nvarchar-backed JSON) accepts nvarchar input.
             StorageColumnType.Json => SqlDbType.NVarChar,
+            // #388: the binary event payload column (pc_events.bdata) is varbinary(max).
+            StorageColumnType.Binary => SqlDbType.VarBinary,
             _ => throw new ArgumentOutOfRangeException(nameof(type))
         };
 

--- a/src/Polecat/StoreOptions.cs
+++ b/src/Polecat/StoreOptions.cs
@@ -491,6 +491,32 @@ public class EventStoreOptions : IEventStoreInstrumentation
     }
 
     /// <summary>
+    ///     #388: store-wide fallback <see cref="Polecat.Events.IEventBinarySerializer" /> for event types
+    ///     marked with <see cref="Polecat.Events.BinaryEventAttribute" /> that have no explicit per-type
+    ///     registration via <see cref="UseBinarySerializer{TEvent}" />. Null by default — every event type
+    ///     stays on the JSON path. Mirrors Marten's <c>opts.Events.DefaultBinarySerializer</c>.
+    /// </summary>
+    public Polecat.Events.IEventBinarySerializer? DefaultBinarySerializer
+    {
+        get => EventGraph!.DefaultBinarySerializer;
+        set => EventGraph!.DefaultBinarySerializer = value;
+    }
+
+    /// <summary>
+    ///     #388: opt <typeparamref name="TEvent" /> into binary serialization — its payload is written to
+    ///     the <c>pc_events.bdata</c> column instead of <c>data</c>, and read back through the same
+    ///     serializer. Per event type rather than store-wide, so JSON and binary rows coexist in one
+    ///     table and the feature can be switched on (or back off) for an existing store with no data
+    ///     migration. Mirrors Marten's <c>opts.Events.UseBinarySerializer&lt;TEvent&gt;(serializer)</c>.
+    /// </summary>
+    public EventStoreOptions UseBinarySerializer<TEvent>(Polecat.Events.IEventBinarySerializer serializer)
+        where TEvent : notnull
+    {
+        EventGraph!.UseBinarySerializer<TEvent>(serializer);
+        return this;
+    }
+
+    /// <summary>
     ///     Register a tag type for Dynamic Consistency Boundary (DCB) support.
     ///     Creates a tag table with an auto-generated suffix.
     /// </summary>


### PR DESCRIPTION
Closes #388.

Parity with Marten's `IEventBinarySerializer` ([marten#4515](https://github.com/JasperFx/marten/issues/4515), shipped in 9.20.2). CritterWatch ships Marten/PostgreSQL and Polecat/SQL Server flavors from one source tree, and [CritterWatch#896](https://github.com/JasperFx/CritterWatch/issues/896) has already opted its highest-volume internal event into binary on the Marten side — measured at field scale as −97.9% on the wire, −60.4% on disk, −73.4% append p50. Until now the SQL Server flavor kept paying the JSON cost the Marten one shed.

## API

Mirrored as-is, so a store-agnostic consumer can wire either flavor:

```csharp
opts.Events.UseBinarySerializer<TEvent>(serializer);   // explicit, per event type
[BinaryEvent] + opts.Events.DefaultBinarySerializer;   // attribute-driven
```

## The coexistence design, which is the part worth copying

An additive nullable `bdata varbinary(max)` column beside `data`, with **`bdata IS NULL` as the per-row discriminator**. JSON and binary rows live in the same `pc_events` table, so the feature switches on for an existing store with no migration of existing event data — and switches back off just as safely.

The column is added unconditionally rather than only when a serializer is configured, so the read projection has one fixed shape. Weasel's additive delta adds it on the next schema apply; rows written before it existed have `bdata = NULL` and keep reading through the JSON path untouched. `data` is `NOT NULL` and typed `json` on SQL Server 2025, so a binary row carries the `'{}'` placeholder there rather than NULL.

**Quick mode was in scope from the start** rather than as a phase 2, per the issue's note. Polecat is QuickAppend-only, so there is no Rich-mode split to sequence and the CritterWatch store's configuration is covered by the first pass.

## Implementation notes worth review attention

**Every read path dispatches, not just the main one.** Polecat has four independent readers over `pc_events`, each with its own SELECT and its own deserialization: `PcEventsRowReader` (the canonical one), the two DCB tag-query readers in `EventOperations`, the LINQ `EventListHandler`, and the daemon's `PolecatEventLoader`. `bdata` is pinned at ordinal 10 — after the previously-locked 0–9 block, before the optional metadata columns, which shift to 11 — so the dispatch reads a stable ordinal everywhere. The two `EventOperations` projections that duplicated the canonical column list by hand now compose it from `PcEventsRowReader`; three hand-written copies of one list is how they stop agreeing.

**Masking rewrites `bdata`, not just `data`.** `OverwriteEventOperation` (behind `ApplyEventDataMasking`) previously wrote only the JSON column. For a binary event that would have left the original, unmasked payload readable in `bdata` — for a GDPR masking operation, the entire point missed. There is a test for exactly this. The same reasoning applies to `CompletelyReplaceEvent` and stream compaction, where the *replacement* body's type decides the row's format and a stale `bdata` would keep being read.

**A `[BinaryEvent]` type with no serializer configured throws** instead of silently writing JSON, and the append path deliberately does *not* short-circuit the resolve to make the common case cheaper. A store that quietly ignored the attribute would have write-amplification characteristics that do not match its configuration, which is the problem the feature exists to solve. The resolve is a per-event-type cached `ConcurrentDictionary` hit.

## Tests

12 new tests: the wire format (payload in `bdata`, `'{}'` in `data`, and a magic-header serializer so an assertion can prove the bytes really took the binary path), JSON/binary coexistence within a single stream, reading rows written before the serializer was configured, attribute-vs-explicit precedence, the misconfiguration throw, and the dispatch through each of inline projections, the async daemon, the event LINQ provider, and masking.

Full `Polecat.Tests` suite locally against dockerized SQL Server 2025, net10.0: **1650 total, 0 failed, 1647 passed, 3 skipped.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8tN8ApXiKhyVzia4iwmof