### PR TITLE
Throw ObjectDisposedException from a disposed session (#462)

### DIFF
--- a/src/Polecat.Tests/Session/disposed_session_tests.cs
+++ b/src/Polecat.Tests/Session/disposed_session_tests.cs
@@ -1,0 +1,208 @@
+using Polecat.Tests.Harness;
+using Shouldly;
+
+namespace Polecat.Tests.Session;
+
+/// <summary>
+///     #462: a disposed session must not keep working. Before this guard, Polecat's session had no
+///     disposed flag, so after <c>DisposeAsync</c> the same instance still accepted Store/Append and
+///     still <em>committed successfully</em> on SaveChangesAsync -- the connection lifetime simply
+///     re-established itself lazily. Use-after-dispose is normally a loud, immediate bug; here it was
+///     silent, and the silence favoured the worst case: a session captured past the scope that owned
+///     it going on writing with nobody owning the transaction boundary.
+/// </summary>
+[Collection("integration")]
+public class disposed_session_tests : IntegrationContext
+{
+    public disposed_session_tests(DefaultStoreFixture fixture) : base(fixture)
+    {
+    }
+
+    private async Task<IDocumentSession> disposedSession()
+    {
+        var session = theStore.LightweightSession();
+        await session.DisposeAsync();
+        return session;
+    }
+
+    // ===== The reported case: writes on a disposed session used to commit =====
+
+    [Fact]
+    public async Task store_on_a_disposed_session_throws()
+    {
+        var session = await disposedSession();
+
+        Should.Throw<ObjectDisposedException>(() =>
+            session.Store(new User { Id = Guid.NewGuid(), FirstName = "After", LastName = "Dispose", Age = 1 }));
+    }
+
+    [Fact]
+    public async Task save_changes_on_a_disposed_session_throws_instead_of_committing()
+    {
+        var id = Guid.NewGuid();
+
+        var session = theStore.LightweightSession();
+        session.Store(new User { Id = id, FirstName = "Never", LastName = "Committed", Age = 1 });
+        await session.DisposeAsync();
+
+        await Should.ThrowAsync<ObjectDisposedException>(async () =>
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken));
+
+        // And nothing reached the database.
+        await using var query = theStore.QuerySession();
+        (await query.LoadAsync<User>(id, TestContext.Current.CancellationToken)).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task insert_on_a_disposed_session_throws()
+    {
+        var session = await disposedSession();
+
+        Should.Throw<ObjectDisposedException>(() =>
+            session.Insert(new User { Id = Guid.NewGuid(), FirstName = "A", LastName = "B", Age = 1 }));
+    }
+
+    [Fact]
+    public async Task update_on_a_disposed_session_throws()
+    {
+        var session = await disposedSession();
+
+        Should.Throw<ObjectDisposedException>(() =>
+            session.Update(new User { Id = Guid.NewGuid(), FirstName = "A", LastName = "B", Age = 1 }));
+    }
+
+    [Fact]
+    public async Task delete_by_document_on_a_disposed_session_throws()
+    {
+        var session = await disposedSession();
+
+        Should.Throw<ObjectDisposedException>(() =>
+            session.Delete(new User { Id = Guid.NewGuid(), FirstName = "A", LastName = "B", Age = 1 }));
+    }
+
+    [Fact]
+    public async Task delete_by_id_on_a_disposed_session_throws()
+    {
+        var session = await disposedSession();
+
+        Should.Throw<ObjectDisposedException>(() => session.Delete<User>(Guid.NewGuid()));
+    }
+
+    [Fact]
+    public async Task delete_where_on_a_disposed_session_throws()
+    {
+        var session = await disposedSession();
+
+        Should.Throw<ObjectDisposedException>(() => session.DeleteWhere<User>(x => x.Age > 10));
+    }
+
+    [Fact]
+    public async Task queue_sql_command_on_a_disposed_session_throws()
+    {
+        var session = await disposedSession();
+
+        Should.Throw<ObjectDisposedException>(() => session.QueueSqlCommand("select 1"));
+    }
+
+    // ===== Event operations =====
+
+    [Fact]
+    public async Task start_stream_on_a_disposed_session_throws()
+    {
+        var session = await disposedSession();
+
+        Should.Throw<ObjectDisposedException>(() =>
+            session.Events.StartStream(Guid.NewGuid(), new QuestStarted("Too late")));
+    }
+
+    [Fact]
+    public async Task append_on_a_disposed_session_throws()
+    {
+        var session = await disposedSession();
+
+        Should.Throw<ObjectDisposedException>(() =>
+            session.Events.Append(Guid.NewGuid(), new QuestStarted("Too late")));
+    }
+
+    // ===== Read operations, on both session flavours =====
+
+    [Fact]
+    public async Task load_on_a_disposed_session_throws()
+    {
+        var session = await disposedSession();
+
+        await Should.ThrowAsync<ObjectDisposedException>(async () =>
+            await session.LoadAsync<User>(Guid.NewGuid(), TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task load_on_a_disposed_identity_session_throws()
+    {
+        var session = theStore.IdentitySession();
+        await session.DisposeAsync();
+
+        await Should.ThrowAsync<ObjectDisposedException>(async () =>
+            await session.LoadAsync<User>(Guid.NewGuid(), TestContext.Current.CancellationToken));
+    }
+
+    // An identity-map hit short-circuits before the base class's guard, so the override needs its own.
+    [Fact]
+    public async Task load_of_a_mapped_document_on_a_disposed_identity_session_throws()
+    {
+        var id = Guid.NewGuid();
+        theSession.Store(new User { Id = id, FirstName = "Mapped", LastName = "Already", Age = 1 });
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var session = theStore.IdentitySession();
+        (await session.LoadAsync<User>(id, TestContext.Current.CancellationToken)).ShouldNotBeNull();
+        await session.DisposeAsync();
+
+        await Should.ThrowAsync<ObjectDisposedException>(async () =>
+            await session.LoadAsync<User>(id, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task query_on_a_disposed_query_session_throws()
+    {
+        var session = theStore.QuerySession();
+        await session.DisposeAsync();
+
+        Should.Throw<ObjectDisposedException>(() => session.Query<User>());
+    }
+
+    [Fact]
+    public async Task load_on_a_disposed_query_session_throws()
+    {
+        var session = theStore.QuerySession();
+        await session.DisposeAsync();
+
+        await Should.ThrowAsync<ObjectDisposedException>(async () =>
+            await session.LoadAsync<User>(Guid.NewGuid(), TestContext.Current.CancellationToken));
+    }
+
+    // ===== Disposal itself stays well behaved =====
+
+    [Fact]
+    public async Task dispose_is_idempotent()
+    {
+        var session = theStore.LightweightSession();
+
+        await session.DisposeAsync();
+        await Should.NotThrowAsync(async () => await session.DisposeAsync());
+    }
+
+    [Fact]
+    public async Task a_live_session_is_unaffected()
+    {
+        var id = Guid.NewGuid();
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Store(new User { Id = id, FirstName = "Still", LastName = "Works", Age = 1 });
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using var query = theStore.QuerySession();
+        (await query.LoadAsync<User>(id, TestContext.Current.CancellationToken)).ShouldNotBeNull();
+    }
+}

--- a/src/Polecat/Internal/DocumentSessionBase.cs
+++ b/src/Polecat/Internal/DocumentSessionBase.cs
@@ -54,8 +54,16 @@ internal abstract class DocumentSessionBase : QuerySession, IDocumentSession
     Polecat.Events.IQueryEventStore IQuerySession.Events => EventOps;
     public new Polecat.Events.IEventOperations Events => EventOps;
 
-    private EventOperations EventOps =>
-        _eventOperations ??= new EventOperations(this, _eventGraph, Options, _workTracker, TenantId);
+    private EventOperations EventOps
+    {
+        get
+        {
+            // #462: every event operation -- Append, StartStream, AppendOptimistic -- reaches the
+            // session through here, so one guard covers the whole event-write surface.
+            assertNotDisposed();
+            return _eventOperations ??= new EventOperations(this, _eventGraph, Options, _workTracker, TenantId);
+        }
+    }
 
     internal WorkTracker WorkTracker => _workTracker;
 
@@ -90,6 +98,7 @@ internal abstract class DocumentSessionBase : QuerySession, IDocumentSession
 
     public void Store<T>(T document) where T : notnull
     {
+        assertNotDisposed();
         SyncMetadata(document);
         var provider = _providers.GetProvider<T>();
         _workTracker.Add(BuildClosedShapeWrite(document, provider, WriteKind.Upsert));
@@ -180,6 +189,7 @@ internal abstract class DocumentSessionBase : QuerySession, IDocumentSession
 
     public void StoreObjects(IEnumerable<object> documents)
     {
+        assertNotDisposed();
         // Per-document runtime-type dispatch through the closed-shape object-write bridge
         // (#273 E2e). Mirrors Store<T> otherwise.
         foreach (var document in documents)
@@ -196,6 +206,7 @@ internal abstract class DocumentSessionBase : QuerySession, IDocumentSession
 
     public void Insert<T>(T document) where T : notnull
     {
+        assertNotDisposed();
         SyncMetadata(document);
         var provider = _providers.GetProvider<T>();
         _workTracker.Add(BuildClosedShapeWrite(document, provider, WriteKind.Insert));
@@ -204,6 +215,7 @@ internal abstract class DocumentSessionBase : QuerySession, IDocumentSession
 
     public void Update<T>(T document) where T : notnull
     {
+        assertNotDisposed();
         SyncMetadata(document);
         var provider = _providers.GetProvider<T>();
         _workTracker.Add(BuildClosedShapeWrite(document, provider, WriteKind.Update));
@@ -212,6 +224,7 @@ internal abstract class DocumentSessionBase : QuerySession, IDocumentSession
 
     public void Delete<T>(T document) where T : notnull
     {
+        assertNotDisposed();
         var provider = _providers.GetProvider<T>();
         var session = (Weasel.Storage.IStorageSession)this;
         var storage = (Weasel.Storage.IDocumentStorage<T>)session.StorageFor<T>();
@@ -250,6 +263,7 @@ internal abstract class DocumentSessionBase : QuerySession, IDocumentSession
     // #273 E2c/E2e: all by-id deletions route through the closed-shape storage layer.
     private void DeleteByObjectId<T>(object id) where T : notnull
     {
+        assertNotDisposed();
         var session = (Weasel.Storage.IStorageSession)this;
         var storage = (Polecat.Storage.ClosedShape.IPolecatObjectStorage<T>)session.StorageFor<T>();
         _workTracker.Add(new Operations.ClosedShapeOperationAdapter(
@@ -259,6 +273,7 @@ internal abstract class DocumentSessionBase : QuerySession, IDocumentSession
     // #273 E2e: hard deletions route through the closed-shape storage layer.
     public void HardDelete<T>(T document) where T : notnull
     {
+        assertNotDisposed();
         var session = (Weasel.Storage.IStorageSession)this;
         var storage = (Weasel.Storage.IDocumentStorage<T>)session.StorageFor<T>();
         _workTracker.Add(new Operations.ClosedShapeOperationAdapter(
@@ -276,6 +291,7 @@ internal abstract class DocumentSessionBase : QuerySession, IDocumentSession
 
     private void HardDeleteByObjectId<T>(object id) where T : notnull
     {
+        assertNotDisposed();
         var session = (Weasel.Storage.IStorageSession)this;
         var storage = (Polecat.Storage.ClosedShape.IPolecatObjectStorage<T>)session.StorageFor<T>();
         _workTracker.Add(new Operations.ClosedShapeOperationAdapter(
@@ -315,6 +331,8 @@ internal abstract class DocumentSessionBase : QuerySession, IDocumentSession
 
     private Linq.SqlGeneration.ISqlFragment ParseDeleteWhere<T>(Expression<Func<T, bool>> predicate) where T : notnull
     {
+        // #462: the single entry every *Where deletion passes through before queueing work.
+        assertNotDisposed();
         var provider = _providers.GetProvider<T>();
         var memberFactory = new MemberFactory(Options, provider.Mapping);
         return new WhereClauseParser(memberFactory).Parse(predicate.Body);
@@ -327,6 +345,7 @@ internal abstract class DocumentSessionBase : QuerySession, IDocumentSession
 
     public ITenantOperations ForTenant(string tenantId)
     {
+        assertNotDisposed();
         _byTenant ??= new Dictionary<string, NestedTenantSession>();
 
         if (_byTenant.TryGetValue(tenantId, out var tenantSession))
@@ -375,12 +394,15 @@ internal abstract class DocumentSessionBase : QuerySession, IDocumentSession
 
     public void QueueSqlCommand(string sql, params object[] parameterValues)
     {
+        assertNotDisposed();
         var operation = new Operations.ExecuteSqlStorageOperation(sql, parameterValues);
         _workTracker.Add(operation);
     }
 
     public async Task SaveChangesAsync(CancellationToken token = default)
     {
+        assertNotDisposed();
+
         // _workTracker tracks document operations and event streams - it does NOT include
         // ITransactionParticipants registered via AddTransactionParticipant. Skipping the entire
         // SaveChangesAsync pipeline when _workTracker is empty therefore silently drops queued

--- a/src/Polecat/Internal/IdentityMapDocumentSession.cs
+++ b/src/Polecat/Internal/IdentityMapDocumentSession.cs
@@ -33,6 +33,9 @@ internal class IdentityMapDocumentSession : DocumentSessionBase
 
     protected override async Task<T?> LoadInternalAsync<T>(object id, CancellationToken token) where T : default
     {
+        // #462: guard here too -- an identity-map hit short-circuits before the base class's guard.
+        assertNotDisposed();
+
         // Check identity map first
         if (_identityMap.TryGetValue(typeof(T), out var typeMap) && typeMap.TryGetValue(id, out var cached))
         {
@@ -55,6 +58,9 @@ internal class IdentityMapDocumentSession : DocumentSessionBase
     protected override async Task<IReadOnlyList<T>> LoadManyInternalAsync<T>(
         List<object> ids, CancellationToken token) where T : class
     {
+        // #462: guard here too -- a fully-satisfied identity-map read never reaches the base class.
+        assertNotDisposed();
+
         var results = new List<T>();
         var missingIds = new List<object>();
 

--- a/src/Polecat/Internal/QuerySession.cs
+++ b/src/Polecat/Internal/QuerySession.cs
@@ -140,6 +140,7 @@ internal partial class QuerySession : IQuerySession
 
     internal Task<int> ExecuteAsync(SqlCommand command, CancellationToken token)
     {
+        assertNotDisposed();
         RequestCount++;
         return _resilience.ExecuteAsync(
             static (state, t) => new ValueTask<int>(state.Lifetime.ExecuteAsync(state.Command, t)),
@@ -148,6 +149,7 @@ internal partial class QuerySession : IQuerySession
 
     internal Task<object?> ExecuteScalarAsync(SqlCommand command, CancellationToken token)
     {
+        assertNotDisposed();
         RequestCount++;
         return _resilience.ExecuteAsync(
             static (state, t) => new ValueTask<object?>(state.Lifetime.ExecuteScalarAsync(state.Command, t)),
@@ -156,6 +158,7 @@ internal partial class QuerySession : IQuerySession
 
     internal Task<DbDataReader> ExecuteReaderAsync(SqlCommand command, CancellationToken token)
     {
+        assertNotDisposed();
         RequestCount++;
         return _resilience.ExecuteAsync(
             static (state, t) => new ValueTask<DbDataReader>(state.Lifetime.ExecuteReaderAsync(state.Command, t)),
@@ -164,6 +167,7 @@ internal partial class QuerySession : IQuerySession
 
     internal Task<DbDataReader> ExecuteReaderAsync(SqlBatch batch, CancellationToken token)
     {
+        assertNotDisposed();
         RequestCount++;
         return _resilience.ExecuteAsync(
             static (state, t) => new ValueTask<DbDataReader>(state.Lifetime.ExecuteReaderAsync(state.Batch, t)),
@@ -192,6 +196,7 @@ internal partial class QuerySession : IQuerySession
 
     private async Task<bool> CheckExistsInternalAsync<T>(object id, CancellationToken token) where T : class
     {
+        assertNotDisposed();
         var provider = _providers.GetProvider<T>();
         await _tableEnsurer.EnsureTableAsync(provider, token);
 
@@ -245,6 +250,7 @@ internal partial class QuerySession : IQuerySession
 
     protected virtual async Task<T?> LoadInternalAsync<T>(object id, CancellationToken token) where T : notnull
     {
+        assertNotDisposed();
         var provider = _providers.GetProvider<T>();
         await _tableEnsurer.EnsureTableAsync(provider, token);
 
@@ -271,6 +277,7 @@ internal partial class QuerySession : IQuerySession
     protected virtual async Task<IReadOnlyList<T>> LoadManyInternalAsync<T>(
         List<object> ids, CancellationToken token) where T : class
     {
+        assertNotDisposed();
         if (ids.Count == 0) return [];
 
         var provider = _providers.GetProvider<T>();
@@ -284,12 +291,14 @@ internal partial class QuerySession : IQuerySession
 
     public IPolecatQueryable<T> Query<T>() where T : notnull
     {
+        assertNotDisposed();
         var provider = new PolecatLinqQueryProvider(this, _providers, _tableEnsurer);
         return new PolecatLinqQueryable<T>(provider);
     }
 
     public IBatchedQuery CreateBatchQuery()
     {
+        assertNotDisposed();
         return new BatchedQuery(this, _providers, _tableEnsurer);
     }
 
@@ -312,6 +321,7 @@ internal partial class QuerySession : IQuerySession
 
     private async Task<string?> LoadJsonInternalAsync<T>(object id, CancellationToken token) where T : class
     {
+        assertNotDisposed();
         var provider = _providers.GetProvider<T>();
         await _tableEnsurer.EnsureTableAsync(provider, token);
 
@@ -352,8 +362,31 @@ internal partial class QuerySession : IQuerySession
         return polecatProvider.BuildSql(queryable.Expression, TenantId);
     }
 
+    // ── Disposal ────────────────────────────────────────────────────────
+
+    private bool _disposed;
+
+    /// <summary>
+    ///     #462: guard every session entry point against use-after-dispose. Polecat re-establishes
+    ///     its connection lifetime lazily, so without a flag a disposed session went on accepting
+    ///     writes and <em>committing them successfully</em> -- silently, and past the scope that
+    ///     owned the transaction boundary. Mirrors Marten's
+    ///     <c>QuerySession.Disposal.assertNotDisposed()</c>.
+    /// </summary>
+    protected void assertNotDisposed()
+    {
+        if (_disposed)
+        {
+            throw new ObjectDisposedException(GetType().FullName, "This session has been disposed");
+        }
+    }
+
     public virtual async ValueTask DisposeAsync()
     {
+        // Idempotent: disposing twice is legal and must not re-dispose the lifetime.
+        if (_disposed) return;
+
+        _disposed = true;
         await _lifetime.DisposeAsync();
     }
 }


### PR DESCRIPTION
Closes #462.

Polecat's session had no disposed flag. After `await session.DisposeAsync()` the same instance still accepted `Store` / `Events.Append` and still **committed successfully** on `SaveChangesAsync` — the connection lifetime just re-established itself lazily. Nothing downstream could check a flag, because there was none to set:

```csharp
public virtual async ValueTask DisposeAsync()
{
    await _lifetime.DisposeAsync();
}
```

Use-after-dispose is normally a loud, immediate bug. Here it was silent, and the silence favoured the worst case: a session captured past the scope that owned it goes on writing to the database. Under DI that is a session whose scope has ended — the writes land, but nothing owns the transaction boundary any more.

## Change

Mirrors `Marten/Internal/Sessions/QuerySession.Disposal.cs`: a `_disposed` field set by an idempotent `DisposeAsync`, plus `assertNotDisposed()` called from the session entry points.

```csharp
protected void assertNotDisposed()
{
    if (_disposed)
    {
        throw new ObjectDisposedException(GetType().FullName, "This session has been disposed");
    }
}
```

Guarded entry points:

| Where | Members |
|---|---|
| `DocumentSessionBase` | `Store`, `StoreObjects`, `Insert`, `Update`, every `Delete`/`HardDelete` shape, `DeleteWhere`/`HardDeleteWhere`/`UndoDeleteWhere`, `QueueSqlCommand`, `SaveChangesAsync`, `ForTenant` |
| `DocumentSessionBase.EventOps` | the accessor every event operation — `Append`, `StartStream`, `AppendOptimistic` — reaches the session through, so one guard covers the event-write surface |
| `QuerySession` | `Load*`, `LoadMany*`, `CheckExists*`, `LoadJson*`, `Query<T>()`, `CreateBatchQuery()` |
| `QuerySession.Execute*` (×4) | backstop, so no DB round-trip from any path — LINQ, batched queries, event reads — can outlive disposal |
| `IdentityMapDocumentSession` | its `LoadInternalAsync` / `LoadManyInternalAsync` overrides, because an identity-map hit short-circuits before the base class's guard |

`Delete`-by-id and `HardDelete`-by-id are guarded at their shared private `*ByObjectId` chokepoints, and the three `*Where` deletions at `ParseDeleteWhere`, which each of them passes through before queueing work.

`DisposeAsync` now returns early when already disposed, so double disposal stays legal and does not re-dispose the lifetime.

## Verification

New `Session/disposed_session_tests.cs`, 17 tests: every guarded write shape, both event operations, reads on lightweight / identity / query sessions (including the identity-map-hit path), idempotent disposal, and a live session still working end to end. All 17 pass.

The headline case is pinned directly — a disposed session with pending work throws instead of committing, **and** the document is confirmed absent from the database afterwards:

```csharp
await Should.ThrowAsync<ObjectDisposedException>(async () => await session.SaveChangesAsync(ct));
(await query.LoadAsync<User>(id, ct)).ShouldBeNull();
```

Full local suite is running; CI is the referee on the fresh database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PwvC24c5dNxv7DJR7RUjv