### PR TITLE
Cut 5.10.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>5.9.1</Version>
+        <Version>5.10.0</Version>
         <LangVersion>latest</LangVersion>
         <Authors>Jeremy D. Miller</Authors>
         <PackageIcon>logo.png</PackageIcon>


### PR DESCRIPTION
Version bump only — `Directory.Build.props` 5.9.1 → **5.10.0**.

Minor rather than patch: the line since 5.9.1 added public surface and moved the whole
JasperFx/Weasel matrix forward.

## What is in 5.10.0

**Features**
- Pluggable binary event serialization via `IEventBinarySerializer` (#388 / #402)
- `EventStoreOptions.AddEventType` / `AddEventTypes` (#395 / #396)

**Fixes**
- Interpolated identifiers and literals in constructed SQL are escaped (#390 / #403)
- A lone `DcbConcurrencyException` comes out of `SaveChangesAsync` unwrapped rather than aggregated
  (#394 / #397)

**Dependencies**
- JasperFx 2.37.2 → **2.38.0**, Weasel 9.23.0 → **9.23.2** (#405, #407)

**Behavior change worth calling out**
- `Polecat.Events.TestSupport.ProjectionScenario` is now a thin subclass of the lifted
  `JasperFx.Events.TestSupport` harness rather than a seven-file copy of Marten's (#404 / #408,
  jasperfx#616). It gains 15 overloads, but `Execute` → `ExecuteAsync`,
  `DoNotDeleteExistingData` → `DeleteExistingData` (default `true`), and the exception type moves
  namespace. Detailed in the release notes.

**Test infrastructure** (no shipped surface)
- Cross-store compliance waves 1–3 (#393, #400, #407), a parallel-safe test suite (#389), and
  document cleaning when `IntegrationContext.StoreOptions` builds a store (#398 / #401)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8tN8ApXiKhyVzia4iwmof