### PR TITLE
Populate the ISoftDeleted metadata members on read (#421)

### DIFF
--- a/src/Polecat.Tests/SoftDeletes/soft_delete_metadata_on_read.cs
+++ b/src/Polecat.Tests/SoftDeletes/soft_delete_metadata_on_read.cs
@@ -1,0 +1,161 @@
+using Polecat.Attributes;
+using Polecat.Linq;
+using Polecat.Linq.SoftDeletes;
+using Polecat.Tests.Harness;
+
+namespace Polecat.Tests.SoftDeletes;
+
+/// <summary>
+///     A soft-deleted type carrying the deletion timestamp on a member of its own rather than
+///     through <see cref="ISoftDeleted" />, so the attribute path is covered independently of the
+///     interface path. #421.
+/// </summary>
+[SoftDeleted]
+public class AttributeMappedDeletedAtDoc
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+
+    [IsSoftDeletedMetadata] public bool IsGone { get; set; }
+
+    [SoftDeletedAtMetadata] public DateTimeOffset? GoneAt { get; set; }
+}
+
+/// <summary>
+///     #421: <c>JasperFx.Metadata.ISoftDeleted</c> declares two members — <c>Deleted</c> and
+///     <c>DeletedAt</c> — and Polecat populated neither on read. <c>deleted_at</c> had no
+///     member-mapping config at all (only <c>is_deleted</c> did) and its binder was built
+///     write-only, so a document implementing the interface loaded back with <c>DeletedAt</c> at
+///     <c>default</c> — null where the column holds a real timestamp. The value is in the database
+///     and reachable through <c>DeletedSince</c> / <c>DeletedBefore</c>; it just never reached the
+///     member the interface says holds it.
+/// </summary>
+[Collection("integration")]
+public class soft_delete_metadata_on_read : IntegrationContext
+{
+    public soft_delete_metadata_on_read(DefaultStoreFixture fixture) : base(fixture)
+    {
+    }
+
+    public override async ValueTask InitializeAsync()
+    {
+        await StoreOptions(opts =>
+        {
+            opts.DatabaseSchemaName = "soft_delete_read_meta";
+            opts.Schema.For<AttributeMappedDeletedAtDoc>();
+        });
+    }
+
+    [Fact]
+    public async Task deleted_at_reaches_the_isoftdeleted_member_on_read()
+    {
+        var doc = new SoftDeletedWithInterface { Id = Guid.NewGuid(), Name = "read-deleted-at" };
+
+        theSession.Store(doc);
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var before = DateTimeOffset.UtcNow.AddMinutes(-1);
+
+        await using (var session2 = theStore.LightweightSession())
+        {
+            session2.Delete(doc);
+            await session2.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        var after = DateTimeOffset.UtcNow.AddMinutes(1);
+
+        // A soft-deleted document is hidden from ordinary queries, so MaybeDeleted is the read
+        // path where these members are observable at all.
+        await using var query = theStore.QuerySession();
+        var loaded = (await query.Query<SoftDeletedWithInterface>()
+            .MaybeDeleted()
+            .Where(x => x.Id == doc.Id)
+            .ToListAsync(TestContext.Current.CancellationToken)).ShouldHaveSingleItem();
+
+        loaded.Deleted.ShouldBeTrue();
+        loaded.DeletedAt.ShouldNotBeNull();
+        loaded.DeletedAt!.Value.ShouldBeInRange(before, after);
+    }
+
+    /// <summary>
+    ///     Half a populated interface is arguably worse than none, because <c>Deleted</c> being
+    ///     right is what suggests <c>DeletedAt</c> is too. A live document has to report both
+    ///     members honestly as well.
+    /// </summary>
+    [Fact]
+    public async Task a_live_document_reports_not_deleted_with_no_timestamp()
+    {
+        var doc = new SoftDeletedWithInterface { Id = Guid.NewGuid(), Name = "still-here" };
+
+        theSession.Store(doc);
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        await using var query = theStore.QuerySession();
+        var loaded = await query.LoadAsync<SoftDeletedWithInterface>(doc.Id, TestContext.Current.CancellationToken);
+
+        loaded.ShouldNotBeNull();
+        loaded.Deleted.ShouldBeFalse();
+        loaded.DeletedAt.ShouldBeNull();
+    }
+
+    /// <summary>
+    ///     Undelete sets <c>deleted_at = NULL</c>, so the member must come back to null rather than
+    ///     keeping the stale instant the document was loaded with earlier.
+    /// </summary>
+    [Fact]
+    public async Task undeleting_clears_the_timestamp_member_on_read()
+    {
+        var doc = new SoftDeletedWithInterface { Id = Guid.NewGuid(), Name = "undelete-read" };
+
+        theSession.Store(doc);
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        await using (var session2 = theStore.LightweightSession())
+        {
+            session2.Delete(doc);
+            await session2.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using (var session3 = theStore.LightweightSession())
+        {
+            session3.UndoDeleteWhere<SoftDeletedWithInterface>(x => x.Name == "undelete-read");
+            await session3.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using var query = theStore.QuerySession();
+        var loaded = await query.LoadAsync<SoftDeletedWithInterface>(doc.Id, TestContext.Current.CancellationToken);
+
+        loaded.ShouldNotBeNull();
+        loaded.Deleted.ShouldBeFalse();
+        loaded.DeletedAt.ShouldBeNull();
+    }
+
+    /// <summary>
+    ///     The same mapping via <c>[SoftDeletedAtMetadata]</c> on an arbitrarily-named member, so
+    ///     the feature is not tied to implementing <see cref="ISoftDeleted" />. Mirrors Marten's
+    ///     <c>SoftDeletedAtMetadataAttribute</c>.
+    /// </summary>
+    [Fact]
+    public async Task deleted_at_reaches_a_member_mapped_by_attribute()
+    {
+        var doc = new AttributeMappedDeletedAtDoc { Id = Guid.NewGuid(), Name = "attr-mapped" };
+
+        theSession.Store(doc);
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        await using (var session2 = theStore.LightweightSession())
+        {
+            session2.Delete(doc);
+            await session2.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using var query = theStore.QuerySession();
+        var loaded = (await query.Query<AttributeMappedDeletedAtDoc>()
+            .MaybeDeleted()
+            .Where(x => x.Id == doc.Id)
+            .ToListAsync(TestContext.Current.CancellationToken)).ShouldHaveSingleItem();
+
+        loaded.IsGone.ShouldBeTrue();
+        loaded.GoneAt.ShouldNotBeNull();
+    }
+}

--- a/src/Polecat/Attributes/MetadataAttributes.cs
+++ b/src/Polecat/Attributes/MetadataAttributes.cs
@@ -78,6 +78,12 @@ public sealed class IsSoftDeletedMetadataAttribute : MetadataAttribute
     internal override void Apply(DocumentMetadataConfig config, MemberInfo member) => Map(config.IsSoftDeleted, member);
 }
 
+/// <summary>#421: maps the <c>deleted_at</c> soft-delete timestamp onto this member.</summary>
+public sealed class SoftDeletedAtMetadataAttribute : MetadataAttribute
+{
+    internal override void Apply(DocumentMetadataConfig config, MemberInfo member) => Map(config.SoftDeletedAt, member);
+}
+
 /// <summary>Maps the <c>dotnet_type</c> discriminator onto this member.</summary>
 public sealed class DotNetTypeMetadataAttribute : MetadataAttribute
 {

--- a/src/Polecat/Storage/DocumentMapping.cs
+++ b/src/Polecat/Storage/DocumentMapping.cs
@@ -115,6 +115,19 @@ internal class DocumentMapping
             DeleteStyle = DeleteStyle.SoftDelete;
         }
 
+        // #421: ISoftDeleted declares both `Deleted` and `DeletedAt`, so implementing it maps both
+        // columns onto their members and they are populated on load. Previously deleted_at had no
+        // member-mapping config at all and its binder was write-only, so a type implementing the
+        // interface loaded back with DeletedAt at default -- null where the column holds a real
+        // timestamp -- while Deleted looked right, which is what made it read as populated.
+        // Mirrors Marten's SoftDeletedPolicy. ??= so an explicit [IsSoftDeletedMetadata] /
+        // [SoftDeletedAtMetadata] attribute (discovered just above) or the fluent DSL wins.
+        if (typeof(ISoftDeleted).IsAssignableFrom(documentType))
+        {
+            Metadata.IsSoftDeleted.Member ??= documentType.GetProperty(nameof(ISoftDeleted.Deleted));
+            Metadata.SoftDeletedAt.Member ??= documentType.GetProperty(nameof(ISoftDeleted.DeletedAt));
+        }
+
         // Detect optimistic concurrency: IVersioned (Guid), IRevisioned (int), or ILongVersioned (long)
         if (typeof(IVersioned).IsAssignableFrom(documentType))
         {

--- a/src/Polecat/Storage/Metadata/DocumentMetadataConfig.cs
+++ b/src/Polecat/Storage/Metadata/DocumentMetadataConfig.cs
@@ -35,6 +35,14 @@ public class DocumentMetadataConfig
     /// <summary>The <c>is_deleted</c> soft-delete flag; <see cref="MetadataColumn.Member" /> maps it onto a document member.</summary>
     public MetadataColumn IsSoftDeleted { get; } = new("is_deleted");
 
+    /// <summary>
+    ///     #421: the <c>deleted_at</c> soft-delete timestamp; <see cref="MetadataColumn.Member" />
+    ///     maps it onto a document member so the value reaches
+    ///     <see cref="JasperFx.Metadata.ISoftDeleted.DeletedAt" /> on load. Mirrors Marten's
+    ///     <c>DocumentMetadataCollection.SoftDeletedAt</c>.
+    /// </summary>
+    public MetadataColumn SoftDeletedAt { get; } = new("deleted_at");
+
     /// <summary>The always-present <c>dotnet_type</c> column; <see cref="MetadataColumn.Member" /> maps it onto a document member.</summary>
     public MetadataColumn DotNetType { get; } = new("dotnet_type") { Enabled = true };
 
@@ -52,6 +60,7 @@ public class DocumentMetadataConfig
         yield return Version;
         yield return TenantId;
         yield return IsSoftDeleted;
+        yield return SoftDeletedAt;
         yield return DotNetType;
     }
 

--- a/src/Polecat/Storage/Metadata/MetadataConfig.cs
+++ b/src/Polecat/Storage/Metadata/MetadataConfig.cs
@@ -61,6 +61,7 @@ public class MetadataConfig<T>
     public MetadataColumnExpression<T> Version => new(_config.Version);
     public MetadataColumnExpression<T> TenantId => new(_config.TenantId);
     public MetadataColumnExpression<T> IsSoftDeleted => new(_config.IsSoftDeleted);
+    public MetadataColumnExpression<T> SoftDeletedAt => new(_config.SoftDeletedAt);
     public MetadataColumnExpression<T> DotNetType => new(_config.DotNetType);
 }
 

--- a/src/Polecat/Storage/SqlServerDocumentStorageDescriptorBuilder.cs
+++ b/src/Polecat/Storage/SqlServerDocumentStorageDescriptorBuilder.cs
@@ -162,9 +162,18 @@ internal static class SqlServerDocumentStorageDescriptorBuilder
                 readBinders.Add(isDeleted);
             }
 
-            // Polecat has no member-mapping config for deleted_at (only is_deleted);
-            // write-only with the column's fixed name.
-            writeBinders.Add(new DocumentSoftDeletedAtBinder<TDoc>("deleted_at", dialect, member: null));
+            // #421: deleted_at carries a mapped member just like is_deleted, so an ISoftDeleted
+            // document (or one using [SoftDeletedAtMetadata] / the fluent DSL) gets DeletedAt
+            // populated on load instead of left at default. Read slot only with a mapped member --
+            // the SELECT column list is built from this same binder array, so adding one here keeps
+            // the read ordinals aligned by construction.
+            var deletedAt = new DocumentSoftDeletedAtBinder<TDoc>(
+                mapping.Metadata.SoftDeletedAt.Name, dialect, mapping.Metadata.SoftDeletedAt.Member);
+            writeBinders.Add(deletedAt);
+            if (mapping.Metadata.SoftDeletedAt.Member is not null)
+            {
+                readBinders.Add(deletedAt);
+            }
         }
 
         // Range-partitioned documents (#211): the duplicated partition column is written on


