### PR TITLE
5.12.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>5.11.0</Version>
+        <Version>5.12.0</Version>
         <LangVersion>latest</LangVersion>
         <Authors>Jeremy D. Miller</Authors>
         <PackageIcon>logo.png</PackageIcon>


### PR DESCRIPTION
Version bump only — `Directory.Build.props` 5.11.0 → 5.12.0.

Cuts the release carrying the ten-issue cross-store parity wave: #434, #435, #436, #437, #438, #439, #440, #441, #442 and the Polecat half of #443.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VGv25AmDKnNu5mqtRQEn36