### PR TITLE
Add a ConfigurePolecat((sp, opts) => ...) overload for the main store (#456)

### DIFF
--- a/docs/configuration/hostbuilder.md
+++ b/docs/configuration/hostbuilder.md
@@ -54,6 +54,34 @@ builder.Services.AddPolecat(sp =>
 | `IDocumentSession` | Scoped | Read/write session with unit of work |
 | `IQuerySession` | Scoped | Read-only session for queries |
 
+## ConfigurePolecat
+
+`ConfigurePolecat()` registers a post-configuration action that runs against `StoreOptions` after
+`AddPolecat()` has built them. Use it when a module other than the one that called `AddPolecat()`
+owns part of the store configuration:
+
+```cs
+builder.Services.ConfigurePolecat(options =>
+{
+    options.CommandTimeout = 120;
+});
+```
+
+There is a second overload that also hands you the built `IServiceProvider`, for configuration that
+depends on other registered services:
+
+```cs
+builder.Services.ConfigurePolecat((services, options) =>
+{
+    var settings = services.GetRequiredService<IOptions<RetentionSettings>>().Value;
+    options.Schema.For<MetricsSample>().PartitionOn(x => x.Timestamp)
+        .ByRollingRange(RollingPeriod.Day, ahead: 2, behind: settings.DaysRetained);
+});
+```
+
+Both overloads have a `ConfigurePolecat<T>()` counterpart that targets an ancillary store registered
+with `AddPolecatStore<T>()`.
+
 ## IConfigurePolecat
 
 You can implement `IConfigurePolecat` to modularize your configuration:

--- a/src/Polecat.Tests/DependencyInjection/service_registration_tests.cs
+++ b/src/Polecat.Tests/DependencyInjection/service_registration_tests.cs
@@ -183,6 +183,29 @@ public class service_registration_tests
         options.CommandTimeout.ShouldBe(120);
     }
 
+    // #456: the (IServiceProvider, StoreOptions) shape existed only on the generic
+    // ConfigurePolecat<T> for ancillary stores, so code post-configuring the *main*
+    // store from a resolved service had no extension to call.
+    [Fact]
+    public void configure_polecat_with_service_provider_applies_post_configuration()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(new SchemaNameSource("from_the_container"));
+        services.AddPolecat(opts =>
+        {
+            opts.ConnectionString = ConnectionSource.ConnectionString;
+        });
+
+        services.ConfigurePolecat((sp, opts) =>
+        {
+            opts.DatabaseSchemaName = sp.GetRequiredService<SchemaNameSource>().Name;
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<StoreOptions>();
+        options.DatabaseSchemaName.ShouldBe("from_the_container");
+    }
+
     [Fact]
     public void iconfigure_polecat_is_applied()
     {
@@ -228,6 +251,8 @@ public class service_registration_tests
         var hostedServices = provider.GetServices<IHostedService>().ToList();
         hostedServices.OfType<PolecatActivator>().Count().ShouldBe(1);
     }
+
+    private record SchemaNameSource(string Name);
 
     private class TestConfigurePolecat : IConfigurePolecat
     {

--- a/src/Polecat/PolecatConfigurationExpression.cs
+++ b/src/Polecat/PolecatConfigurationExpression.cs
@@ -167,6 +167,18 @@ public static class PolecatServiceConfigurationExtensions
     public static IServiceCollection ConfigurePolecat(
         this IServiceCollection services, Action<StoreOptions> configure)
     {
+        services.AddSingleton<IConfigurePolecat>(new LambdaConfigurePolecat((_, opts) => configure(opts)));
+        return services;
+    }
+
+    /// <summary>
+    ///     Register a post-configuration action for StoreOptions that has access to the
+    ///     service provider. Use this when the configuration depends on other services --
+    ///     options bound from configuration, a logger, or a running host component.
+    /// </summary>
+    public static IServiceCollection ConfigurePolecat(
+        this IServiceCollection services, Action<IServiceProvider, StoreOptions> configure)
+    {
         services.AddSingleton<IConfigurePolecat>(new LambdaConfigurePolecat(configure));
         return services;
     }
@@ -174,15 +186,15 @@ public static class PolecatServiceConfigurationExtensions
 
 internal class LambdaConfigurePolecat : IConfigurePolecat
 {
-    private readonly Action<StoreOptions> _configure;
+    private readonly Action<IServiceProvider, StoreOptions> _configure;
 
-    public LambdaConfigurePolecat(Action<StoreOptions> configure)
+    public LambdaConfigurePolecat(Action<IServiceProvider, StoreOptions> configure)
     {
         _configure = configure;
     }
 
     public void Configure(IServiceProvider serviceProvider, StoreOptions options)
     {
-        _configure(options);
+        _configure(serviceProvider, options);
     }
 }


### PR DESCRIPTION
Closes #456.

`PolecatServiceConfigurationExtensions.ConfigurePolecat` took only `Action<StoreOptions>`. The `(IServiceProvider, StoreOptions)` shape existed **only** on the generic `ConfigurePolecat<T>` for typed/ancillary stores, so code that post-configures the **main** store and needs the built provider had no extension method to call.

That is exactly the situation a consumer lands in when it collapses onto a single store: the configuration is still provider-dependent (a rolling-partition window that has to follow operator-configured retention, a store `Listener` that has to reach the host runtime), but the ancillary-store overload that used to carry the provider is gone.

`IConfigurePolecat.Configure(IServiceProvider, StoreOptions)` already carries the provider, so the workaround was a small hand-written class — on the supported path, but the extension method was the gap. Marten has the equivalent `ConfigureMarten((sp, opts) => ...)`, so this is a parity item too.

## Change

```csharp
services.ConfigurePolecat((sp, opts) =>
{
    opts.DatabaseSchemaName = sp.GetRequiredService<SchemaNameSource>().Name;
});
```

`LambdaConfigurePolecat` now holds an `Action<IServiceProvider, StoreOptions>` and the existing single-argument overload adapts onto it — the same shape `LambdaConfigurePolecat<T>` already had. No ambiguity between the two overloads: a one-parameter lambda only matches `Action<StoreOptions>`.

## Verification

New test `configure_polecat_with_service_provider_applies_post_configuration` resolves a service from the container inside the callback and asserts the value reaches `StoreOptions`. `service_registration_tests`: 17/17 green.

Docs: `docs/configuration/hostbuilder.md` gains a `ConfigurePolecat` section covering both overloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PwvC24c5dNxv7DJR7RUjv