### PR DESCRIPTION
Closes #421.

## The gap

`JasperFx.Metadata.ISoftDeleted` declares two members — `Deleted` and `DeletedAt` — and Polecat populated **neither** on read.

`deleted_at` had no member-mapping config at all (only `is_deleted` did), so its binder was built write-only with the column's fixed name and the value never reached the member the interface says holds it. The value is in the database and reachable through `DeletedSince` / `DeletedBefore`; it just never got to the document.

### Correction to the issue

The issue predicted `Deleted` was already populated and only `DeletedAt` was missing — "half a populated interface is arguably worse than none, because `Deleted` being right is what suggests `DeletedAt` is too." It turned out to be neither half: the pre-fix probe fails on `loaded.Deleted` **first**. `Metadata.IsSoftDeleted.Member` was never resolved from the interface either — only `[IsSoftDeletedMetadata]` or the fluent DSL set it — so an `ISoftDeleted` document loaded back with both members at `default`. The gap was one column wider than filed, and the fix covers both.

## The change

Mirrors Marten, which resolves both members from the interface in `SoftDeletedPolicy` and adds each binder to the read set on the same condition:

- `DocumentMetadataConfig` gains `SoftDeletedAt` (`"deleted_at"`) beside `IsSoftDeleted`, yielded from `AllColumns()` so `MergeFrom` carries it.
- `DocumentMapping` resolves both members from `ISoftDeleted` when the type implements it, with `??=` so an explicit attribute or DSL mapping still wins.
- `SoftDeletedAtMetadataAttribute` maps the column onto an arbitrary member, matching Marten's attribute of the same name; `MetadataConfig` exposes `SoftDeletedAt` for the fluent DSL.
- The descriptor builder builds the `deleted_at` binder **with** that member and adds it to `readBinders` on the same condition as `is_deleted`.

## On the read-layout care point

The issue flagged the read layout as the risk, since the shared closed-shape selectors bind by position. It is safe by construction rather than by care: `PolecatDocumentStorage` builds the SELECT column list from the same `ReadBinders()` array in the same order, so a binder and its column are added together and the ordinals cannot drift. The `QueryOnly` flavor overrides `ReadBinders()` and gets the same treatment.

## Tests

Test-first; the interface test fails pre-fix.

- `deleted_at_reaches_the_isoftdeleted_member_on_read` — via `MaybeDeleted()`, the only read path where a soft-deleted document is visible at all.
- `a_live_document_reports_not_deleted_with_no_timestamp`
- `undeleting_clears_the_timestamp_member_on_read`
- `deleted_at_reaches_a_member_mapped_by_attribute` — a type that does **not** implement the interface, covering the attribute path independently.

Verified on SQL Server 2025: soft-delete set 27/27, and the **full suite 1830 total / 0 failed / 3 skipped** (net10.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pza51JxtP29jgWNAeyEvvM