### PR TITLE
Implement the tenant-filtered progression read (#441)

### DIFF
--- a/src/Polecat.Tests/Daemon/tenant_filtered_progression_read_tests.cs
+++ b/src/Polecat.Tests/Daemon/tenant_filtered_progression_read_tests.cs
@@ -1,0 +1,180 @@
+using JasperFx.Events;
+using JasperFx.Events.Projections;
+using Polecat.Internal.Operations;
+using Polecat.Tests.Harness;
+
+namespace Polecat.Tests.Daemon;
+
+/// <summary>
+///     polecat#441: the tenant-filtered progression read. <c>IEventDatabase</c> has carried
+///     <c>AllProjectionProgress(string? tenantId, ...)</c> since jasperfx#407 with a default that
+///     <em>throws</em> for a non-null tenant, and Polecat had never overridden it — so every consumer
+///     reading progression through the shared abstractions could not scope to a tenant on the SQL Server
+///     flavour at all.
+///     <para>
+///         Rows are matched structurally, on the parsed <see cref="ShardName" />, not by testing whether
+///         a name ends with the tenant id. That is the marten#5179 lesson, and the cases below are the
+///         ones a suffix test gets wrong.
+///     </para>
+/// </summary>
+[Collection("integration")]
+public class tenant_filtered_progression_read_tests : IntegrationContext
+{
+    public tenant_filtered_progression_read_tests(DefaultStoreFixture fixture) : base(fixture)
+    {
+    }
+
+    private async Task WithStoreAsync(string schema)
+    {
+        await StoreOptions(opts =>
+        {
+            opts.DatabaseSchemaName = schema;
+            opts.AutoCreateSchemaObjects = JasperFx.AutoCreate.All;
+        });
+
+        await using var conn = await OpenConnectionAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"DELETE FROM {theStore.Events.ProgressionTableName};";
+        await cmd.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+    }
+
+    private IEventDatabase theEventDatabase => theStore.Database;
+
+    [Fact]
+    public async Task returns_only_the_named_tenants_rows()
+    {
+        await WithStoreAsync("tenantprog_basic");
+
+        await SeedAsync(new ShardName("Trip").ForTenant("acme"), 10);
+        await SeedAsync(new ShardName("Trip").ForTenant("globex"), 20);
+        await SeedAsync(new ShardName("Other", "All", 9).ForTenant("acme"), 30);
+        await SeedAsync(new ShardName("Trip"), 40);                       // store-global row
+        await SeedAsync(new ShardName(ShardState.HighWaterMark), 50);
+
+        var acme = await theEventDatabase.AllProjectionProgress("acme", TestContext.Current.CancellationToken);
+
+        acme.Select(x => x.ShardName).OrderBy(x => x)
+            .ShouldBe(["Other:V9:All:acme", "Trip:All:acme"]);
+        acme.Single(x => x.ShardName == "Trip:All:acme").Sequence.ShouldBe(10);
+    }
+
+    [Fact]
+    public async Task a_null_tenant_is_store_global_and_matches_the_tenant_less_overload()
+    {
+        await WithStoreAsync("tenantprog_global");
+
+        await SeedAsync(new ShardName("Trip").ForTenant("acme"), 10);
+        await SeedAsync(new ShardName("Trip"), 20);
+
+        var scoped = await theEventDatabase.AllProjectionProgress(null, TestContext.Current.CancellationToken);
+        var all = await theEventDatabase.AllProjectionProgress(TestContext.Current.CancellationToken);
+
+        scoped.Select(x => x.ShardName).OrderBy(x => x)
+            .ShouldBe(all.Select(x => x.ShardName).OrderBy(x => x));
+        scoped.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task a_tenant_whose_id_is_a_suffix_of_another_is_not_confused_with_it()
+    {
+        // The marten#5179 case a string suffix test gets wrong: "acme" is a suffix of "megaacme", so
+        // `name LIKE '%acme'` would hand back the wrong tenant's progress.
+        await WithStoreAsync("tenantprog_suffix");
+
+        await SeedAsync(new ShardName("Trip").ForTenant("acme"), 10);
+        await SeedAsync(new ShardName("Trip").ForTenant("megaacme"), 20);
+
+        var acme = await theEventDatabase.AllProjectionProgress("acme", TestContext.Current.CancellationToken);
+        acme.Select(x => x.ShardName).ShouldBe(["Trip:All:acme"]);
+
+        var mega = await theEventDatabase.AllProjectionProgress("megaacme", TestContext.Current.CancellationToken);
+        mega.Select(x => x.ShardName).ShouldBe(["Trip:All:megaacme"]);
+    }
+
+    [Fact]
+    public async Task a_tenant_id_carrying_a_like_wildcard_matches_only_itself()
+    {
+        await WithStoreAsync("tenantprog_wildcards");
+
+        await SeedAsync(new ShardName("Trip").ForTenant("a_me"), 10);
+        await SeedAsync(new ShardName("Trip").ForTenant("axme"), 20);
+
+        var scoped = await theEventDatabase.AllProjectionProgress("a_me", TestContext.Current.CancellationToken);
+        scoped.Select(x => x.ShardName).ShouldBe(["Trip:All:a_me"]);
+    }
+
+    [Fact]
+    public async Task the_store_global_and_high_water_rows_are_never_attributed_to_a_tenant()
+    {
+        await WithStoreAsync("tenantprog_nontenant");
+
+        await SeedAsync(new ShardName("Trip"), 10);
+        await SeedAsync(new ShardName(ShardState.HighWaterMark), 20);
+
+        (await theEventDatabase.AllProjectionProgress("acme", TestContext.Current.CancellationToken))
+            .ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task an_unknown_tenant_returns_an_empty_list_rather_than_throwing()
+    {
+        await WithStoreAsync("tenantprog_unknown");
+
+        await SeedAsync(new ShardName("Trip").ForTenant("acme"), 10);
+
+        (await theEventDatabase.AllProjectionProgress("nobody", TestContext.Current.CancellationToken))
+            .ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task extended_columns_are_carried_on_the_tenant_scoped_read()
+    {
+        // The tenant-scoped path selects the same column list as the store-global one; this pins that a
+        // narrowed read is not quietly a reduced one.
+        await StoreOptions(opts =>
+        {
+            opts.DatabaseSchemaName = "tenantprog_extended";
+            opts.AutoCreateSchemaObjects = JasperFx.AutoCreate.All;
+            opts.Events.EnableExtendedProgressionTracking = true;
+        });
+
+        await using (var conn = await OpenConnectionAsync())
+        {
+            await using var clear = conn.CreateCommand();
+            clear.CommandText = $"DELETE FROM {theStore.Events.ProgressionTableName};";
+            await clear.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+        }
+
+        var shard = new ShardName("Trip").ForTenant("acme");
+        await SeedAsync(shard, 10);
+
+        await theStore.Database.WriteExtendedProgressionAsync(
+            new ShardState(shard.Identity, 10) { AgentStatus = "Running", LastHeartbeat = DateTimeOffset.UtcNow },
+            TestContext.Current.CancellationToken);
+
+        var scoped = await theEventDatabase.AllProjectionProgress("acme", TestContext.Current.CancellationToken);
+        var row = scoped.Single();
+        row.AgentStatus.ShouldBe("Running");
+        row.LastHeartbeat.ShouldNotBeNull();
+    }
+
+    private async Task SeedAsync(ShardName shardName, long ceiling)
+    {
+        // The production write path (polecat#323).
+        var events = theStore.Database.Events;
+        var op = new RecordProgressionOperation(
+            events.ProgressionTableName,
+            shardName.Identity,
+            ceiling,
+            events.EnableExtendedProgressionTracking,
+            upsert: true);
+
+        await using var conn = await OpenConnectionAsync();
+        await using var batch = new Microsoft.Data.SqlClient.SqlBatch(conn);
+        var builder = new Weasel.SqlServer.BatchBuilder(batch);
+        op.ConfigureCommand(builder);
+        builder.Compile();
+        await using var reader = await batch.ExecuteReaderAsync(TestContext.Current.CancellationToken);
+        await op.PostprocessAsync(reader, new List<Exception>(), TestContext.Current.CancellationToken);
+    }
+}

--- a/src/Polecat/Storage/PolecatDatabase.cs
+++ b/src/Polecat/Storage/PolecatDatabase.cs
@@ -235,30 +235,78 @@ public class PolecatDatabase : DatabaseBase<SqlConnection>, IEventDatabase, IPro
         }, (_connectionString, _events.ProgressionTableName, state), token);
     }
 
-    public async Task<IReadOnlyList<ShardState>> AllProjectionProgress(CancellationToken token = default)
+    public Task<IReadOnlyList<ShardState>> AllProjectionProgress(CancellationToken token = default)
+        => AllProjectionProgress(tenantId: null, token);
+
+    /// <summary>
+    ///     #441: the tenant-filtered progression read. The JasperFx abstraction has carried this overload
+    ///     since jasperfx#407 with a default that <em>throws</em> for a non-null tenant, and Polecat had
+    ///     never overridden it — so every consumer reading progression through the shared contracts
+    ///     (per-tenant progression views, per-tenant rebuild scoping) simply could not scope to a tenant on
+    ///     the SQL Server flavour.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         A null <paramref name="tenantId" /> is store-global and returns every row, which is the
+    ///         tenant-less overload's behaviour unchanged.
+    ///     </para>
+    ///     <para>
+    ///         Rows are matched <b>structurally</b>, by parsing each name back into a
+    ///         <see cref="ShardName" /> and comparing its <c>TenantId</c> — never by testing whether the
+    ///         name ends with the tenant id. That is the marten#5179 lesson: the shard grammar has
+    ///         versioned and tenant-scoped forms (<c>Name:V2:All:tenant</c>), a tenant id may legally
+    ///         contain a <c>:</c> or end with another tenant's id as a suffix, and a string test gets all
+    ///         of those wrong in a way that silently returns another tenant's progress.
+    ///     </para>
+    ///     <para>
+    ///         The SQL <c>LIKE</c> is a narrowing pass only, so a fleet with thousands of tenants does not
+    ///         drag every projection x tenant row across the wire to keep a handful. Its pattern is
+    ///         escaped and anchored on the <c>:</c> separator (see <c>ProgressionNameFilter</c>), and the
+    ///         <c>ShardName.TryParse</c> check above remains the authority on what actually matches.
+    ///     </para>
+    /// </remarks>
+    public async Task<IReadOnlyList<ShardState>> AllProjectionProgress(string? tenantId,
+        CancellationToken token = default)
     {
         return await _resilience.ExecuteAsync(static async (state, ct) =>
         {
-            var (connectionString, events) = state;
+            var (connectionString, events, tenant) = state;
             var list = new List<ShardState>();
 
             await using var conn = new SqlConnection(connectionString);
             await conn.OpenAsync(ct);
 
             await using var cmd = conn.CreateCommand();
-            if (events.EnableExtendedProgressionTracking)
+            var columns = events.EnableExtendedProgressionTracking
+                ? "name, last_seq_id, heartbeat, agent_status, pause_reason, running_on_node, warning_behind_threshold, critical_behind_threshold, failure_category, failure_event_sequence, failure_event_type, failure_event_tenant_id"
+                : "name, last_seq_id";
+
+            if (tenant == null)
             {
-                cmd.CommandText = $"SELECT name, last_seq_id, heartbeat, agent_status, pause_reason, running_on_node, warning_behind_threshold, critical_behind_threshold, failure_category, failure_event_sequence, failure_event_type, failure_event_tenant_id FROM {events.ProgressionTableName};";
+                cmd.CommandText = $"SELECT {columns} FROM {events.ProgressionTableName};";
             }
             else
             {
-                cmd.CommandText = $"SELECT name, last_seq_id FROM {events.ProgressionTableName};";
+                cmd.CommandText =
+                    $"SELECT {columns} FROM {events.ProgressionTableName} WHERE name LIKE @tenantSuffix ESCAPE '{ProgressionNameFilter.LikeEscapeCharacter}';";
+                cmd.Parameters.AddVarChar("@tenantSuffix",
+                    "%:" + ProgressionNameFilter.EscapeLikePattern(tenant));
             }
 
             await using var reader = await cmd.ExecuteReaderAsync(ct);
             while (await reader.ReadAsync(ct))
             {
                 var name = reader.GetString(0);
+
+                // The LIKE above only narrows. Whether a row genuinely belongs to this tenant is decided
+                // structurally, on the parsed ShardName — a tenant id containing a ':' or ending with
+                // another tenant's id would fool any string test (marten#5179).
+                if (tenant != null &&
+                    !(ShardName.TryParse(name, out var parsed) && parsed?.TenantId == tenant))
+                {
+                    continue;
+                }
+
                 var seq = reader.GetInt64(1);
                 var shardState = new ShardState(name, seq);
 
@@ -287,7 +335,7 @@ public class PolecatDatabase : DatabaseBase<SqlConnection>, IEventDatabase, IPro
             }
 
             return (IReadOnlyList<ShardState>)list;
-        }, (_connectionString, _events), token);
+        }, (_connectionString, _events, tenantId), token);
     }
 
     /// <summary>


