### PR TITLE
Adopt JasperFx 2.42.2, catch up to Marten's compliance coverage, and fix two defects the suites found

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -73,15 +73,40 @@
              namespaces do not collide. (c) jasperfx#611 (EventProjection published types discovered
              semantically rather than syntactically), jasperfx#615 (the blue/green side-effect gate
              warm-up moved off the agent start path, #598/#610) and jasperfx#617 (container-scoped
-             projections usable by live aggregation, marten#5095). Same lockstep rule as above. -->
-        <PackageVersion Include="JasperFx" Version="2.39.4" />
-        <PackageVersion Include="JasperFx.Events" Version="2.39.4" />
+             projections usable by live aggregation, marten#5095). Same lockstep rule as above.
+             JasperFx 2.42.2 (from 2.39.4, catching up four releases at once):
+             2.40.0 (jasperfx#634) — compliance wave 5 part 2: FlatTableProjectionCompliance,
+             StringStreamIdentityCompliance, MultiStreamProjectionCompliance and
+             SnapshotLifecycleCompliance, plus the ComplianceStoreConfig/fixture seam they need
+             (QueryTableAsync). This is the half of the catch-up that costs Polecat work.
+             2.41.0 (jasperfx#635) — TWO LIFTS, and the first one is SOURCE-BREAKING HERE.
+             CompactStreamAsync<T> moves onto JasperFx.Events.IEventStoreOperations as
+             default-implemented members that throw, so a store without compacting stays
+             source-compatible. Polecat.Events.IEventOperations already declares the same two
+             signatures *and* Polecat's operations surface already inherits
+             JasperFx.Events.IEventStoreOperations, so on this bump the signature is reachable
+             through two paths and every CALL SITE goes ambiguous (CS0121) — the library itself
+             still compiles. Adopting means deleting the local declarations, which is the point of
+             the lift. IEventDataMasking moves into JasperFx.Events.Protected beside
+             StreamCompactingRequest<T>; the two products' copies were member-for-member identical,
+             so this is a straight swap and EventDataMasking still implements it unchanged.
+             2.42.0 (jasperfx#636) — StrongTypedIdentityCompliance (11 tests) plus the
+             ComplianceStoreConfig.RegisterValueType<T>() seam member, which no-ops here because
+             Polecat derives the same information from ValueTypeInfo when building the document
+             mapping. Pairs with the polecat#418 fetch fix already on main.
+             2.42.1 (jasperfx#637, marten#5192) — the source generator registers an
+             EventProjection's published types via a PublishedTypes() override rather than a
+             primary-constructor argument, fixing CS8862 on primary-ctor projections.
+             2.42.2 (jasperfx#638, marten#5195) — EventProjectionScenario wakes the high-water
+             agent in process instead of polling. Same lockstep rule as above. -->
+        <PackageVersion Include="JasperFx" Version="2.42.2" />
+        <PackageVersion Include="JasperFx.Events" Version="2.42.2" />
         <!--
              The shared cross-store event sourcing compliance suites. Source-only package: the
              suites compile inside Polecat.Tests so JasperFx's aggregate source generator binds
              Polecat's own session types.
         -->
-        <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.39.4" />
+        <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.42.2" />
         <!-- Pin the sibling JasperFx packages for parity with Marten 9's matrix
              even though Polecat doesn't currently reference them directly —
              keeps the lockstep matrix coherent when transitive resolution
@@ -89,7 +114,7 @@
              RuntimeCompiler 5.x line is the active continuation of the 4.x
              lineage; do not pin against the parallel stale 2.0.x series. -->
         <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.39.4" />
+        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.42.2" />
         <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
@@ -185,7 +210,7 @@
         <PackageVersion Include="StronglyTypedId" Version="1.0.0-beta08" />
 
         <!-- Source generators (matched to JasperFx.Events above) -->
-        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.39.4" />
+        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.42.2" />
 
         <!-- Build automation -->
         <PackageVersion Include="Nuke.Common" Version="9.0.4" />

--- a/src/Polecat.Tests/Compliance/ComplianceFlatTableProjection.Polecat.cs
+++ b/src/Polecat.Tests/Compliance/ComplianceFlatTableProjection.Polecat.cs
@@ -1,0 +1,28 @@
+using Polecat.Projections.Flattened;
+
+namespace JasperFx.Events.ComplianceTests;
+
+/*
+ * Polecat's half of the shared flat-table compliance projection.
+ *
+ * The compliance library owns the table name, the projection name and every event mapping; this
+ * partial supplies the two things that cannot be portable. Flat-table projection bases take
+ * constructor arguments describing where the table lives and those signatures genuinely differ
+ * between products -- Polecat takes a literal schema name, Marten resolves one through a
+ * SchemaNameSource enum -- and the column-declaration API hangs off each dialect's own Weasel Table
+ * type, so the primary key cannot be declared portably either.
+ *
+ * The literal SchemaName rather than the store's schema: Polecat's base defaults to "dbo" when no
+ * schema is passed, so the suite's constant is what keeps the projection writing where
+ * QueryTableAsync looks. It is already lower case, which is what PolecatComplianceFixture
+ * normalizes config.SchemaName to.
+ */
+public partial class ComplianceFlatTableProjection: FlatTableProjection
+{
+    public ComplianceFlatTableProjection(): base(TableName, SchemaName)
+    {
+        Table.AddColumn("id", "uniqueidentifier").AsPrimaryKey();
+
+        ConfigureMappings();
+    }
+}

--- a/src/Polecat.Tests/Compliance/ComplianceQuerySessionAlias.cs
+++ b/src/Polecat.Tests/Compliance/ComplianceQuerySessionAlias.cs
@@ -14,3 +14,9 @@ global using ComplianceEventProjection = Polecat.Projections.EventProjection;
 // generic rather than an open one.
 global using ComplianceStringPartyProjectionBase =
     Polecat.Projections.SingleStreamProjection<JasperFx.Events.ComplianceTests.StringQuestParty, string>;
+
+// The multi-stream projection suite declares its projection at file scope for the same reason, and
+// its base is generic over both the document and the identity, so this alias names a closed generic.
+global using ComplianceMultiStreamProjectionBase =
+    Polecat.Projections.MultiStreamProjection<
+        JasperFx.Events.ComplianceTests.ComplianceDepartment, string>;

--- a/src/Polecat.Tests/Compliance/PolecatComplianceFixture.cs
+++ b/src/Polecat.Tests/Compliance/PolecatComplianceFixture.cs
@@ -132,6 +132,39 @@ public class PolecatComplianceFixture : EventStoreComplianceFixture<IDocumentSes
     public override Task WaitForNonStaleProjectionDataAsync(TimeSpan timeout)
         => _store.Database.WaitForNonStaleProjectionDataAsync(timeout);
 
+    // A flat table is not a document, so there is no supported Polecat read path for its rows. The
+    // schema comes from the store rather than the caller so the compliance suite never has to spell
+    // a qualified name, and the reader is deliberately untyped: the suite asserts values, not the
+    // SqlClient types they arrive as.
+    public override async Task<IReadOnlyList<IReadOnlyDictionary<string, object?>>> QueryTableAsync(
+        string tableName, CancellationToken token)
+    {
+        var rows = new List<IReadOnlyDictionary<string, object?>>();
+
+        await using var conn = _store.Database.CreateStorageConnection();
+        await conn.OpenAsync(token).ConfigureAwait(false);
+
+        await using var command = conn.CreateCommand();
+        command.CommandText =
+            $"select * from [{_store.Options.DatabaseSchemaName}].[{tableName}]";
+
+        await using var reader = await command.ExecuteReaderAsync(token).ConfigureAwait(false);
+        while (await reader.ReadAsync(token).ConfigureAwait(false))
+        {
+            var row = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
+            for (var i = 0; i < reader.FieldCount; i++)
+            {
+                row[reader.GetName(i)] = await reader.IsDBNullAsync(i, token).ConfigureAwait(false)
+                    ? null
+                    : reader.GetValue(i);
+            }
+
+            rows.Add(row);
+        }
+
+        return rows;
+    }
+
     /// <summary>
     ///     Polecat derives live aggregators automatically from self-aggregating types; there is no
     ///     explicit registration call to make.
@@ -175,6 +208,14 @@ public class PolecatComplianceFixture : EventStoreComplianceFixture<IDocumentSes
 
         // Live aggregators are derived automatically -- see SupportsLiveAggregationRegistration.
         public void LiveAggregation<TDoc>() where TDoc : notnull
+        {
+        }
+
+        // Polecat derives everything it needs about a value type from ValueTypeInfo when it builds
+        // the DocumentMapping, so there is no registration call to make here. Marten needs the type
+        // registered up front before it can use it in LINQ and identity mapping, which is why the
+        // seam member exists at all -- the mirror image of LiveAggregation above.
+        public void RegisterValueType<TValue>() where TValue : notnull
         {
         }
 

--- a/src/Polecat.Tests/Compliance/polecat_event_store_compliance_wave6.cs
+++ b/src/Polecat.Tests/Compliance/polecat_event_store_compliance_wave6.cs
@@ -1,0 +1,24 @@
+using JasperFx.Events.ComplianceTests;
+
+namespace Polecat.Tests.Compliance;
+
+/*
+ * Wave 5 part 2 (JasperFx 2.40.0) plus the strong-typed identity suite (2.42.0), enrolled together
+ * because this repo took all four releases in one bump. Same shape as the earlier enrollment files
+ * -- empty subclasses closing the shared suites over Polecat's session pair.
+ */
+
+public class flat_table_projection_compliance
+    : FlatTableProjectionCompliance<PolecatComplianceFixture, IDocumentSession, IQuerySession>;
+
+public class string_stream_identity_compliance
+    : StringStreamIdentityCompliance<PolecatComplianceFixture, IDocumentSession, IQuerySession>;
+
+public class multi_stream_projection_compliance
+    : MultiStreamProjectionCompliance<PolecatComplianceFixture, IDocumentSession, IQuerySession>;
+
+public class snapshot_lifecycle_compliance
+    : SnapshotLifecycleCompliance<PolecatComplianceFixture, IDocumentSession, IQuerySession>;
+
+public class strong_typed_identity_compliance
+    : StrongTypedIdentityCompliance<PolecatComplianceFixture, IDocumentSession, IQuerySession>;

--- a/src/Polecat.Tests/Events/event_data_masking_tests.cs
+++ b/src/Polecat.Tests/Events/event_data_masking_tests.cs
@@ -7,6 +7,19 @@ namespace Polecat.Tests.Events;
 public record PersonCreated(string Name, string Email, string SocialSecurityNumber);
 public record PersonUpdated(string Email);
 
+// A mutable event with two protected members, so an interface rule and a concrete-type rule can
+// each mask a different one and prove both ran. See #422.
+public interface IHasSubject
+{
+    string Subject { get; set; }
+}
+
+public class PersonRecorded: IHasSubject
+{
+    public string Subject { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
+}
+
 [Collection("integration")]
 public class event_data_masking_tests : IntegrationContext
 {
@@ -111,5 +124,66 @@ public class event_data_masking_tests : IntegrationContext
         {
             await theStore.Advanced.ApplyEventDataMasking(_ => { });
         });
+    }
+
+    /// <summary>
+    ///     Regression for #422. Every other test here registers a single rule, so no event ever
+    ///     matched more than one and the short-circuiting `matched || masker.TryMask(e)` in TryMask
+    ///     was unobservable: the first rule to match an event stopped every later rule from being
+    ///     invoked at all, and the operation still reported success. On a right-to-erasure path
+    ///     that leaves protected information in place.
+    /// </summary>
+    [Fact]
+    public async Task every_matching_rule_runs_not_just_the_first()
+    {
+        await StoreOptions(opts => opts.DatabaseSchemaName = "mask_compose");
+
+        // Two rules that both match PersonCreated: one contravariantly through the interface, one
+        // against the concrete type. Each masks a different member.
+        theStore.Events.AddMaskingRuleForProtectedInformation<IHasSubject>(e => e.Subject = "***masked***");
+        theStore.Events.AddMaskingRuleForProtectedInformation<PersonRecorded>(e => e.Email = "***masked***");
+
+        var streamId = Guid.NewGuid();
+        theSession.Events.StartStream(streamId,
+            new PersonRecorded { Subject = "Alice", Email = "alice@example.com" });
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        await theStore.Advanced.ApplyEventDataMasking(masking => masking.IncludeStream(streamId),
+            TestContext.Current.CancellationToken);
+
+        await using var query = theStore.QuerySession();
+        var events = await query.Events.FetchStreamAsync(streamId, token: TestContext.Current.CancellationToken);
+
+        var recorded = events[0].Data.ShouldBeOfType<PersonRecorded>();
+        recorded.Subject.ShouldBe("***masked***");
+        recorded.Email.ShouldBe("***masked***");
+    }
+
+    /// <summary>
+    ///     ... and in the other registration order, so the test cannot pass by accident of which
+    ///     rule happens to be registered first.
+    /// </summary>
+    [Fact]
+    public async Task every_matching_rule_runs_regardless_of_registration_order()
+    {
+        await StoreOptions(opts => opts.DatabaseSchemaName = "mask_compose_reversed");
+
+        theStore.Events.AddMaskingRuleForProtectedInformation<PersonRecorded>(e => e.Email = "***masked***");
+        theStore.Events.AddMaskingRuleForProtectedInformation<IHasSubject>(e => e.Subject = "***masked***");
+
+        var streamId = Guid.NewGuid();
+        theSession.Events.StartStream(streamId,
+            new PersonRecorded { Subject = "Alice", Email = "alice@example.com" });
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        await theStore.Advanced.ApplyEventDataMasking(masking => masking.IncludeStream(streamId),
+            TestContext.Current.CancellationToken);
+
+        await using var query = theStore.QuerySession();
+        var events = await query.Events.FetchStreamAsync(streamId, token: TestContext.Current.CancellationToken);
+
+        var recorded = events[0].Data.ShouldBeOfType<PersonRecorded>();
+        recorded.Subject.ShouldBe("***masked***");
+        recorded.Email.ShouldBe("***masked***");
     }
 }

--- a/src/Polecat.Tests/Events/stream_compacting_tests.cs
+++ b/src/Polecat.Tests/Events/stream_compacting_tests.cs
@@ -1,4 +1,5 @@
 using JasperFx.Events;
+using JasperFx.Events.Protected;
 using Polecat.Tests.Harness;
 using Polecat.Tests.Projections;
 
@@ -106,5 +107,90 @@ public class stream_compacting_tests : IntegrationContext
         await using var session = theStore.LightweightSession();
         await session.Events.CompactStreamAsync<QuestParty>(streamId);
         await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+
+    /// <summary>
+    ///     Regression for #423, and the first coverage this hook has ever had here. The compactor
+    ///     gated the archiving callback on IEventsArchiver&lt;IDocumentOperations&gt; alone.
+    ///     IEventsArchiver&lt;T&gt; is INVARIANT, so an archiver closed over IDocumentSession -- the
+    ///     operations type Polecat closes IEventStore&lt;,&gt; over, and therefore the one every
+    ///     JasperFx-generic caller supplies -- never matched. The callback was skipped silently and
+    ///     compaction went on to permanently delete the very events the archiver existed to copy
+    ///     into cold storage first.
+    /// </summary>
+    [Fact]
+    public async Task the_archiver_runs_before_the_events_are_deleted()
+    {
+        await StoreOptions(opts => opts.DatabaseSchemaName = "compact_archiver");
+
+        var streamId = Guid.NewGuid();
+        theSession.Events.StartStream(streamId,
+            new QuestStarted("Archived Quest"),
+            new MembersJoined(1, "Town", ["Alice"]),
+            new MonsterSlain("Goblin", 10));
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var archiver = new RecordingArchiver();
+
+        await using var session2 = theStore.LightweightSession();
+        await session2.Events.CompactStreamAsync<QuestParty>(streamId, x => x.Archiver = archiver);
+        await session2.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        archiver.Calls.ShouldBe(1);
+        archiver.Events.Count.ShouldBe(3);
+        archiver.Events.Select(x => x.Version).ShouldBe(new long[] { 1, 2, 3 });
+    }
+
+    /// <summary>
+    ///     The historical closure keeps working, so the #423 fix is not a breaking change for
+    ///     anyone who hand-wrote an archiver against IDocumentOperations.
+    /// </summary>
+    [Fact]
+    public async Task an_archiver_closed_over_the_operations_type_still_runs()
+    {
+        await StoreOptions(opts => opts.DatabaseSchemaName = "compact_archiver_ops");
+
+        var streamId = Guid.NewGuid();
+        theSession.Events.StartStream(streamId,
+            new QuestStarted("Archived Quest"),
+            new MembersJoined(1, "Town", ["Alice"]));
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var archiver = new RecordingOperationsArchiver();
+
+        await using var session2 = theStore.LightweightSession();
+        await session2.Events.CompactStreamAsync<QuestParty>(streamId, x => x.Archiver = archiver);
+        await session2.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        archiver.Calls.ShouldBe(1);
+        archiver.Events.Count.ShouldBe(2);
+    }
+
+    private sealed class RecordingArchiver: IEventsArchiver<IDocumentSession>
+    {
+        public int Calls { get; private set; }
+        public IReadOnlyList<IEvent> Events { get; private set; } = [];
+
+        public Task MaybeArchiveAsync<T>(IDocumentSession operations, StreamCompactingRequest<T> request,
+            IReadOnlyList<IEvent> events, CancellationToken cancellation) where T : class
+        {
+            Calls++;
+            Events = events;
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class RecordingOperationsArchiver: IEventsArchiver<IDocumentOperations>
+    {
+        public int Calls { get; private set; }
+        public IReadOnlyList<IEvent> Events { get; private set; } = [];
+
+        public Task MaybeArchiveAsync<T>(IDocumentOperations operations, StreamCompactingRequest<T> request,
+            IReadOnlyList<IEvent> events, CancellationToken cancellation) where T : class
+        {
+            Calls++;
+            Events = events;
+            return Task.CompletedTask;
+        }
     }
 }

--- a/src/Polecat/AdvancedOperations.cs
+++ b/src/Polecat/AdvancedOperations.cs
@@ -600,7 +600,8 @@ public class AdvancedOperations
     ///     Configure and execute a batch masking of protected data for a subset of the events
     ///     in the event store. Used for GDPR right-to-erasure compliance.
     /// </summary>
-    public Task ApplyEventDataMasking(Action<Events.Protected.IEventDataMasking> configure, CancellationToken token = default)
+    public Task ApplyEventDataMasking(Action<JasperFx.Events.Protected.IEventDataMasking> configure,
+        CancellationToken token = default)
     {
         var masking = new Events.Protected.EventDataMasking(_store);
         configure(masking);

--- a/src/Polecat/Events/EventGraph.cs
+++ b/src/Polecat/Events/EventGraph.cs
@@ -657,7 +657,11 @@ public class EventGraph : EventRegistry, IAggregationSourceFactory<IQuerySession
         var matched = false;
         foreach (var masker in _maskers)
         {
-            matched = matched || masker.TryMask(e);
+            // |= and NOT ||=. With the short-circuiting form, the first rule to match an event
+            // stopped every later rule from even being invoked, so only one of several applicable
+            // rules ever ran -- and the operation still reported success. For a right-to-erasure
+            // feature that means protected information silently survives a masking pass. See #422.
+            matched |= masker.TryMask(e);
         }
         return matched;
     }

--- a/src/Polecat/Events/IEventOperations.cs
+++ b/src/Polecat/Events/IEventOperations.cs
@@ -19,11 +19,12 @@ namespace Polecat.Events;
 /// <list type="bullet">
 ///   <item><c>UnArchiveStream</c> + <c>TombstoneStream</c> — Polecat-specific
 ///   archive-lifecycle operations not yet present in the canonical surface.</item>
-///   <item><c>CompactStreamAsync&lt;T&gt;</c> — execution depends on Polecat's
-///   product-specific <see cref="StreamCompactingExecution.ExecuteAsync{T}"/>
-///   extension over the lifted <see cref="StreamCompactingRequest{T}"/> data
-///   shape from <c>JasperFx.Events.Protected</c>.</item>
 /// </list>
+/// <c>CompactStreamAsync&lt;T&gt;</c> was one of those extras until jasperfx#635 (2.41.0) lifted
+/// it onto <see cref="JasperFx.Events.IEventStoreOperations"/> alongside the
+/// <see cref="StreamCompactingRequest{T}"/> data shape it already shared. Execution still depends
+/// on Polecat's product-specific <see cref="StreamCompactingExecution.ExecuteAsync{T}"/> extension;
+/// only the declaration is now canonical.
 /// Note: <c>FetchForWritingByTags&lt;T&gt;(EventTagQuery)</c> is now inherited
 /// from <see cref="JasperFx.Events.IEventStoreOperations"/> per the dedupe
 /// pillar (lifted in JasperFx/jasperfx#270 once Polecat reached DCB parity via
@@ -55,15 +56,12 @@ public interface IEventOperations : JasperFx.Events.IEventStoreOperations, IQuer
     /// </summary>
     void TombstoneStream(string streamKey);
 
-    /// <summary>
-    ///     Compact a stream by replacing its events with a single Compacted&lt;T&gt; snapshot event.
-    /// </summary>
-    Task CompactStreamAsync<T>(Guid streamId, Action<StreamCompactingRequest<T>>? configure = null) where T : class;
-
-    /// <summary>
-    ///     Compact a stream by replacing its events with a single Compacted&lt;T&gt; snapshot event.
-    /// </summary>
-    Task CompactStreamAsync<T>(string streamKey, Action<StreamCompactingRequest<T>>? configure = null) where T : class;
+    // CompactStreamAsync<T> used to be declared here. It was lifted onto
+    // JasperFx.Events.IEventStoreOperations in jasperfx#635 (2.41.0) as default-implemented members
+    // that throw, so a store without compacting stays source-compatible. This interface already
+    // inherits that one, so keeping the local copy would make the signature reachable through two
+    // paths and every CALL SITE ambiguous (CS0121) -- the same break Marten took in marten#5194.
+    // EventOperations still implements the overloads; only the declaration moved.
 
     // FetchLatest is declared on two parent interfaces — JasperFx.Events.IEventStoreOperations
     // (where Marten put it canonically) and Polecat.Events.IQueryEventStore (kept on the

--- a/src/Polecat/Events/Protected/EventDataMasking.cs
+++ b/src/Polecat/Events/Protected/EventDataMasking.cs
@@ -1,51 +1,22 @@
 using System.Linq.Expressions;
 using JasperFx.Events;
+using JasperFx.Events.Protected;
 using Polecat.Linq;
 
 namespace Polecat.Events.Protected;
 
-/// <summary>
-///     Fluent interface for configuring and executing GDPR data masking operations
-///     on events in the event store.
-/// </summary>
-public interface IEventDataMasking
-{
-    /// <summary>
-    ///     Isolate the event masking to a specific tenant if using multi-tenancy.
-    /// </summary>
-    IEventDataMasking ForTenant(string tenantId);
-
-    /// <summary>
-    ///     Apply data protection masking to all events in this stream.
-    /// </summary>
-    IEventDataMasking IncludeStream(Guid streamId);
-
-    /// <summary>
-    ///     Apply data protection masking to all events in this stream.
-    /// </summary>
-    IEventDataMasking IncludeStream(string streamKey);
-
-    /// <summary>
-    ///     Apply data protection masking to events in this stream that match the filter.
-    /// </summary>
-    IEventDataMasking IncludeStream(Guid streamId, Func<IEvent, bool> filter);
-
-    /// <summary>
-    ///     Apply data protection masking to events in this stream that match the filter.
-    /// </summary>
-    IEventDataMasking IncludeStream(string streamKey, Func<IEvent, bool> filter);
-
-    /// <summary>
-    ///     Apply data protection masking to events matching this LINQ criteria.
-    /// </summary>
-    IEventDataMasking IncludeEvents(Expression<Func<IEvent, bool>> filter);
-
-    /// <summary>
-    ///     Add a new header value to the metadata for any event that is masked
-    ///     as part of this batch operation.
-    /// </summary>
-    IEventDataMasking AddHeader(string key, object value);
-}
+/*
+ * IEventDataMasking used to be declared here. It was lifted into JasperFx.Events.Protected in
+ * jasperfx#635 (2.41.0), beside the StreamCompactingRequest<T> it belongs with: a fluent
+ * description of a masking intent is database-agnostic, while executing it is unavoidably
+ * store-specific. Marten's copy and this one were member-for-member identical -- ForTenant, four
+ * IncludeStream overloads, IncludeEvents, AddHeader, same order and same signatures -- which is
+ * what made the lift a straight swap.
+ *
+ * This DOES move the interface's namespace, so user code that names Polecat.Events.Protected.
+ * IEventDataMasking explicitly has to update its using. The common fluent usage,
+ * Advanced.ApplyEventDataMasking(x => x.IncludeStream(...)), never names the type.
+ */
 
 /// <summary>
 ///     Implementation of IEventDataMasking that fetches events, applies masking rules,

--- a/src/Polecat/Events/Protected/StreamCompacting.cs
+++ b/src/Polecat/Events/Protected/StreamCompacting.cs
@@ -58,9 +58,22 @@ internal static class StreamCompactingExecution
 
         // 4. Optional archiving. The lifted IEventsArchiver marker is non-generic
         //    so the data class doesn't have to flow a TOperations parameter; the
-        //    product downcasts to the closed-generic at execution time. Polecat's
-        //    callbacks close on IDocumentOperations.
-        if (request.Archiver is IEventsArchiver<IDocumentOperations> archiver)
+        //    product downcasts to the closed-generic at execution time.
+        //
+        //    BOTH closures are accepted, and that is not belt-and-braces (#423).
+        //    IEventsArchiver<T> is invariant, so IEventsArchiver<IDocumentSession> is NOT an
+        //    IEventsArchiver<IDocumentOperations> even though IDocumentSession derives from
+        //    IDocumentOperations. Polecat closes IEventStore<,> over IDocumentSession, so that is
+        //    the type any JasperFx-generic caller -- the compliance suites included -- will hand
+        //    us, while hand-written Polecat archivers have historically used IDocumentOperations.
+        //    Matching only one of the two made the other silently skip archiving and then delete
+        //    the events anyway, which is the exact opposite of what this hook is for.
+        if (request.Archiver is IEventsArchiver<IDocumentSession> sessionArchiver)
+        {
+            await sessionArchiver.MaybeArchiveAsync(session, request, events, request.CancellationToken)
+                .ConfigureAwait(false);
+        }
+        else if (request.Archiver is IEventsArchiver<IDocumentOperations> archiver)
         {
             await archiver.MaybeArchiveAsync(session, request, events, request.CancellationToken)
                 .ConfigureAwait(false);


### PR DESCRIPTION
Catches up four JasperFx releases at once (**2.39.4 → 2.42.2**) and closes the gap with Marten, which had pulled a full wave ahead. Also carries the two product defects the new suites surfaced, each with its own local regression test.

## Suites enrolled — 5, +54 tests, 17 → 22 suites

| Suite | Tests | Shipped in |
|---|---|---|
| `FlatTableProjectionCompliance` | 8 | 2.40.0 |
| `StringStreamIdentityCompliance` | 19 | 2.40.0 |
| `MultiStreamProjectionCompliance` | 10 | 2.40.0 |
| `SnapshotLifecycleCompliance` | 6 | 2.40.0 |
| `StrongTypedIdentityCompliance` | 11 | 2.42.0 |

Polecat now runs **178 shared compliance tests across 22 suites, no capability gates** — the same 178 Marten runs.

## Seam cost, all on the test side

- `QueryTableAsync` on the fixture. A flat table is not a document, so there is no supported read path for its rows; the schema comes off the store so the shared suite never spells a qualified name.
- `ComplianceFlatTableProjection.Polecat.cs`, the per-consumer partial. Polecat's flat-table base takes a literal schema name where Marten's takes a `SchemaNameSource`, and the column-declaration API hangs off each dialect's own Weasel `Table`.
- `ComplianceMultiStreamProjectionBase`, a fourth global alias.
- `RegisterValueType<T>()` on the registrar, a deliberate no-op — Polecat derives what it needs from `ValueTypeInfo` when building the `DocumentMapping`. Mirror image of the existing `LiveAggregation<T>()` no-op.

## The two lifts (jasperfx#635, 2.41.0)

`CompactStreamAsync<T>` is deleted from `Polecat.Events.IEventOperations` — it now lives on `JasperFx.Events.IEventStoreOperations`, which that interface already inherits, so keeping the local copy would make every **call site** ambiguous (CS0121). Worth recording: Polecat itself never went red, because nothing in this repo calls it. `EventOperations` still implements both overloads; only the declaration moved.

`IEventDataMasking` is deleted and bound to the lifted `JasperFx.Events.Protected` one; the copies were member-for-member identical. ⚠️ **This moves the interface's namespace** — user code naming `Polecat.Events.Protected.IEventDataMasking` explicitly must update its `using`. The common fluent usage never names the type.

## ⚠️ Two real defects, fixed here

### #422 — only the first matching masking rule ever ran

`EventGraph.TryMask` used `matched = matched || masker.TryMask(e)`. `||` short-circuits, so the first rule to match an event stopped every later rule from being invoked — while the operation still reported success. On the right-to-erasure path that leaves protected information in the database after a masking pass that looked clean. Registration order silently decided which of your rules was honoured.

Marten had the identical defect byte-for-byte (marten#5199, fixed in marten#5200) — the implementations were duplicated, not shared.

Nothing caught it because `event_data_masking_tests.cs` registers a single rule per test, so no event ever matched two.

### #423 — compacting silently skipped the archiver, then deleted the events

`StreamCompacting.ExecuteAsync` gated the archiving callback on `IEventsArchiver<IDocumentOperations>` alone. That interface is **invariant**, so `IEventsArchiver<IDocumentSession>` did not match — and `IDocumentSession` is the operations type Polecat closes `IEventStore<,>` over, so it is what every JasperFx-generic caller supplies. The callback was skipped without a word and compaction proceeded to **permanently delete the events the archiver existed to copy into cold storage first**.

Marten has no equivalent: its gate and its closure agree. This one looks copied across without adjusting for the different closure — the comment above it still said "Polecat's callbacks close on IDocumentOperations".

Now accepts both closures, non-breaking. **This path had no test and no doc coverage in this repo at all.**

Left open on the issue rather than decided here: should a non-null `Archiver` matching *neither* closure throw instead of silently no-opping? Given what the hook guards, failing loudly looks better — but that is a behaviour change.

## Worked around, not fixed — #424

`EventStoreOptions` does not re-expose `AddMaskingRuleForProtectedInformation`, so masking rules are unreachable from `StoreOptions.Events`. The compliance registrar goes through `StoreOptions.EventGraph` and says why. Same class as #395.

## Verification

Four new regression tests, and **3 of the 4 fail with both fixes reverted** — the fourth (`an_archiver_closed_over_the_operations_type_still_runs`) passes either way on purpose, since it pins the non-breakage.

- Compliance **178/178**
- Full suite **1802 / 0 / 3** on net9.0

Wave 6 itself (`StreamCompacting` + `EventDataMasking`, 24 suites / 199 tests) is stacked on this branch and waits on the 2.43.0 publish.

Closes #422
Closes #423

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VpDCvJcBDZerieJB4JEHde