### PR TITLE
5.13.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>5.12.0</Version>
+        <Version>5.13.0</Version>
         <LangVersion>latest</LangVersion>
         <Authors>Jeremy D. Miller</Authors>
         <PackageIcon>logo.png</PackageIcon>


### PR DESCRIPTION
Minor version bump for the strong-typed-identifier work merged in #457.

Minor rather than patch because it adds capability: a strong-typed value type is now usable on **any** document member, not just the identity, and is queryable there through `Where` / `OrderBy` / `IsOneOf` / `Select`. Four defects in the existing support are also fixed — see #457 for the detail.

Docs: [Document Identity → Strongly Typed IDs](https://polecat.jasperfx.net/documents/identity.html#strongly-typed-ids)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PwvC24c5dNxv7DJR7RUjv