### PR TITLE
Expose AddMaskingRuleForProtectedInformation on EventStoreOptions (#424)

### DIFF
--- a/src/Polecat.Tests/Compliance/PolecatComplianceFixture.cs
+++ b/src/Polecat.Tests/Compliance/PolecatComplianceFixture.cs
@@ -226,15 +226,13 @@ public class PolecatComplianceFixture : EventStoreComplianceFixture<IDocumentSes
         {
         }
 
-        // Through StoreOptions.EventGraph rather than StoreOptions.Events: masking rules live on the
-        // EventGraph and EventStoreOptions does not re-expose them, so the configuration-time
-        // surface has no way to register one. Same class of gap as #395 (AddEventType) -- filed
-        // as #424; revert to _options.Events once that lands.
+        // #424 landed the re-exposure on EventStoreOptions, so this goes through the ordinary
+        // configuration surface rather than reaching past it to StoreOptions.EventGraph.
         public void AddMaskingRule<TEvent>(Action<TEvent> rule) where TEvent : notnull
-            => _options.EventGraph.AddMaskingRuleForProtectedInformation(rule);
+            => _options.Events.AddMaskingRuleForProtectedInformation(rule);
 
         public void AddMaskingRule<TEvent>(Func<TEvent, TEvent> rule) where TEvent : notnull
-            => _options.EventGraph.AddMaskingRuleForProtectedInformation(rule);
+            => _options.Events.AddMaskingRuleForProtectedInformation(rule);
 
         public void AddProjection(ProjectionBase projection, ProjectionLifecycle lifecycle)
             => _options.Projections.Add((IProjectionSource<IDocumentSession, IQuerySession>)projection, lifecycle);

--- a/src/Polecat.Tests/Events/event_data_masking_tests.cs
+++ b/src/Polecat.Tests/Events/event_data_masking_tests.cs
@@ -160,6 +160,70 @@ public class event_data_masking_tests : IntegrationContext
     }
 
     /// <summary>
+    ///     #424. Every other test here registers its rules on <c>theStore.Events</c> — the *built*
+    ///     store's <see cref="EventGraph" /> — so none of them goes through
+    ///     <see cref="EventStoreOptions" />, which is what <c>StoreOptions.Events</c> hands you at
+    ///     configuration time and is how the rest of the store (and Marten's docs) spell this. The
+    ///     method was declared only on <c>EventGraph</c>, so the ordinary spelling did not compile
+    ///     and callers had to reach past to <c>opts.EventGraph</c>.
+    /// </summary>
+    [Fact]
+    public async Task register_func_masking_rule_at_configuration_time()
+    {
+        await StoreOptions(opts =>
+        {
+            opts.DatabaseSchemaName = "mask_opts_func";
+            opts.Events.AddMaskingRuleForProtectedInformation<PersonCreated>(e =>
+                e with { Email = "***masked***", SocialSecurityNumber = "***masked***" });
+        });
+
+        var streamId = Guid.NewGuid();
+        theSession.Events.StartStream(streamId,
+            new PersonCreated("Alice", "alice@example.com", "123-45-6789"));
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        await theStore.Advanced.ApplyEventDataMasking(masking => masking.IncludeStream(streamId),
+            TestContext.Current.CancellationToken);
+
+        await using var query = theStore.QuerySession();
+        var events = await query.Events.FetchStreamAsync(streamId, token: TestContext.Current.CancellationToken);
+
+        var created = events[0].Data.ShouldBeOfType<PersonCreated>();
+        created.Email.ShouldBe("***masked***");
+        created.SocialSecurityNumber.ShouldBe("***masked***");
+        created.Name.ShouldBe("Alice");
+    }
+
+    /// <summary>
+    ///     #424, the <c>Action&lt;T&gt;</c> overload — both are declared on <see cref="EventGraph" />
+    ///     and both have to be reachable from the options surface.
+    /// </summary>
+    [Fact]
+    public async Task register_action_masking_rule_at_configuration_time()
+    {
+        await StoreOptions(opts =>
+        {
+            opts.DatabaseSchemaName = "mask_opts_action";
+            opts.Events.AddMaskingRuleForProtectedInformation<PersonRecorded>(e => e.Email = "***masked***");
+        });
+
+        var streamId = Guid.NewGuid();
+        theSession.Events.StartStream(streamId,
+            new PersonRecorded { Subject = "Alice", Email = "alice@example.com" });
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        await theStore.Advanced.ApplyEventDataMasking(masking => masking.IncludeStream(streamId),
+            TestContext.Current.CancellationToken);
+
+        await using var query = theStore.QuerySession();
+        var events = await query.Events.FetchStreamAsync(streamId, token: TestContext.Current.CancellationToken);
+
+        var recorded = events[0].Data.ShouldBeOfType<PersonRecorded>();
+        recorded.Email.ShouldBe("***masked***");
+        recorded.Subject.ShouldBe("Alice");
+    }
+
+    /// <summary>
     ///     ... and in the other registration order, so the test cannot pass by accident of which
     ///     rule happens to be registered first.
     /// </summary>

