### PR TITLE
Compliance wave 8: adopt JasperFx 2.45.0, enroll conjoined event tenancy + subscriptions (#429)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -113,15 +113,26 @@
              policy (IEventStore<,>.ContinuousErrors) plus dead-letter reads
              (IEventStore.AllDatabases() -> IEventDatabase.QueryDeadLetterEventsAsync) were already
              shared and already overridden here. Compliance sources only, so again behaviourally
-             inert for the shipping libraries. Same lockstep rule as above. -->
-        <PackageVersion Include="JasperFx" Version="2.44.0" />
-        <PackageVersion Include="JasperFx.Events" Version="2.44.0" />
+             inert for the shipping libraries. Same lockstep rule as above.
+             JasperFx 2.45.0 (jasperfx#642, marten#5148/#5151) — compliance wave 8, the LAST wave:
+             ConjoinedEventTenancyCompliance and SubscriptionCompliance take the library to
+             28 suites / 230 tests and empty the cross-store event sourcing backlog filed under
+             marten#5118. Two seam additions: ComplianceStoreConfig.ConjoinedEventTenancy (a bool
+             the fixture maps onto Events.TenancyStyle) and IComplianceStoreRegistrar.Subscribe
+             (typed as the concrete ComplianceSubscription, because neither product exposes a
+             Subscribe overload taking a shared subscription type). ComplianceSubscription is a
+             partial the library half-owns; Polecat completes it in Polecat.Tests, which — unlike
+             Marten, where two assemblies compile the source-only package — is the only assembly
+             here that does. Compliance sources only, so again behaviourally inert for the
+             shipping libraries. Same lockstep rule as above. -->
+        <PackageVersion Include="JasperFx" Version="2.45.0" />
+        <PackageVersion Include="JasperFx.Events" Version="2.45.0" />
         <!--
              The shared cross-store event sourcing compliance suites. Source-only package: the
              suites compile inside Polecat.Tests so JasperFx's aggregate source generator binds
              Polecat's own session types.
         -->
-        <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.44.0" />
+        <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.45.0" />
         <!-- Pin the sibling JasperFx packages for parity with Marten 9's matrix
              even though Polecat doesn't currently reference them directly —
              keeps the lockstep matrix coherent when transitive resolution
@@ -129,7 +140,7 @@
              RuntimeCompiler 5.x line is the active continuation of the 4.x
              lineage; do not pin against the parallel stale 2.0.x series. -->
         <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.44.0" />
+        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.45.0" />
         <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
@@ -225,7 +236,7 @@
         <PackageVersion Include="StronglyTypedId" Version="1.0.0-beta08" />
 
         <!-- Source generators (matched to JasperFx.Events above) -->
-        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.44.0" />
+        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.45.0" />
 
         <!-- Build automation -->
         <PackageVersion Include="Nuke.Common" Version="9.0.4" />

--- a/src/Polecat.Tests/Compliance/ComplianceSubscription.Polecat.cs
+++ b/src/Polecat.Tests/Compliance/ComplianceSubscription.Polecat.cs
@@ -1,0 +1,43 @@
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Projections;
+using Polecat;
+using Polecat.Subscriptions;
+
+namespace JasperFx.Events.ComplianceTests;
+
+/// <summary>
+///     The Polecat half of the shared <c>ComplianceSubscription</c> partial (compliance wave 8).
+///     The library owns the recording, the locking and the pinned name; each consumer supplies
+///     <c>ProcessEventsAsync</c>, because both products declare an <c>ISubscription</c> with a
+///     member of identical shape but over their own <c>IChangeListener</c> and
+///     <c>IDocumentOperations</c> types, so the signature cannot be written once upstream.
+///     <para>
+///     Lives in <c>Polecat.Tests</c> beside the fixture. Marten had to put its half in
+///     <c>Marten.Testing</c> because two assemblies there compile the source-only package and both
+///     therefore need the completing half; Polecat.Tests is the only assembly here that references
+///     it, so there is no such constraint.
+///     </para>
+///     <para>
+///     Marten's half also supplies <c>ValueTask DisposeAsync() =&gt; default;</c>. Polecat's
+///     <see cref="ISubscription" /> declares only <c>ProcessEventsAsync</c> and its registration
+///     path never asks for disposal, so that member is deliberately not carried across.
+///     </para>
+///     <para>
+///     The namespace is the library's, not Polecat's, because this completes a type the library
+///     declares.
+///     </para>
+/// </summary>
+public partial class ComplianceSubscription : ISubscription
+{
+    public Task<IChangeListener> ProcessEventsAsync(
+        EventRange page,
+        ISubscriptionController controller,
+        IDocumentOperations operations,
+        CancellationToken cancellationToken)
+    {
+        Record(page.Events);
+        // Polecat already ships a public no-op listener for subscriptions that need no commit
+        // hooks, so there is nothing to hand-roll here.
+        return Task.FromResult<IChangeListener>(NullChangeListener.Instance);
+    }
+}

--- a/src/Polecat.Tests/Compliance/PolecatComplianceFixture.cs
+++ b/src/Polecat.Tests/Compliance/PolecatComplianceFixture.cs
@@ -53,6 +53,15 @@ public class PolecatComplianceFixture : EventStoreComplianceFixture<IDocumentSes
             options.Events.EnableHeaders = true;
         }
 
