### PR TITLE
Tear down composite members registered through a wrapper (#439)

### DIFF
--- a/src/Polecat.Tests/Projections/Bug_439_composite_member_teardown.cs
+++ b/src/Polecat.Tests/Projections/Bug_439_composite_member_teardown.cs
@@ -1,0 +1,236 @@
+using JasperFx;
+using JasperFx.Events;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Projections;
+using Microsoft.Data.SqlClient;
+using Polecat.Linq;
+using Polecat.Projections;
+using Polecat.TestUtils;
+using Shouldly;
+
+namespace Polecat.Tests.Projections;
+
+/// <summary>
+///     polecat#439 (parity with marten#5175): a composite's rebuild tears its members down by reading
+///     each member's own <c>PublishedTypes()</c> and <c>Options.CleanUps</c>. A member registered as a
+///     raw <see cref="IProjection" /> is wrapped in <c>CompositeIProjectionSource</c>, which carried a
+///     fresh, EMPTY <c>AsyncOptions</c> and published nothing — so that member contributed no teardown
+///     at all. Its progression row was deleted anyway, so the rebuild restarted from sequence zero and
+///     replayed onto a table still holding the previous run's rows: a silent double-count.
+///     <para>
+///         The composite's own <c>Options</c> were never consulted either, so
+///         <c>composite.Options.DeleteViewTypeOnTeardown&lt;T&gt;()</c> was a no-op on the parent.
+///     </para>
+/// </summary>
+public class Bug_439_composite_member_teardown : IAsyncLifetime
+{
+    private const string Schema = "composite_teardown_439";
+    private const string CompositeName = "Teardown439";
+
+    public async ValueTask InitializeAsync() => await DropSchemaTablesAsync(Schema);
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+    private static DocumentStore CreateStore()
+    {
+        return DocumentStore.For(opts =>
+        {
+            opts.ConnectionString = ConnectionSource.ConnectionString;
+            opts.DatabaseSchemaName = Schema;
+            opts.AutoCreateSchemaObjects = AutoCreate.All;
+            opts.UseNativeJsonType = ConnectionSource.SupportsNativeJson;
+
+            opts.Projections.CompositeProjectionFor(CompositeName, composite =>
+            {
+                // A regular projection source: its own PublishedTypes() already reached teardown
+                // through the composite parent's fan-out, so this is the control.
+                composite.Add(new Teardown439ProductProjection());
+
+                // The regression: a raw IProjection wrapped in CompositeIProjectionSource. It declares
+                // nothing about its own storage, so the teardown rule is declared at registration —
+                // which is what the new Add(IProjection, Action<AsyncOptions>) overload is for.
+                composite.Add(new Teardown439MetricProjection(),
+                    options => options.DeleteViewTypeOnTeardown<Teardown439Metric>());
+            });
+        });
+    }
+
+    private static PolecatCompositeProjection CompositeFor(DocumentStore store) =>
+        store.Options.Projections.All.OfType<PolecatCompositeProjection>().Single(x => x.Name == CompositeName);
+
+    [Fact]
+    public async Task every_member_reports_its_own_teardown_rules()
+    {
+        using var store = CreateStore();
+        await store.Database.ApplyAllConfiguredChangesToDatabaseAsync(ct: TestContext.Current.CancellationToken);
+
+        var members = CompositeFor(store).AllProjections();
+
+        // The source-registered member publishes its view type.
+        members.SelectMany(x => x.PublishedTypes()).ShouldContain(typeof(Teardown439Product));
+
+        // Before #439 this was absent: the wrapper carried an empty AsyncOptions and there was no
+        // overload through which the rule could be declared.
+        members.SelectMany(x => x.Options.CleanUps)
+            .OfType<DeleteDocuments>()
+            .Select(x => x.DocumentType)
+            .ShouldContain(typeof(Teardown439Metric));
+    }
+
+    [Fact]
+    public async Task rebuilding_deletes_every_members_documents_first()
+    {
+        using var store = CreateStore();
+        await store.Database.ApplyAllConfiguredChangesToDatabaseAsync(ct: TestContext.Current.CancellationToken);
+
+        var streamId = Guid.NewGuid();
+        await using (var session = store.LightweightSession())
+        {
+            session.Events.StartStream(streamId, new Teardown439Registered("Ankle Socks", "Socks"));
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        using (var daemon = (IProjectionDaemon)await store.BuildProjectionDaemonAsync())
+        {
+            await daemon.RebuildProjectionAsync(CompositeName, CancellationToken.None);
+        }
+
+        // Orphans: rows of each member's view type that NO event can reproduce. If the rebuild's
+        // teardown reaches every member they are gone afterwards; if a member contributes no teardown,
+        // its orphan survives — which is the same table state a replay would double-count into.
+        var orphanId = Guid.NewGuid();
+        await using (var session = store.LightweightSession())
+        {
+            session.Store(new Teardown439Product { Id = orphanId, Name = "Ghost", Category = "Ghost" });
+            session.Store(new Teardown439Metric { Id = orphanId, Price = 999 });
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        using (var daemon = (IProjectionDaemon)await store.BuildProjectionDaemonAsync())
+        {
+            await daemon.RebuildProjectionAsync(CompositeName, CancellationToken.None);
+        }
+
+        await using var query = store.QuerySession();
+
+        (await query.LoadAsync<Teardown439Product>(orphanId, TestContext.Current.CancellationToken))
+            .ShouldBeNull("the source-registered member's documents must be torn down on rebuild");
+        (await query.LoadAsync<Teardown439Metric>(orphanId, TestContext.Current.CancellationToken))
+            .ShouldBeNull("the raw IProjection member's documents must be torn down on rebuild");
+
+        // ...and the rebuild genuinely reproduced the read models it deleted.
+        (await query.Query<Teardown439Product>().CountAsync(TestContext.Current.CancellationToken)).ShouldBe(1);
+        (await query.Query<Teardown439Metric>().CountAsync(TestContext.Current.CancellationToken)).ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task the_composites_own_teardown_rules_are_applied()
+    {
+        // Second half of #5175: the parent goes through the same teardown collection as any other
+        // source, so a view type declared on the COMPOSITE (not on any member) is wiped too.
+        using var store = DocumentStore.For(opts =>
+        {
+            opts.ConnectionString = ConnectionSource.ConnectionString;
+            opts.DatabaseSchemaName = Schema;
+            opts.AutoCreateSchemaObjects = AutoCreate.All;
+            opts.UseNativeJsonType = ConnectionSource.SupportsNativeJson;
+
+            opts.Projections.CompositeProjectionFor(CompositeName, composite =>
+            {
+                composite.Add(new Teardown439ProductProjection());
+                composite.Options.DeleteViewTypeOnTeardown<Teardown439Metric>();
+            });
+        });
+
+        await store.Database.ApplyAllConfiguredChangesToDatabaseAsync(ct: TestContext.Current.CancellationToken);
+
+        var streamId = Guid.NewGuid();
+        await using (var session = store.LightweightSession())
+        {
+            session.Events.StartStream(streamId, new Teardown439Registered("Ankle Socks", "Socks"));
+            session.Store(new Teardown439Metric { Id = Guid.NewGuid(), Price = 999 });
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        using (var daemon = (IProjectionDaemon)await store.BuildProjectionDaemonAsync())
+        {
+            await daemon.RebuildProjectionAsync(CompositeName, CancellationToken.None);
+        }
+
+        await using var query = store.QuerySession();
+        (await query.Query<Teardown439Metric>().CountAsync(TestContext.Current.CancellationToken)).ShouldBe(0);
+    }
+
+    private static async Task DropSchemaTablesAsync(string schema)
+    {
+        await using var conn = new SqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = """
+            DECLARE @sql nvarchar(max) = N'';
+            SELECT @sql = @sql + 'ALTER TABLE [' + s.name + '].[' + t.name + '] DROP CONSTRAINT [' + fk.name + '];'
+            FROM sys.foreign_keys fk
+            JOIN sys.tables t ON fk.parent_object_id = t.object_id
+            JOIN sys.schemas s ON t.schema_id = s.schema_id
+            WHERE s.name = @schema;
+
+            SELECT @sql = @sql + 'DROP TABLE [' + s.name + '].[' + t.name + '];'
+            FROM sys.tables t
+            JOIN sys.schemas s ON t.schema_id = s.schema_id
+            WHERE s.name = @schema;
+            EXEC sp_executesql @sql;
+            """;
+        cmd.Parameters.AddWithValue("@schema", schema);
+        await cmd.ExecuteNonQueryAsync();
+    }
+}
+
+public record Teardown439Registered(string Name, string Category);
+
+public class Teardown439Product
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string Category { get; set; } = string.Empty;
+}
+
+public class Teardown439Metric
+{
+    public Guid Id { get; set; }
+    public double Price { get; set; }
+}
+
+public partial class Teardown439ProductProjection : SingleStreamProjection<Teardown439Product, Guid>
+{
+    public Teardown439ProductProjection()
+    {
+        Name = "Teardown439Product";
+    }
+
+    public void Apply(Teardown439Registered e, Teardown439Product view)
+    {
+        view.Name = e.Name;
+        view.Category = e.Category;
+    }
+}
+
+/// <summary>
+///     A raw <see cref="IProjection" />: it declares neither its storage nor its teardown, which is
+///     exactly the shape #439 is about.
+/// </summary>
+public class Teardown439MetricProjection : IProjection
+{
+    public Task ApplyAsync(IDocumentSession operations, IReadOnlyList<IEvent> events,
+        CancellationToken cancellation)
+    {
+        foreach (var e in events)
+        {
+            if (e.Data is Teardown439Registered)
+            {
+                operations.Store(new Teardown439Metric { Id = e.StreamId, Price = 1 });
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Polecat/DocumentStore.EventStore.cs
+++ b/src/Polecat/DocumentStore.EventStore.cs
@@ -515,9 +515,9 @@ public partial class DocumentStore : IEventStore<IDocumentSession, IQuerySession
         var shardIdentities = Array.Empty<string>();
         if (Options.Projections.TryFindProjection(subscriptionName, out var source))
         {
-            publishedTableNames = source.PublishedTypes()
-                .Select(t => GetProvider(t).QualifiedTableName)
-                .ToArray();
+            // #439: same collection as the store-global twin, so a composite's members and the
+            // composite's own declared clean-ups are both honoured here too.
+            publishedTableNames = TeardownTargetsFor(source);
 
             // The exact per-tenant progression rows to delete: each shard's identity composed for
             // this tenant (carries the trailing :tenantId).
@@ -604,6 +604,95 @@ public partial class DocumentStore : IEventStore<IDocumentSession, IQuerySession
         }
     }
 
+    /// <summary>
+    ///     Every table a rebuild of <paramref name="source" /> must empty first: the document tables of
+    ///     the types it publishes, the <c>pc_natural_key_X</c> lookup of a <c>[NaturalKey]</c> aggregate,
+    ///     and whatever it declared through <c>AsyncOptions.CleanUps</c>.
+    /// </summary>
+    /// <remarks>
+    ///     #439 / marten#5175: a composite is torn down by walking its MEMBERS as well as itself. The
+    ///     parent's <c>PublishedTypes()</c> already fans out to the members, but each member carries its
+    ///     own <c>AsyncOptions</c>, and those are where a flat-table or view-type member declares the
+    ///     table it writes — a composite whose member declared
+    ///     <c>DeleteDataInTableOnTeardown</c> had that table left untouched while its progression row was
+    ///     deleted anyway, so the rebuild restarted at sequence zero and replayed onto the previous
+    ///     run's rows. The parent goes through the same collection rather than only having its
+    ///     progression dropped, so <c>composite.Options.DeleteViewTypeOnTeardown&lt;T&gt;()</c> and
+    ///     <c>TeardownDataOnRebuild = false</c> stop being silent no-ops on it.
+    /// </remarks>
+    private string[] TeardownTargetsFor(IProjectionSource<IDocumentSession, IQuerySession> source)
+    {
+        var tables = new List<string>();
+
+        foreach (var member in WithCompositeMembers(source))
+        {
+            CollectTeardownTargets(member, tables);
+        }
+
+        return tables.Distinct().ToArray();
+    }
+
+    /// <summary>
+    ///     <paramref name="source" /> followed by every projection registered inside it when it is a
+    ///     composite. Not recursive: a composite cannot contain a composite.
+    /// </summary>
+    private static IEnumerable<IProjectionSource<IDocumentSession, IQuerySession>> WithCompositeMembers(
+        IProjectionSource<IDocumentSession, IQuerySession> source)
+    {
+        yield return source;
+
+        if (source is JasperFx.Events.Projections.Composite.CompositeProjection<IDocumentSession, IQuerySession> composite)
+        {
+            foreach (var member in composite.AllProjections())
+            {
+                yield return member;
+            }
+        }
+    }
+
+    private void CollectTeardownTargets(IProjectionSource<IDocumentSession, IQuerySession> source,
+        List<string> tables)
+    {
+        tables.AddRange(source.PublishedTypes().Select(t => GetProvider(t).QualifiedTableName));
+
+        // #259: a [NaturalKey] aggregate maintains its pc_natural_key_X lookup table via the
+        // auto-registered NaturalKeyProjection on the inline-append path. Teardown of the parent
+        // projection must also wipe that table so the rebuild repopulates it from scratch
+        // (the rebuild re-emits the upserts via StartProjectionBatchAsync). DELETE FROM works the
+        // same as for the doc tables, so it rides the same loop as everything else.
+        if (source is JasperFx.Events.Aggregation.IAggregateProjection { NaturalKeyDefinition: not null } natural)
+        {
+            tables.Add(Events.NaturalKeyTableName(natural.NaturalKeyDefinition.AggregateType));
+        }
+
+        // A projection can also declare teardown targets explicitly through JasperFx's shared
+        // AsyncOptions surface -- DeleteDataInTableOnTeardown / DeleteViewTypeOnTeardown, which
+        // land in Options.CleanUps. PublishedTypes() alone does not cover those: a flat table
+        // projection publishes no document type at all, so before this its table was never wiped
+        // and a rebuild left behind every row whose events the replay could no longer see.
+        if (!source.Options.TeardownDataOnRebuild)
+        {
+            return;
+        }
+
+        foreach (var cleanUp in source.Options.CleanUps)
+        {
+            switch (cleanUp)
+            {
+                case DeleteTableData tableData:
+                    tables.Add(tableData.TableIdentifier);
+                    break;
+
+                // Normally already covered by PublishedTypes(), but a projection is free to
+                // register a view type it does not publish. DELETE FROM twice is harmless,
+                // and the Distinct() in the caller keeps it to once anyway.
+                case DeleteDocuments documents:
+                    tables.Add(GetProvider(documents.DocumentType).QualifiedTableName);
+                    break;
+            }
+        }
+    }
+
     private async Task TeardownProjectionStateAsync(IEventDatabase database, string subscriptionName,
         CancellationToken token)
     {
@@ -613,46 +702,7 @@ public partial class DocumentStore : IEventStore<IDocumentSession, IQuerySession
         var publishedTableNames = Array.Empty<string>();
         if (Options.Projections.TryFindProjection(subscriptionName, out var source))
         {
-            var tables = source.PublishedTypes()
-                .Select(t => GetProvider(t).QualifiedTableName)
-                .ToList();
-
-            // #259: a [NaturalKey] aggregate maintains its pc_natural_key_X lookup table via the
-            // auto-registered NaturalKeyProjection on the inline-append path. Teardown of the parent
-            // projection must also wipe that table so the rebuild repopulates it from scratch
-            // (the rebuild re-emits the upserts via StartProjectionBatchAsync). DELETE FROM works the
-            // same as for the doc tables, so it rides the same loop below.
-            if (source is JasperFx.Events.Aggregation.IAggregateProjection { NaturalKeyDefinition: not null } natural)
-            {
-                tables.Add(Events.NaturalKeyTableName(natural.NaturalKeyDefinition.AggregateType));
-            }
-
-            // A projection can also declare teardown targets explicitly through JasperFx's shared
-            // AsyncOptions surface -- DeleteDataInTableOnTeardown / DeleteViewTypeOnTeardown, which
-            // land in Options.CleanUps. PublishedTypes() alone does not cover those: a flat table
-            // projection publishes no document type at all, so before this its table was never wiped
-            // and a rebuild left behind every row whose events the replay could no longer see.
-            if (source.Options.TeardownDataOnRebuild)
-            {
-                foreach (var cleanUp in source.Options.CleanUps)
-                {
-                    switch (cleanUp)
-                    {
-                        case DeleteTableData tableData:
-                            tables.Add(tableData.TableIdentifier);
-                            break;
-
-                        // Normally already covered by PublishedTypes(), but a projection is free to
-                        // register a view type it does not publish. DELETE FROM twice is harmless,
-                        // and the distinct below keeps it to once anyway.
-                        case DeleteDocuments documents:
-                            tables.Add(GetProvider(documents.DocumentType).QualifiedTableName);
-                            break;
-                    }
-                }
-            }
-
-            publishedTableNames = tables.Distinct().ToArray();
+            publishedTableNames = TeardownTargetsFor(source);
         }
 
         await Options.ResiliencePipeline.ExecuteAsync(static async (state, ct) =>
@@ -669,7 +719,15 @@ public partial class DocumentStore : IEventStore<IDocumentSession, IQuerySession
             foreach (var tableName in tableNames)
             {
                 await using var truncCmd = conn.CreateCommand();
-                truncCmd.CommandText = $"DELETE FROM {tableName};";
+                // A projection's table is created lazily on first write, so on a first-ever rebuild it
+                // may not exist yet — the same guard the per-tenant twin has always carried. #439 makes
+                // this reachable far more often: the teardown target set now includes every composite
+                // member's tables and every declared clean-up, and a member that has never written
+                // anything has no table.
+                // #390: the same name occupies a string-literal position (OBJECT_ID) and a bare
+                // identifier position, which take different escaping.
+                truncCmd.CommandText =
+                    $"IF OBJECT_ID({SqlEscaping.Literal(tableName)}, 'U') IS NOT NULL DELETE FROM {tableName};";
                 await truncCmd.ExecuteNonQueryAsync(ct);
             }
         }, (connStr, Events.ProgressionTableName, subscriptionName, publishedTableNames), token);

--- a/src/Polecat/Projections/CompositeIProjectionSource.cs
+++ b/src/Polecat/Projections/CompositeIProjectionSource.cs
@@ -31,6 +31,29 @@ internal class CompositeIProjectionSource :
         {
             Version = att.Version;
         }
+
+        // #439 / marten#5175: adopt the wrapped projection's options and published types when it has
+        // any. Without this the wrapper keeps the empty AsyncOptions it was constructed with, and a
+        // composite rebuild -- whose teardown reads each member's PublishedTypes() and Options.CleanUps
+        // -- queues NOTHING for this member. The rebuild then restarts from sequence zero (its
+        // progression row IS deleted) and replays onto the previous run's surviving rows, which is a
+        // silent double-count.
+        //
+        // Name and Version are deliberately NOT adopted: they compose this member's
+        // ShardName.Identity, and changing them would orphan every existing progression row.
+        //
+        // A raw IProjection that is not a ProjectionBase declares neither storage nor teardown, so
+        // there is nothing to adopt and nothing this wrapper can invent. Declare it at registration
+        // instead -- see PolecatCompositeProjection.Add(IProjection, Action&lt;AsyncOptions&gt;, int).
+        if (projection is ProjectionBase source)
+        {
+            replaceOptions(source.Options);
+
+            foreach (var publishedType in source.PublishedTypes())
+            {
+                RegisterPublishedType(publishedType);
+            }
+        }
     }
 
     public SubscriptionType Type => SubscriptionType.EventProjection;

--- a/src/Polecat/Projections/PolecatCompositeProjection.cs
+++ b/src/Polecat/Projections/PolecatCompositeProjection.cs
@@ -47,6 +47,30 @@ public class PolecatCompositeProjection : CompositeProjection<IDocumentSession, 
     }
 
     /// <summary>
+    ///     Add a custom <see cref="IProjection" /> implementation to be executed within this composite,
+    ///     declaring what it writes so that a rebuild can tear that data down first.
+    /// </summary>
+    /// <remarks>
+    ///     #439 / marten#5175: a raw <see cref="IProjection" /> describes neither its storage nor its
+    ///     teardown, so a composite rebuild has nothing to delete for it and would replay onto surviving
+    ///     rows. Use this overload — typically
+    ///     <c>options =&gt; options.DeleteViewTypeOnTeardown&lt;MyView&gt;()</c> — for any custom
+    ///     projection that writes documents. A member that derives from <c>ProjectionBase</c> already
+    ///     carries its own options and needs no declaration here.
+    /// </remarks>
+    /// <param name="projection">The custom IProjection implementation.</param>
+    /// <param name="configure">Configures the member's async options, principally its teardown rules.</param>
+    /// <param name="stageNumber">Optionally move the execution to a later stage. The default is 1.</param>
+    public void Add(IProjection projection, Action<AsyncOptions> configure, int stageNumber = 1)
+    {
+        ArgumentNullException.ThrowIfNull(configure);
+
+        var wrapper = new CompositeIProjectionSource(projection);
+        configure(wrapper.Options);
+        StageFor(stageNumber).Add(wrapper);
+    }
+
+    /// <summary>
     ///     Add a projection source by type to be executed within this composite.
     /// </summary>
     public void Add<T>(int stageNumber = 1) where T : IProjectionSource<IDocumentSession, IQuerySession>, new()


### PR DESCRIPTION
Closes #439. Parity with marten#5175.

A composite's rebuild deletes each member's data by reading the member's own `PublishedTypes()` and `Options.CleanUps`. A member registered as a raw `IProjection` is wrapped in `CompositeIProjectionSource`, which carried a fresh, **empty** `AsyncOptions` and published nothing — so that member contributed no teardown at all. Its progression row was deleted anyway, so the rebuild restarted from sequence zero and replayed onto a table still holding the previous run's rows: a silent double-count.

The composite's own `Options` were never consulted either, so `composite.Options.DeleteViewTypeOnTeardown<T>()` and `TeardownDataOnRebuild = false` were no-ops on the parent.

### Three changes

1. **`CompositeIProjectionSource` adopts the wrapped projection's options and published types** when it is a `ProjectionBase`, the way Marten's `ProjectionWrapper` always has. `Name` and `Version` are deliberately *not* adopted — they compose the member's `ShardName.Identity`, and changing them would orphan every existing progression row.

2. **New `PolecatCompositeProjection.Add(IProjection, Action<AsyncOptions>, int)` overload.** A raw `IProjection` that is not a `ProjectionBase` declares nothing about what it writes and the composite cannot invent it, so it has to be declarable at registration — typically `options => options.DeleteViewTypeOnTeardown<MyView>()`.

3. **The teardown target collection moves into `TeardownTargetsFor`**, which walks the composite's members as well as the composite itself, and both the store-global and per-tenant teardown paths now go through it. Previously only `PublishedTypes()` fanned out to members; each member's own `CleanUps` — where a flat-table member declares the table it writes — were never read.

### Also: a missing existence guard

The store-global teardown's `DELETE FROM {table}` is now guarded with `IF OBJECT_ID(...) IS NOT NULL`, which the per-tenant twin has always carried. A projection's table is created lazily on first write, so a first-ever rebuild could hit a table that doesn't exist. Widening the target set to every composite member makes that reachable far more often — it's how the new tests first failed.

Note: Polecat has no `AddProjectionWithServices` path, so the `CompositeProjectionWithServicesSource<T>` half of marten#5175 has no counterpart here.

### Tests

`Bug_439_composite_member_teardown` — 3 cases:

- every member reports its own teardown rules
- rebuilding deletes every member's documents first (orphan rows of each member's view type must not survive; the real read models are reproduced)
- the composite's own teardown rules are applied

Regression sweep on this branch: `Polecat.Tests.Projections` 110/0, `Polecat.Tests.Daemon` 107/0/3 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VGv25AmDKnNu5mqtRQEn36