### PR TITLE
Retire the previous natural key row when the key changes (#435)

### DIFF
--- a/src/Polecat.Tests/Events/Bug_435_natural_key_retire.cs
+++ b/src/Polecat.Tests/Events/Bug_435_natural_key_retire.cs
@@ -1,0 +1,306 @@
+using JasperFx;
+using JasperFx.Events;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Projections;
+using Microsoft.Data.SqlClient;
+using Polecat.Projections;
+using Polecat.TestUtils;
+using Shouldly;
+
+namespace Polecat.Tests.Events;
+
+/// <summary>
+///     polecat#435 (parity with marten#5041/#5044): a stream has exactly one <em>current</em> natural
+///     key, but <c>NaturalKeyProjection</c> only ever upserted. An event that renamed an aggregate
+///     therefore left the row carrying the previous value behind, still pointing at the same stream, so
+///     three things went wrong at once — the superseded alias kept resolving forever, the table
+///     accumulated one dead row per rename, and (because <c>natural_key_value</c> is the primary key)
+///     the retired value permanently squatted on its slot so no other stream could ever claim it.
+///     <para>
+///         The fix queues a stream-scoped retire ahead of each upsert. Reuses the
+///         OrderAggregate/OrderNumber/Nk* types from <c>natural_key_tests.cs</c>.
+///     </para>
+/// </summary>
+public class Bug_435_natural_key_retire : IAsyncLifetime
+{
+    private const string Schema = "natural_key_retire";
+    private const string Table = "pc_natural_key_orderaggregate";
+
+    public async ValueTask InitializeAsync() => await DropSchemaTablesAsync(Schema);
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+    private static DocumentStore CreateStore()
+    {
+        return DocumentStore.For(opts =>
+        {
+            opts.ConnectionString = ConnectionSource.ConnectionString;
+            opts.DatabaseSchemaName = Schema;
+            opts.AutoCreateSchemaObjects = AutoCreate.All;
+            opts.UseNativeJsonType = ConnectionSource.SupportsNativeJson;
+            opts.Projections.Add<SingleStreamProjection<OrderAggregate, Guid>>(ProjectionLifecycle.Inline);
+        });
+    }
+
+    [Fact]
+    public async Task the_superseded_key_stops_resolving_and_its_row_is_gone()
+    {
+        using var store = CreateStore();
+
+        var streamId = Guid.NewGuid();
+        var oldKey = new OrderNumber("ORD-OLD");
+        var newKey = new OrderNumber("ORD-NEW");
+
+        await using (var session = store.LightweightSession())
+        {
+            session.Events.StartStream(streamId, new NkOrderCreated(oldKey, "Eve"));
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        (await KeysAsync()).ShouldBe(["ORD-OLD"]);
+
+        await using (var session = store.LightweightSession())
+        {
+            var stream = await session.Events.FetchForWriting<OrderAggregate, OrderNumber>(oldKey,
+                TestContext.Current.CancellationToken);
+            stream.AppendOne(new NkOrderNumberChanged(newKey));
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        // One row, carrying only the current value.
+        (await KeysAsync()).ShouldBe(["ORD-NEW"]);
+
+        await using (var query = store.LightweightSession())
+        {
+            var byNew = await query.Events.FetchForWriting<OrderAggregate, OrderNumber>(newKey,
+                TestContext.Current.CancellationToken);
+            byNew.Id.ShouldBe(streamId);
+
+            await Should.ThrowAsync<InvalidOperationException>(
+                query.Events.FetchForWriting<OrderAggregate, OrderNumber>(oldKey,
+                    TestContext.Current.CancellationToken));
+        }
+    }
+
+    [Fact]
+    public async Task a_retired_key_can_be_claimed_by_another_stream()
+    {
+        // The sharpest consequence of the leak: natural_key_value is the PRIMARY KEY, so a value that
+        // was never retired is unavailable to every other stream for the life of the table.
+        using var store = CreateStore();
+
+        var first = Guid.NewGuid();
+        var second = Guid.NewGuid();
+        var contested = new OrderNumber("ORD-CONTESTED");
+
+        await using (var session = store.LightweightSession())
+        {
+            session.Events.StartStream(first, new NkOrderCreated(contested, "Eve"));
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using (var session = store.LightweightSession())
+        {
+            var stream = await session.Events.FetchForWriting<OrderAggregate, OrderNumber>(contested,
+                TestContext.Current.CancellationToken);
+            stream.AppendOne(new NkOrderNumberChanged(new OrderNumber("ORD-RENAMED")));
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        // The second stream takes the value the first one gave up.
+        await using (var session = store.LightweightSession())
+        {
+            session.Events.StartStream(second, new NkOrderCreated(contested, "Mallory"));
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using (var query = store.LightweightSession())
+        {
+            var resolved = await query.Events.FetchForWriting<OrderAggregate, OrderNumber>(contested,
+                TestContext.Current.CancellationToken);
+            resolved.Id.ShouldBe(second);
+        }
+    }
+
+    [Fact]
+    public async Task repeated_renames_never_accumulate_dead_rows()
+    {
+        using var store = CreateStore();
+
+        var streamId = Guid.NewGuid();
+        await using (var session = store.LightweightSession())
+        {
+            session.Events.StartStream(streamId, new NkOrderCreated(new OrderNumber("ORD-0"), "Eve"));
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        for (var i = 1; i <= 4; i++)
+        {
+            await using var session = store.LightweightSession();
+            var stream = await session.Events.FetchForWriting<OrderAggregate, OrderNumber>(
+                new OrderNumber($"ORD-{i - 1}"), TestContext.Current.CancellationToken);
+            stream.AppendOne(new NkOrderNumberChanged(new OrderNumber($"ORD-{i}")));
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        (await KeysAsync()).ShouldBe(["ORD-4"]);
+    }
+
+    [Fact]
+    public async Task a_create_then_rename_in_one_batch_lands_on_the_newest_value()
+    {
+        // Ordering check: retire and upsert are queued in pairs, so the LAST pair in the batch wins.
+        // A retire that ran after its own upsert, or a batch that reordered them, would leave the
+        // table empty or holding the intermediate value.
+        using var store = CreateStore();
+
+        var streamId = Guid.NewGuid();
+        await using (var session = store.LightweightSession())
+        {
+            session.Events.StartStream(streamId,
+                new NkOrderCreated(new OrderNumber("ORD-FIRST"), "Eve"),
+                new NkOrderNumberChanged(new OrderNumber("ORD-SECOND")),
+                new NkOrderNumberChanged(new OrderNumber("ORD-THIRD")));
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        (await KeysAsync()).ShouldBe(["ORD-THIRD"]);
+
+        await using var query = store.LightweightSession();
+        var resolved = await query.Events.FetchForWriting<OrderAggregate, OrderNumber>(
+            new OrderNumber("ORD-THIRD"), TestContext.Current.CancellationToken);
+        resolved.Id.ShouldBe(streamId);
+    }
+
+    [Fact]
+    public async Task another_streams_key_is_never_retired()
+    {
+        // The delete is scoped to the renaming stream. A value legitimately owned by a different
+        // stream must survive, whatever the renamer does.
+        using var store = CreateStore();
+
+        var mine = Guid.NewGuid();
+        var theirs = Guid.NewGuid();
+
+        await using (var session = store.LightweightSession())
+        {
+            session.Events.StartStream(mine, new NkOrderCreated(new OrderNumber("ORD-MINE"), "Eve"));
+            session.Events.StartStream(theirs, new NkOrderCreated(new OrderNumber("ORD-THEIRS"), "Bob"));
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using (var session = store.LightweightSession())
+        {
+            var stream = await session.Events.FetchForWriting<OrderAggregate, OrderNumber>(
+                new OrderNumber("ORD-MINE"), TestContext.Current.CancellationToken);
+            stream.AppendOne(new NkOrderNumberChanged(new OrderNumber("ORD-MINE-2")));
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        (await KeysAsync()).ShouldBe(["ORD-MINE-2", "ORD-THEIRS"]);
+
+        await using var query = store.LightweightSession();
+        var resolved = await query.Events.FetchForWriting<OrderAggregate, OrderNumber>(
+            new OrderNumber("ORD-THEIRS"), TestContext.Current.CancellationToken);
+        resolved.Id.ShouldBe(theirs);
+    }
+
+    [Fact]
+    public async Task a_rebuild_reproduces_only_the_current_key()
+    {
+        // #259 established that a rebuild replays through the same operation builder. Without the
+        // retire it therefore reproduced exactly the same set of dead rows after teardown.
+        using var store = CreateStore();
+
+        var streamId = Guid.NewGuid();
+        await using (var session = store.LightweightSession())
+        {
+            session.Events.StartStream(streamId, new NkOrderCreated(new OrderNumber("ORD-A"), "Eve"));
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using (var session = store.LightweightSession())
+        {
+            var stream = await session.Events.FetchForWriting<OrderAggregate, OrderNumber>(
+                new OrderNumber("ORD-A"), TestContext.Current.CancellationToken);
+            stream.AppendOne(new NkOrderNumberChanged(new OrderNumber("ORD-B")));
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        using var daemon = (IProjectionDaemon)await store.BuildProjectionDaemonAsync();
+        var projectionName = store.Options.Projections.All.Single().Name;
+        await daemon.RebuildProjectionAsync(projectionName, CancellationToken.None);
+
+        (await KeysAsync()).ShouldBe(["ORD-B"]);
+
+        await using var query = store.LightweightSession();
+        (await query.Events.FetchForWriting<OrderAggregate, OrderNumber>(new OrderNumber("ORD-B"),
+            TestContext.Current.CancellationToken)).Id.ShouldBe(streamId);
+    }
+
+    [Fact]
+    public async Task archiving_a_stream_does_not_retire_its_row()
+    {
+        // The retire is queued only alongside an upsert, so the archive path is untouched: an archived
+        // stream keeps its lookup row rather than losing it. (Whether that row also ends up flagged
+        // is_archived is the separate concern of the NaturalKeyArchiveOperation path and is not
+        // asserted here — #435 only widened the upsert path.)
+        using var store = CreateStore();
+
+        var streamId = Guid.NewGuid();
+        await using (var session = store.LightweightSession())
+        {
+            session.Events.StartStream(streamId, new NkOrderCreated(new OrderNumber("ORD-ARCH"), "Eve"));
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using (var session = store.LightweightSession())
+        {
+            session.Events.ArchiveStream(streamId);
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        (await KeysAsync()).ShouldBe(["ORD-ARCH"]);
+    }
+
+    private static async Task<string[]> KeysAsync()
+    {
+        await using var conn = new SqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"SELECT natural_key_value FROM [{Schema}].[{Table}] ORDER BY natural_key_value;";
+        await using var reader = await cmd.ExecuteReaderAsync();
+
+        var keys = new List<string>();
+        while (await reader.ReadAsync())
+        {
+            keys.Add(reader.GetString(0));
+        }
+
+        return keys.ToArray();
+    }
+
+
+    private static async Task DropSchemaTablesAsync(string schema)
+    {
+        await using var conn = new SqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = """
+            DECLARE @sql nvarchar(max) = N'';
+            SELECT @sql = @sql + 'ALTER TABLE [' + s.name + '].[' + t.name + '] DROP CONSTRAINT [' + fk.name + '];'
+            FROM sys.foreign_keys fk
+            JOIN sys.tables t ON fk.parent_object_id = t.object_id
+            JOIN sys.schemas s ON t.schema_id = s.schema_id
+            WHERE s.name = @schema;
+
+            SELECT @sql = @sql + 'DROP TABLE [' + s.name + '].[' + t.name + '];'
+            FROM sys.tables t
+            JOIN sys.schemas s ON t.schema_id = s.schema_id
+            WHERE s.name = @schema;
+            EXEC sp_executesql @sql;
+            """;
+        cmd.Parameters.AddWithValue("@schema", schema);
+        await cmd.ExecuteNonQueryAsync();
+    }
+}

--- a/src/Polecat.Tests/Events/natural_key_tests.cs
+++ b/src/Polecat.Tests/Events/natural_key_tests.cs
@@ -252,12 +252,16 @@ public class natural_key_inline_guid_tests : OneOffConfigurationsContext
             byNewKey.Id.ShouldBe(streamId);
         }
 
-        // Fetch by old key still works because the old mapping row persists
+        // #435 / marten#5041: the superseded key no longer resolves. This block previously asserted the
+        // opposite — "fetch by old key still works because the old mapping row persists" — which pinned
+        // the defect rather than the intent: a stream has exactly one *current* natural key, and leaving
+        // the old row behind meant the retired alias resolved forever while permanently occupying its
+        // slot in pc_natural_key_X's primary key, so no other stream could ever claim it.
         {
             await using var session4 = theStore.LightweightSession();
-            var byOldKey = await session4.Events.FetchForWriting<OrderAggregate, OrderNumber>(originalKey, TestContext.Current.CancellationToken);
-            byOldKey.Aggregate.ShouldNotBeNull();
-            byOldKey.Id.ShouldBe(streamId);
+            await Should.ThrowAsync<InvalidOperationException>(
+                session4.Events.FetchForWriting<OrderAggregate, OrderNumber>(originalKey,
+                    TestContext.Current.CancellationToken));
         }
     }
 

--- a/src/Polecat/Events/Projections/NaturalKeyProjection.cs
+++ b/src/Polecat/Events/Projections/NaturalKeyProjection.cs
@@ -105,6 +105,15 @@ internal class NaturalKeyProjection : IInlineProjection<IDocumentSession>
         var unwrapped = _definition.Unwrap(naturalKeyValue);
         if (unwrapped == null) return;
 
+        // #435 / marten#5041: retire any OTHER key this stream still owns before writing the current
+        // one. The upsert below only ever MERGEs, so without this a renamed aggregate leaves its
+        // previous value behind — still resolving to the same stream, and permanently occupying that
+        // slot in the primary key. Queued ahead of the upsert; WorkTracker preserves order, so a
+        // create-then-rename inside one SaveChangesAsync still lands on the newest value.
+        sessionBase.WorkTracker.Add(
+            new NaturalKeyRetireOperation(_qualifiedTableName, unwrapped, streamId, _isGuidStream,
+                _isConjoined, tenantId));
+
         sessionBase.WorkTracker.Add(
             new NaturalKeyUpsertOperation(_qualifiedTableName, unwrapped, streamId, _isGuidStream,
                 _isConjoined, tenantId));

--- a/src/Polecat/Events/Projections/NaturalKeyRetireOperation.cs
+++ b/src/Polecat/Events/Projections/NaturalKeyRetireOperation.cs
@@ -1,0 +1,82 @@
+using System.Data.Common;
+using Polecat.Internal;
+using Weasel.Core;
+using Weasel.SqlServer;
+
+namespace Polecat.Events.Projections;
+
+/// <summary>
+///     Retires every <c>pc_natural_key_{type}</c> row that maps a natural key to this stream
+///     <em>other</em> than the one the accompanying upsert is about to write (polecat#435, the twin of
+///     marten#5041/#5044).
+/// </summary>
+/// <remarks>
+///     <para>
+///         A stream has exactly one <em>current</em> natural key, but
+///         <see cref="NaturalKeyUpsertOperation" /> only ever MERGEs. When an event changes the key,
+///         the row carrying the previous value stays behind still pointing at the same stream, so
+///         <c>FetchForWriting</c>-by-natural-key keeps resolving the superseded alias, the table
+///         accumulates one dead row per rename, and — because <c>natural_key_value</c> is the primary
+///         key — the retired value permanently squats on its slot so no other stream can ever claim it.
+///     </para>
+///     <para>
+///         The delete is scoped to this stream (and tenant, when conjoined) so a key legitimately owned
+///         by some <em>other</em> stream is never touched, and it is queued immediately ahead of the
+///         upsert. <c>WorkTracker</c> preserves insertion order and the session flushes its operations
+///         in that order, so a create-then-rename inside a single <c>SaveChangesAsync</c> still lands on
+///         the newest value: each retire only ever clears values that differ from the one its own
+///         upsert is about to write.
+///     </para>
+///     <para>
+///         The rebuild path gets this for free — it shares
+///         <c>NaturalKeyProjection.QueueOperationForEvent</c> with the inline append path — which
+///         matters because a rebuild replays the same rename sequence and would otherwise reproduce
+///         exactly the same set of dead rows after teardown.
+///     </para>
+/// </remarks>
+internal class NaturalKeyRetireOperation : Polecat.Internal.IStorageOperation
+{
+    private readonly string _tableName;
+    private readonly object _currentNaturalKeyValue;
+    private readonly object _streamId;
+    private readonly bool _isGuidStream;
+    private readonly bool _isConjoined;
+    private readonly string? _tenantId;
+
+    public NaturalKeyRetireOperation(string tableName, object currentNaturalKeyValue, object streamId,
+        bool isGuidStream, bool isConjoined = false, string? tenantId = null)
+    {
+        _tableName = tableName;
+        _currentNaturalKeyValue = currentNaturalKeyValue;
+        _streamId = streamId;
+        _isGuidStream = isGuidStream;
+        _isConjoined = isConjoined;
+        _tenantId = tenantId;
+    }
+
+    public Type DocumentType => typeof(object);
+    public OperationRole Role() => OperationRole.Deletion;
+
+    public void ConfigureCommand(ICommandBuilder builder)
+    {
+        var streamColumn = _isGuidStream ? "stream_id" : "stream_key";
+
+        builder.Append($"DELETE FROM {_tableName} WHERE {streamColumn} = ");
+        // #363: a string stream key must bind varchar to seek the varchar(250) stream_key column.
+        builder.AppendParameter(_streamId, _streamId is string ? System.Data.SqlDbType.VarChar : null);
+
+        if (_isConjoined)
+        {
+            builder.Append(" AND tenant_id = ");
+            builder.AppendParameter(_tenantId!, System.Data.SqlDbType.VarChar);
+        }
+
+        builder.Append(" AND natural_key_value <> ");
+        builder.AppendParameter(_currentNaturalKeyValue);
+
+        builder.Append(";");
+    }
+
+    public Task PostprocessAsync(DbDataReader reader, IList<Exception> exceptions, CancellationToken token)
+        => Task.CompletedTask;
+}


### PR DESCRIPTION
Closes #435. Parity with marten#5041 / marten#5044.

A stream has exactly one *current* natural key, but `NaturalKeyProjection` only ever upserted. An event that renamed an aggregate left the row carrying the previous value behind, still pointing at the same stream — so three things went wrong at once:

- the superseded alias kept resolving to the stream **indefinitely** (`FetchForWriting` by the old key still found it, forever);
- the table accumulated one dead row per rename;
- because `natural_key_value` is the **primary key**, the retired value permanently squatted on its slot, so no other stream could ever claim it.

A projection rebuild replays through the same operation builder, so it reproduced exactly the same set of dead rows after teardown.

### The fix

`NaturalKeyRetireOperation` queues a stream-scoped `DELETE` ahead of each upsert, clearing any *other* row this stream still owns (and, under conjoined tenancy, only within its own tenant) so a key legitimately owned by another stream is never touched.

`WorkTracker` preserves insertion order and the session flushes in that order, so a create-then-rename inside a single `SaveChangesAsync` still lands on the newest value: each retire only ever clears values that differ from the one its own upsert is about to write. The rebuild path shares `QueueOperationForEvent`, so it gets this for free.

### ⚠️ Behavior change, and an existing assertion inverted

`natural_key_is_mutable_fetch_after_change` ended with *"fetch by old key still works because the old mapping row persists"*. That block pinned the defect rather than the intent, so it now asserts the superseded key no longer resolves. Flagging it explicitly rather than burying it — no test was deleted.

### The marten#5044 half does not apply

Checked as the issue asked. Marten's unscoped guard was a hand-written `DO $$ IF NOT EXISTS (... WHERE conname = ...)` block, and `conname` is only unique *per relation* in PostgreSQL. Polecat's `NaturalKeyTable` declares its foreign key through Weasel's `ForeignKeys` collection instead, whose delta comparison is already scoped to the table's own `object_id` — and SQL Server constraint names are schema-scoped, so two stores in different schemas of one database cannot see each other's constraint. No change needed.

### Tests

`Bug_435_natural_key_retire` — 7 cases:

- the superseded key stops resolving and its row is gone
- a retired key can be claimed by another stream (the primary-key squat)
- repeated renames never accumulate dead rows
- a create-then-rename in one batch lands on the newest value (ordering)
- another stream's key is never retired (scoping)
- a rebuild reproduces only the current key
- archiving a stream does not retire its row

Full `Polecat.Tests.Events` namespace green on this branch: 340 passed / 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VGv25AmDKnNu5mqtRQEn36