### PR TITLE
Adopt JasperFx 2.39.1 and compliance wave 4

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -74,14 +74,14 @@
              semantically rather than syntactically), jasperfx#615 (the blue/green side-effect gate
              warm-up moved off the agent start path, #598/#610) and jasperfx#617 (container-scoped
              projections usable by live aggregation, marten#5095). Same lockstep rule as above. -->
-        <PackageVersion Include="JasperFx" Version="2.38.0" />
-        <PackageVersion Include="JasperFx.Events" Version="2.38.0" />
+        <PackageVersion Include="JasperFx" Version="2.39.1" />
+        <PackageVersion Include="JasperFx.Events" Version="2.39.1" />
         <!--
              The shared cross-store event sourcing compliance suites. Source-only package: the
              suites compile inside Polecat.Tests so JasperFx's aggregate source generator binds
              Polecat's own session types.
         -->
-        <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.38.0" />
+        <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.39.1" />
         <!-- Pin the sibling JasperFx packages for parity with Marten 9's matrix
              even though Polecat doesn't currently reference them directly —
              keeps the lockstep matrix coherent when transitive resolution
@@ -89,7 +89,7 @@
              RuntimeCompiler 5.x line is the active continuation of the 4.x
              lineage; do not pin against the parallel stale 2.0.x series. -->
         <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.38.0" />
+        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.39.1" />
         <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
@@ -185,7 +185,7 @@
         <PackageVersion Include="StronglyTypedId" Version="1.0.0-beta08" />
 
         <!-- Source generators (matched to JasperFx.Events above) -->
-        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.38.0" />
+        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.39.1" />
 
         <!-- Build automation -->
         <PackageVersion Include="Nuke.Common" Version="9.0.4" />

--- a/src/Polecat.Tests/Compliance/PolecatComplianceFixture.cs
+++ b/src/Polecat.Tests/Compliance/PolecatComplianceFixture.cs
@@ -48,6 +48,11 @@ public class PolecatComplianceFixture : EventStoreComplianceFixture<IDocumentSes
             options.Events.EnableCausationId = true;
         }
 
+        if (config.EnableHeaders)
+        {
+            options.Events.EnableHeaders = true;
+        }
+
         config.ApplyTo(new PolecatComplianceRegistrar(options));
 
         _store = new DocumentStore(options);

--- a/src/Polecat.Tests/Compliance/polecat_event_store_compliance_wave4.cs
+++ b/src/Polecat.Tests/Compliance/polecat_event_store_compliance_wave4.cs
@@ -1,0 +1,20 @@
+using JasperFx.Events.ComplianceTests;
+
+namespace Polecat.Tests.Compliance;
+
+/*
+ * Wave 4 enrollments. Separate file only while the suites are still in flight upstream; fold into
+ * polecat_event_store_compliance.cs once the JasperFx package ships them.
+ */
+
+public class fetch_for_writing_compliance
+    : FetchForWritingCompliance<PolecatComplianceFixture, IDocumentSession, IQuerySession>;
+
+public class stream_read_compliance
+    : StreamReadCompliance<PolecatComplianceFixture, IDocumentSession, IQuerySession>;
+
+public class event_metadata_compliance
+    : EventMetadataCompliance<PolecatComplianceFixture, IDocumentSession, IQuerySession>;
+
+public class live_aggregation_compliance
+    : LiveAggregationCompliance<PolecatComplianceFixture, IDocumentSession, IQuerySession>;


### PR DESCRIPTION
Bumps JasperFx 2.38.0 → **2.39.1** and enrolls the four compliance suites that shipped in it (JasperFx/jasperfx#620).

| Suite | Tests |
|---|---|
| `fetch_for_writing_compliance` | 13 |
| `stream_read_compliance` | 11 |
| `event_metadata_compliance` | 9 |
| `live_aggregation_compliance` | 7 |

Polecat's compliance coverage goes **65 → 105 tests, zero capability gates**.

## Verified

Against the published 2.39.1 packages, net9.0:

- 105/105 compliance
- **1703/0/3** for the full Polecat.Tests suite

The suites were authored against a Polecat working copy from the start (via the `ComplianceSourceDir` dev loop this repo already supports), so they were passing here before the upstream PR was opened — not ported blind and fixed afterwards.

## The one code change

`PolecatComplianceFixture` resolves the new `ComplianceStoreConfig.EnableHeaders` flag onto `Events.EnableHeaders`, alongside the existing correlation wiring. That flag exists only because the two products spell it differently (Marten uses `Events.MetadataConfig.HeadersEnabled`); stamping the headers themselves needed nothing new, because `IEvent.SetHeader` is already on the shared event interface.

Nothing else in Polecat changed. Everything the four suites exercise — `FetchForWriting`, `WriteToAggregate`, `AppendOptimistic`/`AppendExclusive`, `FetchStreamAsync` with its version/timestamp bounds, `FetchStreamStateAsync`, the `IEvent` envelope, `AggregateStreamAsync` / `AggregateStreamToLastKnownAsync` — was already reachable through the shared JasperFx surfaces.

## Note on live aggregation

`LiveAggregationCompliance` deliberately folds an **unregistered** aggregate type rather than calling `config.LiveAggregation<T>()`, because Polecat derives live aggregators automatically and sets `SupportsLiveAggregationRegistration => false`. Folding an unregistered type is the common ground between the two stores, so the suite needs no capability gate here.

Marten's matching adoption is JasperFx/marten#5176.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VpDCvJcBDZerieJB4JEHde

