### PR TITLE
A rebuild empties a flat table projection's table before replaying it (#415)

### DIFF
--- a/src/Polecat.Tests/Projections/flat_table_projection_tests.cs
+++ b/src/Polecat.Tests/Projections/flat_table_projection_tests.cs
@@ -274,6 +274,46 @@ public class flat_table_projection_tests : IntegrationContext
         memberCount.ShouldBe(2);
     }
 
+    // A rebuild has to start the flat table from empty. A flat table projection publishes no
+    // document type, so PublishedTypes() -- which is what the rebuild teardown used to consult
+    // exclusively -- reported nothing to wipe, and every row whose events the replay could no longer
+    // see survived the rebuild. The projection now registers its table through JasperFx's shared
+    // AsyncOptions.DeleteDataInTableOnTeardown, and the teardown honours Options.CleanUps.
+    [Fact]
+    public async Task rebuild_empties_the_flat_table_before_replaying_it()
+    {
+        var store = await CreateStoreWithFlatTable(ProjectionLifecycle.Async);
+
+        // One stream that will be archived out from under its row, and one that survives.
+        var archived = Guid.NewGuid();
+        var replayed = Guid.NewGuid();
+
+        await using (var session = store.LightweightSession())
+        {
+            session.Events.StartStream(archived, new QuestStarted("Forgotten Quest"));
+            session.Events.StartStream(replayed, new QuestStarted("Remembered Quest"));
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await store.WaitForProjectionAsync();
+
+        (await ReadMetric<string>("quest_name", archived)).ShouldBe("Forgotten Quest");
+
+        await using (var session = store.LightweightSession())
+        {
+            session.Events.ArchiveStream(archived);
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        var daemon = await store.BuildProjectionDaemonAsync();
+        await daemon.RebuildProjectionAsync<QuestMetricsProjection>(TestContext.Current.CancellationToken);
+
+        // Nothing can recreate the archived stream's row, so a rebuild that did not empty the table
+        // first would leave it behind.
+        (await ReadMetric<string>("quest_name", archived)).ShouldBeNull();
+        (await ReadMetric<string>("quest_name", replayed)).ShouldBe("Remembered Quest");
+    }
+
     // polecat#181 — flat-table projection data must be erasable via the Clean* admin helpers.
     [Fact]
     public async Task clean_all_documents_erases_flat_table_projection_data()

--- a/src/Polecat/DocumentStore.EventStore.cs
+++ b/src/Polecat/DocumentStore.EventStore.cs
@@ -627,7 +627,32 @@ public partial class DocumentStore : IEventStore<IDocumentSession, IQuerySession
                 tables.Add(Events.NaturalKeyTableName(natural.NaturalKeyDefinition.AggregateType));
             }
 
-            publishedTableNames = tables.ToArray();
+            // A projection can also declare teardown targets explicitly through JasperFx's shared
+            // AsyncOptions surface -- DeleteDataInTableOnTeardown / DeleteViewTypeOnTeardown, which
+            // land in Options.CleanUps. PublishedTypes() alone does not cover those: a flat table
+            // projection publishes no document type at all, so before this its table was never wiped
+            // and a rebuild left behind every row whose events the replay could no longer see.
+            if (source.Options.TeardownDataOnRebuild)
+            {
+                foreach (var cleanUp in source.Options.CleanUps)
+                {
+                    switch (cleanUp)
+                    {
+                        case DeleteTableData tableData:
+                            tables.Add(tableData.TableIdentifier);
+                            break;
+
+                        // Normally already covered by PublishedTypes(), but a projection is free to
+                        // register a view type it does not publish. DELETE FROM twice is harmless,
+                        // and the distinct below keeps it to once anyway.
+                        case DeleteDocuments documents:
+                            tables.Add(GetProvider(documents.DocumentType).QualifiedTableName);
+                            break;
+                    }
+                }
+            }
+
+            publishedTableNames = tables.Distinct().ToArray();
         }
 
         await Options.ResiliencePipeline.ExecuteAsync(static async (state, ct) =>

--- a/src/Polecat/Projections/Flattened/FlatTableProjection.cs
+++ b/src/Polecat/Projections/Flattened/FlatTableProjection.cs
@@ -55,6 +55,11 @@ public abstract class FlatTableProjection : ProjectionBase,
         var schema = schemaName ?? "dbo";
         Table = new Table(new SqlServerObjectName(schema, tableName));
         Name = GetType().FullName ?? GetType().Name;
+
+        // A flat table projection publishes no document type, so nothing else tells the rebuild path
+        // which storage belongs to it. Registering the table here is what makes a rebuild start from
+        // an empty table instead of replaying onto whatever rows survived.
+        Options.DeleteDataInTableOnTeardown(Table.Identifier.QualifiedName);
     }
 
     public Table Table { get; }


