### PR TITLE
The generic <T, TId> fetch overloads accept a strong-typed stream id (#417)

### DIFF
--- a/src/Polecat.Tests/Events/strong_typed_id_fetch_overload_tests.cs
+++ b/src/Polecat.Tests/Events/strong_typed_id_fetch_overload_tests.cs
@@ -1,0 +1,153 @@
+using System.Text.Json.Serialization;
+using JasperFx.Events;
+using JasperFx.Events.Projections;
+using Polecat.Projections;
+using Polecat.Tests.Harness;
+using Shouldly;
+
+namespace Polecat.Tests.Events;
+
+// polecat#417 / marten#5144: the generic <T, TId> fetch overloads assumed TId was always a natural
+// key, so a strong-typed identifier wrapping the stream identity failed with a confusing
+// "no natural key definition found" error. A wrapper IS the stream identity, just wrapped.
+public readonly record struct Stid5144PaymentId(Guid Value);
+
+public readonly record struct Stid5144InvoiceId(string Value);
+
+public record Stid5144Raised(decimal Amount);
+
+public record Stid5144Settled(decimal Amount);
+
+public partial class Stid5144Payment
+{
+    [JsonInclude] public Stid5144PaymentId Id { get; private set; }
+    [JsonInclude] public decimal Outstanding { get; private set; }
+
+    public static Stid5144Payment Create(IEvent<Stid5144Raised> e)
+        => new() { Id = new Stid5144PaymentId(e.StreamId), Outstanding = e.Data.Amount };
+
+    public void Apply(Stid5144Settled e) => Outstanding -= e.Amount;
+}
+
+public partial class Stid5144Invoice
+{
+    [JsonInclude] public Stid5144InvoiceId Id { get; private set; }
+    [JsonInclude] public decimal Outstanding { get; private set; }
+
+    public static Stid5144Invoice Create(IEvent<Stid5144Raised> e)
+        => new() { Id = new Stid5144InvoiceId(e.StreamKey!), Outstanding = e.Data.Amount };
+
+    public void Apply(Stid5144Settled e) => Outstanding -= e.Amount;
+}
+
+[Collection("integration")]
+public class strong_typed_id_fetch_overload_tests : IntegrationContext
+{
+    public strong_typed_id_fetch_overload_tests(DefaultStoreFixture fixture) : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task fetch_for_writing_by_a_guid_backed_strong_typed_id()
+    {
+        await StoreOptions(opts =>
+        {
+            opts.DatabaseSchemaName = "stid5144_guid";
+            opts.Projections.Snapshot<Stid5144Payment>(SnapshotLifecycle.Inline);
+        });
+
+        var streamId = Guid.NewGuid();
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Events.StartStream<Stid5144Payment>(streamId, new Stid5144Raised(100m));
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using var session2 = theStore.LightweightSession();
+        var stream = await session2.Events
+            .FetchForWriting<Stid5144Payment, Stid5144PaymentId>(
+                new Stid5144PaymentId(streamId), TestContext.Current.CancellationToken);
+
+        stream.Aggregate.ShouldNotBeNull();
+        stream.Aggregate.Id.Value.ShouldBe(streamId);
+        stream.Aggregate.Outstanding.ShouldBe(100m);
+    }
+
+    [Fact]
+    public async Task fetch_latest_by_a_guid_backed_strong_typed_id()
+    {
+        await StoreOptions(opts =>
+        {
+            opts.DatabaseSchemaName = "stid5144_latest";
+            opts.Projections.Snapshot<Stid5144Payment>(SnapshotLifecycle.Inline);
+        });
+
+        var streamId = Guid.NewGuid();
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Events.StartStream<Stid5144Payment>(streamId,
+                new Stid5144Raised(100m), new Stid5144Settled(40m));
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using var session2 = theStore.LightweightSession();
+        var payment = await session2.Events
+            .FetchLatest<Stid5144Payment, Stid5144PaymentId>(
+                new Stid5144PaymentId(streamId), TestContext.Current.CancellationToken);
+
+        payment.ShouldNotBeNull();
+        payment.Outstanding.ShouldBe(60m);
+    }
+
+    [Fact]
+    public async Task fetch_for_exclusive_writing_by_a_strong_typed_id()
+    {
+        await StoreOptions(opts =>
+        {
+            opts.DatabaseSchemaName = "stid5144_excl";
+            opts.Projections.Snapshot<Stid5144Payment>(SnapshotLifecycle.Inline);
+        });
+
+        var streamId = Guid.NewGuid();
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Events.StartStream<Stid5144Payment>(streamId, new Stid5144Raised(60m));
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using var session2 = theStore.LightweightSession();
+        var stream = await session2.Events
+            .FetchForExclusiveWriting<Stid5144Payment, Stid5144PaymentId>(
+                new Stid5144PaymentId(streamId), TestContext.Current.CancellationToken);
+
+        stream.Aggregate.ShouldNotBeNull();
+        stream.Aggregate.Outstanding.ShouldBe(60m);
+    }
+
+    [Fact]
+    public async Task fetch_for_writing_by_a_string_backed_strong_typed_id()
+    {
+        await StoreOptions(opts =>
+        {
+            opts.DatabaseSchemaName = "stid5144_string";
+            opts.Events.StreamIdentity = StreamIdentity.AsString;
+            opts.Projections.Snapshot<Stid5144Invoice>(SnapshotLifecycle.Inline);
+        });
+
+        var key = "invoice/" + Guid.NewGuid().ToString("N");
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Events.StartStream<Stid5144Invoice>(key, new Stid5144Raised(25m));
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using var session2 = theStore.LightweightSession();
+        var stream = await session2.Events
+            .FetchForWriting<Stid5144Invoice, Stid5144InvoiceId>(
+                new Stid5144InvoiceId(key), TestContext.Current.CancellationToken);
+
+        stream.Aggregate.ShouldNotBeNull();
+        stream.Aggregate.Id.Value.ShouldBe(key);
+        stream.Aggregate.Outstanding.ShouldBe(25m);
+    }
+}

--- a/src/Polecat/Events/EventOperations.cs
+++ b/src/Polecat/Events/EventOperations.cs
@@ -3,6 +3,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Text;
+using JasperFx.Core.Reflection;
 using JasperFx.Events;
 using JasperFx.Events.Aggregation;
 using JasperFx.Events.Protected;
@@ -667,9 +668,48 @@ internal class EventOperations : QueryEventStore, IEventOperations
         }
     }
 
