### PR TITLE
Guard DeleteWhere against re-stamping deleted_at on already-deleted rows (#419)

### DIFF
--- a/src/Polecat.Tests/SoftDeletes/soft_delete_operations.cs
+++ b/src/Polecat.Tests/SoftDeletes/soft_delete_operations.cs
@@ -203,6 +203,173 @@ public class soft_delete_operations : IntegrationContext
         all.Count.ShouldBe(0);
     }
 
+    /// <summary>
+    ///     #419. <c>DeleteWhere</c> was an <c>UPDATE … SET is_deleted = 1, deleted_at =
+    ///     SYSDATETIMEOFFSET()</c> with no guard on the row's current state, so it re-stamped
+    ///     <c>deleted_at</c> on rows that were already deleted. Nothing errors and nothing looks
+    ///     wrong — the rows were already deleted and stay deleted. What changes is the answer to
+    ///     every question about *when*: <c>DeletedSince</c> / <c>DeletedBefore</c>, an audit, or a
+    ///     retention sweep all silently read the later bulk-delete call instead of the deletion,
+    ///     and the real value is unrecoverable.
+    ///     <para>
+    ///     Two deletes in the same millisecond agree either way, so calling <c>DeleteWhere</c>
+    ///     twice proves nothing on its own. This plants a known <c>deleted_at</c> far in the past
+    ///     on the already-deleted row and asserts the second call leaves it alone.
+    ///     </para>
+    /// </summary>
+    [Fact]
+    public async Task delete_where_does_not_restamp_deleted_at_on_already_deleted_rows()
+    {
+        var planted = new DateTimeOffset(2020, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+        var alreadyDeleted = new SoftDeletedDoc { Id = Guid.NewGuid(), Name = "restamp-old", Number = 50 };
+        var stillLive = new SoftDeletedDoc { Id = Guid.NewGuid(), Name = "restamp-new", Number = 50 };
+
+        theSession.Store(alreadyDeleted, stillLive);
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        await using (var session2 = theStore.LightweightSession())
+        {
+            session2.Delete(alreadyDeleted);
+            await session2.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        // Plant a deletion instant well in the past, so a re-stamp is unmistakable.
+        await PlantDeletedAtAsync(alreadyDeleted.Id, planted);
+
+        // A later bulk delete whose predicate still matches the already-deleted row.
+        await using (var session3 = theStore.LightweightSession())
+        {
+            session3.DeleteWhere<SoftDeletedDoc>(x => x.Number == 50);
+            await session3.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        // The already-deleted row keeps the instant it was actually deleted.
+        var untouched = await ReadDeletedAtAsync(alreadyDeleted.Id);
+        untouched.ShouldNotBeNull();
+        untouched.Value.ToUniversalTime().ShouldBe(planted.ToUniversalTime());
+
+        // ... and the row that was still live is deleted now, with a real (recent) timestamp.
+        var freshlyDeleted = await ReadDeletedAtAsync(stillLive.Id);
+        freshlyDeleted.ShouldNotBeNull();
+        freshlyDeleted.Value.ShouldBeGreaterThan(planted);
+
+        await using var query = theStore.QuerySession();
+        var visible = await query.LoadAsync<SoftDeletedDoc>(stillLive.Id, TestContext.Current.CancellationToken);
+        visible.ShouldBeNull();
+    }
+
+    /// <summary>
+    ///     #419, the other half: <c>HardDeleteWhere</c> must NOT get the guard. A hard delete of an
+    ///     already-soft-deleted row is a real delete and has to proceed — guarding it would strand
+    ///     soft-deleted rows permanently beyond the reach of the purge that is supposed to remove
+    ///     them.
+    /// </summary>
+    [Fact]
+    public async Task hard_delete_where_still_removes_already_soft_deleted_rows()
+    {
+        var doc = new SoftDeletedDoc { Id = Guid.NewGuid(), Name = "purge-me", Number = 60 };
+
+        theSession.Store(doc);
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        await using (var session2 = theStore.LightweightSession())
+        {
+            session2.Delete(doc);
+            await session2.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using (var session3 = theStore.LightweightSession())
+        {
+            session3.HardDeleteWhere<SoftDeletedDoc>(x => x.Number == 60);
+            await session3.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        var conn = await OpenConnectionAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = "SELECT COUNT(*) FROM [soft_delete_ops].[pc_doc_softdeleteddoc] WHERE id = @id";
+        cmd.Parameters.AddWithValue("@id", doc.Id);
+        var count = await cmd.ExecuteScalarAsync(TestContext.Current.CancellationToken);
+        count.ShouldBe(0);
+    }
+
+    /// <summary>
+    ///     #419, the symmetry nit: <c>UnDeleteByIdOperation</c> had no <c>is_deleted = 1</c> guard
+    ///     where <c>UndoDeleteWhereOperation</c> does. It is harmless — undeleting a live row writes
+    ///     exactly the values the row already holds — but the guard has to not break the case it
+    ///     applies to, which is undeleting a row that really is deleted.
+    /// </summary>
+    [Fact]
+    public async Task undelete_by_id_still_restores_a_deleted_document()
+    {
+        var doc = new SoftDeletedDoc { Id = Guid.NewGuid(), Name = "undelete-by-id", Number = 70 };
+
+        theSession.Store(doc);
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        await using (var session2 = theStore.LightweightSession())
+        {
+            session2.Delete(doc);
+            await session2.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using (var session3 = theStore.LightweightSession())
+        {
+            session3.UndoDeleteWhere<SoftDeletedDoc>(x => x.Number == 70);
+            await session3.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using var query = theStore.QuerySession();
+        var restored = await query.LoadAsync<SoftDeletedDoc>(doc.Id, TestContext.Current.CancellationToken);
+        restored.ShouldNotBeNull();
+        (await ReadDeletedAtAsync(doc.Id)).ShouldBeNull();
+    }
+
+    /// <summary>
+    ///     #419: a live row left alone by a soft <c>DeleteWhere</c> whose predicate excludes it must
+    ///     still be deletable later — the guard scopes the UPDATE, it does not disable it.
+    /// </summary>
+    [Fact]
+    public async Task delete_where_still_stamps_deleted_at_on_a_live_row()
+    {
+        var doc = new SoftDeletedDoc { Id = Guid.NewGuid(), Name = "first-delete", Number = 80 };
+
+        theSession.Store(doc);
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        (await ReadDeletedAtAsync(doc.Id)).ShouldBeNull();
+
+        await using (var session2 = theStore.LightweightSession())
+        {
+            session2.DeleteWhere<SoftDeletedDoc>(x => x.Number == 80);
+            await session2.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        (await ReadDeletedAtAsync(doc.Id)).ShouldNotBeNull();
+    }
+
+    private async Task PlantDeletedAtAsync(Guid id, DateTimeOffset value)
+    {
+        var conn = await OpenConnectionAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText =
+            "UPDATE [soft_delete_ops].[pc_doc_softdeleteddoc] SET deleted_at = @at WHERE id = @id";
+        cmd.Parameters.AddWithValue("@at", value);
+        cmd.Parameters.AddWithValue("@id", id);
+        var rows = await cmd.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+        rows.ShouldBe(1);
+    }
+
+    private async Task<DateTimeOffset?> ReadDeletedAtAsync(Guid id)
+    {
+        var conn = await OpenConnectionAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = "SELECT deleted_at FROM [soft_delete_ops].[pc_doc_softdeleteddoc] WHERE id = @id";
+        cmd.Parameters.AddWithValue("@id", id);
+        var raw = await cmd.ExecuteScalarAsync(TestContext.Current.CancellationToken);
+        return raw is null or DBNull ? null : (DateTimeOffset)raw;
+    }
+
     [Fact]
     public async Task delete_where_on_non_soft_deleted_type_does_hard_delete()
     {

--- a/src/Polecat/Internal/DocumentSessionBase.cs
+++ b/src/Polecat/Internal/DocumentSessionBase.cs
@@ -288,14 +288,19 @@ internal abstract class DocumentSessionBase : QuerySession, IDocumentSession
         // #273 doc-side convergence: the DELETE / soft-delete-UPDATE prefix and tenancy come from
         // the shared closed-shape storage. DeleteFragment is already soft-or-hard per the type.
         var storage = ClosedShapeDeletionStorageFor<T>();
+        // #419: when DeleteFragment is the soft-delete UPDATE, exclude rows that are already
+        // deleted so the operation cannot re-stamp their deleted_at.
         _workTracker.Add(new DeleteWhereOperation(
-            storage.DeleteFragment, storage.IsConjoined, TenantId, fragment, typeof(T)));
+            storage.DeleteFragment, storage.IsConjoined, TenantId, fragment, typeof(T),
+            excludeAlreadyDeleted: storage.IsSoftDeleted));
     }
 
     public void HardDeleteWhere<T>(Expression<Func<T, bool>> predicate) where T : class
     {
         var fragment = ParseDeleteWhere(predicate);
         var storage = ClosedShapeDeletionStorageFor<T>();
+        // #419: deliberately no is_deleted guard -- a hard delete of an already-soft-deleted row
+        // is a real delete and must proceed.
         _workTracker.Add(new DeleteWhereOperation(
             storage.HardDeleteFragment, storage.IsConjoined, TenantId, fragment, typeof(T)));
     }

--- a/src/Polecat/Internal/Operations/DeleteWhereOperation.cs
+++ b/src/Polecat/Internal/Operations/DeleteWhereOperation.cs
@@ -18,18 +18,20 @@ internal class DeleteWhereOperation : IStorageOperation
 {
     private readonly IOperationFragment _fragment;
     private readonly bool _conjoined;
+    private readonly bool _excludeAlreadyDeleted;
     private readonly string _tenantId;
     private readonly ISqlFragment _whereFragment;
     private readonly Type _documentType;
 
     public DeleteWhereOperation(IOperationFragment fragment, bool conjoined, string tenantId,
-        ISqlFragment whereFragment, Type documentType)
+        ISqlFragment whereFragment, Type documentType, bool excludeAlreadyDeleted = false)
     {
         _fragment = fragment;
         _conjoined = conjoined;
         _tenantId = tenantId;
         _whereFragment = whereFragment;
         _documentType = documentType;
+        _excludeAlreadyDeleted = excludeAlreadyDeleted;
     }
 
     public Type DocumentType => _documentType;
@@ -45,6 +47,20 @@ internal class DeleteWhereOperation : IStorageOperation
             builder.Append("tenant_id = ");
             builder.AppendParameter(_tenantId, System.Data.SqlDbType.VarChar);
             builder.Append(" AND ");
+        }
+
+        // #419: a soft DeleteWhere is an UPDATE that stamps deleted_at, so it has to skip rows that
+        // are already deleted -- otherwise a later bulk delete whose predicate still matches them
+        // moves their deleted_at forward and the real deletion instant is gone for good, taking
+        // DeletedSince / DeletedBefore and any retention sweep with it. This matches the guard the
+        // by-id soft delete already carries (PolecatDocumentStorage.BuildDeletion) and the one
+        // UndoDeleteWhereOperation carries. HardDeleteWhere never sets this: a hard delete of an
+        // already-soft-deleted row is a real delete and must proceed. Appended ahead of the caller's
+        // predicate for the same reason the tenant scope is -- a compound user predicate arrives
+        // parenthesized and cannot swallow it.
+        if (_excludeAlreadyDeleted)
+        {
+            builder.Append("is_deleted = 0 AND ");
         }
 
         _whereFragment.Apply(builder);

--- a/src/Polecat/Internal/Operations/UnDeleteByIdOperation.cs
+++ b/src/Polecat/Internal/Operations/UnDeleteByIdOperation.cs
@@ -45,6 +45,12 @@ internal class UnDeleteByIdOperation : IStorageOperation
             builder.AppendParameter(_tenantId, System.Data.SqlDbType.VarChar);
         }
 
+        // #419 (symmetry): UndoDeleteWhereOperation scopes to currently-deleted rows and this did
+        // not. Harmless either way -- undeleting a live row writes is_deleted = 0, deleted_at = NULL
+        // onto a row that already holds exactly those values -- but the two undelete paths should
+        // not disagree about what they target.
+        builder.Append(" AND is_deleted = 1");
+
         builder.Append(";");
     }
 

--- a/src/Polecat/Storage/ClosedShape/PolecatDocumentStorage.cs
+++ b/src/Polecat/Storage/ClosedShape/PolecatDocumentStorage.cs
@@ -127,6 +127,13 @@ internal interface IPolecatDeletionStorage
 
     /// <summary>#234: conjoined tables carry a <c>tenant_id</c> column to scope the WHERE by.</summary>
     bool IsConjoined { get; }
+
+    /// <summary>
+    ///     #419: true when <see cref="DeleteFragment" /> is the soft-delete <c>UPDATE</c> rather than
+    ///     a hard <c>DELETE</c>. Criteria-based soft deletes have to exclude rows that are already
+    ///     deleted, or they re-stamp <c>deleted_at</c> and destroy the real deletion instant.
+    /// </summary>
+    bool IsSoftDeleted { get; }
 }
 
 internal abstract class PolecatDocumentStorage<TDoc, TId>
@@ -257,6 +264,7 @@ internal abstract class PolecatDocumentStorage<TDoc, TId>
     public IOperationFragment HardDeleteFragment => _hardDeleteFragment;
     public IOperationFragment UndeleteFragment => _undeleteFragment;
     public bool IsConjoined => _mapping.TenancyStyle == TenancyStyle.Conjoined;
+    public bool IsSoftDeleted => _mapping.DeleteStyle == DeleteStyle.SoftDelete;
     public IReadOnlyList<IDuplicatedField> DuplicatedFields => Array.Empty<IDuplicatedField>();
 
     // ---- select clause (E1-minimal; full LINQ retarget is E2) ----

--- a/src/Polecat/Storage/ClosedShape/SubClassPolecatStorage.cs
+++ b/src/Polecat/Storage/ClosedShape/SubClassPolecatStorage.cs
@@ -71,6 +71,7 @@ internal sealed class SubClassPolecatStorage<T, TRoot, TId>
     public IOperationFragment HardDeleteFragment => _parent.HardDeleteFragment;
     public IOperationFragment UndeleteFragment => ((IPolecatDeletionStorage)_parent).UndeleteFragment;
     public bool IsConjoined => ((IPolecatDeletionStorage)_parent).IsConjoined;
+    public bool IsSoftDeleted => ((IPolecatDeletionStorage)_parent).IsSoftDeleted;
     public IReadOnlyList<IDuplicatedField> DuplicatedFields => _parent.DuplicatedFields;
 
     // ---- select clause ----


### PR DESCRIPTION
Closes #419.

## The bug

`DeleteWhere<T>(predicate)` against a soft-deleted type is an `UPDATE … SET is_deleted = 1, deleted_at = SYSDATETIMEOFFSET()` with **no guard on the row's current state**, so it re-stamped `deleted_at` on rows that were already deleted.

Delete a batch on Monday, run any later `DeleteWhere` whose predicate still matches them, and their `deleted_at` moves to the later call. Nothing errors and nothing looks wrong — the rows were already deleted and stay deleted. What changes is the answer to every question about *when*: `DeletedSince` / `DeletedBefore` report the most recent bulk-delete call rather than the deletion, and an audit or retention sweep built on `deleted_at` silently reads the wrong instant. The real value is unrecoverable afterwards.

Polecat already guards the two neighbouring paths — the by-id soft delete (`PolecatDocumentStorage.BuildDeletion`) and `UndoDeleteWhere` — so the by-id and criteria paths disagreed about whether a second delete may move the timestamp.

## The fix

The guard rides a new `IPolecatDeletionStorage.IsSoftDeleted` fact, so `DeleteWhereOperation` stays ignorant of `DocumentMapping`. It is appended **before** the caller's predicate for the same reason the tenant scope is: a compound user predicate arrives parenthesized and cannot swallow it.

`HardDeleteWhere` deliberately does **not** opt in — a hard delete of an already-soft-deleted row is a real delete and must proceed, or the purge that is supposed to remove soft-deleted rows would strand them permanently.

Also closes the symmetry nit the issue flags in the same family: `UnDeleteByIdOperation` had no `is_deleted = 1` guard where `UndoDeleteWhereOperation` does. Harmless either way (undeleting a live row writes the values it already holds), but the two undelete paths should not disagree about what they target. Its only call site is already gated on `DeleteStyle == SoftDelete`, so the column always exists.

## On Marten

The issue asked to confirm Marten's behaviour before settling on the fix. **Marten has no guard on either path** — its `SoftDelete` fragment is a bare `update … set mt_deleted = True, mt_deleted_at = now()`, and `DeleteForId` composes that same fragment with `ByIdFilter(id)` and nothing else. So Marten re-stamps on both paths, consistently.

That means Polecat's existing by-id guard was already a deliberate divergence, and this change makes Polecat internally consistent rather than matching Marten. Flagging it explicitly since it is a knowing divergence: the alternative — dropping the by-id guard to match Marten — would spread the data loss rather than contain it. Fisher carries the guard on both paths.

## Tests

Test-first. Two deletes in the same millisecond agree either way, so calling `DeleteWhere` twice proves nothing; the regression plants a known `deleted_at` in 2020 on the already-deleted row and asserts the second `DeleteWhere` leaves it alone. It fails on pre-fix code (`untouched.Value.ToUniversalTime() should be …`) and passes after.

Three more pin the behaviour the guard must not break:
- `hard_delete_where_still_removes_already_soft_deleted_rows`
- `undelete_by_id_still_restores_a_deleted_document`
- `delete_where_still_stamps_deleted_at_on_a_live_row`

Verified locally on SQL Server 2025: soft-delete set 27/27, and the **full suite 1830 total / 0 failed / 3 skipped** (net10.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pza51JxtP29jgWNAeyEvvM