### PR TITLE
Read an Inline-projected aggregate from its document in FetchLatest (#463)

### DIFF
--- a/docs/events/snapshots.md
+++ b/docs/events/snapshots.md
@@ -71,6 +71,21 @@ var party = await session.LoadAsync<QuestParty>(streamId);
 var latest = await session.Events.FetchLatest<QuestParty>(streamId);
 ```
 
+For an aggregate registered with an `Inline` lifecycle, `FetchLatest<T>()` reads the projected
+document rather than re-aggregating the stream — the same thing `LoadAsync<T>()` does, and the same
+route Marten takes. It therefore returns `null` for a stream that exists but belongs to some other
+aggregate sharing the key space, because the inline projection never wrote a document for a stream it
+does not own. That makes `FetchLatest<T>(id) is null` a reliable "does this aggregate exist?" probe,
+which is what code branching between `StartStream` and `Append` depends on.
+
+This matters most for an aggregate whose only handler is a catch-all `Evolve(IEvent)`: a catch-all
+accepts every event type at the method level, so live aggregation over a foreign stream would
+otherwise hand back a default-constructed instance — and default property values read as real state,
+not as absence.
+
+Aggregates on the `Live` and `Async` lifecycles still aggregate the stream, since there is no
+committed document to read.
+
 ## Snapshot in a Composite Projection
 
 Composite projections support the same shortcut via `composite.Snapshot<T>()`:

--- a/src/Polecat.Tests/Events/fetch_latest_for_unhandled_stream_tests.cs
+++ b/src/Polecat.Tests/Events/fetch_latest_for_unhandled_stream_tests.cs
@@ -1,0 +1,220 @@
+using JasperFx.Events;
+using JasperFx.Events.Projections;
+using Polecat.Linq;
+using Polecat.Tests.Harness;
+using Shouldly;
+
+namespace Polecat.Tests.Events;
+
+#region unrelated_aggregates
+
+public record ServiceRegistered(string Name, string Uri);
+
+public record AlertRaised(string Reason);
+
+public record AlertCleared(string Reason);
+
+/// <summary>
+///     Cares about service registration, and nothing else.
+/// </summary>
+public partial class ServiceSummary
+{
+    public string Id { get; set; } = "";
+    public string Name { get; set; } = "";
+    public string Uri { get; set; } = "";
+
+    public static ServiceSummary Create(ServiceRegistered e) => new() { Name = e.Name, Uri = e.Uri };
+}
+
+/// <summary>
+///     A self-aggregating type whose only handler is a catch-all <c>Evolve(IEvent)</c> — the shape
+///     that surfaced #463. A catch-all accepts every event type at the method level, so nothing in
+///     the aggregation path filtered by event applicability; the aggregator default-constructed an
+///     instance and the switch simply matched nothing.
+///     <para>
+///     <see cref="IsActive" /> defaults to <c>true</c> on purpose, as in the reported aggregate: a
+///     default-constructed phantom does not read as "empty", it reads as an <em>active alert</em>.
+///     </para>
+/// </summary>
+public partial class AlertRecord
+{
+    public string Id { get; set; } = "";
+    public string Reason { get; set; } = "";
+    public bool IsActive { get; set; } = true;
+
+    public void Evolve(IEvent e)
+    {
+        switch (e.Data)
+        {
+            case AlertRaised raised:
+                Reason = raised.Reason;
+                IsActive = true;
+                break;
+
+            case AlertCleared cleared:
+                Reason = cleared.Reason;
+                IsActive = false;
+                break;
+        }
+    }
+}
+
+#endregion
+
+/// <summary>
+///     #463: <c>FetchLatest&lt;T&gt;(key)</c> on a stream that exists but contains no event
+///     <c>T</c> handles used to return a non-null, default-constructed aggregate; Marten returns
+///     null. <c>FetchLatest&lt;T&gt;(key) is null</c> is the idiomatic "does this aggregate exist?"
+///     probe, so under the old behaviour it was satisfied by any stream key that had events at all
+///     and the answer depended on whether some other aggregate happened to share the key space.
+/// </summary>
+/// <remarks>
+///     The fix is Marten's mechanism, not a filter bolted onto aggregation: an Inline-projected
+///     aggregate is read from its projected document (Marten's <c>FetchInlinedPlan</c>) rather than
+///     re-aggregated off the stream. That makes the read agree with what the write side already
+///     believed — the inline projection screens out streams it does not own, which is why no
+///     document was ever written for them.
+/// </remarks>
+[Collection("integration")]
+public class fetch_latest_for_unhandled_stream_tests : OneOffConfigurationsContext
+{
+    public fetch_latest_for_unhandled_stream_tests()
+    {
+        ConfigureStore(opts =>
+        {
+            opts.Events.StreamIdentity = StreamIdentity.AsString;
+            opts.Projections.Snapshot<ServiceSummary>(SnapshotLifecycle.Inline);
+            opts.Projections.Snapshot<AlertRecord>(SnapshotLifecycle.Inline);
+        });
+    }
+
+    private async Task startServiceStream(string key)
+    {
+        await using var session = theStore.LightweightSession();
+        session.Events.StartStream<ServiceSummary>(key,
+            new ServiceRegistered(key, "rabbitmq://queue/test_service"));
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+
+    // ===== The reported case =====
+
+    [Fact]
+    public async Task fetch_latest_is_null_for_a_stream_the_aggregate_does_not_handle()
+    {
+        await startServiceStream("TestService");
+
+        await using var session = theStore.LightweightSession();
+        var alert = await session.Events.FetchLatest<AlertRecord>("TestService",
+            TestContext.Current.CancellationToken);
+
+        // Before the fix this was a default-valued AlertRecord -- and since IsActive defaults to
+        // true, the phantom read as an active alert rather than as absence.
+        alert.ShouldBeNull();
+    }
+
+    // The issue verified this passed even before the fix -- the inline projection was already
+    // screening the stream out. Keeping it pins the two halves together: the read path now agrees
+    // with the persistence path.
+    [Fact]
+    public async Task no_document_is_written_for_a_stream_the_aggregate_does_not_handle()
+    {
+        await startServiceStream("NoDocService");
+
+        await using var query = theStore.QuerySession();
+        (await query.Query<AlertRecord>().CountAsync(TestContext.Current.CancellationToken)).ShouldBe(0);
+    }
+
+    // ===== The aggregate that DOES own the stream is unaffected =====
+
+    [Fact]
+    public async Task fetch_latest_still_returns_the_aggregate_that_handles_the_stream()
+    {
+        await startServiceStream("OwnedService");
+
+        await using var session = theStore.LightweightSession();
+        var summary = await session.Events.FetchLatest<ServiceSummary>("OwnedService",
+            TestContext.Current.CancellationToken);
+
+        summary.ShouldNotBeNull();
+        summary!.Name.ShouldBe("OwnedService");
+        summary.Uri.ShouldBe("rabbitmq://queue/test_service");
+    }
+
+    [Fact]
+    public async Task fetch_latest_returns_the_alert_when_the_stream_does_hold_its_events()
+    {
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Events.StartStream<AlertRecord>("RealAlert", new AlertRaised("disk full"));
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using var query = theStore.LightweightSession();
+        var alert = await query.Events.FetchLatest<AlertRecord>("RealAlert",
+            TestContext.Current.CancellationToken);
+
+        alert.ShouldNotBeNull();
+        alert!.Reason.ShouldBe("disk full");
+        alert.IsActive.ShouldBeTrue();
+    }
+
+    // A later append is reflected -- the projected document is what FetchLatest now reads, and the
+    // inline projection has already written it by the time SaveChangesAsync returns.
+    [Fact]
+    public async Task fetch_latest_reflects_events_appended_after_the_stream_started()
+    {
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Events.StartStream<AlertRecord>("EvolvingAlert", new AlertRaised("cpu pegged"));
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Events.Append("EvolvingAlert", new AlertCleared("operator cleared"));
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using var query = theStore.LightweightSession();
+        var alert = await query.Events.FetchLatest<AlertRecord>("EvolvingAlert",
+            TestContext.Current.CancellationToken);
+
+        alert.ShouldNotBeNull();
+        alert!.IsActive.ShouldBeFalse();
+        alert.Reason.ShouldBe("operator cleared");
+    }
+
+    // A stream that mixes a foreign event with the aggregate's own still resolves -- the inline
+    // projection owns that stream, so the document exists.
+    [Fact]
+    public async Task a_stream_mixing_handled_and_unhandled_events_still_resolves()
+    {
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Events.StartStream<AlertRecord>("MixedStream",
+                new ServiceRegistered("MixedStream", "rabbitmq://queue/mixed"),
+                new AlertRaised("mixed"));
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using var query = theStore.LightweightSession();
+        var alert = await query.Events.FetchLatest<AlertRecord>("MixedStream",
+            TestContext.Current.CancellationToken);
+
+        alert.ShouldNotBeNull();
+        alert!.Reason.ShouldBe("mixed");
+        alert.IsActive.ShouldBeTrue();
+    }
+
+    // ===== Pre-existing guarantees =====
+
+    [Fact]
+    public async Task fetch_latest_is_still_null_for_a_stream_that_does_not_exist()
+    {
+        await using var session = theStore.LightweightSession();
+        var alert = await session.Events.FetchLatest<AlertRecord>("NeverExisted",
+            TestContext.Current.CancellationToken);
+
+        alert.ShouldBeNull();
+    }
+}

--- a/src/Polecat/Events/QueryEventStore.cs
+++ b/src/Polecat/Events/QueryEventStore.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.Reflection;
 using JasperFx.Events;
+using JasperFx.Events.Projections;
 using Microsoft.Data.SqlClient;
 using Polecat.Events.Internal;
 using Polecat.Events.Linq;
@@ -377,6 +378,13 @@ internal class QueryEventStore : IQueryEventStore, IReadOnlyEventStore
             return cached;
         }
 
+        // #463: an Inline-projected aggregate is READ from its projected document rather than
+        // re-aggregated off the stream. See CanReadInlineDocument.
+        if (CanReadInlineDocument<T>(typeof(Guid)))
+        {
+            return await _session.LoadAsync<T>(id, cancellation);
+        }
+
         return await AggregateStreamAsync<T>(id, token: cancellation);
     }
 
@@ -388,8 +396,60 @@ internal class QueryEventStore : IQueryEventStore, IReadOnlyEventStore
             return cached;
         }
 
+        // #463: see CanReadInlineDocument.
+        if (CanReadInlineDocument<T>(typeof(string)))
+        {
+            return await _session.LoadAsync<T>(key, cancellation);
+        }
+
         return await AggregateStreamAsync<T>(key, token: cancellation);
     }
+
+    /// <summary>
+    ///     #463: is <typeparamref name="T" /> the subject of an <c>Inline</c> projection whose
+    ///     projected document can be loaded by a <paramref name="keyType" />-typed identity?
+    /// </summary>
+    /// <remarks>
+    ///     Polecat used to live-aggregate the stream for <em>every</em> <c>FetchLatest&lt;T&gt;</c>,
+    ///     whatever <c>T</c>'s lifecycle. Marten does not: its fetch planner routes an Inline
+    ///     aggregate to <c>FetchInlinedPlan</c>, which simply loads the projected document. The
+    ///     visible difference is on a stream that exists but holds nothing <c>T</c> owns -- Marten
+    ///     finds no document and returns <c>null</c>, while Polecat aggregated the foreign events
+    ///     and handed back whatever the aggregator constructed.
+    ///     <para>
+    ///     For an aggregate whose handlers are conventional <c>Create</c>/<c>Apply</c> methods the
+    ///     old path came out <c>null</c> anyway, because nothing built an instance. The shape that
+    ///     surfaced this is a single catch-all <c>Evolve(IEvent)</c>, which accepts every event type
+    ///     by construction: the aggregator default-constructed an instance, the switch inside matched
+    ///     nothing, and the default came back as though it were state. Since
+    ///     <c>FetchLatest&lt;T&gt;(key) is null</c> is the idiomatic "does this aggregate exist?"
+    ///     probe that code branching between <c>StartStream</c> and <c>Append</c> depends on, that
+    ///     probe was satisfied by any stream key holding events at all -- so the answer depended on
+    ///     whether some other aggregate happened to share the key space.
+    ///     </para>
+    ///     <para>
+    ///     Reading the document is also what the persistence side already believed: the inline
+    ///     projection screens streams it does not own out of the apply pass, so no row was ever
+    ///     written for them. The two halves now agree.
+    ///     </para>
+    ///     <para>
+    ///     Deliberately Inline only, mirroring <c>InlineFetchPlanner</c>. Marten routes Async
+    ///     aggregates to the document only when the mapping is revisioned, and falls back to live
+    ///     aggregation otherwise; Live aggregates have no document to read.
+    ///     </para>
+    ///     <para>
+    ///     The <paramref name="keyType" /> check matters because the stream identity and the
+    ///     aggregate's document id are not always the same type. A natural key resolves to a stream
+    ///     <em>key</em> (string) for an aggregate whose document id is a Guid, and that key cannot
+    ///     address the document at all -- so those fall back to live aggregation, exactly as before.
+    ///     <c>InnerIdType</c> rather than <c>IdType</c> so a strongly-typed id still matches on the
+    ///     value it wraps; the storage layer re-wraps it on the way through.
+    ///     </para>
+    /// </remarks>
+    private bool CanReadInlineDocument<T>(Type keyType) where T : class
+        => _options.Projections.TryFindAggregate(typeof(T), out var projection)
+           && projection.Lifecycle == ProjectionLifecycle.Inline
+           && _session.Providers.GetProvider<T>().Mapping.InnerIdType == keyType;
 
     internal static void TrySetIdentity<T>(T aggregate, object streamId) where T : class
     {


### PR DESCRIPTION
Closes #463.

`FetchLatest<T>(key)` on a stream that exists but contains no event `T` handles returned a non-null, default-constructed aggregate. Marten returns `null`.

That matters because `FetchLatest<T>(key) is null` is the idiomatic "does this aggregate exist?" probe — code branching between `StartStream` and `Append` depends on it. Under the old behaviour the probe was satisfied by any stream key that had events at all, so the answer depended on whether some *other* aggregate happened to share the key space. And the phantom was actively misleading: with `IsActive` defaulting to `true`, absence read as an **active alert**.

## Root cause: a missing fetch plan, not a missing filter

Polecat live-aggregated the stream for **every** `FetchLatest`, whatever `T`'s lifecycle. Marten's planner does not — it routes an Inline aggregate to `FetchInlinedPlan`, which simply loads the projected document. It therefore finds nothing and returns `null` for a stream the projection does not own.

Polecat now does the same, and that makes the read agree with what the write side already believed: the inline projection screens out streams it does not own, which is exactly why the issue's `Query<AlertRecord>().CountAsync() == 0` check passed all along. The two halves were disagreeing; now they don't.

Inline only, mirroring `InlineFetchPlanner`. `Live` aggregates have no document to read, and Marten routes `Async` ones to the document only when the mapping is revisioned.

## Which aggregates were affected

Only aggregates whose handler is a catch-all `Evolve(IEvent)` — the shape of the reported `AlertRecord`. I confirmed this by probe rather than assuming:

| aggregate shape | `FetchLatest` on a foreign stream (before) |
|---|---|
| `Create` + `Apply` methods | `null` — nothing built an instance |
| `Apply` only | `null` |
| catch-all `Evolve(IEvent)` | **default-constructed instance** |

A catch-all accepts every event type at the method level, so nothing in the aggregation path filtered by applicability: the aggregator default-constructed an instance, the `switch` inside matched nothing, and the default came back as though it were state.

This is also why an event-type applicability filter is *not* the right fix — a catch-all genuinely does declare that it handles everything, so such a filter would have to let it through.

## The id-type gate

The document path is gated on the aggregate's `InnerIdType` matching the key type. The stream identity and the aggregate's document id are not always the same: a natural key resolves to a stream **key** (string) for an aggregate whose document id is a `Guid`, and that key cannot address the document at all. Those fall back to live aggregation exactly as before.

That was not theoretical — a full-suite run caught it as `InvalidCastException: Unable to cast object of type 'System.String' to type 'System.Guid'` in `natural_key_string_identity_tests.string_identity_fetch_latest_by_natural_key`. `InnerIdType` rather than `IdType` so a strongly-typed id still matches on the value it wraps; the storage layer re-wraps it on the way through.

## Verification

Reproduction of the reported case, with the aggregate shaped exactly like `AlertRecord`:

| | `FetchLatest<AlertRecord>("TestService")` | documents |
|---|---|---|
| before | `PHANTOM(IsActive=True)` | 0 |
| after | `null` | 0 |

New `Events/fetch_latest_for_unhandled_stream_tests.cs`, 7 tests. The headline test **fails without the fix** and passes with it; the rest pin that the owning aggregate still resolves, that a later append is reflected, that a stream mixing foreign and owned events still resolves, and that a non-existent stream is still null.

- `*fetch_latest*` (incl. the shared `fetch_latest_compliance` suite): 17/17
- `*natural_key*`: 40/40
- Full local suite: **2136 total, 0 failed**, 3 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PwvC24c5dNxv7DJR7RUjv