### PR DESCRIPTION
Closes #415.

## The bug

`RebuildProjectionAsync` against a `FlatTableProjection` replayed events onto whatever rows were already in the table instead of starting from empty. A row whose events the replay can no longer see — archived, compacted, otherwise gone — survived the rebuild indefinitely.

## Root cause: a shared JasperFx contract with one consumer

`AsyncOptions.DeleteDataInTableOnTeardown(...)` → `AsyncOptions.CleanUps` (`JasperFx.Events/Projections/AsyncOptions.cs:119`) is how a projection declares teardown targets that are not document types. Grepping both products:

| | registers | consumes |
|---|---|---|
| Marten | `Events/Projections/Flattened/FlatTableProjection.cs:228` | `Events/Daemon/AsyncOptionsExtensions.cs:12,40` |
| Polecat | — | — |

`TeardownProjectionStateAsync` derived its targets solely from `source.PublishedTypes()`, and `FlatTableProjection.PublishedTypes()` correctly returns nothing — a flat table is not a document — so the rebuild wiped only the progression row.

**The gap was wider than flat tables.** Any teardown rule registered through the shared `AsyncOptions` surface was ignored, including `DeleteViewTypeOnTeardown` for a view type a projection does not publish.

## The fix

Two parts, both small:

1. `FlatTableProjection`'s constructor registers its table via `Options.DeleteDataInTableOnTeardown(Table.Identifier.QualifiedName)` — matching what Marten's does.
2. `TeardownProjectionStateAsync` folds `Options.CleanUps` into the table list it already `DELETE FROM`s, honouring `TeardownDataOnRebuild` and handling both `DeleteTableData` and `DeleteDocuments`. Deduped, so the overlap with `PublishedTypes()` costs nothing.

## Regression test

`Projections/flat_table_projection_tests.cs : rebuild_empties_the_flat_table_before_replaying_it`.

Getting this test to *discriminate* took some care and is worth knowing about. Because `Map` overwrites rather than accumulates, a rebuild that replayed onto surviving rows lands on **identical values** to one that emptied the table first — so no assertion about a row the replay recreates can detect the bug. The test therefore creates a row the replay *cannot* recreate, by archiving its stream.

Deleting event data would have been the obvious way to orphan a row, and it does not work here: Polecat's `Clean` helpers also erase flat-table rows (per its own `clean_all_event_data_erases_flat_table_projection_data`), so the assertion would have passed for the wrong reason.

**Verified to fail on `main` before the fix** (`should be null but was`) and pass after.

## How it was found

The cross-store `FlatTableProjectionCompliance` suite in `JasperFx.Events.ComplianceTests` (jasperfx#634, marten#5147), where Marten passed and Polecat did not.

## Verification

`flat_table_projection_tests` runs **10/10** with the fix and **9/10** without it.

Full local suite on this branch: **1726 total, 0 failed, 1723 passed, 3 skipped** (16m). That is `main`'s 1722 passed plus the one regression test added here.