### PR DESCRIPTION
Closes #441. Verified first, as the issue asked.

**The abstraction surface already carries it.** `IEventDatabase.AllProjectionProgress(string? tenantId, ...)` has existed since jasperfx#407 with a *default that throws* `NotSupportedException` for a non-null tenant, and Polecat had never overridden it. So this wasn't "the fix may start upstream in JasperFx.Events" — it was a Polecat-side hole, and every consumer reading progression through the shared abstractions (per-tenant progression views, per-tenant rebuild scoping) hit that throw on the SQL Server flavour.

### The implementation

A null `tenantId` is store-global and returns every row, which is the tenant-less overload's behaviour unchanged; that overload now delegates here so there's one implementation rather than two.

**Rows are matched structurally**, by parsing each name back into a `ShardName` and comparing its `TenantId` — never by testing whether the name ends with the tenant id. That's the marten#5179 lesson the issue called out: the shard grammar has versioned and tenant-scoped forms (`Name:V2:All:tenant`), a tenant id may legally contain a `:` or end with another tenant's id as a suffix, and a string test gets all of those wrong in a way that silently returns *another tenant's* progress.

The SQL `LIKE` is a **narrowing pass only**, so a fleet with thousands of tenants doesn't drag every projection × tenant row across the wire to keep a handful. Its pattern is escaped and anchored through `ProgressionNameFilter` (#436), and `ShardName.TryParse` remains the authority on what actually matches.

### Tests

`tenant_filtered_progression_read_tests` — 7 cases:

- returns only the named tenant's rows
- a null tenant is store-global and matches the tenant-less overload
- **a tenant whose id is a suffix of another is not confused with it** (`acme` vs `megaacme` — the case a `LIKE '%acme'` gets wrong)
- a tenant id carrying a `LIKE` wildcard matches only itself
- the store-global and `HighWaterMark` rows are never attributed to a tenant
- an unknown tenant returns an empty list rather than throwing
- the extended telemetry columns are carried on the tenant-scoped read (a narrowed read is not a reduced one)

Depends on `ProgressionNameFilter` from #436, now merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VGv25AmDKnNu5mqtRQEn36