--- a/src/Polecat/StoreOptions.cs
+++ b/src/Polecat/StoreOptions.cs
@@ -491,6 +491,30 @@ public class EventStoreOptions : IEventStoreInstrumentation
     }
 
     /// <summary>
+    ///     #424: register a policy for how to remove or mask protected information for an event type
+    ///     <typeparamref name="T" /> or any event type assignable to it, mutating the event data in
+    ///     place. Rules are applied by <c>IDocumentStore.Advanced.ApplyEventDataMasking(...)</c>.
+    ///     Mirrors Marten's <c>opts.Events.AddMaskingRuleForProtectedInformation&lt;T&gt;(...)</c> —
+    ///     the rule was previously only reachable through the <c>StoreOptions.EventGraph</c> escape
+    ///     hatch, which is not how the rest of the store is configured.
+    /// </summary>
+    public void AddMaskingRuleForProtectedInformation<T>(Action<T> action) where T : notnull
+    {
+        EventGraph!.AddMaskingRuleForProtectedInformation(action);
+    }
+
+    /// <summary>
+    ///     #424: register a policy for how to remove or mask protected information for an event type
+    ///     <typeparamref name="T" /> or any event type assignable to it, replacing the event data
+    ///     with a new instance — the overload records and other immutable event types need. Mirrors
+    ///     Marten's <c>opts.Events.AddMaskingRuleForProtectedInformation&lt;T&gt;(...)</c>.
+    /// </summary>
+    public void AddMaskingRuleForProtectedInformation<T>(Func<T, T> func) where T : notnull
+    {
+        EventGraph!.AddMaskingRuleForProtectedInformation(func);
+    }
+
+    /// <summary>
     ///     #388: store-wide fallback <see cref="Polecat.Events.IEventBinarySerializer" /> for event types
     ///     marked with <see cref="Polecat.Events.BinaryEventAttribute" /> that have no explicit per-type
     ///     registration via <see cref="UseBinarySerializer{TEvent}" />. Null by default — every event type


### PR DESCRIPTION
Closes #424.

## The gap

Both `AddMaskingRuleForProtectedInformation<T>` overloads — `Action<T>` and `Func<T,T>` — were declared on `EventGraph` but not re-exposed on `EventStoreOptions`, which is what `StoreOptions.Events` hands you at configuration time. So the natural spelling did not compile:

```csharp
options.Events.AddMaskingRuleForProtectedInformation<PersonCreated>(x => x.Name = "****");
// CS1061: 'EventStoreOptions' does not contain a definition for ...
```

and you had to reach past it to the public `StoreOptions.EventGraph`. `EventStoreOptions` already re-exposes neighbours like `AddEventType` and `RegisterTagType` — same class of gap as #395.

## Why it went unnoticed

`event_data_masking_tests.cs` registers its rules on `theStore.Events` — the **built store's** `EventGraph` — so it never went through `EventStoreOptions` at all. That works, but it registers rules after the store is built, which is not how the rest of the store is configured and is not what the docs show.

## The change

- Two delegating methods on `EventStoreOptions`. `EventGraph` is assigned to `Events` in the `StoreOptions` constructor, so both are usable from inside the configuration lambda.
- `PolecatComplianceFixture`'s masking registrar reverts from its `_options.EventGraph` workaround (whose comment says "revert to `_options.Events` once #424 lands") to the ordinary surface.

## Tests

Test-first — both new tests failed with the exact CS1061 from the issue before the fix.

- `register_func_masking_rule_at_configuration_time` — the `Func<T,T>` overload, registered inside `StoreOptions(opts => ...)`.
- `register_action_masking_rule_at_configuration_time` — the `Action<T>` overload, asserting the untouched member survives.

`event_data_masking_tests` 8/8 green; the whole masking set including the `EventDataMaskingCompliance` suite now driven through `_options.Events` is 18/18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pza51JxtP29jgWNAeyEvvM