### PR TITLE
Delete progression rows by exact identity, never by a prefix LIKE (#436)

### DIFF
--- a/src/Polecat.Tests/Daemon/progression_delete_scoping_tests.cs
+++ b/src/Polecat.Tests/Daemon/progression_delete_scoping_tests.cs
@@ -1,0 +1,313 @@
+using JasperFx;
+using JasperFx.Events;
+using JasperFx.Events.Projections;
+using Polecat.Internal.Operations;
+using Polecat.Projections;
+using Polecat.Tests.Harness;
+
+namespace Polecat.Tests.Daemon;
+
+/// <summary>
+///     polecat#436 (the twin of marten#5179): the three progression-delete paths that take a
+///     projection or subscription NAME — rewind, delete-progress and rebuild teardown — used to run
+///     <c>DELETE ... WHERE name LIKE @name</c> with <c>@name</c> bound to <c>name + "%"</c>. That is
+///     wrong twice over, and each half silently destroys a *different* projection's progression state:
+///     <list type="number">
+///         <item>
+///             <description>
+///                 <c>_</c>, <c>%</c> and <c>[</c> are all legal in a projection name and all three
+///                 are T-SQL <c>LIKE</c> metacharacters, so <c>day_summary</c> matched
+///                 <c>dayXsummary</c> and a bracketed name did not even match itself.
+///             </description>
+///         </item>
+///         <item>
+///             <description>
+///                 A plain prefix sweep on <c>day_summary</c> also took <c>day_summary_v2</c>'s rows,
+///                 with no wildcard involved at all.
+///             </description>
+///         </item>
+///     </list>
+///     Every case below fails on the old predicate and passes on the exact-identity /
+///     <c>':'</c>-anchored-and-escaped one.
+/// </summary>
+[Collection("integration")]
+public class progression_delete_scoping_tests : IntegrationContext
+{
+    public progression_delete_scoping_tests(DefaultStoreFixture fixture) : base(fixture)
+    {
+    }
+
+    private IEventStore<IDocumentSession, IQuerySession> theEventStore => theStore;
+
+    /// <summary>
+    ///     A store with no projection registered under the names being deleted, which is the path that
+    ///     falls back on the anchored pattern — and therefore the one where the escaping has to hold.
+    /// </summary>
+    private async Task WithBareStoreAsync(string schema)
+    {
+        await StoreOptions(opts =>
+        {
+            opts.DatabaseSchemaName = schema;
+            opts.AutoCreateSchemaObjects = AutoCreate.All;
+        });
+
+        await ClearProgressionAsync();
+    }
+
+    [Fact]
+    public async Task delete_progress_leaves_a_sibling_sharing_the_name_prefix_alone()
+    {
+        await WithBareStoreAsync("progdel_sibling");
+
+        var victim = new ShardName("day_summary");        // day_summary:All
+        var sibling = new ShardName("day_summary_v2");    // day_summary_v2:All
+
+        await SeedAsync(victim, 10);
+        await SeedAsync(sibling, 20);
+
+        await theEventStore.DeleteProjectionProgressAsync(theStore.Database, "day_summary",
+            TestContext.Current.CancellationToken);
+
+        await AssertProgressAsync(victim, 0);
+        await AssertProgressAsync(sibling, 20);
+    }
+
+    [Fact]
+    public async Task the_underscore_in_a_name_is_not_treated_as_a_wildcard()
+    {
+        await WithBareStoreAsync("progdel_underscore");
+
+        var victim = new ShardName("day_summary");     // day_summary:All
+        var bystander = new ShardName("dayXsummary");  // dayXsummary:All — matched by an unescaped '_'
+
+        await SeedAsync(victim, 10);
+        await SeedAsync(bystander, 20);
+
+        await theEventStore.DeleteProjectionProgressAsync(theStore.Database, "day_summary",
+            TestContext.Current.CancellationToken);
+
+        await AssertProgressAsync(victim, 0);
+        await AssertProgressAsync(bystander, 20);
+    }
+
+    [Fact]
+    public async Task a_bracket_in_a_name_still_matches_itself()
+    {
+        await WithBareStoreAsync("progdel_bracket");
+
+        // The other direction of the same defect: '[' opens a character class, so the unescaped
+        // pattern "day[s]ummary%" matches "daysummary..." and NOT the rows it was aimed at. The
+        // projection's own progression therefore survived its own teardown.
+        var victim = new ShardName("day[s]ummary");
+        var bystander = new ShardName("daysummary");
+
+        await SeedAsync(victim, 10);
+        await SeedAsync(bystander, 20);
+
+        await theEventStore.DeleteProjectionProgressAsync(theStore.Database, "day[s]ummary",
+            TestContext.Current.CancellationToken);
+
+        await AssertProgressAsync(victim, 0);
+        await AssertProgressAsync(bystander, 20);
+    }
+
+    [Fact]
+    public async Task a_percent_in_a_name_is_not_treated_as_a_wildcard()
+    {
+        await WithBareStoreAsync("progdel_percent");
+
+        var victim = new ShardName("day%summary");
+        var bystander = new ShardName("dayANYTHINGsummary");
+
+        await SeedAsync(victim, 10);
+        await SeedAsync(bystander, 20);
+
+        await theEventStore.DeleteProjectionProgressAsync(theStore.Database, "day%summary",
+            TestContext.Current.CancellationToken);
+
+        await AssertProgressAsync(victim, 0);
+        await AssertProgressAsync(bystander, 20);
+    }
+
+    [Fact]
+    public async Task per_tenant_rows_of_the_named_projection_are_still_deleted()
+    {
+        await WithBareStoreAsync("progdel_tenants");
+
+        // The anchored pattern exists precisely for these: the tenant suffix is not enumerable up
+        // front, so exact identities alone would leave every per-tenant row behind.
+        var shard = new ShardName("day_summary");
+        var acme = shard.ForTenant("acme");        // day_summary:All:acme
+        var globex = shard.ForTenant("globex");    // day_summary:All:globex
+        var sibling = new ShardName("day_summary_v2").ForTenant("acme");
+
+        await SeedAsync(shard, 5);
+        await SeedAsync(acme, 6);
+        await SeedAsync(globex, 7);
+        await SeedAsync(sibling, 8);
+
+        await theEventStore.DeleteProjectionProgressAsync(theStore.Database, "day_summary",
+            TestContext.Current.CancellationToken);
+
+        await AssertProgressAsync(shard, 0);
+        await AssertProgressAsync(acme, 0);
+        await AssertProgressAsync(globex, 0);
+        await AssertProgressAsync(sibling, 8);
+    }
+
+    [Fact]
+    public async Task rewind_to_the_floor_leaves_a_prefix_sibling_alone()
+    {
+        await WithBareStoreAsync("progdel_rewind");
+
+        var victim = new ShardName("day_summary");
+        var sibling = new ShardName("day_summary_v2");
+
+        await SeedAsync(victim, 10);
+        await SeedAsync(sibling, 20);
+
+        // A null/zero floor is the branch that DELETEs rather than re-stamping.
+        await theEventStore.RewindSubscriptionProgressAsync(theStore.Database, "day_summary",
+            TestContext.Current.CancellationToken, null);
+
+        await AssertProgressAsync(victim, 0);
+        await AssertProgressAsync(sibling, 20);
+    }
+
+    [Fact]
+    public async Task rebuild_teardown_leaves_a_prefix_sibling_alone()
+    {
+        await WithBareStoreAsync("progdel_teardown");
+
+        var victim = new ShardName("day_summary");
+        var sibling = new ShardName("day_summary_v2");
+
+        await SeedAsync(victim, 10);
+        await SeedAsync(sibling, 20);
+
+        await theEventStore.TeardownExistingProjectionStateAsync(theStore.Database, "day_summary",
+            TestContext.Current.CancellationToken);
+
+        await AssertProgressAsync(victim, 0);
+        await AssertProgressAsync(sibling, 20);
+    }
+
+    [Fact]
+    public async Task a_registered_projection_is_deleted_by_its_exact_shard_identities()
+    {
+        // Two independently registered async projections whose names share a prefix, which is the
+        // shape the issue reports: tearing "day_summary" down must not touch "day_summary_v2".
+        await StoreOptions(opts =>
+        {
+            opts.DatabaseSchemaName = "progdel_registered";
+            opts.AutoCreateSchemaObjects = AutoCreate.All;
+            opts.Projections.Add(new DaySummaryProjection(), ProjectionLifecycle.Async);
+            opts.Projections.Add(new DaySummaryV2Projection(), ProjectionLifecycle.Async);
+        });
+
+        await ClearProgressionAsync();
+
+        var victim = theStore.Options.Projections.AllShards()
+            .Single(x => x.Name.Name == "day_summary").Name;
+        var sibling = theStore.Options.Projections.AllShards()
+            .Single(x => x.Name.Name == "day_summary_v2").Name;
+
+        await SeedAsync(victim, 10);
+        await SeedAsync(victim.ForTenant("acme"), 11);
+        await SeedAsync(sibling, 20);
+        await SeedAsync(sibling.ForTenant("acme"), 21);
+
+        await theEventStore.DeleteProjectionProgressAsync(theStore.Database, "day_summary",
+            TestContext.Current.CancellationToken);
+
+        await AssertProgressAsync(victim, 0);
+        await AssertProgressAsync(victim.ForTenant("acme"), 0);
+        await AssertProgressAsync(sibling, 20);
+        await AssertProgressAsync(sibling.ForTenant("acme"), 21);
+    }
+
+    [Fact]
+    public async Task an_unknown_name_deletes_nothing_and_does_not_throw()
+    {
+        await WithBareStoreAsync("progdel_unknown");
+
+        var keep = new ShardName("day_summary");
+        await SeedAsync(keep, 10);
+
+        // Teardown and rewind are both run against projections that were removed from the
+        // configuration since they last wrote progress, so an unknown name has to stay a no-op.
+        await Should.NotThrowAsync(theEventStore.DeleteProjectionProgressAsync(theStore.Database,
+            "never_registered", TestContext.Current.CancellationToken));
+
+        await AssertProgressAsync(keep, 10);
+    }
+
+    private async Task ClearProgressionAsync()
+    {
+        await using var conn = await OpenConnectionAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"DELETE FROM {theStore.Events.ProgressionTableName};";
+        await cmd.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+    }
+
+    private async Task AssertProgressAsync(ShardName shard, long expected)
+    {
+        var actual = await theStore.Database.ProjectionProgressFor(shard, TestContext.Current.CancellationToken);
+        actual.ShouldBe(expected, $"progression for '{shard.Identity}'");
+    }
+
+    private async Task SeedAsync(ShardName shardName, long ceiling)
+    {
+        // Seed through the production write path (polecat#323), same as
+        // delete_projection_progress_by_shard_name_tests.
+        var events = theStore.Database.Events;
+        var op = new RecordProgressionOperation(
+            events.ProgressionTableName,
+            shardName.Identity,
+            ceiling,
+            events.EnableExtendedProgressionTracking,
+            upsert: true);
+
+        await using var conn = await OpenConnectionAsync();
+        await using var batch = new Microsoft.Data.SqlClient.SqlBatch(conn);
+        var builder = new Weasel.SqlServer.BatchBuilder(batch);
+        op.ConfigureCommand(builder);
+        builder.Compile();
+        await using var reader = await batch.ExecuteReaderAsync(TestContext.Current.CancellationToken);
+        await op.PostprocessAsync(reader, new List<Exception>(), TestContext.Current.CancellationToken);
+    }
+}
+
+public class DaySummary
+{
+    public Guid Id { get; set; }
+    public int Count { get; set; }
+}
+
+public class DaySummaryV2
+{
+    public Guid Id { get; set; }
+    public int Count { get; set; }
+}
+
+public partial class DaySummaryProjection : SingleStreamProjection<DaySummary, Guid>
+{
+    public DaySummaryProjection()
+    {
+        Name = "day_summary";
+    }
+
+    public void Apply(DaySummaryCounted e, DaySummary view) => view.Count++;
+}
+
+public partial class DaySummaryV2Projection : SingleStreamProjection<DaySummaryV2, Guid>
+{
+    public DaySummaryV2Projection()
+    {
+        Name = "day_summary_v2";
+    }
+
+    public void Apply(DaySummaryCounted e, DaySummaryV2 view) => view.Count++;
+}
+
+public record DaySummaryCounted(int Amount);

--- a/src/Polecat/DocumentStore.EventStore.cs
+++ b/src/Polecat/DocumentStore.EventStore.cs
@@ -410,21 +410,86 @@ public partial class DocumentStore : IEventStore<IDocumentSession, IQuerySession
         return database is PolecatDatabase pdb ? pdb.ConnectionString : options.ConnectionString;
     }
 
