### PR TITLE
Populate usage.Events and return an empty StreamMetadata.Tags (#411, #412)

### DIFF
--- a/src/Polecat/DocumentStore.EventStore.cs
+++ b/src/Polecat/DocumentStore.EventStore.cs
@@ -315,8 +315,18 @@ public partial class DocumentStore : IEventStore<IDocumentSession, IQuerySession
 
         // Event-type registry — populates the explorer's "known event types"
         // panel without forcing operators to crack open assembly metadata.
+        //
+        // #411: BOTH collections have to be filled. EventStoreUsage carries the event registry
+        // twice — Events (List<EventDescriptor>) and RegisteredEventTypes
+        // (List<EventTypeDescriptor>) — and Marten populates both. Filling only
+        // RegisteredEventTypes left usage.Events empty, which reads to a consumer as "this store
+        // has no event types configured" rather than "this store describes them elsewhere".
         foreach (var registered in Options.EventGraph.AllKnownEventTypes())
         {
+            usage.Events.Add(new EventDescriptor(
+                registered.EventTypeName,
+                TypeDescriptor.For(registered.EventType)));
+
             usage.RegisteredEventTypes.Add(new EventTypeDescriptor(
                 EventType: TypeDescriptor.For(registered.EventType),
                 Alias: registered.EventTypeName,

--- a/src/Polecat/Events/Internal/PcStreamsRowReader.cs
+++ b/src/Polecat/Events/Internal/PcStreamsRowReader.cs
@@ -111,6 +111,14 @@ internal static class PcStreamsRowReader
     ///     column is used as the fallback, mirroring the pre-consolidation
     ///     behavior in <c>DocumentStore.GetStreamMetadataAsync</c>.
     /// </summary>
+    /// <summary>
+    ///     Shared empty tag set for <see cref="StreamMetadata.Tags"/>. Polecat does not persist
+    ///     DCB stream tags yet, so every row reports the same immutable empty dictionary rather
+    ///     than allocating one per stream.
+    /// </summary>
+    private static readonly IReadOnlyDictionary<string, string> EmptyTags =
+        new Dictionary<string, string>();
+
     internal static StreamMetadata ReadStreamMetadata(
         DbDataReader reader,
         string defaultTenantId,
@@ -134,7 +142,12 @@ internal static class PcStreamsRowReader
             LastSnapshotVersion: null,
             IsArchived: isArchived,
             TenantId: tenantId,
-            Tags: null!);
+            // #412: an empty dictionary, never null. StreamMetadata.Tags is declared as a
+            // non-nullable IReadOnlyDictionary, so "this stream has no tags" is spelled with an
+            // empty collection -- a null forces every consumer that trusts the declaration into a
+            // NullReferenceException instead of an empty loop. The `null!` that used to be here
+            // silenced the compiler's warning rather than answering it.
+            Tags: EmptyTags);
     }
 
     private static string StreamIdToString(object value) => value switch


### PR DESCRIPTION
Two explorer-surface defects, both found by a new cross-store compliance suite (`EventStoreExplorerCompliance`, JasperFx/jasperfx#633) rather than by Polecat's own tests.

## #411 — `usage.Events` was empty

`EventStoreUsage` carries the event registry **twice**: `Events` (`List<EventDescriptor>`) and `RegisteredEventTypes` (`List<EventTypeDescriptor>`). Marten fills both. Polecat filled only `RegisteredEventTypes`, so `usage.Events` came back empty.

That matters because this descriptor is read **out of repo** by CritterWatch, where an empty `Events` list reads as *"this store has no event types configured"* rather than *"this store describes them under a different key"* — the tooling degrades silently instead of failing.

Now populated from the same `AllKnownEventTypes()` loop that already fed `RegisteredEventTypes`.

## #412 — `StreamMetadata.Tags` was null

`GetStreamMetadataAsync` returned `Tags: null!`, but the record declares it non-nullable:

```csharp
public sealed record StreamMetadata(..., IReadOnlyDictionary<string, string> Tags);
```

"No tags" is spelled with an **empty dictionary**. A null forces every consumer that trusts the declaration into a `NullReferenceException` instead of an empty loop. The `null!` had silenced the compiler's warning rather than answering it.

Now a shared `static readonly` empty dictionary, so there is no per-stream allocation. Polecat does not persist DCB stream tags yet, so every row legitimately reports the same empty set.

## Scope

Deliberately **product-only**. The compliance enrollment that proves both fixes needs a JasperFx release carrying the new suite, so it lands separately — at which point the two temporary capability gates come out and the suite runs ungated. Verified locally against that suite: explorer suite 6/6, compliance 124/124 with no gates, full Polecat.Tests **1722/0/3**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VpDCvJcBDZerieJB4JEHde
