### PR TITLE
Bump Weasel 9.23.0 → 9.23.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -156,10 +156,14 @@
              Weasel 9.22.0 (weasel#417): carries the JasperFx 2.37.0 floor.
              Weasel 9.23.0: weasel#415 — EnsureDatabaseExistsAsync is safe under concurrent callers,
              which is the SQL Server path Polecat provisions on; plus weasel#416, where
-             AssertValidIdentifier now rejects a quote or semicolon outright. -->
-        <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.23.0" />
-        <PackageVersion Include="Weasel.SqlServer" Version="9.23.0" />
-        <PackageVersion Include="Weasel.Storage" Version="9.23.0" />
+             AssertValidIdentifier now rejects a quote or semicolon outright.
+             Weasel 9.23.1 (weasel#420): the weasel#416 identifier validation finally reaches the SQL
+             Server migrator, which validated NOTHING before this — the directly relevant half for
+             Polecat. Companion providers (Oracle, MySQL, Sqlite) fixed in the same pass, and
+             PostgreSQL's copy folded onto the shared Weasel.Core helper (weasel#422). -->
+        <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.23.1" />
+        <PackageVersion Include="Weasel.SqlServer" Version="9.23.1" />
+        <PackageVersion Include="Weasel.Storage" Version="9.23.1" />
 
         <!-- Strongly typed IDs -->
         <PackageVersion Include="StronglyTypedId" Version="1.0.0-beta08" />


### PR DESCRIPTION
Rolls Weasel forward to [9.23.1](https://github.com/JasperFx/weasel/releases/tag/V9.23.1) — `Weasel.SqlServer`, `Weasel.Storage`, `Weasel.EntityFrameworkCore`.

## What's in it, and why Polecat cares more than Marten does

weasel#420 + weasel#422: the identifier validation added for weasel#416 now covers **every** provider migrator instead of PostgreSQL alone, and PostgreSQL's own copy is folded onto the shared `Weasel.Core` helper so the providers cannot drift apart again.

**The SQL Server migrator previously validated nothing at all.** That is the directly relevant half for Polecat — Marten already had its check in 9.23.0 and takes this bump as hardening only. Oracle, MySQL and Sqlite each missed their own quoting characters and were fixed in the same pass.

Pairs naturally with #403, which escaped Polecat's own interpolated identifiers and literals: that closed the call sites, this closes the layer underneath them.

## Verification

Full suite net9.0: **1657 / 0 / 3** — identical to the same-day `main` baseline, so the bump moves nothing.

Kept as its own PR because a Weasel bump has form for landing outside the area it looks like it touches (Weasel 9.18–9.20.1 broke a Marten regression test through `MatchesForDelta`, nowhere near its release notes). One changed file means a bisect lands on one line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VpDCvJcBDZerieJB4JEHde