+    /// <summary>
+    ///     The <see cref="ShardName" />s whose progression rows belong to <paramref name="subscriptionName" />
+    ///     — the registered shards of a projection or subscription, matched either by its name or by an
+    ///     exact shard identity. Empty when nothing is registered under that name.
+    /// </summary>
+    /// <remarks>
+    ///     polecat#436: this is the enumeration the three progression-delete paths lacked, and the reason
+    ///     they fell back on a prefix <c>LIKE</c>. It mirrors Marten's
+    ///     <c>DocumentStore.EventStore.RewindSubscriptionProgressAsync</c>/<c>DeleteProjectionProgressAsync</c>,
+    ///     which delete <c>agent.Name.Identity</c> per registered shard. Identities are only ever read off
+    ///     <see cref="ShardName.Identity" /> — the grammar has versioned and per-tenant forms
+    ///     (<c>Name:V2:All:tenant</c>) that string surgery gets wrong.
+    /// </remarks>
+    private ShardName[] ProgressionShardsFor(string subscriptionName)
+    {
+        // AllShards() spans async projections AND subscriptions, so this covers both callers of
+        // RewindSubscriptionProgressAsync. Matching on Identity as well as Name lets a caller name a
+        // single shard without dragging in its siblings.
+        var shards = Options.Projections.AllShards()
+            .Where(x => string.Equals(x.Name.Name, subscriptionName, StringComparison.OrdinalIgnoreCase)
+                        || x.Name.Identity == subscriptionName)
+            .Select(x => x.Name)
+            .ToArray();
+
+        if (shards.Length > 0)
+        {
+            return shards;
+        }
+
+        // Inline and Live projections are absent from AllShards() (it is async-only), but Polecat still
+        // tears their progression down around a rebuild — ask the source itself for its shards.
+        if (Options.Projections.TryFindProjection(subscriptionName, out var source))
+        {
+            return source.Shards().Select(x => x.Name).ToArray();
+        }
+
+        return [];
+    }
+
+    /// <summary>
+    ///     The <c>WHERE</c> predicate + parameters selecting exactly the progression rows owned by
+    ///     <paramref name="subscriptionName" />. See <see cref="ProgressionNameFilter" /> for why a bare
+    ///     prefix <c>LIKE</c> is never one of the options (polecat#436, twin of marten#5179).
+    /// </summary>
+    private (string Where, IReadOnlyList<KeyValuePair<string, string>> Parameters) ProgressionFilterFor(
+        string subscriptionName)
+    {
+        var shards = ProgressionShardsFor(subscriptionName);
+
+        // Registered → exact identities (plus each one's per-tenant rows, which are not enumerable).
+        // Unregistered → the name itself, where only the ':'-anchored, escaped pattern can match; an
+        // unknown name has to stay a no-op rather than an error, because teardown/rewind are also run
+        // against projections that were removed from the configuration since they last wrote progress.
+        var roots = shards.Length > 0
+            ? shards.Select(x => x.Identity).Distinct().ToArray()
+            : [subscriptionName];
+
+        return ProgressionNameFilter.For(roots);
+    }
+
     async Task IEventStore<IDocumentSession, IQuerySession>.RewindSubscriptionProgressAsync(
         IEventDatabase database, string subscriptionName, CancellationToken token, long? sequenceFloor)
     {
         var connStr = ResolveConnectionString(database, Options);
+        var filter = ProgressionFilterFor(subscriptionName);
         await Options.ResiliencePipeline.ExecuteAsync(static async (state, ct) =>
         {
-            var (connString, progressionTable, name, seqFloor) = state;
+            var (connString, progressionTable, name, seqFloor, where, filterParameters) = state;
             await using var conn = new SqlConnection(connString);
             await conn.OpenAsync(ct);
 
             if (seqFloor is null or 0)
             {
                 await using var cmd = conn.CreateCommand();
-                cmd.CommandText = $"DELETE FROM {progressionTable} WHERE name LIKE @name;";
-                cmd.Parameters.AddVarChar("@name", name + "%");
+                cmd.CommandText = $"DELETE FROM {progressionTable} WHERE {where};";
+                foreach (var parameter in filterParameters)
+                {
+                    cmd.Parameters.AddVarChar(parameter.Key, parameter.Value);
+                }
+
                 await cmd.ExecuteNonQueryAsync(ct);
             }
             else
@@ -441,7 +506,8 @@ public partial class DocumentStore : IEventStore<IDocumentSession, IQuerySession
                 cmd.Parameters.AddWithValue("@seq", seqFloor.Value);
                 await cmd.ExecuteNonQueryAsync(ct);
             }
-        }, (connStr, Events.ProgressionTableName, subscriptionName, sequenceFloor), token);
+        }, (connStr, Events.ProgressionTableName, subscriptionName, sequenceFloor, filter.Where,
+            filter.Parameters), token);
     }
 
     async Task IEventStore<IDocumentSession, IQuerySession>.RewindAgentProgressAsync(
@@ -482,17 +548,22 @@ public partial class DocumentStore : IEventStore<IDocumentSession, IQuerySession
         IEventDatabase database, string subscriptionName, CancellationToken token)
     {
         var connStr = ResolveConnectionString(database, Options);
+        var filter = ProgressionFilterFor(subscriptionName);
         await Options.ResiliencePipeline.ExecuteAsync(static async (state, ct) =>
         {
-            var (connString, progressionTable, name) = state;
+            var (connString, progressionTable, where, filterParameters) = state;
             await using var conn = new SqlConnection(connString);
             await conn.OpenAsync(ct);
 
             await using var cmd = conn.CreateCommand();
-            cmd.CommandText = $"DELETE FROM {progressionTable} WHERE name LIKE @name;";
-            cmd.Parameters.AddVarChar("@name", name + "%");
+            cmd.CommandText = $"DELETE FROM {progressionTable} WHERE {where};";
+            foreach (var parameter in filterParameters)
+            {
+                cmd.Parameters.AddVarChar(parameter.Key, parameter.Value);
+            }
+
             await cmd.ExecuteNonQueryAsync(ct);
-        }, (connStr, Events.ProgressionTableName, subscriptionName), token);
+        }, (connStr, Events.ProgressionTableName, filter.Where, filter.Parameters), token);
     }
 
     // #163 Phase 2 — per-tenant rebuild teardown (jasperfx#407 Phase 2b). A non-null tenantId scopes the
