### PR TITLE
5.14.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>5.13.0</Version>
+        <Version>5.14.0</Version>
         <LangVersion>latest</LangVersion>
         <Authors>Jeremy D. Miller</Authors>
         <PackageIcon>logo.png</PackageIcon>


### PR DESCRIPTION
Minor version bump for #460.

Minor rather than patch because it adds public API surface: `StoreOptions.RegisterValueType<T>()` and `RegisterValueType(Type)`, added so that store-configuration source can be shared across Marten and Polecat (#459). Additive only — nothing existing changes behaviour.

Docs: [Document Identity → Registering a Value Type](https://polecat.jasperfx.net/documents/identity.html#registering-a-value-type)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PwvC24c5dNxv7DJR7RUjv