### PR TITLE
Compliance wave 7: enroll projection rebuild/catch-up and dead letters

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -105,16 +105,23 @@
              (EventStoreComplianceFixture.ApplyEventDataMaskingAsync and the two
              ComplianceStoreConfig.AddMaskingRule overloads). Compliance sources only — nothing
              outside JasperFx.Events.ComplianceTests changed, so this bump is behaviourally inert
-             for the shipping libraries and only affects Polecat.Tests. Same lockstep rule as
-             above. -->
-        <PackageVersion Include="JasperFx" Version="2.43.0" />
-        <PackageVersion Include="JasperFx.Events" Version="2.43.0" />
+             for the shipping libraries and only affects Polecat.Tests.
+             JasperFx 2.44.0 (jasperfx#641, marten#5149/#5150) — compliance wave 7, the last two
+             event sourcing suites in the backlog. RebuildAndCatchUpCompliance and
+             DeadLetterCompliance take the library to 26 suites / 216 tests. Neither needed a seam
+             addition: IProjectionDaemon already declared the whole rebuild surface, and the error
+             policy (IEventStore<,>.ContinuousErrors) plus dead-letter reads
+             (IEventStore.AllDatabases() -> IEventDatabase.QueryDeadLetterEventsAsync) were already
+             shared and already overridden here. Compliance sources only, so again behaviourally
+             inert for the shipping libraries. Same lockstep rule as above. -->
+        <PackageVersion Include="JasperFx" Version="2.44.0" />
+        <PackageVersion Include="JasperFx.Events" Version="2.44.0" />
         <!--
              The shared cross-store event sourcing compliance suites. Source-only package: the
              suites compile inside Polecat.Tests so JasperFx's aggregate source generator binds
              Polecat's own session types.
         -->
-        <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.43.0" />
+        <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.44.0" />
         <!-- Pin the sibling JasperFx packages for parity with Marten 9's matrix
              even though Polecat doesn't currently reference them directly —
              keeps the lockstep matrix coherent when transitive resolution
@@ -122,7 +129,7 @@
              RuntimeCompiler 5.x line is the active continuation of the 4.x
              lineage; do not pin against the parallel stale 2.0.x series. -->
         <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.43.0" />
+        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.44.0" />
         <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
@@ -218,7 +225,7 @@
         <PackageVersion Include="StronglyTypedId" Version="1.0.0-beta08" />
 
         <!-- Source generators (matched to JasperFx.Events above) -->
-        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.43.0" />
+        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.44.0" />
 
         <!-- Build automation -->
         <PackageVersion Include="Nuke.Common" Version="9.0.4" />

--- a/src/Polecat.Tests/Compliance/polecat_event_store_compliance_wave7.cs
+++ b/src/Polecat.Tests/Compliance/polecat_event_store_compliance_wave7.cs
@@ -1,0 +1,13 @@
+using JasperFx.Events.ComplianceTests;
+
+namespace Polecat.Tests.Compliance;
+
+/*
+ * Wave 7 enrollments. Separate file only while the suites are in flight upstream.
+ */
+
+public class rebuild_and_catch_up_compliance
+    : RebuildAndCatchUpCompliance<PolecatComplianceFixture, IDocumentSession, IQuerySession>;
+
+public class dead_letter_compliance
+    : DeadLetterCompliance<PolecatComplianceFixture, IDocumentSession, IQuerySession>;


### PR DESCRIPTION
**Draft — blocked on the JasperFx 2.44.0 publish (jasperfx#641).** Ready otherwise; the only remaining change is the version pin.

Enrolls the last two event-sourcing suites in the backlog. **24 → 26 suites, 199 → 216 shared compliance tests**, still no capability gates. Marten enrols the same two in marten#5203.

| Suite | Tests | Seam cost |
|---|---|---|
| `RebuildAndCatchUpCompliance` | 11 | **none** |
| `DeadLetterCompliance` | 6 | **none** |

Both were filed as needing a seam addition and neither does. `IProjectionDaemon` already declares the whole rebuild surface, and the error policy plus dead-letter reads sit on shared interfaces this store already overrides rather than inheriting the empty DIMs — `PolecatDatabase.QueryDeadLetterEventsAsync`, and `AllDatabases` / `ContinuousErrors` on `DocumentStore.EventStore.cs`.

## ⚠️ Known intermittent, disclosed upstream

`a_rebuild_reproduces_the_projected_state` **failed twice here** early in development, both at ~31s, and has passed **7 consecutive full 216-test compliance runs** since.

Marten has never seen it — 5 consecutive clean runs there. Since the suite source is identical on both stores, a fault confined to this one points at a **Polecat-side race under concurrency, or SQL Server timing**, rather than anything wrong with the test. That asymmetry is exactly why I did not harden the assertion to make it quiet.

No error text and no reproduction, so it is recorded rather than guess-fixed. Worth watching in CI — if it reappears, jasperfx#641 has the first sighting.

## Verification

Compliance **216/216**; full suite **1823 / 0 / 3** on net9.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VpDCvJcBDZerieJB4JEHde