### PR TITLE
5.15.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>5.14.0</Version>
+        <Version>5.15.0</Version>
         <LangVersion>latest</LangVersion>
         <Authors>Jeremy D. Miller</Authors>
         <PackageIcon>logo.png</PackageIcon>


### PR DESCRIPTION
Version bump for the 5.15.0 release.

Four issues, all Marten-parity items surfaced by running one shared test suite against both stores:

| Issue | PR | Change |
|---|---|---|
| #455 | #465 | The document-contract adoption re-declared 11 inherited members, so each hid the contract member it also inherits — 44 CS0108 warnings. Marked `new`; no behaviour change. |
| #456 | #464 | `ConfigurePolecat` had no `(IServiceProvider, StoreOptions)` overload for the **main** store, only for typed/ancillary ones. Added, matching Marten's `ConfigureMarten((sp, opts) => ...)`. |
| #462 | #466 | A disposed session kept accepting writes and still **committed** on `SaveChangesAsync`. Added Marten's `_disposed` flag + `assertNotDisposed()` across the session entry points. |
| #463 | #467 | `FetchLatest<T>` live-aggregated the stream whatever `T`'s lifecycle, so a catch-all `Evolve(IEvent)` aggregate materialized a default-valued phantom off another aggregate's stream. An Inline-projected aggregate is now read from its projected document, as Marten's `FetchInlinedPlan` does. |

#462 and #463 are behaviour changes worth calling out in release notes:

- **#462** — code that used a session past its `DisposeAsync` now throws `ObjectDisposedException` instead of silently committing. That is the point of the fix, but it can surface latent use-after-dispose in consuming code.
- **#463** — `FetchLatest<T>` on an `Inline`-projected aggregate now reads the projected document rather than re-aggregating the stream. Within a session, before `SaveChangesAsync` has run the inline projection, it therefore returns committed state; `ProjectLatest` remains the call that folds in pending events. `Live` and `Async` aggregates are unchanged.

Each PR was merged with green CI, and each was additionally verified against a full local suite run (2136–2146 tests, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PwvC24c5dNxv7DJR7RUjv