### PR TITLE
Close four strong-typed-id gaps found by porting Marten's ValueTypeTests

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -274,8 +274,12 @@
         <PackageVersion Include="Weasel.SqlServer" Version="9.24.0" />
         <PackageVersion Include="Weasel.Storage" Version="9.24.0" />
 
-        <!-- Strongly typed IDs -->
+        <!-- Strongly typed IDs. Both generators are test-only: they prove Polecat's value-type id
+             support against the two libraries Marten's ValueTypeTests exercise. StronglyTypedId emits
+             a record struct with a public ctor; Vogen emits a struct with a private ctor plus static
+             From/TryFrom factories, which is the "builder" shape of JasperFx's ValueTypeInfo. -->
         <PackageVersion Include="StronglyTypedId" Version="1.0.0-beta08" />
+        <PackageVersion Include="Vogen" Version="7.0.0" />
 
         <!-- Source generators (matched to JasperFx.Events above) -->
         <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.47.0" />

--- a/docs/documents/identity.md
+++ b/docs/documents/identity.md
@@ -42,13 +42,17 @@ Numeric IDs are automatically assigned using the [HiLo algorithm](#hilo-sequence
 
 ## Strongly Typed IDs
 
-Polecat supports [strong typed identifiers](https://en.wikipedia.org/wiki/Strongly_typed_identifier) using immutable `struct` types that wrap one of the supported primitive ID types (`Guid`, `string`, `int`, or `long`).
+Polecat supports [strong typed identifiers](https://en.wikipedia.org/wiki/Strongly_typed_identifier) —
+types that wrap one of the supported primitive ID types (`Guid`, `string`, `int`, or `long`) so that an
+`OrderId` can never be passed where a `CustomerId` was meant.
 
 ### Supported Patterns
 
-Polecat automatically detects wrapper types via JasperFx's `ValueTypeInfo`. Two patterns are supported:
+Polecat detects wrapper types through JasperFx's `ValueTypeInfo`. A type qualifies when it exposes
+exactly one public, readable property wrapping a supported inner type, plus a way to build it from that
+value — either a matching constructor or a public static factory method. Two shapes follow:
 
-**1. Record struct with constructor (recommended):**
+**1. Record struct with constructor:**
 
 ```cs
 public record struct OrderId(Guid Value);
@@ -60,7 +64,7 @@ public class Order
 }
 ```
 
-**2. Struct with static builder method:**
+**2. Struct with a static builder method:**
 
 ```cs
 public readonly struct TaskId
@@ -77,23 +81,67 @@ public class TaskDoc
 }
 ```
 
-These patterns are compatible with libraries like [Vogen](https://github.com/SteveDunn/Vogen) and [StronglyTypedId](https://github.com/andrewlock/StronglyTypedId).
+There is **no naming requirement** — neither the wrapper type nor its inner property has to be called
+anything in particular. `Value` and `From` are simply the conventional names, and the ones both source
+generators below emit.
 
-### Supported Inner Types
+### Using Vogen or StronglyTypedId
 
-| Wrapper Pattern | ID Generation |
+Hand-rolled wrappers work, but a generator gives you equality, comparison, `ToString()`, and — most
+importantly — a `System.Text.Json` converter that writes the *inner* value. That last part is what lets
+Polecat treat the member as a scalar in SQL. Polecat's test suite exercises both libraries directly.
+
+[Vogen](https://github.com/SteveDunn/Vogen) emits a private constructor plus a static `From` factory:
+
+```cs
+[ValueObject<Guid>]
+public readonly partial struct InvoiceId;
+
+public class Invoice
+{
+    // Polecat will use this as the Invoice's identity
+    public InvoiceId? Id { get; set; }
+    public string Name { get; set; } = "";
+}
+```
+
+[StronglyTypedId](https://github.com/andrewlock/StronglyTypedId) emits a public constructor:
+
+```cs
+[StronglyTypedId(Template.Int)]
+public readonly partial struct OrderId;
+
+public class Order
+{
+    public OrderId Id { get; set; }
+    public string Name { get; set; } = "";
+}
+```
+
+::: warning
+**Vogen identities must be declared `Nullable`** — `InvoiceId? Id`, as above. Vogen forbids an
+uninitialized value object, so reading `.Value` off a `default` instance throws. Polecat inspects the
+identity to decide whether one needs assigning, and on a non-nullable Vogen id that inspection throws
+before Polecat can see that the id was unset. StronglyTypedId permits `default` and so can be declared
+either way.
+:::
+
+### Identity Assignment
+
+| Inner type | ID generation |
 | --- | --- |
-| `record struct InvoiceId(Guid Value)` | Auto-assigned sequential Guid |
-| `record struct OrderItemId(int Value)` | HiLo sequence |
-| `record struct IssueId(long Value)` | HiLo sequence |
-| `record struct TeamId(string Value)` | Manual assignment required |
+| `Guid` | Auto-assigned sequential `Guid` |
+| `int` | [HiLo sequence](#hilo-sequences) |
+| `long` | [HiLo sequence](#hilo-sequences) |
+| `string` | You assign it — Polecat never generates string identities |
+
+The identity column is created with the **inner** type (`uniqueidentifier`, `int`, `bigint`,
+`varchar`), not a serialized form of the wrapper.
 
 ### Usage
 
-Strong-typed IDs work transparently with all Polecat operations:
-
 ```cs
-// Store with auto-assigned Guid wrapper
+// Store with an auto-assigned Guid wrapper
 var order = new Order { Name = "Widget" };
 session.Store(order);
 await session.SaveChangesAsync();
@@ -102,14 +150,19 @@ await session.SaveChangesAsync();
 // Load by inner value
 var loaded = await query.LoadAsync<Order>(order.Id.Value);
 
-// LINQ queries work with the wrapper type directly
+// LINQ queries take the wrapper type directly
 var result = await query.Query<Order>()
     .Where(x => x.Id == order.Id)
     .FirstOrDefaultAsync();
 
-// IsOneOf for multiple IDs
+// IsOneOf for multiple ids
 var results = await query.Query<Order>()
     .Where(x => x.Id.IsOneOf(id1, id2, id3))
+    .ToListAsync();
+
+// Select projects the wrapper back out
+var ids = await query.Query<Order>()
+    .Select(x => x.Id)
     .ToListAsync();
 
 // Delete by inner value
@@ -119,20 +172,75 @@ session.Delete<Order>(order.Id.Value);
 var exists = await query.CheckExistsAsync<Order>(order.Id.Value);
 ```
 
-All of the following operations are supported:
+Supported across:
 
-- `Store()` / `Insert()` / `Update()` with automatic ID assignment
-- `LoadAsync()` by inner value
+- `Store()` / `Insert()` / `Update()`, with automatic identity assignment
+- `LoadAsync()` and `LoadManyAsync()` by inner value
 - `Delete()` by inner value or by document
 - `CheckExistsAsync()` by inner value
-- LINQ `Where`, `OrderBy`, `IsOneOf`
+- LINQ `Where`, `OrderBy` / `OrderByDescending`, `IsOneOf`, `Select`, `Count`
+- Paging via `ToPagedListAsync()`
 - Identity map sessions
 - Bulk insert via `BulkInsertAsync()`
-- Batch queries
+- Batched queries — `Load`, `LoadMany`, `CheckExists`, and `Query<T>()`
+- Aggregate identities in event projections
+
+::: warning
+`LoadAsync()`, `Delete()`, and `CheckExistsAsync()` take the **inner** value (`order.Id.Value`), not the
+wrapper. Polecat has no `LoadAsync<T>(object id)` overload; if you pass the wrapper the call will not
+compile.
+:::
+
+### Value Types on Other Members
+
+A wrapper is not limited to the identity. Any document member can be one, and it stays queryable:
+
+```cs
+[ValueObject<Guid>]
+public readonly partial struct TeacherId;
+
+public class ClassRoom
+{
+    public Guid Id { get; set; }
+    public TeacherId Teacher { get; set; }
+    public string Subject { get; set; } = "";
+}
+
+// Filter, order and project by the wrapper
+var rooms = await query.Query<ClassRoom>()
+    .Where(x => x.Teacher == teacherId)
+    .OrderBy(x => x.Teacher)
+    .ToListAsync();
+
+var teacherIds = await query.Query<ClassRoom>()
+    .Select(x => x.Teacher)
+    .ToListAsync();
+```
+
+This works because the generator's JSON converter writes the inner value, so the member lands in the
+document JSON as a bare scalar. Polecat types the SQL from the inner type and unwraps the parameter
+for you. The same unwrapping applies to:
+
+- **Computed indexes** — `Schema.For<ClassRoom>().Index(x => x.Teacher)` creates a
+  `uniqueidentifier` computed column, and the LINQ predicate matches it so the index stays seekable
+- **Flat table projections** — `map.Map(x => x.Account)` creates a column of the inner type
 
 ::: tip
-For strongly typed Guid IDs, Polecat will auto-assign the inner Guid value if it's empty, just like regular Guid IDs.
+A wrapper written by hand, with no JSON converter, serializes as a nested object (`{"value": ...}`) and
+will **not** match a scalar predicate. Use Vogen or StronglyTypedId for any value type you intend to
+query on a non-identity member.
 :::
+
+A type with more than one public property — `record struct Money(decimal Amount, Guid CurrencyId)` —
+is not a strong typed identifier and is left alone as a nested JSON object, so `x.Amount.CurrencyId`
+keeps resolving as a nested path.
+
+### Not Currently Supported
+
+- No `LoadAsync<T>(object id)` overload taking the wrapper itself
+- No `Include()` LINQ operator
+- No compiled queries
+- F# single-case discriminated unions as identities
 
 ## HiLo Sequences
 

--- a/src/Polecat.Tests/Polecat.Tests.csproj
+++ b/src/Polecat.Tests/Polecat.Tests.csproj
@@ -16,6 +16,7 @@
         <PackageReference Include="Microsoft.Extensions.Hosting" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
         <PackageReference Include="StronglyTypedId" />
+        <PackageReference Include="Vogen" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Polecat.Tests/StrongTypedId/GeneratedIds/generated_id_types.cs
+++ b/src/Polecat.Tests/StrongTypedId/GeneratedIds/generated_id_types.cs
@@ -1,0 +1,48 @@
+using StronglyTypedIds;
+
+namespace Polecat.Tests.StrongTypedId.GeneratedIds;
+
+// The StronglyTypedId generator, which Marten's ValueTypeTests/StrongTypedId suites use alongside
+// hand-written record structs. It emits a readonly record struct with a *public* constructor, so
+// these cover the "ctor" branch of JasperFx's ValueTypeInfo the way ../VogenIds covers the static
+// factory branch — and, unlike Vogen, it permits `default`, so the ids here are non-nullable and
+// exercise identity assignment against a zero-valued wrapper.
+//
+// Polecat already used this generator for aggregate identities (see ../../Projections); these are
+// the document-side equivalents.
+
+[StronglyTypedId(Template.Guid)]
+public readonly partial struct GeneratedInvoiceId;
+
+public class GeneratedInvoice
+{
+    public GeneratedInvoiceId Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+}
+
+[StronglyTypedId(Template.Int)]
+public readonly partial struct GeneratedOrderId;
+
+public class GeneratedOrder
+{
+    public GeneratedOrderId Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+}
+
+[StronglyTypedId(Template.Long)]
+public readonly partial struct GeneratedIssueId;
+
+public class GeneratedIssue
+{
+    public GeneratedIssueId Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+}
+
+[StronglyTypedId(Template.String)]
+public readonly partial struct GeneratedTeamId;
+
+public class GeneratedTeam
+{
+    public GeneratedTeamId Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+}

--- a/src/Polecat.Tests/StrongTypedId/GeneratedIds/guid_based_document_operations.cs
+++ b/src/Polecat.Tests/StrongTypedId/GeneratedIds/guid_based_document_operations.cs
@@ -1,0 +1,244 @@
+using Polecat.Linq;
+using Polecat.Tests.Harness;
+using Shouldly;
+
+namespace Polecat.Tests.StrongTypedId.GeneratedIds;
+
+// Mirrors Marten's ValueTypeTests/StrongTypedId/guid_based_document_operations.
+[Collection("integration")]
+public class guid_based_document_operations : IntegrationContext
+{
+    public guid_based_document_operations(DefaultStoreFixture fixture) : base(fixture)
+    {
+    }
+
+    public override async ValueTask InitializeAsync()
+    {
+        await StoreOptions(opts => { opts.DatabaseSchemaName = "stid_guid"; });
+    }
+
+    [Fact]
+    public async Task store_document_will_assign_the_identity()
+    {
+        var invoice = new GeneratedInvoice { Name = "Auto" };
+        invoice.Id.Value.ShouldBe(Guid.Empty);
+
+        await using var session = theStore.LightweightSession();
+        session.Store(invoice);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        invoice.Id.Value.ShouldNotBe(Guid.Empty);
+    }
+
+    [Fact]
+    public async Task store_a_document_smoke_test()
+    {
+        await using var session = theStore.LightweightSession();
+        session.Store(new GeneratedInvoice { Name = "Smoke" });
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        (await session.Query<GeneratedInvoice>().AnyAsync(TestContext.Current.CancellationToken)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task insert_a_document_smoke_test()
+    {
+        var invoice = new GeneratedInvoice { Id = new GeneratedInvoiceId(Guid.NewGuid()), Name = "Inserted" };
+        await using var session = theStore.LightweightSession();
+        session.Insert(invoice);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        (await session.LoadAsync<GeneratedInvoice>(invoice.Id.Value, TestContext.Current.CancellationToken))!
+            .Name.ShouldBe("Inserted");
+    }
+
+    [Fact]
+    public async Task update_a_document_smoke_test()
+    {
+        var invoice = new GeneratedInvoice { Id = new GeneratedInvoiceId(Guid.NewGuid()), Name = "Original" };
+        await using var session = theStore.LightweightSession();
+        session.Insert(invoice);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        invoice.Name = "Updated";
+        session.Update(invoice);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        await using var query = theStore.QuerySession();
+        (await query.LoadAsync<GeneratedInvoice>(invoice.Id.Value, TestContext.Current.CancellationToken))!
+            .Name.ShouldBe("Updated");
+    }
+
+    [Fact]
+    public async Task load_document()
+    {
+        var invoice = new GeneratedInvoice { Id = new GeneratedInvoiceId(Guid.NewGuid()), Name = "Load Me" };
+        await using var session = theStore.LightweightSession();
+        session.Store(invoice);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var loaded = await session.LoadAsync<GeneratedInvoice>(invoice.Id.Value, TestContext.Current.CancellationToken);
+        loaded.ShouldNotBeNull();
+        loaded!.Id.ShouldBe(invoice.Id);
+        loaded.Name.ShouldBe("Load Me");
+    }
+
+    [Fact]
+    public async Task load_many()
+    {
+        var one = new GeneratedInvoice { Id = new GeneratedInvoiceId(Guid.NewGuid()), Name = "One" };
+        var two = new GeneratedInvoice { Id = new GeneratedInvoiceId(Guid.NewGuid()), Name = "Two" };
+
+        await using var session = theStore.LightweightSession();
+        session.Store(one, two);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var loaded = await session.LoadManyAsync<GeneratedInvoice>(
+            [one.Id.Value, two.Id.Value], TestContext.Current.CancellationToken);
+
+        loaded.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task use_within_identity_map()
+    {
+        var invoice = new GeneratedInvoice { Id = new GeneratedInvoiceId(Guid.NewGuid()), Name = "Identity" };
+        await using var session = theStore.IdentitySession();
+        session.Store(invoice);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var first = await session.LoadAsync<GeneratedInvoice>(invoice.Id.Value, TestContext.Current.CancellationToken);
+        var second = await session.LoadAsync<GeneratedInvoice>(invoice.Id.Value, TestContext.Current.CancellationToken);
+
+        first.ShouldNotBeNull();
+        ReferenceEquals(first, second).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task delete_by_id()
+    {
+        var invoice = new GeneratedInvoice { Id = new GeneratedInvoiceId(Guid.NewGuid()), Name = "Delete" };
+        await using var session = theStore.LightweightSession();
+        session.Store(invoice);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        session.Delete<GeneratedInvoice>(invoice.Id.Value);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        await using var query = theStore.QuerySession();
+        (await query.LoadAsync<GeneratedInvoice>(invoice.Id.Value, TestContext.Current.CancellationToken))
+            .ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task delete_by_document()
+    {
+        var invoice = new GeneratedInvoice { Id = new GeneratedInvoiceId(Guid.NewGuid()), Name = "Delete Doc" };
+        await using var session = theStore.LightweightSession();
+        session.Store(invoice);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        session.Delete(invoice);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        await using var query = theStore.QuerySession();
+        (await query.LoadAsync<GeneratedInvoice>(invoice.Id.Value, TestContext.Current.CancellationToken))
+            .ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task use_in_LINQ_where_clause()
+    {
+        var invoice = new GeneratedInvoice { Id = new GeneratedInvoiceId(Guid.NewGuid()), Name = "LINQ Where" };
+        await using var session = theStore.LightweightSession();
+        session.Store(invoice);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var loaded = await session.Query<GeneratedInvoice>()
+            .Where(x => x.Id == invoice.Id)
+            .FirstOrDefaultAsync(TestContext.Current.CancellationToken);
+
+        loaded!.Name.ShouldBe("LINQ Where");
+    }
+
+    [Fact]
+    public async Task use_in_LINQ_order_clause()
+    {
+        await using var session = theStore.LightweightSession();
+        session.Store(new GeneratedInvoice { Id = new GeneratedInvoiceId(Guid.NewGuid()), Name = "A" });
+        session.Store(new GeneratedInvoice { Id = new GeneratedInvoiceId(Guid.NewGuid()), Name = "B" });
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var results = await session.Query<GeneratedInvoice>()
+            .OrderBy(x => x.Id)
+            .Take(3)
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        results.Count.ShouldBeGreaterThanOrEqualTo(2);
+    }
+
+    [Fact]
+    public async Task use_in_LINQ_select_clause()
+    {
+        var invoice = new GeneratedInvoice { Id = new GeneratedInvoiceId(Guid.NewGuid()), Name = "Select" };
+        await using var session = theStore.LightweightSession();
+        session.Store(invoice);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var ids = await session.Query<GeneratedInvoice>()
+            .Where(x => x.Id == invoice.Id)
+            .Select(x => x.Id)
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        ids.Single().ShouldBe(invoice.Id);
+    }
+
+    [Fact]
+    public async Task use_in_LINQ_is_one_of()
+    {
+        var one = new GeneratedInvoice { Id = new GeneratedInvoiceId(Guid.NewGuid()), Name = "One" };
+        var two = new GeneratedInvoice { Id = new GeneratedInvoiceId(Guid.NewGuid()), Name = "Two" };
+
+        await using var session = theStore.LightweightSession();
+        session.Store(one, two);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var results = await session.Query<GeneratedInvoice>()
+            .Where(x => x.Id.IsOneOf(one.Id, two.Id))
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        results.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task bulk_insert()
+    {
+        var invoices = Enumerable.Range(0, 5)
+            .Select(i => new GeneratedInvoice { Id = new GeneratedInvoiceId(Guid.NewGuid()), Name = $"Bulk {i}" })
+            .ToList();
+
+        await theStore.Advanced.BulkInsertAsync(invoices, TestContext.Current.CancellationToken);
+
+        await using var query = theStore.QuerySession();
+        foreach (var invoice in invoices)
+        {
+            (await query.LoadAsync<GeneratedInvoice>(invoice.Id.Value, TestContext.Current.CancellationToken))
+                .ShouldNotBeNull();
+        }
+    }
+
+    [Fact]
+    public async Task check_exists_with_wrapper_id()
+    {
+        var invoice = new GeneratedInvoice { Id = new GeneratedInvoiceId(Guid.NewGuid()), Name = "Exists" };
+        await using var session = theStore.LightweightSession();
+        session.Store(invoice);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        await using var query = theStore.QuerySession();
+        (await query.CheckExistsAsync<GeneratedInvoice>(invoice.Id.Value, TestContext.Current.CancellationToken))
+            .ShouldBeTrue();
+        (await query.CheckExistsAsync<GeneratedInvoice>(Guid.NewGuid(), TestContext.Current.CancellationToken))
+            .ShouldBeFalse();
+    }
+}

--- a/src/Polecat.Tests/StrongTypedId/GeneratedIds/numeric_and_string_document_operations.cs
+++ b/src/Polecat.Tests/StrongTypedId/GeneratedIds/numeric_and_string_document_operations.cs
@@ -1,0 +1,389 @@
+using Polecat.Linq;
+using Polecat.Tests.Harness;
+using Shouldly;
+
+namespace Polecat.Tests.StrongTypedId.GeneratedIds;
+
+// Mirrors Marten's ValueTypeTests/StrongTypedId int_/long_/string_id_document_operations. Grouped
+// into one class per inner type family because the generated ids differ only in what they wrap.
+[Collection("integration")]
+public class int_based_document_operations : IntegrationContext
+{
+    public int_based_document_operations(DefaultStoreFixture fixture) : base(fixture)
+    {
+    }
+
+    public override async ValueTask InitializeAsync()
+    {
+        await StoreOptions(opts => { opts.DatabaseSchemaName = "stid_int"; });
+    }
+
+    [Fact]
+    public async Task store_document_will_assign_the_identity()
+    {
+        var order = new GeneratedOrder { Name = "Auto" };
+        order.Id.Value.ShouldBe(0);
+
+        await using var session = theStore.LightweightSession();
+        session.Store(order);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        order.Id.Value.ShouldBeGreaterThan(0);
+    }
+
+    [Fact]
+    public async Task store_assigns_hilo_ids()
+    {
+        var first = new GeneratedOrder { Name = "First" };
+        var second = new GeneratedOrder { Name = "Second" };
+
+        await using var session = theStore.LightweightSession();
+        session.Store(first, second);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        first.Id.Value.ShouldNotBe(second.Id.Value);
+    }
+
+    [Fact]
+    public async Task insert_update_and_load()
+    {
+        var order = new GeneratedOrder { Id = new GeneratedOrderId(7001), Name = "Original" };
+        await using var session = theStore.LightweightSession();
+        session.Insert(order);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        order.Name = "Updated";
+        session.Update(order);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        await using var query = theStore.QuerySession();
+        var loaded = await query.LoadAsync<GeneratedOrder>(7001, TestContext.Current.CancellationToken);
+        loaded.ShouldNotBeNull();
+        loaded!.Id.ShouldBe(order.Id);
+        loaded.Name.ShouldBe("Updated");
+    }
+
+    [Fact]
+    public async Task use_within_identity_map()
+    {
+        await using var session = theStore.IdentitySession();
+        session.Store(new GeneratedOrder { Id = new GeneratedOrderId(7002), Name = "Identity" });
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var first = await session.LoadAsync<GeneratedOrder>(7002, TestContext.Current.CancellationToken);
+        var second = await session.LoadAsync<GeneratedOrder>(7002, TestContext.Current.CancellationToken);
+
+        first.ShouldNotBeNull();
+        ReferenceEquals(first, second).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task delete_by_id_and_by_document()
+    {
+        var byId = new GeneratedOrder { Id = new GeneratedOrderId(7003), Name = "By Id" };
+        var byDoc = new GeneratedOrder { Id = new GeneratedOrderId(7004), Name = "By Doc" };
+
+        await using var session = theStore.LightweightSession();
+        session.Store(byId, byDoc);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        session.Delete<GeneratedOrder>(7003);
+        session.Delete(byDoc);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        await using var query = theStore.QuerySession();
+        (await query.LoadAsync<GeneratedOrder>(7003, TestContext.Current.CancellationToken)).ShouldBeNull();
+        (await query.LoadAsync<GeneratedOrder>(7004, TestContext.Current.CancellationToken)).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task use_in_LINQ_where_order_select_and_is_one_of()
+    {
+        var one = new GeneratedOrder { Id = new GeneratedOrderId(7005), Name = "One" };
+        var two = new GeneratedOrder { Id = new GeneratedOrderId(7006), Name = "Two" };
+
+        await using var session = theStore.LightweightSession();
+        session.Store(one, two);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        (await session.Query<GeneratedOrder>()
+            .Where(x => x.Id == one.Id)
+            .FirstOrDefaultAsync(TestContext.Current.CancellationToken))!.Name.ShouldBe("One");
+
+        var ordered = await session.Query<GeneratedOrder>()
+            .Where(x => x.Id.IsOneOf(one.Id, two.Id))
+            .OrderBy(x => x.Id)
+            .ToListAsync(TestContext.Current.CancellationToken);
+        ordered.Select(x => x.Name).ShouldBe(["One", "Two"]);
+
+        var ids = await session.Query<GeneratedOrder>()
+            .Where(x => x.Id.IsOneOf(one.Id, two.Id))
+            .OrderBy(x => x.Id)
+            .Select(x => x.Id)
+            .ToListAsync(TestContext.Current.CancellationToken);
+        ids.ShouldBe([one.Id, two.Id]);
+    }
+
+    [Fact]
+    public async Task check_exists_with_wrapper_id()
+    {
+        await using var session = theStore.LightweightSession();
+        session.Store(new GeneratedOrder { Id = new GeneratedOrderId(7007), Name = "Exists" });
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        await using var query = theStore.QuerySession();
+        (await query.CheckExistsAsync<GeneratedOrder>(7007, TestContext.Current.CancellationToken)).ShouldBeTrue();
+        (await query.CheckExistsAsync<GeneratedOrder>(999999, TestContext.Current.CancellationToken)).ShouldBeFalse();
+    }
+}
+
+[Collection("integration")]
+public class long_based_document_operations : IntegrationContext
+{
+    public long_based_document_operations(DefaultStoreFixture fixture) : base(fixture)
+    {
+    }
+
+    public override async ValueTask InitializeAsync()
+    {
+        await StoreOptions(opts => { opts.DatabaseSchemaName = "stid_long"; });
+    }
+
+    [Fact]
+    public async Task store_document_will_assign_the_identity()
+    {
+        var issue = new GeneratedIssue { Name = "Auto" };
+        issue.Id.Value.ShouldBe(0L);
+
+        await using var session = theStore.LightweightSession();
+        session.Store(issue);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        issue.Id.Value.ShouldBeGreaterThan(0L);
+    }
+
+    [Fact]
+    public async Task store_assigns_hilo_ids()
+    {
+        var first = new GeneratedIssue { Name = "First" };
+        var second = new GeneratedIssue { Name = "Second" };
+
+        await using var session = theStore.LightweightSession();
+        session.Store(first, second);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        first.Id.Value.ShouldNotBe(second.Id.Value);
+    }
+
+    [Fact]
+    public async Task insert_update_and_load()
+    {
+        var issue = new GeneratedIssue { Id = new GeneratedIssueId(6001L), Name = "Original" };
+        await using var session = theStore.LightweightSession();
+        session.Insert(issue);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        issue.Name = "Updated";
+        session.Update(issue);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        await using var query = theStore.QuerySession();
+        var loaded = await query.LoadAsync<GeneratedIssue>(6001L, TestContext.Current.CancellationToken);
+        loaded.ShouldNotBeNull();
+        loaded!.Id.ShouldBe(issue.Id);
+        loaded.Name.ShouldBe("Updated");
+    }
+
+    [Fact]
+    public async Task use_within_identity_map()
+    {
+        await using var session = theStore.IdentitySession();
+        session.Store(new GeneratedIssue { Id = new GeneratedIssueId(6002L), Name = "Identity" });
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var first = await session.LoadAsync<GeneratedIssue>(6002L, TestContext.Current.CancellationToken);
+        var second = await session.LoadAsync<GeneratedIssue>(6002L, TestContext.Current.CancellationToken);
+
+        first.ShouldNotBeNull();
+        ReferenceEquals(first, second).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task delete_by_id_and_by_document()
+    {
+        var byId = new GeneratedIssue { Id = new GeneratedIssueId(6003L), Name = "By Id" };
+        var byDoc = new GeneratedIssue { Id = new GeneratedIssueId(6004L), Name = "By Doc" };
+
+        await using var session = theStore.LightweightSession();
+        session.Store(byId, byDoc);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        session.Delete<GeneratedIssue>(6003L);
+        session.Delete(byDoc);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        await using var query = theStore.QuerySession();
+        (await query.LoadAsync<GeneratedIssue>(6003L, TestContext.Current.CancellationToken)).ShouldBeNull();
+        (await query.LoadAsync<GeneratedIssue>(6004L, TestContext.Current.CancellationToken)).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task use_in_LINQ_where_order_select_and_is_one_of()
+    {
+        var one = new GeneratedIssue { Id = new GeneratedIssueId(6005L), Name = "One" };
+        var two = new GeneratedIssue { Id = new GeneratedIssueId(6006L), Name = "Two" };
+
+        await using var session = theStore.LightweightSession();
+        session.Store(one, two);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        (await session.Query<GeneratedIssue>()
+            .Where(x => x.Id == one.Id)
+            .FirstOrDefaultAsync(TestContext.Current.CancellationToken))!.Name.ShouldBe("One");
+
+        var ordered = await session.Query<GeneratedIssue>()
+            .Where(x => x.Id.IsOneOf(one.Id, two.Id))
+            .OrderBy(x => x.Id)
+            .ToListAsync(TestContext.Current.CancellationToken);
+        ordered.Select(x => x.Name).ShouldBe(["One", "Two"]);
+
+        var ids = await session.Query<GeneratedIssue>()
+            .Where(x => x.Id.IsOneOf(one.Id, two.Id))
+            .OrderBy(x => x.Id)
+            .Select(x => x.Id)
+            .ToListAsync(TestContext.Current.CancellationToken);
+        ids.ShouldBe([one.Id, two.Id]);
+    }
+
+    [Fact]
+    public async Task check_exists_with_wrapper_id()
+    {
+        await using var session = theStore.LightweightSession();
+        session.Store(new GeneratedIssue { Id = new GeneratedIssueId(6007L), Name = "Exists" });
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        await using var query = theStore.QuerySession();
+        (await query.CheckExistsAsync<GeneratedIssue>(6007L, TestContext.Current.CancellationToken)).ShouldBeTrue();
+        (await query.CheckExistsAsync<GeneratedIssue>(999999L, TestContext.Current.CancellationToken)).ShouldBeFalse();
+    }
+}
+
+[Collection("integration")]
+public class string_id_document_operations : IntegrationContext
+{
+    public string_id_document_operations(DefaultStoreFixture fixture) : base(fixture)
+    {
+    }
+
+    public override async ValueTask InitializeAsync()
+    {
+        await StoreOptions(opts => { opts.DatabaseSchemaName = "stid_string"; });
+    }
+
+    private static GeneratedTeam Team(string id, string name = "Team") =>
+        new() { Id = new GeneratedTeamId(id), Name = name };
+
+    [Fact]
+    public async Task insert_update_and_load()
+    {
+        var team = Team("g-update-1", "Original");
+        await using var session = theStore.LightweightSession();
+        session.Insert(team);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        team.Name = "Updated";
+        session.Update(team);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        await using var query = theStore.QuerySession();
+        var loaded = await query.LoadAsync<GeneratedTeam>("g-update-1", TestContext.Current.CancellationToken);
+        loaded.ShouldNotBeNull();
+        loaded!.Id.ShouldBe(team.Id);
+        loaded.Name.ShouldBe("Updated");
+    }
+
+    [Fact]
+    public async Task load_many()
+    {
+        await using var session = theStore.LightweightSession();
+        session.Store(Team("g-many-1"), Team("g-many-2"));
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var loaded = await session.LoadManyAsync<GeneratedTeam>(
+            ["g-many-1", "g-many-2"], TestContext.Current.CancellationToken);
+        loaded.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task use_within_identity_map()
+    {
+        await using var session = theStore.IdentitySession();
+        session.Store(Team("g-identity-1"));
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var first = await session.LoadAsync<GeneratedTeam>("g-identity-1", TestContext.Current.CancellationToken);
+        var second = await session.LoadAsync<GeneratedTeam>("g-identity-1", TestContext.Current.CancellationToken);
+
+        first.ShouldNotBeNull();
+        ReferenceEquals(first, second).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task delete_by_id_and_by_document()
+    {
+        var byDoc = Team("g-delete-2");
+        await using var session = theStore.LightweightSession();
+        session.Store(Team("g-delete-1"), byDoc);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        session.Delete<GeneratedTeam>("g-delete-1");
+        session.Delete(byDoc);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        await using var query = theStore.QuerySession();
+        (await query.LoadAsync<GeneratedTeam>("g-delete-1", TestContext.Current.CancellationToken)).ShouldBeNull();
+        (await query.LoadAsync<GeneratedTeam>("g-delete-2", TestContext.Current.CancellationToken)).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task use_in_LINQ_where_order_select_and_is_one_of()
+    {
+        var one = Team("g-linq-1", "One");
+        var two = Team("g-linq-2", "Two");
+
+        await using var session = theStore.LightweightSession();
+        session.Store(one, two);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        (await session.Query<GeneratedTeam>()
+            .Where(x => x.Id == one.Id)
+            .FirstOrDefaultAsync(TestContext.Current.CancellationToken))!.Name.ShouldBe("One");
+
+        var ordered = await session.Query<GeneratedTeam>()
+            .Where(x => x.Id.IsOneOf(one.Id, two.Id))
+            .OrderBy(x => x.Id)
+            .ToListAsync(TestContext.Current.CancellationToken);
+        ordered.Select(x => x.Name).ShouldBe(["One", "Two"]);
+
+        var ids = await session.Query<GeneratedTeam>()
+            .Where(x => x.Id.IsOneOf(one.Id, two.Id))
+            .OrderBy(x => x.Id)
+            .Select(x => x.Id)
+            .ToListAsync(TestContext.Current.CancellationToken);
+        ids.ShouldBe([one.Id, two.Id]);
+    }
+
+    [Fact]
+    public async Task check_exists_with_wrapper_id()
+    {
+        await using var session = theStore.LightweightSession();
+        session.Store(Team("g-exists-1"));
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        await using var query = theStore.QuerySession();
+        (await query.CheckExistsAsync<GeneratedTeam>("g-exists-1", TestContext.Current.CancellationToken))
+            .ShouldBeTrue();
+        (await query.CheckExistsAsync<GeneratedTeam>("nope", TestContext.Current.CancellationToken))
+            .ShouldBeFalse();
+    }
+}

--- a/src/Polecat.Tests/StrongTypedId/VogenIds/guid_based_document_operations.cs
+++ b/src/Polecat.Tests/StrongTypedId/VogenIds/guid_based_document_operations.cs
@@ -1,0 +1,249 @@
+using Polecat.Linq;
+using Polecat.Tests.Harness;
+using Shouldly;
+
+namespace Polecat.Tests.StrongTypedId.VogenIds;
+
+// Mirrors Marten's ValueTypeTests/VogenIds/guid_based_document_operations.
+[Collection("integration")]
+public class guid_based_document_operations : IntegrationContext
+{
+    public guid_based_document_operations(DefaultStoreFixture fixture) : base(fixture)
+    {
+    }
+
+    public override async ValueTask InitializeAsync()
+    {
+        await StoreOptions(opts => { opts.DatabaseSchemaName = "vogen_guid"; });
+    }
+
+    [Fact]
+    public async Task store_document_will_assign_the_identity()
+    {
+        var invoice = new VogenInvoice { Name = "Auto" };
+        invoice.Id.ShouldBeNull();
+
+        await using var session = theStore.LightweightSession();
+        session.Store(invoice);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        invoice.Id.ShouldNotBeNull();
+        invoice.Id!.Value.Value.ShouldNotBe(Guid.Empty);
+    }
+
+    [Fact]
+    public async Task store_a_document_smoke_test()
+    {
+        await using var session = theStore.LightweightSession();
+        session.Store(new VogenInvoice { Name = "Smoke" });
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        (await session.Query<VogenInvoice>().AnyAsync(TestContext.Current.CancellationToken)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task insert_a_document_smoke_test()
+    {
+        var invoice = new VogenInvoice { Id = VogenInvoiceId.From(Guid.NewGuid()), Name = "Inserted" };
+        await using var session = theStore.LightweightSession();
+        session.Insert(invoice);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var loaded = await session.LoadAsync<VogenInvoice>(invoice.Id!.Value.Value, TestContext.Current.CancellationToken);
+        loaded.ShouldNotBeNull();
+        loaded!.Name.ShouldBe("Inserted");
+    }
+
+    [Fact]
+    public async Task update_a_document_smoke_test()
+    {
+        var invoice = new VogenInvoice { Id = VogenInvoiceId.From(Guid.NewGuid()), Name = "Original" };
+        await using var session = theStore.LightweightSession();
+        session.Insert(invoice);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        invoice.Name = "Updated";
+        session.Update(invoice);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        await using var query = theStore.QuerySession();
+        var loaded = await query.LoadAsync<VogenInvoice>(invoice.Id!.Value.Value, TestContext.Current.CancellationToken);
+        loaded!.Name.ShouldBe("Updated");
+    }
+
+    [Fact]
+    public async Task load_document()
+    {
+        var invoice = new VogenInvoice { Id = VogenInvoiceId.From(Guid.NewGuid()), Name = "Load Me" };
+        await using var session = theStore.LightweightSession();
+        session.Store(invoice);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var loaded = await session.LoadAsync<VogenInvoice>(invoice.Id!.Value.Value, TestContext.Current.CancellationToken);
+        loaded.ShouldNotBeNull();
+        loaded!.Id.ShouldBe(invoice.Id);
+        loaded.Name.ShouldBe("Load Me");
+    }
+
+    [Fact]
+    public async Task load_many()
+    {
+        var one = new VogenInvoice { Id = VogenInvoiceId.From(Guid.NewGuid()), Name = "One" };
+        var two = new VogenInvoice { Id = VogenInvoiceId.From(Guid.NewGuid()), Name = "Two" };
+        var three = new VogenInvoice { Id = VogenInvoiceId.From(Guid.NewGuid()), Name = "Three" };
+
+        await using var session = theStore.LightweightSession();
+        session.Store(one, two, three);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var loaded = await session.LoadManyAsync<VogenInvoice>(
+            [one.Id!.Value.Value, two.Id!.Value.Value, three.Id!.Value.Value],
+            TestContext.Current.CancellationToken);
+
+        loaded.Count.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task use_within_identity_map()
+    {
+        var invoice = new VogenInvoice { Id = VogenInvoiceId.From(Guid.NewGuid()), Name = "Identity" };
+        await using var session = theStore.IdentitySession();
+        session.Store(invoice);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var first = await session.LoadAsync<VogenInvoice>(invoice.Id!.Value.Value, TestContext.Current.CancellationToken);
+        var second = await session.LoadAsync<VogenInvoice>(invoice.Id!.Value.Value, TestContext.Current.CancellationToken);
+
+        first.ShouldNotBeNull();
+        ReferenceEquals(first, second).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task delete_by_id()
+    {
+        var invoice = new VogenInvoice { Id = VogenInvoiceId.From(Guid.NewGuid()), Name = "Delete" };
+        await using var session = theStore.LightweightSession();
+        session.Store(invoice);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        session.Delete<VogenInvoice>(invoice.Id!.Value.Value);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        await using var query = theStore.QuerySession();
+        (await query.LoadAsync<VogenInvoice>(invoice.Id!.Value.Value, TestContext.Current.CancellationToken))
+            .ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task delete_by_document()
+    {
+        var invoice = new VogenInvoice { Id = VogenInvoiceId.From(Guid.NewGuid()), Name = "Delete Doc" };
+        await using var session = theStore.LightweightSession();
+        session.Store(invoice);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        session.Delete(invoice);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        await using var query = theStore.QuerySession();
+        (await query.LoadAsync<VogenInvoice>(invoice.Id!.Value.Value, TestContext.Current.CancellationToken))
+            .ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task use_in_LINQ_where_clause()
+    {
+        var invoice = new VogenInvoice { Id = VogenInvoiceId.From(Guid.NewGuid()), Name = "LINQ Where" };
+        await using var session = theStore.LightweightSession();
+        session.Store(invoice);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var loaded = await session.Query<VogenInvoice>()
+            .Where(x => x.Id == invoice.Id)
+            .FirstOrDefaultAsync(TestContext.Current.CancellationToken);
+
+        loaded.ShouldNotBeNull();
+        loaded!.Name.ShouldBe("LINQ Where");
+    }
+
+    [Fact]
+    public async Task use_in_LINQ_order_clause()
+    {
+        await using var session = theStore.LightweightSession();
+        session.Store(new VogenInvoice { Id = VogenInvoiceId.From(Guid.NewGuid()), Name = "A" });
+        session.Store(new VogenInvoice { Id = VogenInvoiceId.From(Guid.NewGuid()), Name = "B" });
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var results = await session.Query<VogenInvoice>()
+            .OrderBy(x => x.Id)
+            .Take(3)
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        results.Count.ShouldBeGreaterThanOrEqualTo(2);
+    }
+
+    [Fact]
+    public async Task use_in_LINQ_select_clause()
+    {
+        var invoice = new VogenInvoice { Id = VogenInvoiceId.From(Guid.NewGuid()), Name = "Select" };
+        await using var session = theStore.LightweightSession();
+        session.Store(invoice);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var ids = await session.Query<VogenInvoice>()
+            .Where(x => x.Id == invoice.Id)
+            .Select(x => x.Id)
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        ids.Single().ShouldBe(invoice.Id);
+    }
+
+    [Fact]
+    public async Task use_in_LINQ_is_one_of()
+    {
+        var one = new VogenInvoice { Id = VogenInvoiceId.From(Guid.NewGuid()), Name = "One" };
+        var two = new VogenInvoice { Id = VogenInvoiceId.From(Guid.NewGuid()), Name = "Two" };
+
+        await using var session = theStore.LightweightSession();
+        session.Store(one, two);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var results = await session.Query<VogenInvoice>()
+            .Where(x => x.Id.IsOneOf(one.Id, two.Id))
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        results.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task bulk_insert()
+    {
+        var invoices = Enumerable.Range(0, 5)
+            .Select(i => new VogenInvoice { Id = VogenInvoiceId.From(Guid.NewGuid()), Name = $"Bulk {i}" })
+            .ToList();
+
+        await theStore.Advanced.BulkInsertAsync(invoices, TestContext.Current.CancellationToken);
+
+        await using var query = theStore.QuerySession();
+        foreach (var invoice in invoices)
+        {
+            (await query.LoadAsync<VogenInvoice>(invoice.Id!.Value.Value, TestContext.Current.CancellationToken))
+                .ShouldNotBeNull();
+        }
+    }
+
+    [Fact]
+    public async Task check_exists_with_wrapper_id()
+    {
+        var invoice = new VogenInvoice { Id = VogenInvoiceId.From(Guid.NewGuid()), Name = "Exists" };
+        await using var session = theStore.LightweightSession();
+        session.Store(invoice);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        await using var query = theStore.QuerySession();
+        (await query.CheckExistsAsync<VogenInvoice>(invoice.Id!.Value.Value, TestContext.Current.CancellationToken))
+            .ShouldBeTrue();
+        (await query.CheckExistsAsync<VogenInvoice>(Guid.NewGuid(), TestContext.Current.CancellationToken))
+            .ShouldBeFalse();
+    }
+}

--- a/src/Polecat.Tests/StrongTypedId/VogenIds/int_based_document_operations.cs
+++ b/src/Polecat.Tests/StrongTypedId/VogenIds/int_based_document_operations.cs
@@ -1,0 +1,236 @@
+using Polecat.Linq;
+using Polecat.Tests.Harness;
+using Shouldly;
+
+namespace Polecat.Tests.StrongTypedId.VogenIds;
+
+// Mirrors Marten's ValueTypeTests/VogenIds/int_based_document_operations.
+[Collection("integration")]
+public class int_based_document_operations : IntegrationContext
+{
+    public int_based_document_operations(DefaultStoreFixture fixture) : base(fixture)
+    {
+    }
+
+    public override async ValueTask InitializeAsync()
+    {
+        await StoreOptions(opts => { opts.DatabaseSchemaName = "vogen_int"; });
+    }
+
+    [Fact]
+    public async Task store_document_will_assign_the_identity()
+    {
+        var order = new VogenOrder { Name = "Auto" };
+        order.Id.ShouldBeNull();
+
+        await using var session = theStore.LightweightSession();
+        session.Store(order);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        order.Id.ShouldNotBeNull();
+        order.Id!.Value.Value.ShouldBeGreaterThan(0);
+    }
+
+    [Fact]
+    public async Task store_assigns_hilo_ids()
+    {
+        var first = new VogenOrder { Name = "First" };
+        var second = new VogenOrder { Name = "Second" };
+
+        await using var session = theStore.LightweightSession();
+        session.Store(first, second);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        first.Id!.Value.Value.ShouldNotBe(second.Id!.Value.Value);
+    }
+
+    [Fact]
+    public async Task store_a_document_smoke_test()
+    {
+        await using var session = theStore.LightweightSession();
+        session.Store(new VogenOrder { Name = "Smoke" });
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        (await session.Query<VogenOrder>().AnyAsync(TestContext.Current.CancellationToken)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task insert_a_document_smoke_test()
+    {
+        var order = new VogenOrder { Id = VogenOrderId.From(9001), Name = "Inserted" };
+        await using var session = theStore.LightweightSession();
+        session.Insert(order);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var loaded = await session.LoadAsync<VogenOrder>(9001, TestContext.Current.CancellationToken);
+        loaded!.Name.ShouldBe("Inserted");
+    }
+
+    [Fact]
+    public async Task update_a_document_smoke_test()
+    {
+        var order = new VogenOrder { Id = VogenOrderId.From(9002), Name = "Original" };
+        await using var session = theStore.LightweightSession();
+        session.Insert(order);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        order.Name = "Updated";
+        session.Update(order);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        await using var query = theStore.QuerySession();
+        (await query.LoadAsync<VogenOrder>(9002, TestContext.Current.CancellationToken))!.Name.ShouldBe("Updated");
+    }
+
+    [Fact]
+    public async Task load_document()
+    {
+        var order = new VogenOrder { Id = VogenOrderId.From(9003), Name = "Load Me" };
+        await using var session = theStore.LightweightSession();
+        session.Store(order);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var loaded = await session.LoadAsync<VogenOrder>(9003, TestContext.Current.CancellationToken);
+        loaded.ShouldNotBeNull();
+        loaded!.Id.ShouldBe(order.Id);
+    }
+
+    [Fact]
+    public async Task use_within_identity_map()
+    {
+        var order = new VogenOrder { Id = VogenOrderId.From(9004), Name = "Identity" };
+        await using var session = theStore.IdentitySession();
+        session.Store(order);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var first = await session.LoadAsync<VogenOrder>(9004, TestContext.Current.CancellationToken);
+        var second = await session.LoadAsync<VogenOrder>(9004, TestContext.Current.CancellationToken);
+
+        first.ShouldNotBeNull();
+        ReferenceEquals(first, second).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task delete_by_id()
+    {
+        var order = new VogenOrder { Id = VogenOrderId.From(9005), Name = "Delete" };
+        await using var session = theStore.LightweightSession();
+        session.Store(order);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        session.Delete<VogenOrder>(9005);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        await using var query = theStore.QuerySession();
+        (await query.LoadAsync<VogenOrder>(9005, TestContext.Current.CancellationToken)).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task delete_by_document()
+    {
+        var order = new VogenOrder { Id = VogenOrderId.From(9006), Name = "Delete Doc" };
+        await using var session = theStore.LightweightSession();
+        session.Store(order);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        session.Delete(order);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        await using var query = theStore.QuerySession();
+        (await query.LoadAsync<VogenOrder>(9006, TestContext.Current.CancellationToken)).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task use_in_LINQ_where_clause()
+    {
+        var order = new VogenOrder { Id = VogenOrderId.From(9007), Name = "LINQ Where" };
+        await using var session = theStore.LightweightSession();
+        session.Store(order);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var loaded = await session.Query<VogenOrder>()
+            .Where(x => x.Id == order.Id)
+            .FirstOrDefaultAsync(TestContext.Current.CancellationToken);
+
+        loaded!.Name.ShouldBe("LINQ Where");
+    }
+
+    [Fact]
+    public async Task use_in_LINQ_order_clause()
+    {
+        await using var session = theStore.LightweightSession();
+        session.Store(new VogenOrder { Id = VogenOrderId.From(9008), Name = "A" });
+        session.Store(new VogenOrder { Id = VogenOrderId.From(9009), Name = "B" });
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var results = await session.Query<VogenOrder>()
+            .OrderBy(x => x.Id)
+            .Take(3)
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        results.Count.ShouldBeGreaterThanOrEqualTo(2);
+    }
+
+    [Fact]
+    public async Task use_in_LINQ_select_clause()
+    {
+        var order = new VogenOrder { Id = VogenOrderId.From(9010), Name = "Select" };
+        await using var session = theStore.LightweightSession();
+        session.Store(order);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var ids = await session.Query<VogenOrder>()
+            .Where(x => x.Id == order.Id)
+            .Select(x => x.Id)
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        ids.Single().ShouldBe(order.Id);
+    }
+
+    [Fact]
+    public async Task use_in_LINQ_is_one_of()
+    {
+        var one = new VogenOrder { Id = VogenOrderId.From(9011), Name = "One" };
+        var two = new VogenOrder { Id = VogenOrderId.From(9012), Name = "Two" };
+
+        await using var session = theStore.LightweightSession();
+        session.Store(one, two);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var results = await session.Query<VogenOrder>()
+            .Where(x => x.Id.IsOneOf(one.Id, two.Id))
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        results.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task bulk_insert()
+    {
+        var orders = Enumerable.Range(9100, 5)
+            .Select(i => new VogenOrder { Id = VogenOrderId.From(i), Name = $"Bulk {i}" })
+            .ToList();
+
+        await theStore.Advanced.BulkInsertAsync(orders, TestContext.Current.CancellationToken);
+
+        await using var query = theStore.QuerySession();
+        foreach (var order in orders)
+        {
+            (await query.LoadAsync<VogenOrder>(order.Id!.Value.Value, TestContext.Current.CancellationToken))
+                .ShouldNotBeNull();
+        }
+    }
+
+    [Fact]
+    public async Task check_exists_with_wrapper_id()
+    {
+        var order = new VogenOrder { Id = VogenOrderId.From(9200), Name = "Exists" };
+        await using var session = theStore.LightweightSession();
+        session.Store(order);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        await using var query = theStore.QuerySession();
+        (await query.CheckExistsAsync<VogenOrder>(9200, TestContext.Current.CancellationToken)).ShouldBeTrue();
+        (await query.CheckExistsAsync<VogenOrder>(999999, TestContext.Current.CancellationToken)).ShouldBeFalse();
+    }
+}

--- a/src/Polecat.Tests/StrongTypedId/VogenIds/long_based_document_operations.cs
+++ b/src/Polecat.Tests/StrongTypedId/VogenIds/long_based_document_operations.cs
@@ -1,0 +1,235 @@
+using Polecat.Linq;
+using Polecat.Tests.Harness;
+using Shouldly;
+
+namespace Polecat.Tests.StrongTypedId.VogenIds;
+
+// Mirrors Marten's ValueTypeTests/VogenIds/long_based_document_operations.
+[Collection("integration")]
+public class long_based_document_operations : IntegrationContext
+{
+    public long_based_document_operations(DefaultStoreFixture fixture) : base(fixture)
+    {
+    }
+
+    public override async ValueTask InitializeAsync()
+    {
+        await StoreOptions(opts => { opts.DatabaseSchemaName = "vogen_long"; });
+    }
+
+    [Fact]
+    public async Task store_document_will_assign_the_identity()
+    {
+        var issue = new VogenIssue { Name = "Auto" };
+        issue.Id.ShouldBeNull();
+
+        await using var session = theStore.LightweightSession();
+        session.Store(issue);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        issue.Id.ShouldNotBeNull();
+        issue.Id!.Value.Value.ShouldBeGreaterThan(0L);
+    }
+
+    [Fact]
+    public async Task store_assigns_hilo_ids()
+    {
+        var first = new VogenIssue { Name = "First" };
+        var second = new VogenIssue { Name = "Second" };
+
+        await using var session = theStore.LightweightSession();
+        session.Store(first, second);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        first.Id!.Value.Value.ShouldNotBe(second.Id!.Value.Value);
+    }
+
+    [Fact]
+    public async Task store_a_document_smoke_test()
+    {
+        await using var session = theStore.LightweightSession();
+        session.Store(new VogenIssue { Name = "Smoke" });
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        (await session.Query<VogenIssue>().AnyAsync(TestContext.Current.CancellationToken)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task insert_a_document_smoke_test()
+    {
+        var issue = new VogenIssue { Id = VogenIssueId.From(8001L), Name = "Inserted" };
+        await using var session = theStore.LightweightSession();
+        session.Insert(issue);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        (await session.LoadAsync<VogenIssue>(8001L, TestContext.Current.CancellationToken))!.Name.ShouldBe("Inserted");
+    }
+
+    [Fact]
+    public async Task update_a_document_smoke_test()
+    {
+        var issue = new VogenIssue { Id = VogenIssueId.From(8002L), Name = "Original" };
+        await using var session = theStore.LightweightSession();
+        session.Insert(issue);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        issue.Name = "Updated";
+        session.Update(issue);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        await using var query = theStore.QuerySession();
+        (await query.LoadAsync<VogenIssue>(8002L, TestContext.Current.CancellationToken))!.Name.ShouldBe("Updated");
+    }
+
+    [Fact]
+    public async Task load_document()
+    {
+        var issue = new VogenIssue { Id = VogenIssueId.From(8003L), Name = "Load Me" };
+        await using var session = theStore.LightweightSession();
+        session.Store(issue);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var loaded = await session.LoadAsync<VogenIssue>(8003L, TestContext.Current.CancellationToken);
+        loaded.ShouldNotBeNull();
+        loaded!.Id.ShouldBe(issue.Id);
+    }
+
+    [Fact]
+    public async Task use_within_identity_map()
+    {
+        var issue = new VogenIssue { Id = VogenIssueId.From(8004L), Name = "Identity" };
+        await using var session = theStore.IdentitySession();
+        session.Store(issue);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var first = await session.LoadAsync<VogenIssue>(8004L, TestContext.Current.CancellationToken);
+        var second = await session.LoadAsync<VogenIssue>(8004L, TestContext.Current.CancellationToken);
+
+        first.ShouldNotBeNull();
+        ReferenceEquals(first, second).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task delete_by_id()
+    {
+        var issue = new VogenIssue { Id = VogenIssueId.From(8005L), Name = "Delete" };
+        await using var session = theStore.LightweightSession();
+        session.Store(issue);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        session.Delete<VogenIssue>(8005L);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        await using var query = theStore.QuerySession();
+        (await query.LoadAsync<VogenIssue>(8005L, TestContext.Current.CancellationToken)).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task delete_by_document()
+    {
+        var issue = new VogenIssue { Id = VogenIssueId.From(8006L), Name = "Delete Doc" };
+        await using var session = theStore.LightweightSession();
+        session.Store(issue);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        session.Delete(issue);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        await using var query = theStore.QuerySession();
+        (await query.LoadAsync<VogenIssue>(8006L, TestContext.Current.CancellationToken)).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task use_in_LINQ_where_clause()
+    {
+        var issue = new VogenIssue { Id = VogenIssueId.From(8007L), Name = "LINQ Where" };
+        await using var session = theStore.LightweightSession();
+        session.Store(issue);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var loaded = await session.Query<VogenIssue>()
+            .Where(x => x.Id == issue.Id)
+            .FirstOrDefaultAsync(TestContext.Current.CancellationToken);
+
+        loaded!.Name.ShouldBe("LINQ Where");
+    }
+
+    [Fact]
+    public async Task use_in_LINQ_order_clause()
+    {
+        await using var session = theStore.LightweightSession();
+        session.Store(new VogenIssue { Id = VogenIssueId.From(8008L), Name = "A" });
+        session.Store(new VogenIssue { Id = VogenIssueId.From(8009L), Name = "B" });
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var results = await session.Query<VogenIssue>()
+            .OrderBy(x => x.Id)
+            .Take(3)
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        results.Count.ShouldBeGreaterThanOrEqualTo(2);
+    }
+
+    [Fact]
+    public async Task use_in_LINQ_select_clause()
+    {
+        var issue = new VogenIssue { Id = VogenIssueId.From(8010L), Name = "Select" };
+        await using var session = theStore.LightweightSession();
+        session.Store(issue);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var ids = await session.Query<VogenIssue>()
+            .Where(x => x.Id == issue.Id)
+            .Select(x => x.Id)
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        ids.Single().ShouldBe(issue.Id);
+    }
+
+    [Fact]
+    public async Task use_in_LINQ_is_one_of()
+    {
+        var one = new VogenIssue { Id = VogenIssueId.From(8011L), Name = "One" };
+        var two = new VogenIssue { Id = VogenIssueId.From(8012L), Name = "Two" };
+
+        await using var session = theStore.LightweightSession();
+        session.Store(one, two);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var results = await session.Query<VogenIssue>()
+            .Where(x => x.Id.IsOneOf(one.Id, two.Id))
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        results.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task bulk_insert()
+    {
+        var issues = Enumerable.Range(8100, 5)
+            .Select(i => new VogenIssue { Id = VogenIssueId.From(i), Name = $"Bulk {i}" })
+            .ToList();
+
+        await theStore.Advanced.BulkInsertAsync(issues, TestContext.Current.CancellationToken);
+
+        await using var query = theStore.QuerySession();
+        foreach (var issue in issues)
+        {
+            (await query.LoadAsync<VogenIssue>(issue.Id!.Value.Value, TestContext.Current.CancellationToken))
+                .ShouldNotBeNull();
+        }
+    }
+
+    [Fact]
+    public async Task check_exists_with_wrapper_id()
+    {
+        var issue = new VogenIssue { Id = VogenIssueId.From(8200L), Name = "Exists" };
+        await using var session = theStore.LightweightSession();
+        session.Store(issue);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        await using var query = theStore.QuerySession();
+        (await query.CheckExistsAsync<VogenIssue>(8200L, TestContext.Current.CancellationToken)).ShouldBeTrue();
+        (await query.CheckExistsAsync<VogenIssue>(999999L, TestContext.Current.CancellationToken)).ShouldBeFalse();
+    }
+}

--- a/src/Polecat.Tests/StrongTypedId/VogenIds/string_id_document_operations.cs
+++ b/src/Polecat.Tests/StrongTypedId/VogenIds/string_id_document_operations.cs
@@ -1,0 +1,223 @@
+using Polecat.Linq;
+using Polecat.Tests.Harness;
+using Shouldly;
+
+namespace Polecat.Tests.StrongTypedId.VogenIds;
+
+// Mirrors Marten's ValueTypeTests/VogenIds/string_id_document_operations. String ids are
+// externally assigned — there is no generation strategy — so there is no "store assigns the
+// identity" case here.
+[Collection("integration")]
+public class string_id_document_operations : IntegrationContext
+{
+    public string_id_document_operations(DefaultStoreFixture fixture) : base(fixture)
+    {
+    }
+
+    public override async ValueTask InitializeAsync()
+    {
+        await StoreOptions(opts => { opts.DatabaseSchemaName = "vogen_string"; });
+    }
+
+    private static VogenTeam Team(string id, string name = "Team") =>
+        new() { Id = VogenTeamId.From(id), Name = name };
+
+    [Fact]
+    public async Task store_a_document_smoke_test()
+    {
+        await using var session = theStore.LightweightSession();
+        session.Store(Team(Guid.NewGuid().ToString(), "Smoke"));
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        (await session.Query<VogenTeam>().AnyAsync(TestContext.Current.CancellationToken)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task insert_a_document_smoke_test()
+    {
+        var team = Team("insert-1", "Inserted");
+        await using var session = theStore.LightweightSession();
+        session.Insert(team);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        (await session.LoadAsync<VogenTeam>("insert-1", TestContext.Current.CancellationToken))!
+            .Name.ShouldBe("Inserted");
+    }
+
+    [Fact]
+    public async Task update_a_document_smoke_test()
+    {
+        var team = Team("update-1", "Original");
+        await using var session = theStore.LightweightSession();
+        session.Insert(team);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        team.Name = "Updated";
+        session.Update(team);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        await using var query = theStore.QuerySession();
+        (await query.LoadAsync<VogenTeam>("update-1", TestContext.Current.CancellationToken))!
+            .Name.ShouldBe("Updated");
+    }
+
+    [Fact]
+    public async Task load_document()
+    {
+        var team = Team("load-1", "Load Me");
+        await using var session = theStore.LightweightSession();
+        session.Store(team);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var loaded = await session.LoadAsync<VogenTeam>("load-1", TestContext.Current.CancellationToken);
+        loaded.ShouldNotBeNull();
+        loaded!.Id.ShouldBe(team.Id);
+        loaded.Name.ShouldBe("Load Me");
+    }
+
+    [Fact]
+    public async Task load_many()
+    {
+        await using var session = theStore.LightweightSession();
+        session.Store(Team("many-1"), Team("many-2"), Team("many-3"));
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var loaded = await session.LoadManyAsync<VogenTeam>(
+            ["many-1", "many-2", "many-3"], TestContext.Current.CancellationToken);
+
+        loaded.Count.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task use_within_identity_map()
+    {
+        await using var session = theStore.IdentitySession();
+        session.Store(Team("identity-1"));
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var first = await session.LoadAsync<VogenTeam>("identity-1", TestContext.Current.CancellationToken);
+        var second = await session.LoadAsync<VogenTeam>("identity-1", TestContext.Current.CancellationToken);
+
+        first.ShouldNotBeNull();
+        ReferenceEquals(first, second).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task delete_by_id()
+    {
+        await using var session = theStore.LightweightSession();
+        session.Store(Team("delete-1"));
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        session.Delete<VogenTeam>("delete-1");
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        await using var query = theStore.QuerySession();
+        (await query.LoadAsync<VogenTeam>("delete-1", TestContext.Current.CancellationToken)).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task delete_by_document()
+    {
+        var team = Team("delete-2");
+        await using var session = theStore.LightweightSession();
+        session.Store(team);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        session.Delete(team);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        await using var query = theStore.QuerySession();
+        (await query.LoadAsync<VogenTeam>("delete-2", TestContext.Current.CancellationToken)).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task use_in_LINQ_where_clause()
+    {
+        var team = Team("where-1", "LINQ Where");
+        await using var session = theStore.LightweightSession();
+        session.Store(team);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var loaded = await session.Query<VogenTeam>()
+            .Where(x => x.Id == team.Id)
+            .FirstOrDefaultAsync(TestContext.Current.CancellationToken);
+
+        loaded!.Name.ShouldBe("LINQ Where");
+    }
+
+    [Fact]
+    public async Task use_in_LINQ_order_clause()
+    {
+        await using var session = theStore.LightweightSession();
+        session.Store(Team("order-1"), Team("order-2"));
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var results = await session.Query<VogenTeam>()
+            .OrderBy(x => x.Id)
+            .Take(3)
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        results.Count.ShouldBeGreaterThanOrEqualTo(2);
+    }
+
+    [Fact]
+    public async Task use_in_LINQ_select_clause()
+    {
+        var team = Team("select-1");
+        await using var session = theStore.LightweightSession();
+        session.Store(team);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var ids = await session.Query<VogenTeam>()
+            .Where(x => x.Id == team.Id)
+            .Select(x => x.Id)
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        ids.Single().ShouldBe(team.Id);
+    }
+
+    [Fact]
+    public async Task use_in_LINQ_is_one_of()
+    {
+        var one = Team("oneof-1");
+        var two = Team("oneof-2");
+
+        await using var session = theStore.LightweightSession();
+        session.Store(one, two);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var results = await session.Query<VogenTeam>()
+            .Where(x => x.Id.IsOneOf(one.Id, two.Id))
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        results.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task bulk_insert()
+    {
+        var teams = Enumerable.Range(0, 5).Select(i => Team($"bulk-{i}", $"Bulk {i}")).ToList();
+
+        await theStore.Advanced.BulkInsertAsync(teams, TestContext.Current.CancellationToken);
+
+        await using var query = theStore.QuerySession();
+        foreach (var team in teams)
+        {
+            (await query.LoadAsync<VogenTeam>(team.Id!.Value.Value, TestContext.Current.CancellationToken))
+                .ShouldNotBeNull();
+        }
+    }
+
+    [Fact]
+    public async Task check_exists_with_wrapper_id()
+    {
+        await using var session = theStore.LightweightSession();
+        session.Store(Team("exists-1"));
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        await using var query = theStore.QuerySession();
+        (await query.CheckExistsAsync<VogenTeam>("exists-1", TestContext.Current.CancellationToken)).ShouldBeTrue();
+        (await query.CheckExistsAsync<VogenTeam>("nope", TestContext.Current.CancellationToken)).ShouldBeFalse();
+    }
+}

--- a/src/Polecat.Tests/StrongTypedId/VogenIds/vogen_id_types.cs
+++ b/src/Polecat.Tests/StrongTypedId/VogenIds/vogen_id_types.cs
@@ -1,0 +1,51 @@
+using Vogen;
+
+namespace Polecat.Tests.StrongTypedId.VogenIds;
+
+// Vogen value objects, the second strong-typed-id library Marten's ValueTypeTests covers. Vogen
+// emits a *private* constructor plus a static `From` factory, so these exercise the "builder" branch
+// of JasperFx's ValueTypeInfo that a hand-written `record struct OrderId(Guid Value)` never reaches.
+// Vogen also generates a System.Text.Json converter that writes the inner value, so a Vogen member
+// lands in the document JSON as a bare scalar rather than a nested object.
+//
+// Every Id below is *nullable*, which is Vogen's own required pattern and what Marten's Vogen tests
+// use: Vogen prohibits an uninitialized value object, so reading `.Value` off a `default` instance
+// throws. A non-nullable Vogen id would throw inside identity assignment before Polecat ever sees
+// whether the id was set. StronglyTypedId, which permits `default`, is exercised non-nullably in
+// ../GeneratedIds.
+
+[ValueObject<Guid>]
+public readonly partial struct VogenInvoiceId;
+
+public class VogenInvoice
+{
+    public VogenInvoiceId? Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+}
+
+[ValueObject<int>]
+public readonly partial struct VogenOrderId;
+
+public class VogenOrder
+{
+    public VogenOrderId? Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+}
+
+[ValueObject<long>]
+public readonly partial struct VogenIssueId;
+
+public class VogenIssue
+{
+    public VogenIssueId? Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+}
+
+[ValueObject<string>]
+public readonly partial struct VogenTeamId;
+
+public class VogenTeam
+{
+    public VogenTeamId? Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+}

--- a/src/Polecat.Tests/StrongTypedId/batch_querying_with_value_types.cs
+++ b/src/Polecat.Tests/StrongTypedId/batch_querying_with_value_types.cs
@@ -1,0 +1,153 @@
+using Polecat.Linq;
+using Polecat.Tests.Harness;
+using Polecat.Tests.StrongTypedId.GeneratedIds;
+using Polecat.Tests.StrongTypedId.VogenIds;
+using Shouldly;
+
+namespace Polecat.Tests.StrongTypedId;
+
+// Mirrors Marten's ValueTypeTests/using_in_batch_queries and the batched half of
+// StrongTypedId/check_exists_with_strong_typed_ids: strong-typed-id documents loaded and probed
+// through a batched query, where every operation shares one round trip and each result has to be
+// matched back to the right reader.
+[Collection("integration")]
+public class batch_querying_with_value_types : IntegrationContext
+{
+    public batch_querying_with_value_types(DefaultStoreFixture fixture) : base(fixture)
+    {
+    }
+
+    public override async ValueTask InitializeAsync()
+    {
+        await StoreOptions(opts => { opts.DatabaseSchemaName = "batch_value_types"; });
+    }
+
+    [Fact]
+    public async Task load_one_at_a_time_in_a_batch()
+    {
+        var one = new VogenInvoice { Id = VogenInvoiceId.From(Guid.NewGuid()), Name = "One" };
+        var two = new VogenInvoice { Id = VogenInvoiceId.From(Guid.NewGuid()), Name = "Two" };
+        var three = new VogenInvoice { Id = VogenInvoiceId.From(Guid.NewGuid()), Name = "Three" };
+
+        await using var session = theStore.LightweightSession();
+        session.Store(one, two, three);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var batch = session.CreateBatchQuery();
+        var first = batch.Load<VogenInvoice>(one.Id!.Value.Value);
+        var second = batch.Load<VogenInvoice>(two.Id!.Value.Value);
+        var third = batch.Load<VogenInvoice>(three.Id!.Value.Value);
+
+        await batch.Execute(TestContext.Current.CancellationToken);
+
+        (await first)!.Name.ShouldBe("One");
+        (await second)!.Name.ShouldBe("Two");
+        (await third)!.Name.ShouldBe("Three");
+    }
+
+    [Fact]
+    public async Task load_many_in_a_batch()
+    {
+        var one = new GeneratedInvoice { Id = new GeneratedInvoiceId(Guid.NewGuid()), Name = "One" };
+        var two = new GeneratedInvoice { Id = new GeneratedInvoiceId(Guid.NewGuid()), Name = "Two" };
+
+        await using var session = theStore.LightweightSession();
+        session.Store(one, two);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var batch = session.CreateBatchQuery();
+        var loaded = batch.LoadMany<GeneratedInvoice>(one.Id.Value, two.Id.Value);
+
+        await batch.Execute(TestContext.Current.CancellationToken);
+
+        (await loaded).Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task check_exists_in_a_batch_with_a_guid_wrapper()
+    {
+        var invoice = new VogenInvoice { Id = VogenInvoiceId.From(Guid.NewGuid()), Name = "Exists" };
+        await using var session = theStore.LightweightSession();
+        session.Store(invoice);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var batch = session.CreateBatchQuery();
+        var hit = batch.CheckExists<VogenInvoice>(invoice.Id!.Value.Value);
+        var miss = batch.CheckExists<VogenInvoice>(Guid.NewGuid());
+
+        await batch.Execute(TestContext.Current.CancellationToken);
+
+        (await hit).ShouldBeTrue();
+        (await miss).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task check_exists_in_a_batch_with_an_int_wrapper()
+    {
+        var order = new VogenOrder { Id = VogenOrderId.From(5001), Name = "Exists" };
+        await using var session = theStore.LightweightSession();
+        session.Store(order);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var batch = session.CreateBatchQuery();
+        var hit = batch.CheckExists<VogenOrder>(5001);
+        var miss = batch.CheckExists<VogenOrder>(999999);
+
+        await batch.Execute(TestContext.Current.CancellationToken);
+
+        (await hit).ShouldBeTrue();
+        (await miss).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task check_exists_in_a_batch_with_a_long_wrapper()
+    {
+        var issue = new VogenIssue { Id = VogenIssueId.From(4001L), Name = "Exists" };
+        await using var session = theStore.LightweightSession();
+        session.Store(issue);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var batch = session.CreateBatchQuery();
+        var hit = batch.CheckExists<VogenIssue>(4001L);
+        var miss = batch.CheckExists<VogenIssue>(999999L);
+
+        await batch.Execute(TestContext.Current.CancellationToken);
+
+        (await hit).ShouldBeTrue();
+        (await miss).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task check_exists_in_a_batch_with_a_string_wrapper()
+    {
+        var team = new VogenTeam { Id = VogenTeamId.From("batch-exists"), Name = "Exists" };
+        await using var session = theStore.LightweightSession();
+        session.Store(team);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var batch = session.CreateBatchQuery();
+        var hit = batch.CheckExists<VogenTeam>("batch-exists");
+        var miss = batch.CheckExists<VogenTeam>("nope");
+
+        await batch.Execute(TestContext.Current.CancellationToken);
+
+        (await hit).ShouldBeTrue();
+        (await miss).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task query_by_a_wrapper_id_in_a_batch()
+    {
+        var invoice = new VogenInvoice { Id = VogenInvoiceId.From(Guid.NewGuid()), Name = "Queried" };
+        await using var session = theStore.LightweightSession();
+        session.Store(invoice);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var batch = session.CreateBatchQuery();
+        var matches = batch.Query<VogenInvoice>().Where(x => x.Id == invoice.Id).ToList();
+
+        await batch.Execute(TestContext.Current.CancellationToken);
+
+        (await matches).Single().Name.ShouldBe("Queried");
+    }
+}

--- a/src/Polecat.Tests/StrongTypedId/linq_querying_with_value_types.cs
+++ b/src/Polecat.Tests/StrongTypedId/linq_querying_with_value_types.cs
@@ -1,0 +1,149 @@
+using Polecat.Linq;
+using Polecat.Pagination;
+using Polecat.Tests.Harness;
+using Shouldly;
+using Vogen;
+
+namespace Polecat.Tests.StrongTypedId;
+
+// Mirrors Marten's ValueTypeTests/linq_querying_with_value_types: several value-typed members on one
+// document, ordered and filtered by, with the results projected back out as value types. The point is
+// the *combination* — order by one wrapper, filter on another, project a third — because each of
+// those reaches the member resolver by a different route.
+
+[ValueObject<int>]
+public readonly partial struct UpperLimit;
+
+[ValueObject<int>]
+public readonly partial struct LowerLimit;
+
+public class LimitedDoc
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public UpperLimit Upper { get; set; }
+    public LowerLimit Lower { get; set; }
+}
+
+[Collection("integration")]
+public class linq_querying_with_value_types : IntegrationContext
+{
+    public linq_querying_with_value_types(DefaultStoreFixture fixture) : base(fixture)
+    {
+    }
+
+    public override async ValueTask InitializeAsync()
+    {
+        await StoreOptions(opts => { opts.DatabaseSchemaName = "linq_value_types"; });
+    }
+
+    private static readonly LimitedDoc Doc1 = new() { Lower = LowerLimit.From(1), Upper = UpperLimit.From(20) };
+    private static readonly LimitedDoc Doc2 = new() { Lower = LowerLimit.From(5), Upper = UpperLimit.From(25) };
+    private static readonly LimitedDoc Doc3 = new() { Lower = LowerLimit.From(4), Upper = UpperLimit.From(15) };
+    private static readonly LimitedDoc Doc4 = new() { Lower = LowerLimit.From(3), Upper = UpperLimit.From(10) };
+
+    private async Task<IDocumentSession> seed()
+    {
+        var session = theStore.LightweightSession();
+        session.Store(Doc1, Doc2, Doc3, Doc4);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        AsyncDisposables.Add(session);
+        return session;
+    }
+
+    [Fact]
+    public async Task store_several_and_order_by()
+    {
+        var session = await seed();
+
+        var ordered = await session.Query<LimitedDoc>()
+            .OrderBy(x => x.Lower)
+            .Select(x => x.Id)
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        ordered.ShouldBe([Doc1.Id, Doc4.Id, Doc3.Id, Doc2.Id]);
+    }
+
+    [Fact]
+    public async Task store_several_and_order_by_descending()
+    {
+        var session = await seed();
+
+        var ordered = await session.Query<LimitedDoc>()
+            .OrderByDescending(x => x.Upper)
+            .Select(x => x.Id)
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        ordered.ShouldBe([Doc2.Id, Doc1.Id, Doc3.Id, Doc4.Id]);
+    }
+
+    [Fact]
+    public async Task store_several_and_query_by()
+    {
+        var session = await seed();
+
+        var ordered = await session.Query<LimitedDoc>()
+            .OrderBy(x => x.Lower)
+            .Where(x => x.Upper == UpperLimit.From(10))
+            .Select(x => x.Id)
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        ordered.ShouldBe([Doc4.Id]);
+    }
+
+    [Fact]
+    public async Task store_several_and_query_by_inequality()
+    {
+        // Vogen does not emit comparison operators, so a range predicate goes through the wrapper's
+        // inner value. That resolves the member by its JSON path rather than as a wrapper, which is
+        // the other half of the member-resolution rule and worth pinning alongside equality.
+        var session = await seed();
+
+        var ordered = await session.Query<LimitedDoc>()
+            .Where(x => x.Upper != Doc4.Upper)
+            .OrderBy(x => x.Lower)
+            .Select(x => x.Id)
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        ordered.ShouldBe([Doc1.Id, Doc3.Id, Doc2.Id]);
+    }
+
+    [Fact]
+    public async Task store_several_and_query_by_with_paging()
+    {
+        var session = await seed();
+
+        var paged = await session.Query<LimitedDoc>()
+            .OrderBy(x => x.Lower)
+            .Where(x => x.Upper == UpperLimit.From(10))
+            .Select(x => x.Id)
+            .ToPagedListAsync(1, 10, TestContext.Current.CancellationToken);
+
+        paged.ShouldBe([Doc4.Id]);
+        paged.TotalItemCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task store_several_and_select_the_value_types()
+    {
+        var session = await seed();
+
+        var uppers = await session.Query<LimitedDoc>()
+            .OrderBy(x => x.Lower)
+            .Select(x => x.Upper)
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        uppers.ShouldBe([Doc1.Upper, Doc4.Upper, Doc3.Upper, Doc2.Upper]);
+    }
+
+    [Fact]
+    public async Task store_several_and_count_by_a_value_type_predicate()
+    {
+        var session = await seed();
+
+        var count = await session.Query<LimitedDoc>()
+            .Where(x => x.Lower.IsOneOf(Doc1.Lower, Doc4.Lower))
+            .CountAsync(TestContext.Current.CancellationToken);
+
+        count.ShouldBe(2);
+    }
+}

--- a/src/Polecat.Tests/StrongTypedId/nullable_value_type_id_operations.cs
+++ b/src/Polecat.Tests/StrongTypedId/nullable_value_type_id_operations.cs
@@ -1,0 +1,154 @@
+using Polecat.Linq;
+using Polecat.Storage;
+using Polecat.Tests.Harness;
+using Shouldly;
+using StronglyTypedIds;
+
+namespace Polecat.Tests.StrongTypedId;
+
+// Mirrors Marten's paired ValueTypeTests/StrongTypedId/string_id_document_operations classes: the
+// same wrapper used as `Id` both nullable and non-nullable. Marten documents the nullable form as the
+// way to let the store see "no identity yet" without materializing a zero-valued wrapper, and it is
+// mandatory for Vogen, which forbids an uninitialized value object. Both forms have to map to the
+// same column and the same LINQ translation.
+
+[StronglyTypedId(Template.String)]
+public readonly partial struct SquadId;
+
+public class NullableSquad
+{
+    public SquadId? Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+}
+
+public class NonNullableSquad
+{
+    public SquadId Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+}
+
+public record struct RosterId(Guid Value);
+
+public class NullableRoster
+{
+    public RosterId? Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+}
+
+[Collection("integration")]
+public class nullable_value_type_id_operations : IntegrationContext
+{
+    public nullable_value_type_id_operations(DefaultStoreFixture fixture) : base(fixture)
+    {
+    }
+
+    public override async ValueTask InitializeAsync()
+    {
+        await StoreOptions(opts => { opts.DatabaseSchemaName = "nullable_value_id"; });
+    }
+
+    [Theory]
+    [InlineData(typeof(NullableSquad), typeof(string))]
+    [InlineData(typeof(NonNullableSquad), typeof(string))]
+    [InlineData(typeof(NullableRoster), typeof(Guid))]
+    public void nullable_and_non_nullable_map_to_the_same_inner_type(Type documentType, Type expectedInner)
+    {
+        var mapping = new DocumentMapping(documentType, new StoreOptions());
+        mapping.IsStrongTypedId.ShouldBeTrue();
+        mapping.InnerIdType.ShouldBe(expectedInner);
+    }
+
+    [Fact]
+    public async Task round_trip_a_nullable_string_wrapper_id()
+    {
+        var squad = new NullableSquad { Id = new SquadId("squad-1"), Name = "Nullable" };
+        await using var session = theStore.LightweightSession();
+        session.Store(squad);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var loaded = await session.LoadAsync<NullableSquad>("squad-1", TestContext.Current.CancellationToken);
+        loaded.ShouldNotBeNull();
+        loaded!.Id.ShouldBe(squad.Id);
+        loaded.Name.ShouldBe("Nullable");
+    }
+
+    [Fact]
+    public async Task round_trip_a_non_nullable_string_wrapper_id()
+    {
+        var squad = new NonNullableSquad { Id = new SquadId("squad-2"), Name = "Non nullable" };
+        await using var session = theStore.LightweightSession();
+        session.Store(squad);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var loaded = await session.LoadAsync<NonNullableSquad>("squad-2", TestContext.Current.CancellationToken);
+        loaded.ShouldNotBeNull();
+        loaded!.Id.ShouldBe(squad.Id);
+    }
+
+    [Fact]
+    public async Task assign_an_identity_to_a_nullable_guid_wrapper()
+    {
+        var roster = new NullableRoster { Name = "Auto" };
+        roster.Id.ShouldBeNull();
+
+        await using var session = theStore.LightweightSession();
+        session.Store(roster);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        roster.Id.ShouldNotBeNull();
+        roster.Id!.Value.Value.ShouldNotBe(Guid.Empty);
+
+        var loaded = await session.LoadAsync<NullableRoster>(
+            roster.Id!.Value.Value, TestContext.Current.CancellationToken);
+        loaded.ShouldNotBeNull();
+        loaded!.Id.ShouldBe(roster.Id);
+    }
+
+    [Fact]
+    public async Task query_by_a_nullable_wrapper_id()
+    {
+        var roster = new NullableRoster { Id = new RosterId(Guid.NewGuid()), Name = "Queried" };
+        await using var session = theStore.LightweightSession();
+        session.Store(roster);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var loaded = await session.Query<NullableRoster>()
+            .Where(x => x.Id == roster.Id)
+            .FirstOrDefaultAsync(TestContext.Current.CancellationToken);
+
+        loaded.ShouldNotBeNull();
+        loaded!.Name.ShouldBe("Queried");
+    }
+
+    [Fact]
+    public async Task select_a_nullable_wrapper_id()
+    {
+        var roster = new NullableRoster { Id = new RosterId(Guid.NewGuid()), Name = "Selected" };
+        await using var session = theStore.LightweightSession();
+        session.Store(roster);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var ids = await session.Query<NullableRoster>()
+            .Where(x => x.Id == roster.Id)
+            .Select(x => x.Id)
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        ids.Single().ShouldBe(roster.Id);
+    }
+
+    [Fact]
+    public async Task delete_by_a_nullable_wrapper_id()
+    {
+        var roster = new NullableRoster { Id = new RosterId(Guid.NewGuid()), Name = "Deleted" };
+        await using var session = theStore.LightweightSession();
+        session.Store(roster);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        session.Delete<NullableRoster>(roster.Id!.Value.Value);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        await using var query = theStore.QuerySession();
+        (await query.LoadAsync<NullableRoster>(roster.Id!.Value.Value, TestContext.Current.CancellationToken))
+            .ShouldBeNull();
+    }
+}

--- a/src/Polecat.Tests/StrongTypedId/value_type_member_operations.cs
+++ b/src/Polecat.Tests/StrongTypedId/value_type_member_operations.cs
@@ -1,0 +1,276 @@
+using Polecat.Linq;
+using Polecat.Tests.Harness;
+using Shouldly;
+using StronglyTypedIds;
+using Vogen;
+
+namespace Polecat.Tests.StrongTypedId;
+
+// Mirrors Marten's ValueTypeTests duplicated_value_type_field_operations, Bugs/querying_by_value_types
+// and Bug_4288: a strong-typed value used somewhere *other* than the Id. Both generators emit a
+// System.Text.Json converter that writes the inner value, so the member lands in the document JSON as
+// a bare scalar and is queryable against its inner type — but the CLR value in the predicate is still
+// the wrapper, which SqlClient has no mapping for. These pin the unwrapping.
+//
+// Marten reaches the same place with `Duplicate(x => x.Member)`, which projects the value into its own
+// column. Polecat has no duplicated columns — it queries the JSON path directly — so there is nothing
+// to configure here.
+
+[ValueObject<Guid>]
+public readonly partial struct TeacherRef;
+
+[ValueObject<string>]
+public readonly partial struct EmailAddress;
+
+[ValueObject<int>]
+public partial record Age;
+
+[StronglyTypedId(Template.Guid)]
+public readonly partial struct GeneratedTeacherRef;
+
+/// <summary>Marten's Bug_4288 shape: a real factory shadowed by a nullable sibling.</summary>
+[ValueObject<string>]
+public readonly partial struct SiblingFactoryValue
+{
+    public static SiblingFactoryValue? FromNullable(string? value)
+        => value is null ? null : From(value);
+}
+
+public class ClassRoom
+{
+    public Guid Id { get; set; }
+    public TeacherRef Teacher { get; set; }
+    public GeneratedTeacherRef Substitute { get; set; }
+    public string Subject { get; set; } = string.Empty;
+}
+
+public class Customer
+{
+    public Guid Id { get; set; }
+    public EmailAddress Email { get; set; }
+    public Age Age { get; set; } = Age.From(0);
+}
+
+public class SiblingFactoryDoc
+{
+    public Guid Id { get; set; }
+    public SiblingFactoryValue Value { get; set; }
+}
+
+[Collection("integration")]
+public class value_type_member_operations : IntegrationContext
+{
+    public value_type_member_operations(DefaultStoreFixture fixture) : base(fixture)
+    {
+    }
+
+    public override async ValueTask InitializeAsync()
+    {
+        await StoreOptions(opts => { opts.DatabaseSchemaName = "value_type_member"; });
+    }
+
+    private static ClassRoom Room(string subject) => new()
+    {
+        Id = Guid.NewGuid(),
+        Teacher = TeacherRef.From(Guid.NewGuid()),
+        Substitute = new GeneratedTeacherRef(Guid.NewGuid()),
+        Subject = subject
+    };
+
+    [Fact]
+    public async Task store_a_document_smoke_test()
+    {
+        await using var session = theStore.LightweightSession();
+        session.Store(Room("Smoke"));
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        (await session.Query<ClassRoom>().AnyAsync(TestContext.Current.CancellationToken)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task load_document_round_trips_the_member()
+    {
+        var room = Room("Round Trip");
+        await using var session = theStore.LightweightSession();
+        session.Store(room);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var loaded = await session.LoadAsync<ClassRoom>(room.Id, TestContext.Current.CancellationToken);
+        loaded.ShouldNotBeNull();
+        loaded!.Teacher.ShouldBe(room.Teacher);
+        loaded.Substitute.ShouldBe(room.Substitute);
+    }
+
+    [Fact]
+    public async Task the_member_serializes_as_a_bare_scalar()
+    {
+        // Not a cosmetic assertion: if the generator's JSON converter were absent, the member would
+        // serialize as { "value": ... } and every predicate below would silently match nothing.
+        var room = Room("Json");
+        await using var session = theStore.LightweightSession();
+        session.Store(room);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var json = await session.Query<ClassRoom>()
+            .Where(x => x.Id == room.Id)
+            .ToJsonArrayAsync(TestContext.Current.CancellationToken);
+
+        json.ShouldContain($"\"teacher\":\"{room.Teacher.Value}\"");
+        json.ShouldContain($"\"substitute\":\"{room.Substitute.Value}\"");
+    }
+
+    [Fact]
+    public async Task use_in_LINQ_where_clause()
+    {
+        var room = Room("Where");
+        await using var session = theStore.LightweightSession();
+        session.Store(room);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var loaded = await session.Query<ClassRoom>()
+            .Where(x => x.Teacher == room.Teacher)
+            .FirstOrDefaultAsync(TestContext.Current.CancellationToken);
+
+        loaded.ShouldNotBeNull();
+        loaded!.Subject.ShouldBe("Where");
+    }
+
+    [Fact]
+    public async Task use_a_generated_id_member_in_LINQ_where_clause()
+    {
+        var room = Room("Generated Where");
+        await using var session = theStore.LightweightSession();
+        session.Store(room);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var loaded = await session.Query<ClassRoom>()
+            .Where(x => x.Substitute == room.Substitute)
+            .FirstOrDefaultAsync(TestContext.Current.CancellationToken);
+
+        loaded.ShouldNotBeNull();
+        loaded!.Subject.ShouldBe("Generated Where");
+    }
+
+    [Fact]
+    public async Task use_in_LINQ_order_clause()
+    {
+        await using var session = theStore.LightweightSession();
+        session.Store(Room("Order A"), Room("Order B"));
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var results = await session.Query<ClassRoom>()
+            .OrderBy(x => x.Teacher)
+            .Take(3)
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        results.Count.ShouldBeGreaterThanOrEqualTo(2);
+    }
+
+    [Fact]
+    public async Task use_in_LINQ_select_clause()
+    {
+        var room = Room("Select");
+        await using var session = theStore.LightweightSession();
+        session.Store(room);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var teachers = await session.Query<ClassRoom>()
+            .Where(x => x.Id == room.Id)
+            .Select(x => x.Teacher)
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        teachers.Single().ShouldBe(room.Teacher);
+    }
+
+    [Fact]
+    public async Task use_in_LINQ_is_one_of()
+    {
+        var one = Room("One");
+        var two = Room("Two");
+
+        await using var session = theStore.LightweightSession();
+        session.Store(one, two);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var results = await session.Query<ClassRoom>()
+            .Where(x => x.Teacher.IsOneOf(one.Teacher, two.Teacher))
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        results.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task collect_the_referenced_ids_for_a_manual_include()
+    {
+        // Polecat has no Include() operator (Marten's include_usage covers that), but the piece an
+        // Include depends on — projecting a wrapper-typed reference out of the matching documents and
+        // loading the referenced documents by it — works.
+        var one = Room("Include One");
+        var two = Room("Include Two");
+
+        await using var session = theStore.LightweightSession();
+        session.Store(one, two);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var teacherIds = await session.Query<ClassRoom>()
+            .Where(x => x.Id.IsOneOf(one.Id, two.Id))
+            .Select(x => x.Teacher)
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        teacherIds.Count.ShouldBe(2);
+        teacherIds.ShouldContain(one.Teacher);
+        teacherIds.ShouldContain(two.Teacher);
+    }
+
+    [Fact]
+    public async Task query_by_a_string_and_a_reference_type_value_object()
+    {
+        // Marten's Bugs/querying_by_value_types. `Age` is a Vogen *record* — a reference-type value
+        // object — so this also covers the non-struct wrapper shape.
+        var customer = new Customer
+        {
+            Id = Guid.NewGuid(),
+            Email = EmailAddress.From("example@me.com"),
+            Age = Age.From(25)
+        };
+
+        await using var session = theStore.LightweightSession();
+        session.Store(customer);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var loaded = await session.LoadAsync<Customer>(customer.Id, TestContext.Current.CancellationToken);
+        loaded.ShouldNotBeNull();
+        loaded!.Email.Value.ShouldBe("example@me.com");
+
+        var byEmail = await session.Query<Customer>()
+            .Where(x => x.Email == customer.Email)
+            .FirstOrDefaultAsync(TestContext.Current.CancellationToken);
+        byEmail.ShouldNotBeNull();
+
+        var byAge = await session.Query<Customer>()
+            .Where(x => x.Age == customer.Age)
+            .FirstOrDefaultAsync(TestContext.Current.CancellationToken);
+        byAge.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task round_trip_and_query_a_value_type_with_a_nullable_sibling_factory()
+    {
+        // marten#4288. Without preferring the factory whose return type is the value type itself,
+        // building the wrapper throws "Expression of type 'Nullable<T>' cannot be used for return
+        // type 'T'" the first time this member is resolved.
+        var doc = new SiblingFactoryDoc { Id = Guid.NewGuid(), Value = SiblingFactoryValue.From("abc") };
+
+        await using var session = theStore.LightweightSession();
+        session.Store(doc);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var key = SiblingFactoryValue.From("abc");
+        var found = await session.Query<SiblingFactoryDoc>()
+            .Where(x => x.Value == key)
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        found.Count.ShouldBe(1);
+        found.Single().Id.ShouldBe(doc.Id);
+    }
+}

--- a/src/Polecat.Tests/StrongTypedId/value_type_resolution_tests.cs
+++ b/src/Polecat.Tests/StrongTypedId/value_type_resolution_tests.cs
@@ -1,0 +1,215 @@
+using Polecat.Storage;
+using Shouldly;
+using StronglyTypedIds;
+using Vogen;
+
+namespace Polecat.Tests.StrongTypedId;
+
+// Mirrors Marten's ValueTypeTests/applicability_of_identity_types + registration: which CLR types
+// Polecat accepts as a strong-typed-id wrapper, which member it treats as the inner value, and
+// whether it builds the wrapper through a constructor or a static factory. These are pure resolution
+// tests — no database — so they pin the rule itself rather than one document type's behavior.
+
+[ValueObject<Guid>]
+public readonly partial struct ResolvableGuidId;
+
+[ValueObject<int>]
+public readonly partial struct ResolvableIntId;
+
+[ValueObject<int>]
+public readonly partial struct WeirdNamed;
+
+[ValueObject<long>]
+public readonly partial struct ResolvableLongId;
+
+[ValueObject<string>]
+public readonly partial struct ResolvableStringId;
+
+[ValueObject<DateOnly>]
+public readonly partial struct ResolvableDateId;
+
+[StronglyTypedId(Template.Guid)]
+public readonly partial struct GeneratedResolvableId;
+
+public record struct NewGuidId(Guid Value);
+
+public record struct NewIntId(int Value);
+
+public record struct NewLongId(long Value);
+
+public record struct NewStringId(string Value);
+
+public record struct NewDateId(DateOnly Value);
+
+/// <summary>
+///     The shape Marten documents as valid: a public property getter for the inner value paired with
+///     a public static factory taking the inner value.
+/// </summary>
+public readonly struct SpecialValue
+{
+    private SpecialValue(string value) => Value = value;
+
+    public string Value { get; }
+
+    public static SpecialValue From(string value) => new(value);
+}
+
+/// <summary>
+///     The same, but with a nullable sibling factory alongside the real one — marten#4288. Picking
+///     the sibling yields a builder that returns <c>SpecialValueWithNullableSibling?</c>, which blows
+///     up when the wrapper delegate is compiled.
+/// </summary>
+public readonly struct SpecialValueWithNullableSibling
+{
+    private SpecialValueWithNullableSibling(string value) => Value = value;
+
+    public string Value { get; }
+
+    public static SpecialValueWithNullableSibling? FromNullable(string? value)
+        => value is null ? null : From(value);
+
+    public static SpecialValueWithNullableSibling From(string value) => new(value);
+}
+
+/// <summary>A struct with two public properties — no single inner value to wrap.</summary>
+public readonly struct NotValidPair
+{
+    public string First { get; init; }
+    public string Second { get; init; }
+}
+
+/// <summary>A struct with one property but no way to build it from that value.</summary>
+public readonly struct NoBuilder
+{
+    public string Value { get; init; }
+}
+
+public class DefinitelyNotValid;
+
+public class Document<T>
+{
+    public T Id { get; set; } = default!;
+}
+
+public class value_type_resolution_tests
+{
+    [Theory]
+    // Plain scalars are ids in their own right, never wrappers.
+    [InlineData(typeof(int), false)]
+    [InlineData(typeof(string), false)]
+    [InlineData(typeof(Guid), false)]
+    // Vogen value objects over each supported inner type.
+    [InlineData(typeof(ResolvableGuidId), true)]
+    [InlineData(typeof(ResolvableIntId), true)]
+    [InlineData(typeof(WeirdNamed), true)]
+    [InlineData(typeof(ResolvableLongId), true)]
+    [InlineData(typeof(ResolvableStringId), true)]
+    // ... and their nullable forms, which resolve to the same wrapper.
+    [InlineData(typeof(ResolvableGuidId?), true)]
+    [InlineData(typeof(ResolvableIntId?), true)]
+    [InlineData(typeof(ResolvableLongId?), true)]
+    [InlineData(typeof(ResolvableStringId?), true)]
+    // A wrapper over an inner type Polecat cannot store as an id is not a candidate.
+    [InlineData(typeof(ResolvableDateId), false)]
+    [InlineData(typeof(ResolvableDateId?), false)]
+    // The StronglyTypedId generator's output.
+    [InlineData(typeof(GeneratedResolvableId), true)]
+    // Hand-written record structs.
+    [InlineData(typeof(NewGuidId), true)]
+    [InlineData(typeof(NewIntId), true)]
+    [InlineData(typeof(NewLongId), true)]
+    [InlineData(typeof(NewStringId), true)]
+    [InlineData(typeof(NewDateId), false)]
+    // Shapes that are not single-value wrappers at all.
+    [InlineData(typeof(NotValidPair), false)]
+    [InlineData(typeof(NoBuilder), false)]
+    [InlineData(typeof(DefinitelyNotValid), false)]
+    public void is_candidate_value_type(Type candidate, bool isCandidate)
+    {
+        (ValueTypes.TryResolve(candidate) != null).ShouldBe(isCandidate);
+    }
+
+    [Theory]
+    [InlineData(typeof(ResolvableGuidId), typeof(Guid))]
+    [InlineData(typeof(ResolvableIntId), typeof(int))]
+    [InlineData(typeof(ResolvableLongId), typeof(long))]
+    [InlineData(typeof(ResolvableStringId), typeof(string))]
+    [InlineData(typeof(ResolvableGuidId?), typeof(Guid))]
+    [InlineData(typeof(GeneratedResolvableId), typeof(Guid))]
+    [InlineData(typeof(NewGuidId), typeof(Guid))]
+    [InlineData(typeof(NewIntId), typeof(int))]
+    [InlineData(typeof(NewLongId), typeof(long))]
+    [InlineData(typeof(NewStringId), typeof(string))]
+    public void resolves_the_inner_type(Type wrapper, Type expectedInner)
+    {
+        ValueTypes.TryResolve(wrapper)!.SimpleType.ShouldBe(expectedInner);
+    }
+
+    [Fact]
+    public void record_struct_resolves_through_its_constructor()
+    {
+        var info = ValueTypes.TryResolve(typeof(NewGuidId))!;
+        info.Ctor.ShouldNotBeNull();
+        info.ValueProperty.Name.ShouldBe("Value");
+    }
+
+    [Fact]
+    public void private_ctor_type_resolves_through_its_static_factory()
+    {
+        var info = ValueTypes.TryResolve(typeof(SpecialValue))!;
+        info.Ctor.ShouldBeNull();
+        info.Builder!.Name.ShouldBe("From");
+        info.ValueProperty.Name.ShouldBe("Value");
+    }
+
+    [Fact]
+    public void picks_the_builder_whose_return_type_matches_the_value_type()
+    {
+        // marten#4288: with FromNullable(string?) alongside From(string), the naive "first static
+        // method taking one string" pick returns Nullable<T> and every wrapper build fails.
+        var info = ValueTypes.TryResolve(typeof(SpecialValueWithNullableSibling))!;
+        info.Builder!.Name.ShouldBe("From");
+        info.Builder.ReturnType.ShouldBe(typeof(SpecialValueWithNullableSibling));
+    }
+
+    [Theory]
+    [InlineData(typeof(ResolvableGuidId), typeof(Guid))]
+    [InlineData(typeof(ResolvableIntId), typeof(int))]
+    [InlineData(typeof(ResolvableLongId), typeof(long))]
+    [InlineData(typeof(ResolvableStringId), typeof(string))]
+    [InlineData(typeof(ResolvableGuidId?), typeof(Guid))]
+    [InlineData(typeof(GeneratedResolvableId), typeof(Guid))]
+    [InlineData(typeof(NewGuidId), typeof(Guid))]
+    public void document_mapping_maps_the_id_to_the_inner_type(Type idType, Type expectedInner)
+    {
+        var mapping = new DocumentMapping(typeof(Document<>).MakeGenericType(idType), new StoreOptions());
+
+        mapping.IsStrongTypedId.ShouldBeTrue();
+        mapping.IdType.ShouldBe(idType);
+        mapping.InnerIdType.ShouldBe(expectedInner);
+    }
+
+    [Theory]
+    [InlineData(typeof(Guid))]
+    [InlineData(typeof(int))]
+    [InlineData(typeof(long))]
+    [InlineData(typeof(string))]
+    public void document_mapping_leaves_plain_ids_alone(Type idType)
+    {
+        var mapping = new DocumentMapping(typeof(Document<>).MakeGenericType(idType), new StoreOptions());
+
+        mapping.IsStrongTypedId.ShouldBeFalse();
+        mapping.InnerIdType.ShouldBe(idType);
+    }
+
+    [Theory]
+    [InlineData(typeof(ResolvableDateId))]
+    [InlineData(typeof(NewDateId))]
+    [InlineData(typeof(NotValidPair))]
+    [InlineData(typeof(DefinitelyNotValid))]
+    public void document_mapping_rejects_an_unusable_id_type(Type idType)
+    {
+        Should.Throw<InvalidOperationException>(() =>
+            new DocumentMapping(typeof(Document<>).MakeGenericType(idType), new StoreOptions()));
+    }
+}

--- a/src/Polecat.Tests/StrongTypedId/value_types_in_adjacent_features.cs
+++ b/src/Polecat.Tests/StrongTypedId/value_types_in_adjacent_features.cs
@@ -1,0 +1,155 @@
+using JasperFx.Events.Projections;
+using Microsoft.Data.SqlClient;
+using Polecat.Linq;
+using Polecat.Projections.Flattened;
+using Polecat.Storage;
+using Polecat.TestUtils;
+using Polecat.Tests.Harness;
+using Shouldly;
+using Vogen;
+
+namespace Polecat.Tests.StrongTypedId;
+
+// Surfaces beyond document Load/Query that also have to unwrap a strong-typed value, plus the
+// regression that keeps the unwrapping from being applied too eagerly. Ported from the Marten tests
+// that live outside ValueTypeTests: LinqTests/Bugs/Bug_money_value_object_misdetected_as_strong_typed_id
+// and EventSourcingTests/Projections/Flattened/Bug_4290_4291_flat_table_enum_and_value_types.
+
+[ValueObject<Guid>]
+public readonly partial struct AccountRef;
+
+[ValueObject<int>]
+public readonly partial struct LineCount;
+
+public record LedgerPosted(Guid Id, AccountRef Account, LineCount Lines);
+
+public class LedgerFlatProjection : FlatTableProjection
+{
+    public LedgerFlatProjection() : base("value_type_ledger", "value_type_flat")
+    {
+        Table.AddColumn("id", "uniqueidentifier").AsPrimaryKey();
+
+        Project<LedgerPosted>(map =>
+        {
+            map.Map(x => x.Account, "account");
+            map.Map(x => x.Lines, "lines");
+        });
+    }
+}
+
+/// <summary>
+///     A multi-property record struct — a value object, but not a strong-typed *id*. It must stay a
+///     nested JSON object; treating it as a scalar wrapper breaks any nested member access.
+/// </summary>
+public readonly record struct Money(decimal Value, Guid CurrencyId)
+{
+    public static Money Zero(Guid currencyId) => new(0m, currencyId);
+}
+
+public class MoneyDoc
+{
+    public Guid Id { get; set; }
+    public Money Amount { get; set; }
+}
+
+public class IndexedRoom
+{
+    public Guid Id { get; set; }
+    public AccountRef Account { get; set; }
+}
+
+[Collection("integration")]
+public class value_types_in_adjacent_features : IntegrationContext
+{
+    public value_types_in_adjacent_features(DefaultStoreFixture fixture) : base(fixture)
+    {
+    }
+
+    [Fact]
+    public void multi_property_record_struct_is_not_a_strong_typed_id()
+    {
+        // Money has two public properties, so there is no single inner value to wrap. If it were
+        // mis-detected, its column would be typed from one of them and `x.Amount.Value` would stop
+        // resolving as a nested JSON path.
+        ValueTypes.TryResolve(typeof(Money)).ShouldBeNull();
+        ValueTypes.TryResolve(typeof(Money), allowReferenceTypes: true).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task linq_resolves_nested_member_access_on_a_multi_property_record_struct()
+    {
+        await StoreOptions(opts => { opts.DatabaseSchemaName = "value_type_money"; });
+
+        var doc = new MoneyDoc { Id = Guid.NewGuid(), Amount = new Money(12.5m, Guid.NewGuid()) };
+
+        await using var session = theStore.LightweightSession();
+        session.Store(doc);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var found = await session.Query<MoneyDoc>()
+            .Where(x => x.Amount.Value > 0m && x.Amount.CurrencyId == doc.Amount.CurrencyId)
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        found.Count.ShouldBe(1);
+        found.Single().Id.ShouldBe(doc.Id);
+    }
+
+    [Fact]
+    public async Task index_over_a_value_type_member_gets_the_inner_column_type()
+    {
+        // Marten's Bug_4288 index-DDL case. The computed column and the LINQ predicate are both built
+        // from the resolved member type, so if the wrapper is not unwrapped here the column lands as
+        // varchar(250), stops matching the uniqueidentifier-typed predicate, and the index is dead.
+        await StoreOptions(opts =>
+        {
+            opts.DatabaseSchemaName = "value_type_index";
+            opts.Schema.For<IndexedRoom>().Index(x => x.Account);
+        });
+
+        await using var session = theStore.LightweightSession();
+        var room = new IndexedRoom { Id = Guid.NewGuid(), Account = AccountRef.From(Guid.NewGuid()) };
+        session.Store(room);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var columns = await SchemaInspector.GetColumnInfoAsync("pc_doc_indexedroom", "value_type_index");
+        columns.Single(c => c.Name.Contains("account", StringComparison.OrdinalIgnoreCase))
+            .TypeName.ShouldBe("uniqueidentifier");
+
+        var found = await session.Query<IndexedRoom>()
+            .Where(x => x.Account == room.Account)
+            .ToListAsync(TestContext.Current.CancellationToken);
+        found.Single().Id.ShouldBe(room.Id);
+    }
+
+    [Fact]
+    public async Task flat_table_projection_maps_value_types_to_their_inner_columns()
+    {
+        await StoreOptions(opts =>
+        {
+            opts.DatabaseSchemaName = "value_type_flat";
+            opts.Projections.Add<LedgerFlatProjection>(ProjectionLifecycle.Inline);
+        });
+
+        var streamId = Guid.NewGuid();
+        var account = AccountRef.From(Guid.NewGuid());
+
+        await using var session = theStore.LightweightSession();
+        session.Events.StartStream(streamId, new LedgerPosted(streamId, account, LineCount.From(7)));
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var columns = await SchemaInspector.GetColumnInfoAsync("value_type_ledger", "value_type_flat");
+        columns.Single(c => c.Name == "account").TypeName.ShouldBe("uniqueidentifier");
+        columns.Single(c => c.Name == "lines").TypeName.ShouldBe("int");
+
+        await using var conn = new SqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync(TestContext.Current.CancellationToken);
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = "select account, lines from value_type_flat.value_type_ledger where id = @id";
+        cmd.Parameters.AddWithValue("@id", streamId);
+
+        await using var reader = await cmd.ExecuteReaderAsync(TestContext.Current.CancellationToken);
+        (await reader.ReadAsync(TestContext.Current.CancellationToken)).ShouldBeTrue();
+        reader.GetGuid(0).ShouldBe(account.Value);
+        reader.GetInt32(1).ShouldBe(7);
+    }
+}

--- a/src/Polecat/Linq/Members/MemberFactory.cs
+++ b/src/Polecat/Linq/Members/MemberFactory.cs
@@ -78,7 +78,15 @@ internal class MemberFactory : IMemberResolver
             return new QueryableMember(rawLocator, rawLocator, memberType, isBoolean: true);
         }
 
-        var sqlType = GetSqlType(underlying);
+        // A strong-typed-id wrapper on a member other than Id (the Id member is short-circuited to
+        // IdMember above). Vogen and StronglyTypedId both emit a System.Text.Json converter that
+        // writes the inner value, so the JSON holds a scalar and the member is typed, cast and indexed
+        // exactly like its inner type. Only the CLR value in the predicate differs — it is still the
+        // wrapper, which SqlClient cannot bind, so ValueTypeMember unwraps it.
+        var valueType = ValueTypes.TryResolve(underlying, allowReferenceTypes: true);
+        var storedType = valueType?.SimpleType ?? underlying;
+
+        var sqlType = GetSqlType(storedType);
         var typedLocator = BuildTypedLocator(jsonPath, rawLocator, sqlType);
 
         // #223: if a Default-casing Index(...) covers this member, emit the EXACT computed-column
@@ -86,12 +94,14 @@ internal class MemberFactory : IMemberResolver
         // the predicate to the persisted computed column and can seek the index. Without this the
         // translator's expression (e.g. bare JSON_VALUE for a string, CAST(... AS datetimeoffset)
         // for a date) never lines up with the index column, so the index is dead weight.
-        if (TryGetIndexedLocator(jsonPath, underlying, out var indexedLocator))
+        if (TryGetIndexedLocator(jsonPath, storedType, out var indexedLocator))
         {
             typedLocator = indexedLocator;
         }
 
-        return new QueryableMember(rawLocator, typedLocator, memberType);
+        return valueType != null
+            ? new ValueTypeMember(rawLocator, typedLocator, memberType, valueType)
+            : new QueryableMember(rawLocator, typedLocator, memberType);
     }
 
     private bool TryGetIndexedLocator(string jsonPath, Type underlying, out string locator)

--- a/src/Polecat/Linq/Members/ValueTypeMember.cs
+++ b/src/Polecat/Linq/Members/ValueTypeMember.cs
@@ -1,0 +1,31 @@
+using JasperFx.Core.Reflection;
+
+namespace Polecat.Linq.Members;
+
+/// <summary>
+///     A document member whose declared type is a strong-typed-id style wrapper (Vogen,
+///     StronglyTypedId, or a hand-written <c>record struct</c>) sitting somewhere other than the Id.
+///     The locator is typed from the wrapper's inner scalar — both generators serialize the inner
+///     value, so the JSON holds a scalar — and <see cref="ConvertValue" /> unwraps the CLR value so
+///     SqlClient binds the inner scalar rather than a type it has no mapping for.
+/// </summary>
+internal class ValueTypeMember : IQueryableMember
+{
+    private readonly ValueTypeInfo _valueType;
+
+    public ValueTypeMember(string rawLocator, string typedLocator, Type memberType, ValueTypeInfo valueType)
+    {
+        RawLocator = rawLocator;
+        TypedLocator = typedLocator;
+        MemberType = memberType;
+        _valueType = valueType;
+    }
+
+    public Type MemberType { get; }
+    public string TypedLocator { get; }
+    public string RawLocator { get; }
+    public bool IsBoolean => false;
+
+    public object? ConvertValue(object? value)
+        => value == null ? null : _valueType.ValueProperty.GetValue(value);
+}

--- a/src/Polecat/Linq/QueryHandlers/ScalarConversion.cs
+++ b/src/Polecat/Linq/QueryHandlers/ScalarConversion.cs
@@ -1,0 +1,34 @@
+using System.Diagnostics.CodeAnalysis;
+using JasperFx.Core.Reflection;
+using Polecat.Storage;
+
+namespace Polecat.Linq.QueryHandlers;
+
+/// <summary>
+///     Converts a raw column value to the CLR type a scalar <c>Select()</c> projection asked for.
+///     Plain scalars go through <see cref="Convert.ChangeType(object, Type)" />; a strong-typed-id
+///     wrapper (Vogen, StronglyTypedId, or a <c>record struct</c>) is rebuilt from its inner value,
+///     since it implements neither <see cref="IConvertible" /> nor any SqlClient mapping.
+/// </summary>
+internal static class ScalarConversion
+{
+    [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
+        Justification = "Reflectively invokes the wrapper's discovered constructor/factory. The wrapper type is the projection's result type, which flows in from caller code the trimmer can see.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+        Justification = "Invokes an already-discovered ConstructorInfo/MethodInfo; no generic closing.")]
+    internal static object Convert(object value, Type targetType)
+    {
+        if (targetType.IsEnum) return Enum.ToObject(targetType, value);
+
+        var wrapper = ValueTypes.TryResolve(targetType, allowReferenceTypes: true);
+        if (wrapper != null)
+        {
+            var inner = System.Convert.ChangeType(value, wrapper.SimpleType);
+            return wrapper.Ctor != null
+                ? wrapper.Ctor.Invoke([inner])
+                : wrapper.Builder!.Invoke(null, [inner])!;
+        }
+
+        return System.Convert.ChangeType(value, targetType);
+    }
+}

--- a/src/Polecat/Linq/QueryHandlers/ScalarHandler.cs
+++ b/src/Polecat/Linq/QueryHandlers/ScalarHandler.cs
@@ -17,6 +17,7 @@ internal class ScalarHandler<T> : IQueryHandler<T>
         }
 
         var value = reader.GetValue(0);
-        return (T)Convert.ChangeType(value, typeof(T));
+        var targetType = Nullable.GetUnderlyingType(typeof(T)) ?? typeof(T);
+        return (T)ScalarConversion.Convert(value, targetType);
     }
 }

--- a/src/Polecat/Linq/QueryHandlers/ScalarListHandler.cs
+++ b/src/Polecat/Linq/QueryHandlers/ScalarListHandler.cs
@@ -20,14 +20,7 @@ internal class ScalarListHandler<T> : IQueryHandler<IReadOnlyList<T>>
             {
                 var value = reader.GetValue(0);
                 var targetType = Nullable.GetUnderlyingType(typeof(T)) ?? typeof(T);
-                if (targetType.IsEnum)
-                {
-                    list.Add((T)Enum.ToObject(targetType, value));
-                }
-                else
-                {
-                    list.Add((T)Convert.ChangeType(value, targetType));
-                }
+                list.Add((T)ScalarConversion.Convert(value, targetType));
             }
         }
 

--- a/src/Polecat/Projections/Flattened/IParameterSetter.cs
+++ b/src/Polecat/Projections/Flattened/IParameterSetter.cs
@@ -1,5 +1,7 @@
+using JasperFx.Core.Reflection;
 using JasperFx.Events;
 using Microsoft.Data.SqlClient;
+using Polecat.Storage;
 
 namespace Polecat.Projections.Flattened;
 
@@ -16,6 +18,12 @@ internal interface IParameterSetter
 /// </summary>
 internal class EventDataParameterSetter<TEvent, TValue> : IParameterSetter
 {
+    // A strong-typed-id wrapper has no SqlClient mapping, so the inner value is what goes on the
+    // parameter — matching the inner-typed column StatementMap builds for it. Resolved once per
+    // closed generic; null for every ordinary value. See marten#4290.
+    private static readonly ValueTypeInfo? Wrapper =
+        ValueTypes.TryResolve(typeof(TValue), allowReferenceTypes: true);
+
     private readonly Func<TEvent, TValue> _accessor;
 
     public EventDataParameterSetter(Func<TEvent, TValue> accessor)
@@ -26,7 +34,15 @@ internal class EventDataParameterSetter<TEvent, TValue> : IParameterSetter
     public void SetValue(SqlParameter parameter, IEvent source)
     {
         var value = _accessor((TEvent)source.Data);
-        parameter.Value = value is not null ? (object)value : DBNull.Value;
+        if (value is null)
+        {
+            parameter.Value = DBNull.Value;
+            return;
+        }
+
+        parameter.Value = Wrapper != null
+            ? Wrapper.ValueProperty.GetValue(value) ?? (object)DBNull.Value
+            : value;
     }
 }
 

--- a/src/Polecat/Projections/Flattened/StatementMap.cs
+++ b/src/Polecat/Projections/Flattened/StatementMap.cs
@@ -3,6 +3,7 @@ using System.Linq.Expressions;
 using System.Reflection;
 using JasperFx.Events;
 using Polecat.Internal;
+using Polecat.Storage;
 using Weasel.Core;
 using Weasel.SqlServer.Tables;
 
@@ -257,6 +258,13 @@ public class StatementMap<TEvent> : IFlatTableEventHandler
     private static string MapToSqlType(Type type)
     {
         var underlying = Nullable.GetUnderlyingType(type) ?? type;
+
+        // A strong-typed-id wrapper column is stored as its inner primitive, the same way a document's
+        // wrapper id is. Without this the wrapper falls through to nvarchar(max) and the MERGE then
+        // fails at execution with "No mapping exists from object type ...". See marten#4290.
+        var wrapper = ValueTypes.TryResolve(underlying, allowReferenceTypes: true);
+        if (wrapper != null) underlying = wrapper.SimpleType;
+
         return underlying switch
         {
             _ when underlying == typeof(Guid) => "uniqueidentifier",

--- a/src/Polecat/Storage/DocumentMapping.cs
+++ b/src/Polecat/Storage/DocumentMapping.cs
@@ -23,8 +23,9 @@ namespace Polecat.Storage;
     Justification = "Class-level: the id accessors close JasperFx's LambdaBuilder / ValueTypeInfo generic converters over the runtime document + id types via MakeGenericMethod once per document type at registration — the same FEC accessor helpers and runtime generic-closing Marten's closed-shape storage / ProviderGraph use. AOT consumers supply a source-generator-backed serializer per the AOT publishing guide; the reflective serialize path is already the gating RUC/RDC surface.")]
 internal class DocumentMapping
 {
-    private static readonly HashSet<Type> SupportedIdTypes =
-        [typeof(Guid), typeof(string), typeof(int), typeof(long)];
+    // The same set that bounds what a strong-typed-id wrapper may wrap — an id and a wrapper's inner
+    // value have to be storable in exactly the same column types.
+    private static readonly HashSet<Type> SupportedIdTypes = ValueTypes.SupportedInnerTypes;
 
     private readonly PropertyInfo _idProperty;
     private readonly Type _documentType;
@@ -168,7 +169,12 @@ internal class DocumentMapping
             current = prop.PropertyType;
         }
 
-        return Nullable.GetUnderlyingType(current) ?? current;
+        var resolved = Nullable.GetUnderlyingType(current) ?? current;
+
+        // A strong-typed-id wrapper serializes as its inner value, so the computed column is typed
+        // from that. This has to agree with MemberFactory, which types the predicate the same way —
+        // if the two disagree the predicate stops matching the persisted column and the index dies.
+        return ValueTypes.TryResolve(resolved, allowReferenceTypes: true)?.SimpleType ?? resolved;
     }
 
     /// <summary>
@@ -625,23 +631,5 @@ internal class DocumentMapping
     ///     Attempts to resolve a value type as a strongly typed ID wrapper.
     ///     Returns null if the type isn't a valid wrapper around a supported ID type.
     /// </summary>
-    private static ValueTypeInfo? TryResolveValueTypeId(Type idType)
-    {
-        if (!idType.IsValueType || idType.IsPrimitive || idType.IsEnum) return null;
-
-        try
-        {
-            var info = ValueTypeInfo.ForType(idType);
-            if (SupportedIdTypes.Contains(info.SimpleType))
-            {
-                return info;
-            }
-
-            return null;
-        }
-        catch
-        {
-            return null;
-        }
-    }
+    private static ValueTypeInfo? TryResolveValueTypeId(Type idType) => ValueTypes.TryResolve(idType);
 }

--- a/src/Polecat/Storage/ValueTypes.cs
+++ b/src/Polecat/Storage/ValueTypes.cs
@@ -1,0 +1,113 @@
+using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using JasperFx.Core.Reflection;
+
+namespace Polecat.Storage;
+
+/// <summary>
+///     Recognizes "strong typed id" style value wrappers — a type whose single public getter wraps one
+///     of the scalar types Polecat can persist, paired with either a matching constructor or a static
+///     factory method. Both Vogen (<c>[ValueObject&lt;Guid&gt;]</c>, private ctor + static <c>From</c>)
+///     and StronglyTypedId (<c>[StronglyTypedId(Template.Guid)]</c>, public ctor) emit that shape, as
+///     does a hand-written <c>record struct OrderId(Guid Value)</c>.
+///     <para>
+///     <see cref="DocumentMapping" /> uses this for the Id member; the LINQ layer uses it for every
+///     other member, so a wrapper-typed property is queried against its inner scalar rather than
+///     handed to SqlClient as an unknown CLR type.
+///     </para>
+/// </summary>
+internal static class ValueTypes
+{
+    /// <summary>
+    ///     The scalar types Polecat can store in a column or compare in a JSON path predicate, and
+    ///     therefore the inner types a recognized wrapper may wrap.
+    /// </summary>
+    internal static readonly HashSet<Type> SupportedInnerTypes =
+        [typeof(Guid), typeof(string), typeof(int), typeof(long)];
+
+    // Negative results are cached too, and that is the point: ValueTypeInfo.ForType signals "not a
+    // wrapper" by throwing, and only caches successes. Every LINQ member resolution over an ordinary
+    // DateTimeOffset or decimal member would otherwise raise and swallow an exception.
+    private static readonly ConcurrentDictionary<(Type, bool), ValueTypeInfo?> Cache = new();
+
+    /// <summary>
+    ///     Resolves <paramref name="type" /> as a value wrapper, or returns null when it is not one.
+    ///     Nullable wrappers are unwrapped first, so <c>OrderId?</c> resolves the same as <c>OrderId</c>.
+    /// </summary>
+    /// <param name="type">The declared type of the id or member.</param>
+    /// <param name="allowReferenceTypes">
+    ///     True for a non-Id member, where a reference-type value object built through a static factory
+    ///     also qualifies. Ids stay struct-only.
+    /// </param>
+    internal static ValueTypeInfo? TryResolve(Type type, bool allowReferenceTypes = false)
+        => Cache.GetOrAdd((type, allowReferenceTypes), key => Resolve(key.Item1, key.Item2));
+
+    [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
+        Justification = "ValueTypeInfo.ForType reflects the candidate's public properties/constructors/static methods. Candidates reach here only as the declared type of a document member, which is preserved at the Schema.For<T>() registration boundary.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2067:DynamicallyAccessedMembers",
+        Justification = "Same as above: the candidate Type originates from a document member on a registered document type.")]
+    private static ValueTypeInfo? Resolve(Type type, bool allowReferenceTypes)
+    {
+        var candidate = Nullable.GetUnderlyingType(type) ?? type;
+
+        // Cheap structural gate before the reflective probe. An id must be a struct — that is the
+        // shape every generator emits and what the identity assigners assume — but a *member* may
+        // also be a reference-type wrapper, which is what Vogen emits for
+        // `[ValueObject<int>] public partial record Age`. Primitives and enums are never wrappers,
+        // and the supported inner types would otherwise be probed on every member resolution.
+        if (candidate.IsPrimitive || candidate.IsEnum) return null;
+        if (!candidate.IsValueType && !(allowReferenceTypes && candidate.IsClass)) return null;
+        if (SupportedInnerTypes.Contains(candidate)) return null;
+
+        try
+        {
+            var info = CorrectBuilder(ValueTypeInfo.ForType(candidate), candidate);
+            if (!SupportedInnerTypes.Contains(info.SimpleType)) return null;
+
+            // A reference-type candidate only qualifies when it is built through a static factory
+            // rather than a public constructor. Vogen's record value objects keep their constructor
+            // private and expose `From`, which is exactly the shape that says "this is a value
+            // object, not a nested entity"; an ordinary single-property DTO such as
+            // `record Address(string City)` resolves through its public constructor and must keep
+            // being treated as a nested object, not silently queried as a scalar.
+            if (!candidate.IsValueType && info.Ctor != null) return null;
+
+            return info;
+        }
+        catch
+        {
+            // ValueTypeInfo throws InvalidValueTypeException for anything that is not a single-value
+            // wrapper. That is the common case for an ordinary struct member, so it is not an error.
+            return null;
+        }
+    }
+
+    /// <summary>
+    ///     ValueTypeInfo.ForType takes the *first* public static method accepting one inner-typed
+    ///     argument as the wrapper's builder, without checking what it returns. A type that pairs
+    ///     <c>static X From(string)</c> with a nullable sibling such as <c>static X? FromNullable(string?)</c>
+    ///     can therefore bind to the sibling, and every wrapper built from it fails with
+    ///     "Expression of type 'Nullable&lt;X&gt;' cannot be used for return type 'X'". Prefer a builder
+    ///     that actually returns the wrapper, and re-register the corrected info so the shared cache —
+    ///     which the event store's stream-id resolution also reads — agrees. Marten fixes the same
+    ///     defect in its own RegisterValueType (marten#4288).
+    /// </summary>
+    [UnconditionalSuppressMessage("Trimming", "IL2070:DynamicallyAccessedMembers",
+        Justification = "Enumerates public static methods on a candidate that reached here as the declared type of a member on a registered document type.")]
+    private static ValueTypeInfo CorrectBuilder(ValueTypeInfo info, Type candidate)
+    {
+        if (info.Builder == null || info.Builder.ReturnType == candidate) return info;
+
+        var better = candidate.GetMethods(BindingFlags.Static | BindingFlags.Public)
+            .FirstOrDefault(x => x.ReturnType == candidate
+                                 && x.GetParameters().Length == 1
+                                 && x.GetParameters()[0].ParameterType == info.SimpleType);
+
+        if (better == null) return info;
+
+        var corrected = new ValueTypeInfo(info.OuterType, info.SimpleType, info.ValueProperty, better);
+        ValueTypeInfo.Register(corrected);
+        return corrected;
+    }
+}


### PR DESCRIPTION
Surveyed Marten's `ValueTypeTests` project (26 files, ~5,200 lines) plus every strong-typed-id test outside it — `LinqTests/Bugs`, `CoreTests/Bugs`, `EventSourcingTests`, `Marten.AspNetCore.Testing` — and ported what Polecat can support.

Four of the ported cases failed on arrival. Each was a real defect, fixed here alongside the test that pins it.

## Defects closed

| Symptom | Marten equivalent | Fix |
|---|---|---|
| A wrapper on any member **other than Id** crashed LINQ with `No mapping exists from object type …` | `duplicated_value_type_field_operations`, `Bugs/querying_by_value_types`, `include_usage` | New `ValueTypeMember` types the locator from the inner scalar and unwraps the parameter |
| `Select(x => x.Id)` on a wrapper threw `Object must implement IConvertible` | `use_in_LINQ_select_clause` | New `ScalarConversion` rebuilds the wrapper from its inner value |
| A wrapper with a nullable sibling factory bound the wrong builder → `Expression of type 'Nullable<T>' cannot be used for return type 'T'` | **marten#4288** | Prefer the builder whose return type is the wrapper; re-register the corrected info in JasperFx's shared cache so stream-id resolution agrees |
| Flat-table projection columns over a wrapper fell to `nvarchar(max)` and failed at MERGE time | **marten#4290** | `StatementMap` types the column from the inner value; the parameter setter unwraps it |

## Consolidation

The rule moves into one place — `Polecat.Storage.ValueTypes` — shared by `DocumentMapping`, the LINQ member factory, the scalar handlers and the flat-table projection.

It caches **negative** results deliberately: `ValueTypeInfo.ForType` signals "not a wrapper" by throwing and only caches successes, so every LINQ member over an ordinary `decimal` or `DateTimeOffset` would otherwise raise and swallow an exception on a hot path.

Index DDL resolves the same way now, so a computed index over a wrapper gets the inner column type and the predicate keeps matching it — otherwise the index is dead weight.

## Guardrails against over-eager detection

- A reference-type value object (Vogen's `[ValueObject<int>] public partial record Age`) is recognized on a member, but **only** when built through a static factory rather than a public constructor. An ordinary `record Address(string City)` must stay a nested JSON object.
- A multi-property `record struct Money(decimal, Guid)` is left alone, so `x.Amount.CurrencyId` keeps resolving as a nested path. That is Marten's `Bug_money_value_object_misdetected_as_strong_typed_id`, ported.

## Tests

**Vogen is referenced by `Polecat.Tests` for the first time** (7.0.0, matching Marten), exercising the private-ctor + static-`From` "builder" shape that a hand-written record struct never reaches. `StronglyTypedId` was already referenced but only used by the projection tests; it gains document-side suites.

163 new tests across 14 files: `VogenIds/` and `GeneratedIds/` operation suites per inner type, `value_type_resolution_tests` (Marten's `applicability_of_identity_types` + `registration`), `value_type_member_operations`, `linq_querying_with_value_types`, `batch_querying_with_value_types`, `nullable_value_type_id_operations`, `value_types_in_adjacent_features`.

Full suite **2118 / 0 failed / 3 skipped** locally.

## Behavioral note worth knowing

**Vogen identities must be declared nullable** (`InvoiceId? Id`) — as they are in every Vogen document in Marten's own `ValueTypeTests`. Vogen forbids an uninitialized value object, so a non-nullable Vogen id throws inside Weasel's `ValueTypeIdentification.AssignIfMissing` before Polecat can see the id was unset. Documented, and the test files say so. StronglyTypedId permits `default` and works either way.

## Not ported — Polecat lacks the feature

Called out in the docs rather than silently worked around:

- No `LoadAsync<T>(object id)` overload taking the wrapper (so no `DocumentIdTypeMismatchException`, and Marten's `throw_id_mismatch_when_wrong` cases have nothing to assert against)
- No `Include()` operator — the piece it depends on is covered instead
- No compiled queries
- F# discriminated-union identities (no F# project in the repo)

Two Marten cases turned out already covered: `Bug_4190` by `archived_partitioning_dcb_tag_tests`, and the event-side overloads by `strong_typed_id_fetch_overload_tests`.

## Docs

`docs/documents/identity.md` — the strong-typed-id section is rewritten: both generators with worked examples, the nullable-Vogen rule, value types on non-identity members, index and flat-table behavior, and an explicit "not currently supported" list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PwvC24c5dNxv7DJR7RUjv