### PR TITLE
Mark the document-contract re-declarations `new` (#455)

### DIFF
--- a/src/Polecat/IDocumentOperations.cs
+++ b/src/Polecat/IDocumentOperations.cs
@@ -23,7 +23,7 @@ public interface IDocumentOperations : IQuerySession, IDocumentWriteOperations
     /// <summary>
     ///     Store multiple documents.
     /// </summary>
-    void Store<T>(params T[] documents) where T : notnull;
+    new void Store<T>(params T[] documents) where T : notnull;
 
     /// <summary>
     ///     Store a heterogeneous collection of documents by their runtime type.
@@ -45,17 +45,17 @@ public interface IDocumentOperations : IQuerySession, IDocumentWriteOperations
     /// <summary>
     ///     Delete a document by entity. For soft-deleted types, marks as deleted.
     /// </summary>
-    void Delete<T>(T document) where T : notnull;
+    new void Delete<T>(T document) where T : notnull;
 
     /// <summary>
     ///     Delete a document by its Guid id. For soft-deleted types, marks as deleted.
     /// </summary>
-    void Delete<T>(Guid id) where T : notnull;
+    new void Delete<T>(Guid id) where T : notnull;
 
     /// <summary>
     ///     Delete a document by its string id. For soft-deleted types, marks as deleted.
     /// </summary>
-    void Delete<T>(string id) where T : notnull;
+    new void Delete<T>(string id) where T : notnull;
 
     /// <summary>
     ///     Delete a document by its int id. For soft-deleted types, marks as deleted.
@@ -95,7 +95,7 @@ public interface IDocumentOperations : IQuerySession, IDocumentWriteOperations
     /// <summary>
     ///     Delete all documents matching the predicate. For soft-deleted types, marks as deleted.
     /// </summary>
-    void DeleteWhere<T>(Expression<Func<T, bool>> predicate) where T : notnull;
+    new void DeleteWhere<T>(Expression<Func<T, bool>> predicate) where T : notnull;
 
     /// <summary>
     ///     Permanently remove all documents matching the predicate, regardless of soft-delete configuration.

--- a/src/Polecat/IDocumentSession.cs
+++ b/src/Polecat/IDocumentSession.cs
@@ -29,7 +29,7 @@ public interface IDocumentSession : IDocumentOperations, IStorageOperations, ITr
     /// <summary>
     ///     Flush all pending operations to the database in a single transaction.
     /// </summary>
-    Task SaveChangesAsync(CancellationToken token = default);
+    new Task SaveChangesAsync(CancellationToken token = default);
 
     /// <summary>
     ///     Remove a specific document from the session's pending operations

--- a/src/Polecat/IDocumentStore.cs
+++ b/src/Polecat/IDocumentStore.cs
@@ -29,7 +29,7 @@ public interface IDocumentStore : IDisposable, IAsyncDisposable, IDocumentStoreU
     /// <summary>
     ///     Open a lightweight session (no identity map).
     /// </summary>
-    IDocumentSession LightweightSession();
+    new IDocumentSession LightweightSession();
 
     /// <summary>
     ///     Open a lightweight session with custom options.
@@ -49,7 +49,7 @@ public interface IDocumentStore : IDisposable, IAsyncDisposable, IDocumentStoreU
     /// <summary>
     ///     Open a read-only query session.
     /// </summary>
-    IQuerySession QuerySession();
+    new IQuerySession QuerySession();
 
     /// <summary>
     ///     #443: the non-generic tier of <see cref="IDocumentSessionFactory" /> returns the shared

--- a/src/Polecat/IQuerySession.cs
+++ b/src/Polecat/IQuerySession.cs
@@ -136,12 +136,12 @@ public interface IQuerySession : IAsyncDisposable, IDocumentReadOperations
     /// <summary>
     ///     Load a document by its id. Returns null if not found.
     /// </summary>
-    Task<T?> LoadAsync<T>(Guid id, CancellationToken token = default) where T : notnull;
+    new Task<T?> LoadAsync<T>(Guid id, CancellationToken token = default) where T : notnull;
 
     /// <summary>
     ///     Load a document by its string id. Returns null if not found.
     /// </summary>
-    Task<T?> LoadAsync<T>(string id, CancellationToken token = default) where T : notnull;
+    new Task<T?> LoadAsync<T>(string id, CancellationToken token = default) where T : notnull;
 
     /// <summary>
     ///     Load multiple documents by their ids.
@@ -166,7 +166,7 @@ public interface IQuerySession : IAsyncDisposable, IDocumentReadOperations
     /// <summary>
     ///     Start a LINQ query against documents of type T.
     /// </summary>
-    IPolecatQueryable<T> Query<T>() where T : notnull;
+    new IPolecatQueryable<T> Query<T>() where T : notnull;
 
     /// <summary>
     ///     #443: the shared contract's <c>Query&lt;T&gt;()</c> returns <see cref="IQueryable{T}" />, and


### PR DESCRIPTION
Closes #455. **Warning-only — no behaviour change.**

Wiring Polecat's session interfaces onto the `JasperFx.Events.Documents` contracts (#443 / PR #453, shipped in 5.12.0) left the pre-existing declarations in place, so each one *hides* the member it also inherits:

```
'IQuerySession.LoadAsync<T>(Guid, CancellationToken)' hides inherited member
'IDocumentReadOperations.LoadAsync<T>(Guid, CancellationToken)'.
Use the new keyword if hiding was intended.
```

22 warnings per TFM, 44 across the matrix.

## Approach

Option 1 from the issue — add `new` — as preferred there. It states the intent and keeps Polecat's own XML doc comments on those members, which are user-facing and better worded for a Polecat audience than the generic contract ones. Deleting the re-declarations would have taken the doc comments with them.

Eleven members:

| Interface | Members |
|---|---|
| `IQuerySession` | `LoadAsync<T>(Guid)`, `LoadAsync<T>(string)`, `Query<T>()` |
| `IDocumentOperations` | `Store<T>(params T[])`, `Delete<T>(T)`, `Delete<T>(Guid)`, `Delete<T>(string)`, `DeleteWhere<T>(...)` |
| `IDocumentSession` | `SaveChangesAsync(CancellationToken)` |
| `IDocumentStore` | `LightweightSession()`, `QuerySession()` |

`Query<T>()` stays declared in either option — `IQuerySession.Query<T>()` returns the narrower `IPolecatQueryable<T>` while the contract returns `IQueryable<T>`, and the existing explicit `IDocumentReadOperations.Query<T>()` default implementation bridges them.

## Verification

`dotnet build polecat.slnx`: **0 errors, 0 CS0108, 0 CS0109** — no `new` is redundant, and no implementor lost a slot. Dispatch is unchanged: a single implementing method still implicitly satisfies both the Polecat member and the contract member.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PwvC24c5dNxv7DJR7RUjv