@@ -655,15 +726,21 @@ public partial class DocumentStore : IEventStore<IDocumentSession, IQuerySession
             publishedTableNames = tables.Distinct().ToArray();
         }
 
+        var filter = ProgressionFilterFor(subscriptionName);
+
         await Options.ResiliencePipeline.ExecuteAsync(static async (state, ct) =>
         {
-            var (connString, progressionTable, name, tableNames) = state;
+            var (connString, progressionTable, where, filterParameters, tableNames) = state;
             await using var conn = new SqlConnection(connString);
             await conn.OpenAsync(ct);
 
             await using var cmd = conn.CreateCommand();
-            cmd.CommandText = $"DELETE FROM {progressionTable} WHERE name LIKE @name;";
-            cmd.Parameters.AddVarChar("@name", name + "%");
+            cmd.CommandText = $"DELETE FROM {progressionTable} WHERE {where};";
+            foreach (var parameter in filterParameters)
+            {
+                cmd.Parameters.AddVarChar(parameter.Key, parameter.Value);
+            }
+
             await cmd.ExecuteNonQueryAsync(ct);
 
             foreach (var tableName in tableNames)
@@ -672,6 +749,7 @@ public partial class DocumentStore : IEventStore<IDocumentSession, IQuerySession
                 truncCmd.CommandText = $"DELETE FROM {tableName};";
                 await truncCmd.ExecuteNonQueryAsync(ct);
             }
-        }, (connStr, Events.ProgressionTableName, subscriptionName, publishedTableNames), token);
+        }, (connStr, Events.ProgressionTableName, filter.Where, filter.Parameters, publishedTableNames),
+            token);
     }
 }