+    /// <summary>
+    ///     Unwrap a strong-typed identifier that wraps the stream identity, so the generic
+    ///     &lt;T, TId&gt; overloads can address a stream rather than assuming a natural key.
+    /// </summary>
+    /// <remarks>
+    ///     polecat#417 / marten#5144. A strong-typed id such as <c>PaymentId(Guid)</c> IS the stream
+    ///     identity, just wrapped -- it is not a natural key, which is a domain value resolved
+    ///     through a lookup table. These overloads previously assumed natural key unconditionally,
+    ///     so a wrapper produced a confusing "no natural key definition found" error.
+    ///     A registered natural key always wins, so existing behavior is untouched.
+    /// </remarks>
+    private object? tryUnwrapStreamIdentity<T, TId>(TId id) where T : class where TId : notnull
+    {
+        if (typeof(TId) == typeof(Guid) || typeof(TId) == typeof(string)) return null;
+
+        if (_sessionBase.Options.Projections.FindNaturalKeyDefinition(typeof(T)) != null) return null;
+
+        ValueTypeInfo info;
+        try
+        {
+            info = ValueTypeInfo.ForType(typeof(TId));
+        }
+        catch (InvalidValueTypeException)
+        {
+            return null;
+        }
+
+        if (info.SimpleType == typeof(Guid)) return info.UnWrapper<TId, Guid>()(id);
+        if (info.SimpleType == typeof(string)) return info.UnWrapper<TId, string>()(id);
+
+        return null;
+    }
+
     public async Task<IEventStream<T>> FetchForWriting<T, TId>(TId id, CancellationToken cancellation = default)
         where T : class where TId : notnull
     {
+        switch (tryUnwrapStreamIdentity<T, TId>(id))
+        {
+            case Guid streamId: return await FetchForWriting<T>(streamId, cancellation);
+            case string streamKey: return await FetchForWriting<T>(streamKey, cancellation);
+        }
+
         var naturalKey = FindNaturalKeyDefinition<T>();
         return await NaturalKeyFetchPlanner.FetchForWritingByNaturalKey<T, TId>(
             _sessionBase, _events, _workTracker, naturalKey, id, _tenantId, cancellation);
@@ -678,6 +718,12 @@ internal class EventOperations : QueryEventStore, IEventOperations
     public async Task<IEventStream<T>> FetchForExclusiveWriting<T, TId>(TId id, CancellationToken cancellation = default)
         where T : class where TId : notnull
     {
+        switch (tryUnwrapStreamIdentity<T, TId>(id))
+        {
+            case Guid streamId: return await FetchForExclusiveWriting<T>(streamId, cancellation);
+            case string streamKey: return await FetchForExclusiveWriting<T>(streamKey, cancellation);
+        }
+
         // FetchForWritingByNaturalKey already uses UPDLOCK, HOLDLOCK for exclusive locking
         var naturalKey = FindNaturalKeyDefinition<T>();
         return await NaturalKeyFetchPlanner.FetchForWritingByNaturalKey<T, TId>(
@@ -687,6 +733,12 @@ internal class EventOperations : QueryEventStore, IEventOperations
     public async ValueTask<T?> FetchLatest<T, TId>(TId id, CancellationToken cancellation = default)
         where T : class where TId : notnull
     {
+        switch (tryUnwrapStreamIdentity<T, TId>(id))
+        {
+            case Guid streamId: return await FetchLatest<T>(streamId, cancellation);
+            case string streamKey: return await FetchLatest<T>(streamKey, cancellation);
+        }
+
         var naturalKey = FindNaturalKeyDefinition<T>();
         var unwrapped = naturalKey.Unwrap(id);
         if (unwrapped == null) return default;


### PR DESCRIPTION
Closes #417. Parity with marten#5193.

## The bug

`FetchForWriting<T, TId>`, `FetchForExclusiveWriting<T, TId>` and `FetchLatest<T, TId>` assumed `TId` always meant **natural key**, so a strong-typed identifier wrapping the stream identity failed with:

> `InvalidOperationException: No natural key definition found for aggregate type 'Payment'. Mark the key property with [NaturalKey]…`

Actively misleading — there is no natural key because the caller was never talking about one.

## Why they are different things

A strong-typed id **is** the stream identity, just wrapped (`PaymentId(Guid)`, `InvoiceId(string)`). A natural key is a *domain value* resolved to a stream through a lookup table. Both arrive as a non-`Guid`/`string` `TId`, and all three overloads went straight to `FindNaturalKeyDefinition<T>()` without distinguishing them.

## The fix

Try to unwrap a value type wrapping `Guid`/`string` first, and delegate to the raw-identity overload. **A registered natural key always wins** — the guard checks `FindNaturalKeyDefinition(typeof(T))` before unwrapping — so existing behaviour is untouched and only the currently-failing case changes.

The shape test is the documented one, `JasperFx.Core.Reflection.ValueTypeInfo.ForType`: exactly one public gettable property plus a matching constructor or static builder.

## Marten had the same gap, differently shaped

Marten routes the same case into its natural-key planning branch, which passes a **null** identity strategy; its lifecycle planners match on the projection alone and stored the null, so it failed with a bare `NullReferenceException` rather than a message. Fixed in marten#5193.

Neither product had ever exercised the overload with a wrapper — every existing test in both repos passes the raw value, and Marten's own doc sample explicitly unwraps (`FetchForWriting<Payment>(id.Value)`). The cross-store compliance suite is what surfaced it, by trying the obvious thing.

## Verification

`Events/strong_typed_id_fetch_overload_tests.cs` — 4 tests over Guid-backed and string-backed wrappers across `FetchForWriting`, `FetchForExclusiveWriting` and `FetchLatest`. **Verified to fail on `main` first** — 4/4 with the natural-key error.

Full local suite: **1729 total, 0 failed, 1726 passed, 3 skipped** (15m). That is `main`'s 1722 passed plus the four regression tests added here.