+        // Wave 8: conjoined event tenancy. TenancyStyle is already the shared
+        // JasperFx.MultiTenancy.TenancyStyle (see GlobalUsings), so this is the whole mapping --
+        // opening a tenant-scoped session needs nothing, because OpenSession(IEventDatabase,
+        // tenantId) is already on the shared IEventStore<,>.
+        if (config.ConjoinedEventTenancy)
+        {
+            options.Events.TenancyStyle = TenancyStyle.Conjoined;
+        }
+
         config.ApplyTo(new PolecatComplianceRegistrar(options));
 
         _store = new DocumentStore(options);
@@ -238,6 +247,12 @@ public class PolecatComplianceFixture : EventStoreComplianceFixture<IDocumentSes
 
         public void AddProjection(ProjectionBase projection, ProjectionLifecycle lifecycle)
             => _options.Projections.Add((IProjectionSource<IDocumentSession, IQuerySession>)projection, lifecycle);
+
+        // Wave 8: the name is pinned to ComplianceSubscription.SubscriptionName rather than left to
+        // default, because the products disagree on whether an unnamed subscription takes its short
+        // or full type name and daemon progression is keyed on it.
+        public void Subscribe(ComplianceSubscription subscription)
+            => _options.Projections.Subscribe(subscription, x => x.Name = ComplianceSubscription.SubscriptionName);
     }
 
     internal class PolecatComplianceBatch : IComplianceBatch

--- a/src/Polecat.Tests/Compliance/polecat_event_store_compliance_wave8.cs
+++ b/src/Polecat.Tests/Compliance/polecat_event_store_compliance_wave8.cs
@@ -1,0 +1,14 @@
+using JasperFx.Events.ComplianceTests;
+
+namespace Polecat.Tests.Compliance;
+
+/*
+ * Wave 8 enrollments -- the LAST wave. With these two the cross-store event sourcing compliance
+ * backlog (marten#5118) is empty and Polecat is at exact parity with Marten: 28 suites.
+ */
+
+public class conjoined_event_tenancy_compliance
+    : ConjoinedEventTenancyCompliance<PolecatComplianceFixture, IDocumentSession, IQuerySession>;
+
+public class subscription_compliance
+    : SubscriptionCompliance<PolecatComplianceFixture, IDocumentSession, IQuerySession>;


### PR DESCRIPTION
Closes #429.

**The last wave.** `ConjoinedEventTenancyCompliance` and `SubscriptionCompliance` take Polecat from 26 suites / 216 tests to **28 / 230**, emptying the cross-store event sourcing backlog filed under marten#5118 and putting Polecat back at exact parity with Marten.

## The bump

`JasperFx`, `JasperFx.Events`, `JasperFx.Events.ComplianceTests`, `JasperFx.SourceGenerator` and `JasperFx.Events.SourceGenerator` 2.44.0 → **2.45.0** (jasperfx#642, marten#5148/#5151), with the usual changelog entry in `Directory.Packages.props`.

## The two seams

Both priced from the interfaces as the issue advised, rather than from the backlog text:

- **`ComplianceStoreConfig.ConjoinedEventTenancy`** → `options.Events.TenancyStyle = TenancyStyle.Conjoined`. That is the whole mapping. The issue was right that this suite was **mispriced by its own filing**: marten#5148 called for a tenant-scoped session seam and it needs none, because `OpenSession(IEventDatabase, tenantId)` is already on the shared `IEventStore<,>`.
- **`IComplianceStoreRegistrar.Subscribe`** → `Projections.Subscribe(subscription, x => x.Name = ComplianceSubscription.SubscriptionName)`. The name is pinned rather than defaulted because the products disagree about whether an unnamed subscription takes its short or full type name, and daemon progression is keyed on it.

## Three questions the issue left open, answered for Polecat

The issue flagged each of these as "confirm rather than copy from Marten", and all three came out differently:

1. **Where the partial goes.** Marten had to put its half in `Marten.Testing` because two assemblies there compile the source-only package and both need the completing half. `Polecat.Tests` is the **only** assembly here that references it (verified by grepping the csproj/props for the package and `ComplianceSourceDir`), so the partial lives beside the fixture with no such constraint.
2. **`DisposeAsync`.** Marten's half supplies `ValueTask DisposeAsync() => default;`. Polecat's `ISubscription` declares only `ProcessEventsAsync` and the `Subscribe` path never asks for disposal, so it is deliberately not carried across.
3. **The no-op listener.** Polecat already ships a public `NullChangeListener.Instance` (private ctor, singleton), so `ProcessEventsAsync` returns that instead of a hand-rolled one.

## Verification

Against the **published 2.45.0 package**, not the `ComplianceSourceDir` dev loop.

The anti-false-green check the issue asks for by name — a bump that satisfies a new registrar member is not evidence the suite runs, which is how `StrongTypedIdentityCompliance` shipped 11 unrun tests on the Marten side in wave 6. Diffing the package's `Suites/*.cs` filenames against the declared subclasses:

```
PACKAGE SUITES: 28
ENROLLED:       28
in package, NOT enrolled: (none)
```

- `conjoined_event_tenancy_compliance` **8/8**, `subscription_compliance` **6/6** — 8 + 6 = the 14 the issue predicted (230 − 216).
- Compliance subset: **230/230, zero skips**.
- Full `Polecat.Tests`: **1840 total / 0 failed / 3 skipped** (net10.0), 1840 = the previous 1826 plus these 14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pza51JxtP29jgWNAeyEvvM