### PR TITLE
Append an async projection's raised events instead of dropping them (#420)

### DIFF
--- a/src/Polecat.Tests/Daemon/async_projection_raised_events_tests.cs
+++ b/src/Polecat.Tests/Daemon/async_projection_raised_events_tests.cs
@@ -1,0 +1,242 @@
+using JasperFx;
+using JasperFx.Events;
+using JasperFx.Events.Projections;
+using Microsoft.Data.SqlClient;
+using Polecat.Projections;
+using Polecat.TestUtils;
+
+namespace Polecat.Tests.Daemon;
+
+/// <summary>
+///     #420 — an async projection's raised events were silently dropped.
+///     <para>
+///     <c>PolecatProjectionBatch</c> implemented the three members JasperFx drives event-raising
+///     through (<c>QuickAppendEventWithVersion</c>, <c>UpdateStreamVersion</c>,
+///     <c>QuickAppendEvents</c>) as empty methods. <c>EventSlice.BuildOperations</c> calls them
+///     whenever a projection raises an event, so an async projection that appends events lost them
+///     with no exception, no shard failure, no dead letter and no log line: the projection's
+///     documents committed, the progression row advanced, and the raised events simply never
+///     existed. The only way to notice was to go looking for events that should be there.
+///     </para>
+///     <para>
+///     Inline projections were never affected — this is the async daemon batch only.
+///     </para>
+/// </summary>
+public partial class async_projection_raised_events_tests : IAsyncLifetime
+{
+    private const string Schema = "async_raised_events";
+
+    public async ValueTask InitializeAsync() => await DropSchemaTablesAsync(Schema);
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+    private static DocumentStore CreateStore()
+    {
+        return DocumentStore.For(opts =>
+        {
+            opts.ConnectionString = ConnectionSource.ConnectionString;
+            opts.DatabaseSchemaName = Schema;
+            opts.AutoCreateSchemaObjects = AutoCreate.All;
+            opts.UseNativeJsonType = ConnectionSource.SupportsNativeJson;
+
+            opts.Projections.Add(new RaisingProjection(), ProjectionLifecycle.Async);
+        });
+    }
+
+    /// <summary>
+    ///     The headline case: a projection raises an event onto a different stream. Before the fix
+    ///     the audit stream did not exist at all.
+    /// </summary>
+    [Fact]
+    public async Task raised_events_are_appended_to_their_stream()
+    {
+        using var store = CreateStore();
+        await store.Database.ApplyAllConfiguredChangesToDatabaseAsync(ct: TestContext.Current.CancellationToken);
+
+        var streamId = Guid.NewGuid();
+        await using (var session = store.LightweightSession())
+        {
+            session.Events.StartStream(streamId, new RaiseStarted("alpha"));
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await store.WaitForProjectionAsync();
+
+        await using var query = store.QuerySession();
+        var audit = await query.Events.FetchStreamAsync(AuditStreamFor(streamId),
+            token: TestContext.Current.CancellationToken);
+
+        audit.Count.ShouldBe(1);
+        var raised = audit[0].Data.ShouldBeOfType<RaiseNoticed>();
+        raised.Label.ShouldBe("alpha");
+
+        // Versions come from the stream row this batch read under UPDLOCK/HOLDLOCK, not from the
+        // slice's client-side count.
+        audit[0].Version.ShouldBe(1);
+        audit[0].StreamId.ShouldBe(AuditStreamFor(streamId));
+    }
+
+    /// <summary>
+    ///     The stream row has to be written too, not just the event rows — otherwise the raised
+    ///     events are invisible to every version-aware read path.
+    /// </summary>
+    [Fact]
+    public async Task the_raised_event_stream_row_is_created_with_the_right_version()
+    {
+        using var store = CreateStore();
+        await store.Database.ApplyAllConfiguredChangesToDatabaseAsync(ct: TestContext.Current.CancellationToken);
+
+        var streamId = Guid.NewGuid();
+        await using (var session = store.LightweightSession())
+        {
+            session.Events.StartStream(streamId, new RaiseStarted("beta"));
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await store.WaitForProjectionAsync();
+
+        await using var query = store.QuerySession();
+        var state = await query.Events.FetchStreamStateAsync(AuditStreamFor(streamId),
+            TestContext.Current.CancellationToken);
+
+        state.ShouldNotBeNull();
+        state!.Version.ShouldBe(1);
+    }
+
+    /// <summary>
+    ///     Two source streams raise onto two distinct audit streams, and appending again to a
+    ///     stream that already exists takes the UPDATE branch rather than trying to insert a second
+    ///     stream row — the version has to continue from what the earlier batch left behind.
+    /// </summary>
+    [Fact]
+    public async Task appends_accumulate_across_batches_on_an_existing_stream()
+    {
+        using var store = CreateStore();
+        await store.Database.ApplyAllConfiguredChangesToDatabaseAsync(ct: TestContext.Current.CancellationToken);
+
+        var streamId = Guid.NewGuid();
+
+        await using (var session = store.LightweightSession())
+        {
+            session.Events.StartStream(streamId, new RaiseStarted("one"));
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await store.WaitForProjectionAsync();
+
+        // A second event on the same source stream produces a second raised event on the same
+        // audit stream, in a later batch.
+        await using (var session = store.LightweightSession())
+        {
+            session.Events.Append(streamId, new RaiseStarted("two"));
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await store.WaitForProjectionAsync();
+
+        await using var query = store.QuerySession();
+        var audit = await query.Events.FetchStreamAsync(AuditStreamFor(streamId),
+            token: TestContext.Current.CancellationToken);
+
+        audit.Count.ShouldBe(2);
+        audit.Select(x => x.Version).ShouldBe(new long[] { 1, 2 });
+        audit.Select(x => ((RaiseNoticed)x.Data).Label).ShouldBe(new[] { "one", "two" });
+    }
+
+    /// <summary>
+    ///     A projection that raises nothing must not pay for the feature — no stray stream rows,
+    ///     and the ordinary projected document still lands.
+    /// </summary>
+    [Fact]
+    public async Task a_batch_with_no_raised_events_is_unaffected()
+    {
+        using var store = DocumentStore.For(opts =>
+        {
+            opts.ConnectionString = ConnectionSource.ConnectionString;
+            opts.DatabaseSchemaName = Schema;
+            opts.AutoCreateSchemaObjects = AutoCreate.All;
+            opts.UseNativeJsonType = ConnectionSource.SupportsNativeJson;
+            opts.Projections.Add(new SingleStreamProjection<RaiseSnap, Guid>(), ProjectionLifecycle.Async);
+        });
+        await store.Database.ApplyAllConfiguredChangesToDatabaseAsync(ct: TestContext.Current.CancellationToken);
+
+        var streamId = Guid.NewGuid();
+        await using (var session = store.LightweightSession())
+        {
+            session.Events.StartStream(streamId, new RaiseStarted("quiet"));
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await store.WaitForProjectionAsync();
+
+        await using var query = store.QuerySession();
+        var snap = await query.LoadAsync<RaiseSnap>(streamId, TestContext.Current.CancellationToken);
+        snap.ShouldNotBeNull();
+        snap.Label.ShouldBe("quiet");
+
+        var audit = await query.Events.FetchStreamAsync(AuditStreamFor(streamId),
+            token: TestContext.Current.CancellationToken);
+        audit.Count.ShouldBe(0);
+    }
+
+    // A deterministic audit stream id per source stream, so the assertions can find it without
+    // the projection having to report anything back.
+    private static Guid AuditStreamFor(Guid streamId)
+    {
+        var bytes = streamId.ToByteArray();
+        bytes[0] ^= 0xFF;
+        return new Guid(bytes);
+    }
+
+    private static async Task DropSchemaTablesAsync(string schema)
+    {
+        await using var conn = new SqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = """
+            DECLARE @sql nvarchar(max) = N'';
+            SELECT @sql = @sql + 'ALTER TABLE [' + s.name + '].[' + t.name + '] DROP CONSTRAINT [' + fk.name + '];'
+            FROM sys.foreign_keys fk
+            JOIN sys.tables t ON fk.parent_object_id = t.object_id
+            JOIN sys.schemas s ON t.schema_id = s.schema_id
+            WHERE s.name = @schema;
+
+            SELECT @sql = @sql + 'DROP TABLE [' + s.name + '].[' + t.name + '];'
+            FROM sys.tables t
+            JOIN sys.schemas s ON t.schema_id = s.schema_id
+            WHERE s.name = @schema;
+            EXEC sp_executesql @sql;
+            """;
+        cmd.Parameters.AddWithValue("@schema", schema);
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    public record RaiseStarted(string Label);
+
+    public record RaiseNoticed(string Label);
+
+    public partial class RaiseSnap
+    {
+        public Guid Id { get; set; }
+        public string Label { get; set; } = "";
+
+        public void Apply(RaiseStarted e) => Label = e.Label;
+    }
+
+    public partial class RaisingProjection : SingleStreamProjection<RaiseSnap, Guid>
+    {
+        public override ValueTask RaiseSideEffects(IDocumentSession session, IEventSlice<RaiseSnap> slice)
+        {
+            // Raise one event per source event onto a separate audit stream — the ordinary
+            // "projection notices something and records it" shape. IEventSlice<T> exposes no id of
+            // its own, so the source stream comes off the events.
+            foreach (var e in slice.Events().Where(x => x.Data is RaiseStarted))
+            {
+                var started = (RaiseStarted)e.Data;
+                slice.AppendEvent(AuditStreamFor(e.StreamId), new RaiseNoticed(started.Label));
+            }
+
+            return ValueTask.CompletedTask;
+        }
+    }
+}

--- a/src/Polecat/Events/Daemon/PolecatProjectionBatch.cs
+++ b/src/Polecat/Events/Daemon/PolecatProjectionBatch.cs
@@ -30,6 +30,11 @@ internal class PolecatProjectionBatch : IProjectionBatch<IDocumentSession, IQuer
     private readonly ConcurrentBag<IDocumentSession> _sessions = new();
     private readonly ConcurrentQueue<Weasel.Storage.IStorageOperation> _progressOps = new();
 
+    // #420: StreamActions a projection raised events onto, captured by the three IProjectionBatch
+    // append members and turned into append operations during ExecuteAsync.
+    private readonly List<StreamAction> _raisedEventActions = new();
+    private readonly object _raisedEventsLock = new();
+
     // The change set committed by this batch, populated during ExecuteAsync. Exposed so the
     // subscription runner can hand it to the IChangeListener returned by ProcessEventsAsync.
     public IChangeSet? Commit { get; private set; }
@@ -88,6 +93,11 @@ internal class PolecatProjectionBatch : IProjectionBatch<IDocumentSession, IQuer
         var tableEnsurer = new DocumentTableEnsurer(
             new ConnectionFactory(_connectionString), _store.Options);
 
+        // #420: built before the session sweep below so any tenant session this creates is picked
+        // up by it (and disposed with the rest). The appends themselves are added after the
+        // document operations, ahead of the progression row.
+        var raisedEventOps = await BuildRaisedEventOperationsAsync(token);
+
         foreach (var session in _sessions)
         {
             if (session is DocumentSessionBase sessionBase)
@@ -120,6 +130,9 @@ internal class PolecatProjectionBatch : IProjectionBatch<IDocumentSession, IQuer
                 await _store.Events.TenantOrdinals.ResolveAsync(adapter.SessionTenantId, token);
             }
         }
+
+        // #420: raised-event appends ride the same transaction as the documents above.
+        allOps.AddRange(raisedEventOps);
 
         // Add progress operations
         while (_progressOps.TryDequeue(out var progressOp))
@@ -283,19 +296,72 @@ internal class PolecatProjectionBatch : IProjectionBatch<IDocumentSession, IQuer
         }
     }
 
-    public void QuickAppendEventWithVersion(StreamAction action, IEvent @event)
+    // #420: the three members JasperFx drives event-raising through. EventSlice.BuildOperations
+    // calls them whenever a projection raises an event; all three were empty, so an async
+    // projection that appends events lost them silently -- no exception, no shard failure, no dead
+    // letter, no log line. The documents committed, the progression row advanced, and the raised
+    // events simply never existed.
+    //
+    // All three funnel into one list because the StreamAction JasperFx hands over already carries
+    // every raised event, and the single-stream-start path passes the SAME instance to each call
+    // (once per event to QuickAppendEventWithVersion, then once to UpdateStreamVersion), so
+    // reference identity dedupes them into one append per stream. The actual operation is built in
+    // ExecuteAsync, because numbering the events correctly needs an async locking read of the
+    // stream row that these synchronous members cannot do.
+
+    public void QuickAppendEventWithVersion(StreamAction action, IEvent @event) => CaptureRaisedEvents(action);
+
+    public void UpdateStreamVersion(StreamAction action) => CaptureRaisedEvents(action);
+
+    public void QuickAppendEvents(StreamAction action) => CaptureRaisedEvents(action);
+
+    private void CaptureRaisedEvents(StreamAction action)
     {
-        // Event appending from projections is not used in Polecat's current scope
+        lock (_raisedEventsLock)
+        {
+            // Reference identity, not stream id: two distinct actions for the same stream in one
+            // batch are two real appends, while the same instance arriving three times is one.
+            foreach (var captured in _raisedEventActions)
+            {
+                if (ReferenceEquals(captured, action)) return;
+            }
+
+            _raisedEventActions.Add(action);
+        }
     }
 
-    public void UpdateStreamVersion(StreamAction action)
+    /// <summary>
+    ///     #420: turn the captured <see cref="StreamAction" />s into append operations that join
+    ///     this batch's transaction, so raised events commit atomically with the projection
+    ///     documents and the progression row they were produced alongside.
+    /// </summary>
+    private async Task<List<Weasel.Storage.IStorageOperation>> BuildRaisedEventOperationsAsync(
+        CancellationToken token)
     {
-        // Stream version updates from projections are not used in Polecat's current scope
-    }
+        List<StreamAction> actions;
+        lock (_raisedEventsLock)
+        {
+            actions = _raisedEventActions.ToList();
+        }
 
-    public void QuickAppendEvents(StreamAction action)
-    {
-        // Event appending from projections is not used in Polecat's current scope
+        var ops = new List<Weasel.Storage.IStorageOperation>();
+        if (actions.Count == 0) return ops;
+
+        // One session per tenant: the stream-state read is scoped by the session's tenant id.
+        foreach (var group in actions.Where(a => a.Events.Any())
+                     .GroupBy(a => a.TenantId ?? JasperFx.StorageConstants.DefaultTenantId))
+        {
+            var session = (DocumentSessionBase)SessionForTenant(group.Key);
+            foreach (var action in group)
+            {
+                var op = await session.BuildRaisedEventAppendAsync(action, token).ConfigureAwait(false);
+                // The batch configures commands with a null session, so the append has to arrive
+                // already bound to the one that will write it.
+                ops.Add(new SessionBoundOperationAdapter(op, (Weasel.Storage.IStorageSession)session));
+            }
+        }
+
+        return ops;
     }
 
     public async Task PublishMessageAsync(object message, string tenantId)

--- a/src/Polecat/Internal/DocumentSessionBase.cs
+++ b/src/Polecat/Internal/DocumentSessionBase.cs
@@ -767,6 +767,52 @@ internal abstract class DocumentSessionBase : QuerySession, IDocumentSession
         await ExecuteClosedShapeEventOperationsAsync(ops, token);
     }
 
+    /// <summary>
+    ///     #420: build the append operation for a <see cref="StreamAction" /> a projection raised,
+    ///     so the async daemon batch can write it inside its own transaction rather than dropping
+    ///     it. Same path as the inline append — resolve the tenant partition, read the stream row
+    ///     under <c>UPDLOCK, HOLDLOCK</c>, assign versions client-side from what that read
+    ///     returned, then build the closed-shape quick-append op.
+    ///     <para>
+    ///     The one deliberate difference is the concurrency expectation. JasperFx's
+    ///     <c>EventSlice.BuildOperations</c> pre-assigns versions on the single-stream-start path
+    ///     from the slice's own event count, which is the stream's real version only when the
+    ///     projection has seen every event on that stream — so that guess is discarded and the
+    ///     version this session just read under lock is used instead, both to number the events
+    ///     and as the guard on the stream-row update.
+    ///     </para>
+    /// </summary>
+    internal async Task<Weasel.Storage.IStorageOperation> BuildRaisedEventAppendAsync(
+        StreamAction stream, CancellationToken token)
+    {
+        var storage = _eventGraph.ClosedShapeEventStorage;
+        var isGuid = _eventGraph.StreamIdentity == JasperFx.Events.StreamIdentity.AsGuid;
+
+        var (partitionOrdinal, partitionSequenceName) = await ResolvePartitionForClosedShapeAsync(stream, token);
+        var (currentVersion, exists, archived) = await ReadStreamStateForClosedShapeAsync(stream, token);
+
+        var streamId = isGuid ? (object)stream.Id : stream.Key!;
+        if (archived)
+        {
+            throw new Exceptions.InvalidStreamException(streamId, "Cannot append to an archived stream.");
+        }
+
+        AssignEventMetadataForClosedShape(stream, currentVersion);
+        stream.Version = currentVersion + stream.Events.Count;
+
+        // Replace (not ??=) JasperFx's client-side guess with the locked read, so the guarded
+        // stream-row update asserts something true rather than failing the shard on a stream the
+        // projection has only partially seen. A stream row that does not exist yet is inserted.
+        stream.ExpectedVersionOnServer = exists ? currentVersion : null;
+
+        var mode = exists
+            ? Polecat.Events.Storage.StreamWriteMode.Update
+            : Polecat.Events.Storage.StreamWriteMode.Insert;
+
+        return QuickAppendEventsClosedShape(storage, isGuid, stream, mode,
+            partitionOrdinal, partitionSequenceName);
+    }
+
     private async Task<(int? ordinal, string? sequenceName)> ResolvePartitionForClosedShapeAsync(
         StreamAction stream, CancellationToken token)
     {

--- a/src/Polecat/Internal/Operations/SessionBoundOperationAdapter.cs
+++ b/src/Polecat/Internal/Operations/SessionBoundOperationAdapter.cs
@@ -1,0 +1,41 @@
+using System.Data.Common;
+using Weasel.Core;
+using Weasel.Storage;
+
+namespace Polecat.Internal.Operations;
+
+/// <summary>
+///     Binds a shared closed-shape operation to the session that must execute it, for pipelines
+///     that configure commands without a session of their own — specifically the async daemon
+///     batch, which calls <see cref="StorageOperationExecution.Configure" /> with a null session
+///     because every operation it carries is expected to be fully bound already.
+///     <para>
+///     Deliberately NOT an <see cref="IDocumentStorageOperation" />, unlike
+///     <see cref="ClosedShapeOperationAdapter" />: the operations wrapped here write events, not
+///     documents. Exposing a <c>Document</c> would put them in the batch's
+///     <see cref="Polecat.Services.IChangeSet" /> <c>Updated</c>/<c>Inserted</c> sets and hand
+///     <c>IChangeListener</c> implementations a <c>StreamAction</c> where they expect a document.
+///     Raised events reach listeners through the change set's stream collection instead.
+///     </para>
+/// </summary>
+internal sealed class SessionBoundOperationAdapter : IStorageOperation
+{
+    private readonly Weasel.Storage.IStorageOperation _inner;
+    private readonly IStorageSession _session;
+
+    public SessionBoundOperationAdapter(Weasel.Storage.IStorageOperation inner, IStorageSession session)
+    {
+        _inner = inner;
+        _session = session;
+    }
+
+    public Type DocumentType => _inner.DocumentType;
+
+    public OperationRole Role() => _inner.Role();
+
+    public void ConfigureCommand(Weasel.SqlServer.ICommandBuilder builder)
+        => _inner.ConfigureCommand(builder, _session);
+
+    public Task PostprocessAsync(DbDataReader reader, IList<Exception> exceptions, CancellationToken token)
+        => _inner.PostprocessAsync(reader, exceptions, token);
+}


### PR DESCRIPTION
Closes #420.

## The bug

`PolecatProjectionBatch` implemented the three members JasperFx drives event-raising through — `QuickAppendEventWithVersion`, `UpdateStreamVersion`, `QuickAppendEvents` — as **empty methods**. `EventSlice.BuildOperations` calls them whenever a projection raises an event, so an async projection that appends events lost them silently: no exception, no shard failure, no dead letter, no log line. The projection's documents committed, the progression row advanced, and the raised events simply never existed. The only way to notice was to go looking for events that should be there.

Inline projections were never affected — this is the async daemon batch only.

This is the **real fix**, not the `NotSupportedException` floor the issue offers as a minimum.

## How it works

The issue's structural prediction held: all three members funnel into one list, because the `StreamAction` JasperFx hands over already carries every raised event and the single-stream-start path passes the **same instance** to each call. Dedupe is by reference identity and deliberately not by stream id — two distinct actions for one stream in a batch are two real appends.

The operation is built during `ExecuteAsync` rather than in the three synchronous members, because numbering the events correctly needs an async read.

### On the version question

The issue asks whether the pre-assigned versions can be trusted, and notes Polecat's answer likely differs from Fisher's. It does. JasperFx assigns versions on the single-stream-start path from the *slice's* own event count, which is the stream's real version only when the projection has seen every event on that stream — and here the raised events go to a **different** stream, so the count is unrelated to it.

Polecat already has a locking read on the inline append path — `SELECT version, is_archived FROM … WITH (UPDLOCK, HOLDLOCK)` — so `BuildRaisedEventAppendAsync` reuses it and lets the server's version win, both to number the events and as the guard on the stream-row update. Streams that do not exist yet are inserted. This is the "SQL Server can do better" the issue anticipated.

The appends join the batch's own transaction, so raised events commit atomically with the documents and progression row they were produced alongside.

### One thing beyond the issue's sketch

The batch configures commands with a null session (every op it carries is expected to be fully bound), so a bare append op threw `requires an executing session`. Worth recording that this intermediate state *was* the issue's "minimum fix" arriving by accident — the silent drop became a loud shard failure. The append now arrives wrapped in a new `SessionBoundOperationAdapter`, which is deliberately **not** an `IDocumentStorageOperation` like `ClosedShapeOperationAdapter`: these write events, not documents, and exposing a `Document` would put them in the batch's `IChangeSet.Updated`/`Inserted` and hand `IChangeListener` implementations a `StreamAction` where they expect a document. Raised events reach listeners through the change set's stream collection instead.

## Tests

Test-first; three fail against the unfixed code:
- `raised_events_are_appended_to_their_stream` — the audit stream did not exist at all
- `the_raised_event_stream_row_is_created_with_the_right_version` — no stream row
- `appends_accumulate_across_batches_on_an_existing_stream` — covers the UPDATE branch on an existing stream
- `a_batch_with_no_raised_events_is_unaffected` — control; passes before and after

Verified on SQL Server 2025: the 4 new tests green, all 110 `Polecat.Tests.Daemon` tests green, and the **full suite 1830 total / 0 failed / 3 skipped** (net10.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pza51JxtP29jgWNAeyEvvM