### PR TITLE
Adopt JasperFx 2.39.4 and compliance wave 5 part 1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -74,14 +74,14 @@
              semantically rather than syntactically), jasperfx#615 (the blue/green side-effect gate
              warm-up moved off the agent start path, #598/#610) and jasperfx#617 (container-scoped
              projections usable by live aggregation, marten#5095). Same lockstep rule as above. -->
-        <PackageVersion Include="JasperFx" Version="2.39.1" />
-        <PackageVersion Include="JasperFx.Events" Version="2.39.1" />
+        <PackageVersion Include="JasperFx" Version="2.39.4" />
+        <PackageVersion Include="JasperFx.Events" Version="2.39.4" />
         <!--
              The shared cross-store event sourcing compliance suites. Source-only package: the
              suites compile inside Polecat.Tests so JasperFx's aggregate source generator binds
              Polecat's own session types.
         -->
-        <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.39.1" />
+        <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.39.4" />
         <!-- Pin the sibling JasperFx packages for parity with Marten 9's matrix
              even though Polecat doesn't currently reference them directly —
              keeps the lockstep matrix coherent when transitive resolution
@@ -89,7 +89,7 @@
              RuntimeCompiler 5.x line is the active continuation of the 4.x
              lineage; do not pin against the parallel stale 2.0.x series. -->
         <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.39.1" />
+        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.39.4" />
         <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
@@ -185,7 +185,7 @@
         <PackageVersion Include="StronglyTypedId" Version="1.0.0-beta08" />
 
         <!-- Source generators (matched to JasperFx.Events above) -->
-        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.39.1" />
+        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.39.4" />
 
         <!-- Build automation -->
         <PackageVersion Include="Nuke.Common" Version="9.0.4" />

--- a/src/Polecat.Tests/Compliance/polecat_event_store_compliance_wave5.cs
+++ b/src/Polecat.Tests/Compliance/polecat_event_store_compliance_wave5.cs
@@ -1,0 +1,17 @@
+using JasperFx.Events.ComplianceTests;
+
+namespace Polecat.Tests.Compliance;
+
+/*
+ * Wave 5 enrollments. Separate file only while the suites are in flight upstream; fold into
+ * polecat_event_store_compliance.cs once the JasperFx package ships them.
+ */
+
+public class fetch_latest_compliance
+    : FetchLatestCompliance<PolecatComplianceFixture, IDocumentSession, IQuerySession>;
+
+public class stream_archiving_compliance
+    : StreamArchivingCompliance<PolecatComplianceFixture, IDocumentSession, IQuerySession>;
+
+public class event_store_explorer_compliance
+    : EventStoreExplorerCompliance<PolecatComplianceFixture, IDocumentSession, IQuerySession>;


### PR DESCRIPTION
Bumps JasperFx 2.39.1 → **2.39.4** and enrolls the three compliance suites that shipped in it (JasperFx/jasperfx#633).

| Suite | Tests |
|---|---|
| `fetch_latest_compliance` | 7 |
| `stream_archiving_compliance` | 6 |
| `event_store_explorer_compliance` | 6 |

Polecat's compliance coverage goes **105 → 124 tests, zero capability gates**.

## No gates, because #413 already fixed what this would have gated

The explorer suite found two defects while it was being written — an empty `usage.Events` collection (#411) and a null `StreamMetadata.Tags` (#412). Those were fixed separately in #413 so they could merge on their own schedule rather than waiting behind a JasperFx release.

The consequence is that this PR needs no capability gates at all. The two temporary ones that existed during diagnosis were removed from the compliance library before it shipped, so the assertions here run unmodified against Polecat.

## Verified

net9.0, against the published 2.39.4 packages: 124/124 compliance and the full Polecat.Tests suite green.

## Note on the version jump

2.39.1 → 2.39.4 also picks up 2.39.2 and 2.39.3, which Polecat had not adopted yet. Marten's matching adoption is JasperFx/marten#5190.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VpDCvJcBDZerieJB4JEHde