--- a/src/Polecat/Internal/ProgressionNameFilter.cs
+++ b/src/Polecat/Internal/ProgressionNameFilter.cs
@@ -1,0 +1,127 @@
+using System.Text;
+
+namespace Polecat.Internal;
+
+/// <summary>
+///     Builds the <c>WHERE</c> predicate that selects exactly one projection's or subscription's rows
+///     in <c>pc_event_progression</c>, and nothing else (polecat#436, the twin of marten#5179).
+/// </summary>
+/// <remarks>
+///     <para>
+///         The predicate this replaces was <c>name LIKE @name</c> with <c>@name</c> bound to
+///         <c>subscriptionName + "%"</c>. That is wrong twice over, and both halves delete another
+///         projection's progression state — silently, and in a way a rebuild cannot undo:
+///     </para>
+///     <list type="number">
+///         <item>
+///             <description>
+///                 <b>Unescaped wildcards.</b> <c>%</c>, <c>_</c> and <c>[</c> are all legal in a
+///                 projection name and all three are T-SQL <c>LIKE</c> metacharacters. A projection
+///                 named <c>day_summary</c> matches <c>dayXsummary</c> through the <c>_</c>; a name
+///                 carrying <c>[</c> opens a character class and matches something else entirely.
+///             </description>
+///         </item>
+///         <item>
+///             <description>
+///                 <b>Prefix over-match even with no wildcards at all.</b> A bare prefix on
+///                 <c>day_summary</c> also sweeps <c>day_summary_v2</c> — a different, independently
+///                 registered projection.
+///             </description>
+///         </item>
+///     </list>
+///     <para>
+///         So every root here is matched with <b>exact equality</b> first, and the only pattern in
+///         play is anchored on the <c>:</c> that separates the slots of the shard grammar
+///         (<c>Name:ShardKey</c> / <c>Name:V{n}:ShardKey</c> / either of those plus <c>:Tenant</c>),
+///         with the wildcards escaped. <c>day_summary</c> therefore never reaches
+///         <c>day_summary_v2</c>: the anchor demands a literal <c>:</c> exactly where the sibling
+///         has a <c>_</c>.
+///     </para>
+///     <para>
+///         The pattern exists only because per-tenant rows are not enumerable: the registered shards
+///         are store-global (<c>Trip:All</c>) while the persisted rows carry a tenant Polecat cannot
+///         know up front (<c>Trip:All:acme</c>). The roots themselves are always
+///         <see cref="JasperFx.Events.Projections.ShardName.Identity" /> values produced by
+///         <c>ShardName</c> — never a hand-composed identity — and appending <c>":%"</c> to one is
+///         building a <em>pattern</em>, not an identity.
+///     </para>
+/// </remarks>
+internal static class ProgressionNameFilter
+{
+    /// <summary>
+    ///     The <c>ESCAPE</c> character used by every pattern this type emits. Backslash has no
+    ///     special meaning in a T-SQL string literal, so it needs no escaping of its own in the SQL
+    ///     text — only in the bound pattern value, which <see cref="EscapeLikePattern" /> handles.
+    /// </summary>
+    public const char LikeEscapeCharacter = '\\';
+
+    /// <summary>
+    ///     Neutralize every T-SQL <c>LIKE</c> metacharacter in <paramref name="value" /> so the
+    ///     result matches only itself, literally, under <c>ESCAPE '\'</c>.
+    /// </summary>
+    /// <remarks>
+    ///     The set is <c>%</c> (any run), <c>_</c> (any single character), <c>[</c> (opens a
+    ///     character class) and the escape character itself. A closing <c>]</c> outside a class is
+    ///     an ordinary character in T-SQL and is deliberately left alone; escaping it would be
+    ///     harmless but implies a symmetry the grammar does not have.
+    /// </remarks>
+    public static string EscapeLikePattern(string value)
+    {
+        var builder = new StringBuilder(value.Length + 8);
+        foreach (var c in value)
+        {
+            if (c is '%' or '_' or '[' or LikeEscapeCharacter)
+            {
+                builder.Append(LikeEscapeCharacter);
+            }
+
+            builder.Append(c);
+        }
+
+        return builder.ToString();
+    }
+
+    /// <summary>
+    ///     Compose the predicate — and the parameters it binds — matching each root exactly, plus
+    ///     that root's per-tenant descendants (<c>{root}:{tenant}</c>).
+    /// </summary>
+    /// <param name="roots">
+    ///     Either the exact <c>ShardName.Identity</c> of every registered shard of the projection
+    ///     (the preferred, Marten-equivalent form), or — when nothing is registered under the name —
+    ///     the projection/subscription name itself, in which case the anchored pattern is what picks
+    ///     up its <c>{name}:{shardKey}</c> rows.
+    /// </param>
+    /// <returns>
+    ///     A predicate suitable for <c>DELETE FROM {table} WHERE {Where}</c> and the varchar
+    ///     parameters it references. An empty <paramref name="roots" /> yields a predicate that
+    ///     matches nothing — deleting nothing is the only safe reading of "no rows were named".
+    /// </returns>
+    public static (string Where, IReadOnlyList<KeyValuePair<string, string>> Parameters) For(
+        IReadOnlyList<string> roots)
+    {
+        if (roots.Count == 0)
+        {
+            return ("1 = 0", []);
+        }
+
+        var clauses = new List<string>(roots.Count);
+        var parameters = new List<KeyValuePair<string, string>>(roots.Count * 2);
+
+        for (var i = 0; i < roots.Count; i++)
+        {
+            var exact = $"@progression_exact{i}";
+            var pattern = $"@progression_pattern{i}";
+
+            clauses.Add($"(name = {exact} OR name LIKE {pattern} ESCAPE '{LikeEscapeCharacter}')");
+
+            parameters.Add(new KeyValuePair<string, string>(exact, roots[i]));
+
+            // Anchored on the shard grammar's ':' separator: matches this root's tenant-scoped
+            // (and, for a bare projection name, shard- and version-scoped) rows, and can never
+            // reach a sibling whose name merely starts with the same characters.
+            parameters.Add(new KeyValuePair<string, string>(pattern, EscapeLikePattern(roots[i]) + ":%"));
+        }
+
+        return (string.Join(" OR ", clauses), parameters);
+    }
+}


