### PR TITLE
Add a public StoreOptions.RegisterValueType so store configuration is portable

### DIFF
--- a/docs/documents/identity.md
+++ b/docs/documents/identity.md
@@ -235,6 +235,27 @@ A type with more than one public property — `record struct Money(decimal Amoun
 is not a strong typed identifier and is left alone as a nested JSON object, so `x.Amount.CurrencyId`
 keeps resolving as a nested path.
 
+### Registering a Value Type
+
+Polecat discovers value types on its own, so **you never need to register one**. The API exists purely
+so that a single store-configuration file can compile against both Marten and Polecat:
+
+```cs
+// Compiles and means the same thing under either store
+opts.RegisterValueType<AlertId>();
+opts.RegisterValueType(typeof(AlertId));
+```
+
+Both overloads return JasperFx's `ValueTypeInfo`, matching Marten's signature. Registration resolves
+the type eagerly and validates it, so passing something that cannot be a value wrapper throws
+`InvalidValueTypeException` at configuration time rather than failing at the first query.
+
+::: tip
+Marten's docs describe a timing issue where value types used in LINQ have to be registered before the
+first expression is evaluated. Polecat has no such issue — it resolves on demand and caches — so
+registration here is genuinely optional.
+:::
+
 ### Not Currently Supported
 
 - No `LoadAsync<T>(object id)` overload taking the wrapper itself

--- a/src/Polecat.Tests/StrongTypedId/register_value_type_tests.cs
+++ b/src/Polecat.Tests/StrongTypedId/register_value_type_tests.cs
@@ -1,0 +1,157 @@
+using JasperFx.Core.Reflection;
+using Polecat.Linq;
+using Polecat.Tests.Harness;
+using Shouldly;
+using Vogen;
+
+namespace Polecat.Tests.StrongTypedId;
+
+// polecat#459. Mirrors Marten's ValueTypeTests/registration.cs. Polecat resolves value types on its
+// own, so nothing here is *required* — the API exists so that one shared store-configuration file can
+// compile against Marten and Polecat both. These tests pin the contract that portability depends on:
+// the same call, the same return type, and the same loud failure on a type that cannot be a wrapper.
+
+[ValueObject<Guid>]
+public readonly partial struct RegisteredAlertId;
+
+public record struct RegisteredExternalId(string Value);
+
+/// <summary>Private ctor plus a static factory — the shape Vogen and hand-rolled wrappers share.</summary>
+public readonly struct RegisteredSpecialValue
+{
+    private RegisteredSpecialValue(string value) => Value = value;
+
+    public string Value { get; }
+
+    public static RegisteredSpecialValue From(string value) => new(value);
+}
+
+public class RegisteredAlert
+{
+    public RegisteredAlertId? Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+}
+
+public class register_value_type_tests
+{
+    [Fact]
+    public void register_happy_path_with_a_constructor()
+    {
+        var value = new StoreOptions().RegisterValueType(typeof(RegisteredExternalId));
+
+        value.Ctor.ShouldNotBeNull();
+        value.ValueProperty.Name.ShouldBe("Value");
+        value.SimpleType.ShouldBe(typeof(string));
+    }
+
+    [Fact]
+    public void register_happy_path_with_a_static_factory()
+    {
+        var value = new StoreOptions().RegisterValueType(typeof(RegisteredSpecialValue));
+
+        value.Builder!.Name.ShouldBe("From");
+        value.ValueProperty.Name.ShouldBe("Value");
+        value.SimpleType.ShouldBe(typeof(string));
+    }
+
+    [Fact]
+    public void register_the_generic_overload()
+    {
+        var value = new StoreOptions().RegisterValueType<RegisteredAlertId>();
+
+        value.OuterType.ShouldBe(typeof(RegisteredAlertId));
+        value.SimpleType.ShouldBe(typeof(Guid));
+    }
+
+    [Fact]
+    public void registering_twice_returns_the_same_resolution()
+    {
+        var options = new StoreOptions();
+
+        var first = options.RegisterValueType<RegisteredAlertId>();
+        var second = options.RegisterValueType<RegisteredAlertId>();
+
+        // Resolution is process-wide and cached, so a second call — from another store, or the same
+        // shared configuration file run twice — must not produce a second, competing answer.
+        ReferenceEquals(first, second).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void registering_on_one_store_options_does_not_disturb_another()
+    {
+        new StoreOptions().RegisterValueType<RegisteredAlertId>();
+
+        var other = new StoreOptions().RegisterValueType<RegisteredAlertId>();
+
+        other.SimpleType.ShouldBe(typeof(Guid));
+    }
+
+    [Theory]
+    // Two public properties — no single inner value to wrap.
+    [InlineData(typeof(NotValidPair))]
+    // One property, but nothing that can build it from that value.
+    [InlineData(typeof(NoBuilder))]
+    // Not a wrapper at all.
+    [InlineData(typeof(DefinitelyNotValid))]
+    // A wrapper over an inner type Polecat cannot store.
+    [InlineData(typeof(ResolvableDateId))]
+    public void sad_path_registration_throws(Type type)
+    {
+        var options = new StoreOptions();
+
+        Should.Throw<InvalidValueTypeException>(() => options.RegisterValueType(type));
+    }
+
+    [Fact]
+    public void the_sad_path_message_names_the_type_and_says_what_is_required()
+    {
+        var ex = Should.Throw<InvalidValueTypeException>(
+            () => new StoreOptions().RegisterValueType(typeof(NotValidPair)));
+
+        ex.Message.ShouldContain(nameof(NotValidPair));
+        ex.Message.ShouldContain("Guid");
+    }
+}
+
+// The registered type still has to actually work as an identity afterwards — registration must not be
+// the only thing that makes a value type usable, since Polecat users will never call it.
+[Collection("integration")]
+public class registered_value_type_still_round_trips : IntegrationContext
+{
+    public registered_value_type_still_round_trips(DefaultStoreFixture fixture) : base(fixture)
+    {
+    }
+
+    public override async ValueTask InitializeAsync()
+    {
+        await StoreOptions(opts =>
+        {
+            opts.DatabaseSchemaName = "registered_value_type";
+
+            // The portable line: identical source under Marten and Polecat.
+            opts.RegisterValueType<RegisteredAlertId>();
+        });
+    }
+
+    [Fact]
+    public async Task store_load_and_query_after_explicit_registration()
+    {
+        var alert = new RegisteredAlert { Name = "Registered" };
+
+        await using var session = theStore.LightweightSession();
+        session.Store(alert);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        alert.Id.ShouldNotBeNull();
+
+        var loaded = await session.LoadAsync<RegisteredAlert>(
+            alert.Id!.Value.Value, TestContext.Current.CancellationToken);
+        loaded.ShouldNotBeNull();
+        loaded!.Id.ShouldBe(alert.Id);
+
+        var queried = await session.Query<RegisteredAlert>()
+            .Where(x => x.Id == alert.Id)
+            .FirstOrDefaultAsync(TestContext.Current.CancellationToken);
+        queried!.Name.ShouldBe("Registered");
+    }
+}

--- a/src/Polecat/Storage/ValueTypes.cs
+++ b/src/Polecat/Storage/ValueTypes.cs
@@ -43,6 +43,36 @@ internal static class ValueTypes
     internal static ValueTypeInfo? TryResolve(Type type, bool allowReferenceTypes = false)
         => Cache.GetOrAdd((type, allowReferenceTypes), key => Resolve(key.Item1, key.Item2));
 
+    /// <summary>
+    ///     Resolves <paramref name="type" /> up front and throws if it is not a usable value wrapper.
+    ///     Polecat never needs this — every path here resolves on demand — but Marten's
+    ///     <c>StoreOptions.RegisterValueType</c> exists, so configuration source shared between the two
+    ///     stores needs the call to compile and to mean the same thing. Registration is therefore
+    ///     eager and loud rather than a no-op: a type that cannot be a value wrapper is a configuration
+    ///     error worth hearing about at startup instead of at the first query.
+    /// </summary>
+    /// <exception cref="InvalidValueTypeException">
+    ///     <paramref name="type" /> has no single readable value property over a supported inner type,
+    ///     or no constructor or static factory that takes one.
+    /// </exception>
+    internal static ValueTypeInfo Register(Type type)
+    {
+        // Prime both cache entries so the id path and the member path agree from here on, and so a
+        // later resolution never re-runs the reflective probe for this type.
+        TryResolve(type);
+        var info = TryResolve(type, allowReferenceTypes: true);
+
+        if (info == null)
+        {
+            throw new InvalidValueTypeException(type,
+                "Polecat requires a single public, readable property wrapping one of "
+                + $"{string.Join(", ", SupportedInnerTypes.Select(x => x.Name))}, paired with either a "
+                + "constructor or a public static factory method taking that value.");
+        }
+
+        return info;
+    }
+
     [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
         Justification = "ValueTypeInfo.ForType reflects the candidate's public properties/constructors/static methods. Candidates reach here only as the declared type of a document member, which is preserved at the Schema.For<T>() registration boundary.")]
     [UnconditionalSuppressMessage("Trimming", "IL2067:DynamicallyAccessedMembers",

--- a/src/Polecat/StoreOptions.cs
+++ b/src/Polecat/StoreOptions.cs
@@ -349,6 +349,35 @@ public class StoreOptions
         Serializer = serializer;
     }
 
+    /// <summary>
+    ///     Register a custom value type — a "strong typed identifier" wrapping a single <see cref="Guid" />,
+    ///     <c>string</c>, <c>int</c> or <c>long</c>.
+    ///     <para>
+    ///     Polecat discovers these on its own, so calling this is never required. It exists because
+    ///     Marten's <c>StoreOptions.RegisterValueType&lt;T&gt;()</c> does, and store-configuration source
+    ///     shared across both — a single file compiled once per store — has to build against either
+    ///     (polecat#459). Calling it here resolves the type eagerly and validates it, so a type that
+    ///     cannot be a value wrapper fails at configuration time rather than at the first query.
+    ///     </para>
+    /// </summary>
+    /// <typeparam name="TValueType">The wrapper type, e.g. <c>record struct OrderId(Guid Value)</c>.</typeparam>
+    /// <returns>The resolved value type metadata, matching Marten's return type.</returns>
+    /// <exception cref="JasperFx.Core.Reflection.InvalidValueTypeException">
+    ///     <typeparamref name="TValueType" /> is not a usable value wrapper.
+    /// </exception>
+    public JasperFx.Core.Reflection.ValueTypeInfo RegisterValueType<TValueType>() where TValueType : notnull
+        => ValueTypes.Register(typeof(TValueType));
+
+    /// <summary>
+    ///     Register a custom value type by <see cref="Type" />. See
+    ///     <see cref="RegisterValueType{TValueType}" /> for why this exists.
+    /// </summary>
+    /// <exception cref="JasperFx.Core.Reflection.InvalidValueTypeException">
+    ///     <paramref name="type" /> is not a usable value wrapper.
+    /// </exception>
+    public JasperFx.Core.Reflection.ValueTypeInfo RegisterValueType(Type type)
+        => ValueTypes.Register(type);
+
     internal ConnectionFactory CreateConnectionFactory()
     {
         if (string.IsNullOrWhiteSpace(_connectionString))


### PR DESCRIPTION
Closes #459.

Marten exposes `StoreOptions.RegisterValueType<T>()`. Polecat had no equivalent, because it discovers strong-typed id wrappers on its own and genuinely never needed one.

That is fine behaviourally and a problem for **source portability**. CritterWatch is standing up a matrix that compiles one set of configuration files per store, and

```csharp
opts.RegisterValueType<AlertId>();
```

builds under Marten and **fails to build** under Polecat. It isn't a runtime difference that can be papered over — the shared file simply doesn't compile. 16 call sites today.

## What's added

```csharp
public ValueTypeInfo RegisterValueType<TValueType>() where TValueType : notnull;
public ValueTypeInfo RegisterValueType(Type type);
```

Both return JasperFx's `ValueTypeInfo`, so the signature matches Marten's and the shared line compiles unchanged.

## One deliberate departure from the issue

The issue suggested a no-op would be enough. This **registers eagerly** instead: it resolves the type, primes both cache entries so the id path and the member path agree from that point on, and throws `InvalidValueTypeException` — the same JasperFx exception Marten throws — when the type cannot be a value wrapper.

A silent no-op would let `RegisterValueType<SomethingBroken>()` pass under Polecat while failing under Marten, which reintroduces the same class of portability gap in the opposite direction. Same call, same meaning, same failure.

Registration remains genuinely optional for Polecat-only code, and the docs say so.

## Tests

Mirrors Marten's `ValueTypeTests/registration.cs`:

- Happy path for both shapes — constructor (`record struct ExternalId(string Value)`) and static factory (private ctor + `From`)
- The generic overload
- Four sad paths, plus the exception message naming the type and the required inner types

Two are Polecat-specific, covering the fact that our cache is process-wide rather than per-store:

- Registering twice returns the *identical* resolution — a second store, or the same shared configuration file run twice, must not produce a competing answer
- Registering on one `StoreOptions` doesn't disturb another

And one integration test proves a registered type still stores, loads and queries — because Polecat users will never call this, and it must not quietly become load-bearing.

## Docs

`docs/documents/identity.md` gains a "Registering a Value Type" section that leads with *you never need to call this*, explains why it exists, and notes that Marten's "register before the first LINQ expression is evaluated" timing caveat does **not** apply here — Polecat resolves on demand and caches.

Full suite **2129 / 0 failed / 3 skipped** locally. No new trimming warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PwvC24c5dNxv7DJR7RUjv