### PR TITLE
5.15.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>5.15.0</Version>
+        <Version>5.15.1</Version>
         <LangVersion>latest</LangVersion>
         <Authors>Jeremy D. Miller</Authors>
         <PackageIcon>logo.png</PackageIcon>


### PR DESCRIPTION
Patch bump for the 5.15.1 release. **Dependency-only** — no Polecat source changed.

Contents: JasperFx 2.47.0 → 2.48.0 (#469). No compliance suites moved in that wave, so nothing was enrolled.

## Why it is worth shipping rather than waiting

**jasperfx#663** is on a path Polecat drives. `StreamAction`'s string-keyed `Append` factories now route through `AddEvents`, like the `Guid` overloads already did, so each envelope gets `StreamId`/`StreamKey`/`TenantId` stamped. They previously appended straight to the backing list and stamped nothing, and `PrepareEvents` does not close the gap — it sets `TenantId`/`Timestamp`/`Version`/`Sequence`, never the stream identity. A store handing `stream.Events` to an inline projection therefore gave it an **empty `StreamKey`**, which is how a string-identified projection learns which entity it is projecting. Polecat treats `StreamIdentity.AsString` as a first-class identity.

The rest are source-generator dispatch fixes that Polecat's generated dispatchers pick up: jasperfx#656 (a method that merely *hides* `Evolve` counted as an override, so the dispatcher was skipped), jasperfx#653 (an evolver built its own shadow projection instance, so injected dependencies were null), jasperfx#652 (an event covered by both `ShouldDelete` and `Create`/`Apply` emitted an unreachable second switch arm, failing the consumer build with CS8120 inside generated code), the narrowed `partial` gate, and jasperfx#654 (a new JFXEVT006 warning for unregistered published types).

## Verification

- Solution builds with **0 errors** and **no `JFXEVT` diagnostics** — neither new generator rule fires anywhere in this codebase
- Full local suite: **2154 total, 0 failed**, 3 skipped — identical to the 2.47.0 baseline
- #469 merged with a fully green CI matrix

No behaviour change in Polecat's own code, hence a patch rather than a minor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PwvC24c5dNxv7DJR7RUjv