### PR DESCRIPTION
Closes #436.

Three sites ran `DELETE FROM pc_event_progression WHERE name LIKE @name` with `@name` bound to `subscriptionName + "%"` — `RewindSubscriptionProgressAsync`, `DeleteProjectionProgressAsync` and the rebuild teardown. That is wrong twice over, and **each half silently destroys a different projection's progression state**, in a way a rebuild cannot undo.

**Unescaped wildcards.** `_`, `%` and `[` are all legal in a projection name and all three are T-SQL `LIKE` metacharacters. `day_summary` matched `dayXsummary` through the `_`; a name carrying a `[` opened a character class, so `day[s]ummary` matched `daysummary` and *did not match itself* — that projection's own teardown left its own rows behind.

**Prefix over-match with no wildcard at all.** A bare prefix sweep on `day_summary` also took `day_summary_v2`'s rows.

Marten doesn't have this class of bug because it deletes exact shard identities per registered shard, and Polecat's own `DeleteProjectionProgressByShardNameAsync` already carries a comment naming precisely this hazard — the exact-identity path existed, these three sites just didn't use it. marten#5179 is the wildcard-lesson twin.

### The fix

Every root is matched with **exact equality**, and the only pattern left is anchored on the `:` that separates the slots of the shard grammar (`Name:ShardKey` / `Name:V{n}:ShardKey`, either plus `:Tenant`) with the wildcards escaped under `ESCAPE '\'`. `day_summary` therefore cannot reach `day_summary_v2`: the anchor demands a literal `:` exactly where the sibling has a `_`.

The pattern is still needed because per-tenant rows are not enumerable — the registered shards are store-global (`Trip:All`) while the persisted rows carry a tenant Polecat cannot know up front (`Trip:All:acme`).

Roots come from the projection's registered shards where there are any (`ShardName.Identity`, never hand-composed), and otherwise from the subscription name itself. An **unknown name stays a no-op** rather than an error, because teardown and rewind are also run against projections that were removed from the configuration since they last wrote progress.

### Tests

`progression_delete_scoping_tests` — 9 cases, all of which fail on the old predicate:

- sibling sharing the name prefix (`day_summary` / `day_summary_v2`) across all three paths
- `_` and `%` in a name not treated as wildcards
- `[` in a name still matching itself
- per-tenant rows of the named projection still deleted
- a registered projection deleted by its exact shard identities, sibling untouched
- an unknown name deletes nothing and doesn't throw

Full local suite green on this branch's base (1851 passed / 0 failed / 3 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VGv25AmDKnNu5mqtRQEn36