### PR TITLE
gh-472: a by-id load for strong-typed-identity documents

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -178,15 +178,32 @@
              required only where the dispatcher is written into the user's class, reported as
              JFXEVT003 rather than silently emitting nothing and failing at store-build time.
              (f) jasperfx#654 — a new JFXEVT006 *warning* names published document types that went
-             unregistered instead of skipping in silence. Diagnostic only, no emission change. -->
-        <PackageVersion Include="JasperFx" Version="2.48.0" />
-        <PackageVersion Include="JasperFx.Events" Version="2.48.0" />
+             unregistered instead of skipping in silence. Diagnostic only, no emission change.
+             JasperFx 2.49.0 — jasperfx#665, and the half of polecat#472 that JasperFx owns.
+             IDocumentReadOperations gains LoadAsync<T>(object id, CancellationToken), the overload a
+             strong-typed identifier needs: before it, store-agnostic source had NO spelling of a
+             by-id load for a document keyed by a wrapper, because the wrapper does not compile
+             against the Guid/string overloads and the wrapped primitive is a runtime id-type fault.
+             NOT a compile break here — the member carries a default implementation that unboxes a
+             Guid or string, forwards to the typed overload, and throws NotSupportedException naming
+             the implementing type for anything else. A store only gains the strong-typed half by
+             OVERRIDING it, which is what polecat#472 does.
+             The compliance half is what costs Polecat work: DocumentComplianceConfig gains
+             ValueTypes / RegisterValueType<T>() and DocumentLoadAndStoreCompliance gains three facts
+             — store_and_load_by_strong_typed_identity, load_returns_null_for_a_missing_strong_typed_identity
+             and the_object_overload_resolves_canonical_identities_too, the last of which pins that a
+             boxed Guid or string arriving through an object-typed local resolves exactly as the typed
+             overload does. The fixture has to replay config.ValueTypes onto
+             StoreOptions.RegisterValueType or the first two fail at runtime with the fixture still
+             compiling cleanly. -->
+        <PackageVersion Include="JasperFx" Version="2.49.0" />
+        <PackageVersion Include="JasperFx.Events" Version="2.49.0" />
         <!--
              The shared cross-store event sourcing compliance suites. Source-only package: the
              suites compile inside Polecat.Tests so JasperFx's aggregate source generator binds
              Polecat's own session types.
         -->
-        <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.48.0" />
+        <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.49.0" />
         <!-- Pin the sibling JasperFx packages for parity with Marten 9's matrix
              even though Polecat doesn't currently reference them directly —
              keeps the lockstep matrix coherent when transitive resolution
@@ -194,7 +211,7 @@
              RuntimeCompiler 5.x line is the active continuation of the 4.x
              lineage; do not pin against the parallel stale 2.0.x series. -->
         <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.48.0" />
+        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.49.0" />
         <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
@@ -307,7 +324,7 @@
         <PackageVersion Include="Vogen" Version="7.0.0" />
 
         <!-- Source generators (matched to JasperFx.Events above) -->
-        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.48.0" />
+        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.49.0" />
 
         <!-- Build automation -->
         <PackageVersion Include="Nuke.Common" Version="9.0.4" />

--- a/docs/documents/identity.md
+++ b/docs/documents/identity.md
@@ -147,8 +147,11 @@ session.Store(order);
 await session.SaveChangesAsync();
 // order.Id is now assigned
 
-// Load by inner value
-var loaded = await query.LoadAsync<Order>(order.Id.Value);
+// Load by the wrapper itself
+var loaded = await query.LoadAsync<Order>(order.Id);
+
+// ...or by the inner value; both resolve the same row
+var alsoLoaded = await query.LoadAsync<Order>(order.Id.Value);
 
 // LINQ queries take the wrapper type directly
 var result = await query.Query<Order>()
@@ -175,7 +178,7 @@ var exists = await query.CheckExistsAsync<Order>(order.Id.Value);
 Supported across:
 
 - `Store()` / `Insert()` / `Update()`, with automatic identity assignment
-- `LoadAsync()` and `LoadManyAsync()` by inner value
+- `LoadAsync()` by the wrapper **or** by the inner value; `LoadManyAsync()` by inner value
 - `Delete()` by inner value or by document
 - `CheckExistsAsync()` by inner value
 - LINQ `Where`, `OrderBy` / `OrderByDescending`, `IsOneOf`, `Select`, `Count`
@@ -186,10 +189,30 @@ Supported across:
 - Aggregate identities in event projections
 
 ::: warning
-`LoadAsync()`, `Delete()`, and `CheckExistsAsync()` take the **inner** value (`order.Id.Value`), not the
-wrapper. Polecat has no `LoadAsync<T>(object id)` overload; if you pass the wrapper the call will not
-compile.
+`Delete()` and `CheckExistsAsync()` take the **inner** value (`order.Id.Value`), not the wrapper. Only
+`LoadAsync()` accepts either — see below.
 :::
+
+#### Loading by the wrapper
+
+`LoadAsync<T>(object id)` is the overload a strong typed identifier binds to, and it accepts either
+spelling: the wrapper (`order.Id`) or the inner value (`order.Id.Value`) resolve the same row, identity
+map included. The `Guid` / `string` / `int` / `long` overloads stay preferred by overload resolution, so
+adding it moved no existing call site — only an argument that fits none of them lands here.
+
+```cs
+var byWrapper = await query.LoadAsync<Order>(order.Id);
+var byInner = await query.LoadAsync<Order>(order.Id.Value);
+```
+
+Passing an identity of any other type throws `ArgumentException` naming the document type and both id
+types, rather than failing later as an id-type mismatch.
+
+This is also the store-agnostic spelling: it satisfies
+`JasperFx.Events.Documents.IDocumentReadOperations.LoadAsync<T>(object, CancellationToken)`, so source
+shared with Marten can do a by-id load of a strong-typed-id document against either store
+([#472](https://github.com/JasperFx/polecat/issues/472),
+[jasperfx#665](https://github.com/JasperFx/jasperfx/issues/665)).
 
 ### Value Types on Other Members
 
@@ -258,7 +281,8 @@ registration here is genuinely optional.
 
 ### Not Currently Supported
 
-- No `LoadAsync<T>(object id)` overload taking the wrapper itself
+- No `LoadManyAsync()`, `Delete()` or `CheckExistsAsync()` overload taking the wrapper itself
+  (`LoadAsync()` does — see [Loading by the wrapper](#loading-by-the-wrapper))
 - No `Include()` LINQ operator
 - No compiled queries
 - F# single-case discriminated unions as identities

--- a/src/Polecat.Tests/Compliance/PolecatDocumentComplianceFixture.cs
+++ b/src/Polecat.Tests/Compliance/PolecatDocumentComplianceFixture.cs
@@ -22,13 +22,29 @@ public class PolecatDocumentComplianceFixture : DocumentStorageComplianceFixture
 
         _store?.Dispose();
 
-        _store = new DocumentStore(new StoreOptions
+        var options = new StoreOptions
         {
             ConnectionString = ConnectionSource.ConnectionString,
             AutoCreateSchemaObjects = AutoCreate.All,
             DatabaseSchemaName = schemaName,
             UseNativeJsonType = ConnectionSource.SupportsNativeJson
-        });
+        };
+
+        // jasperfx#665 / #472: the strong-typed identity facts key a document by a wrapper, and the
+        // suite declares those wrappers separately from the document types because the identity type
+        // is the one thing a document type alone does not tell a store.
+        //
+        // Replayed here for the same reason StoreOptions.RegisterValueType exists at all (#459):
+        // Polecat resolves value types on its own, so this is eager validation rather than a
+        // requirement -- measured, the three new facts pass with this loop removed. It is still the
+        // seam's intent, and it is what a store that does NOT auto-discover would need, so the
+        // fixture honors the declared configuration rather than relying on Polecat's discovery.
+        foreach (var valueType in config.ValueTypes)
+        {
+            options.RegisterValueType(valueType);
+        }
+
+        _store = new DocumentStore(options);
 
         // Polecat applies schema changes explicitly rather than lazily, and the suite's very first
         // act may be a read against a table nothing has written yet.

--- a/src/Polecat.Tests/StrongTypedId/load_by_runtime_typed_identity.cs
+++ b/src/Polecat.Tests/StrongTypedId/load_by_runtime_typed_identity.cs
@@ -1,0 +1,304 @@
+using System.Linq.Expressions;
+using Polecat.Tests.Harness;
+using Shouldly;
+
+namespace Polecat.Tests.StrongTypedId;
+
+// polecat#472 / jasperfx#665: IQuerySession.LoadAsync<T>(object).
+//
+// Before this overload there was no spelling of a by-id load for a document keyed by a strong-typed
+// identifier: the wrapper does not compile against Guid/string/int/long, and passing the wrapped
+// primitive instead is a *runtime* fault on a store that does not accept it -- which is how the
+// CritterWatch MCP get_alert tool shipped broken. The shared DocumentLoadAndStoreCompliance suite
+// pins the Guid-wrapped case and the boxed-canonical case; these are the Polecat-side facts it does
+// not reach: all four inner id types, the inner value accepted alongside its wrapper, the identity
+// map treating the two spellings as one identity, the tenant-scoped session, and the two rejections.
+
+public record struct TicketId(Guid Value);
+
+public class Ticket
+{
+    public TicketId Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+}
+
+public record struct BadgeId(string Value);
+
+public class Badge
+{
+    public BadgeId Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+}
+
+public record struct SeatId(int Value);
+
+public class Seat
+{
+    public SeatId Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+}
+
+public record struct AisleId(long Value);
+
+public class Aisle
+{
+    public AisleId Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+}
+
+public class PlainTicket
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+}
+
+public class PlainBadge
+{
+    public string Id { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+}
+
+[Collection("integration")]
+public class load_by_runtime_typed_identity : IntegrationContext
+{
+    public load_by_runtime_typed_identity(DefaultStoreFixture fixture) : base(fixture)
+    {
+    }
+
+    public override async ValueTask InitializeAsync()
+    {
+        await StoreOptions(opts => { opts.DatabaseSchemaName = "load_by_object_id"; });
+    }
+
+    [Fact]
+    public async Task load_a_guid_wrapped_identity_by_its_wrapper()
+    {
+        var ticket = new Ticket { Id = new TicketId(Guid.NewGuid()), Name = "Wrapped Guid" };
+        await PersistAsync(ticket);
+
+        await using var query = theStore.QuerySession();
+        var loaded = await query.LoadAsync<Ticket>(ticket.Id, TestContext.Current.CancellationToken);
+
+        loaded.ShouldNotBeNull();
+        loaded.Id.ShouldBe(ticket.Id);
+        loaded.Name.ShouldBe("Wrapped Guid");
+    }
+
+    [Fact]
+    public async Task load_a_string_wrapped_identity_by_its_wrapper()
+    {
+        var badge = new Badge { Id = new BadgeId("badge-472"), Name = "Wrapped string" };
+        await PersistAsync(badge);
+
+        await using var query = theStore.QuerySession();
+        var loaded = await query.LoadAsync<Badge>(badge.Id, TestContext.Current.CancellationToken);
+
+        loaded.ShouldNotBeNull();
+        loaded.Id.ShouldBe(badge.Id);
+        loaded.Name.ShouldBe("Wrapped string");
+    }
+
+    [Fact]
+    public async Task load_an_int_wrapped_identity_by_its_wrapper()
+    {
+        var seat = new Seat { Name = "Wrapped int" };
+        await PersistAsync(seat);
+        seat.Id.Value.ShouldBeGreaterThan(0);
+
+        await using var query = theStore.QuerySession();
+        var loaded = await query.LoadAsync<Seat>(seat.Id, TestContext.Current.CancellationToken);
+
+        loaded.ShouldNotBeNull();
+        loaded.Id.ShouldBe(seat.Id);
+        loaded.Name.ShouldBe("Wrapped int");
+    }
+
+    [Fact]
+    public async Task load_a_long_wrapped_identity_by_its_wrapper()
+    {
+        var aisle = new Aisle { Name = "Wrapped long" };
+        await PersistAsync(aisle);
+        aisle.Id.Value.ShouldBeGreaterThan(0);
+
+        await using var query = theStore.QuerySession();
+        var loaded = await query.LoadAsync<Aisle>(aisle.Id, TestContext.Current.CancellationToken);
+
+        loaded.ShouldNotBeNull();
+        loaded.Id.ShouldBe(aisle.Id);
+        loaded.Name.ShouldBe("Wrapped long");
+    }
+
+    /// <remarks>
+    ///     The typed overloads already accept the wrapped inner value for a strong-typed-id document,
+    ///     so the object overload has to as well or the two spellings would disagree about which rows
+    ///     exist.
+    /// </remarks>
+    [Fact]
+    public async Task the_wrapped_inner_value_resolves_the_same_row_as_the_wrapper()
+    {
+        var ticket = new Ticket { Id = new TicketId(Guid.NewGuid()), Name = "Either spelling" };
+        await PersistAsync(ticket);
+
+        await using var query = theStore.QuerySession();
+
+        object inner = ticket.Id.Value;
+        var byInner = await query.LoadAsync<Ticket>(inner, TestContext.Current.CancellationToken);
+        var byWrapper = await query.LoadAsync<Ticket>(ticket.Id, TestContext.Current.CancellationToken);
+
+        byInner.ShouldNotBeNull();
+        byWrapper.ShouldNotBeNull();
+        byInner.Id.ShouldBe(ticket.Id);
+        byWrapper.Id.ShouldBe(ticket.Id);
+    }
+
+    /// <remarks>
+    ///     A caller holding any identity in an <c>object</c>-typed local reaches this overload, not
+    ///     only one holding a wrapper. The shared suite asserts the Guid and string halves; Polecat's
+    ///     id set is wider, so the numeric halves are asserted here.
+    /// </remarks>
+    [Fact]
+    public async Task boxed_canonical_identities_resolve_as_the_typed_overloads_do()
+    {
+        var ticket = new PlainTicket { Id = Guid.NewGuid(), Name = "Boxed Guid" };
+        var badge = new PlainBadge { Id = "plain-badge", Name = "Boxed string" };
+        var seat = new Seat { Name = "Boxed int" };
+        var aisle = new Aisle { Name = "Boxed long" };
+
+        await PersistAsync(ticket, badge, seat, aisle);
+
+        await using var query = theStore.QuerySession();
+
+        object guidIdentity = ticket.Id;
+        (await query.LoadAsync<PlainTicket>(guidIdentity, TestContext.Current.CancellationToken))
+            .ShouldNotBeNull().Name.ShouldBe("Boxed Guid");
+
+        object stringIdentity = badge.Id;
+        (await query.LoadAsync<PlainBadge>(stringIdentity, TestContext.Current.CancellationToken))
+            .ShouldNotBeNull().Name.ShouldBe("Boxed string");
+
+        object intIdentity = seat.Id.Value;
+        (await query.LoadAsync<Seat>(intIdentity, TestContext.Current.CancellationToken))
+            .ShouldNotBeNull().Name.ShouldBe("Boxed int");
+
+        object longIdentity = aisle.Id.Value;
+        (await query.LoadAsync<Aisle>(longIdentity, TestContext.Current.CancellationToken))
+            .ShouldNotBeNull().Name.ShouldBe("Boxed long");
+    }
+
+    [Fact]
+    public async Task a_missing_strong_typed_identity_returns_null()
+    {
+        await using var query = theStore.QuerySession();
+
+        (await query.LoadAsync<Ticket>(new TicketId(Guid.NewGuid()), TestContext.Current.CancellationToken))
+            .ShouldBeNull();
+        (await query.LoadAsync<Badge>(new BadgeId("nothing-here"), TestContext.Current.CancellationToken))
+            .ShouldBeNull();
+    }
+
+    /// <remarks>
+    ///     The identity map is keyed on the unwrapped inner value, so an implementation that handed
+    ///     the wrapper straight down would miss entries the typed overload put there and return a
+    ///     second instance of the same document. That is the reason this overload normalizes through
+    ///     <c>DocumentMapping.UnwrapIdentity</c> rather than opening a parallel load path.
+    /// </remarks>
+    [Fact]
+    public async Task the_identity_map_treats_the_wrapper_and_its_inner_value_as_one_identity()
+    {
+        var ticket = new Ticket { Id = new TicketId(Guid.NewGuid()), Name = "Identity" };
+        await PersistAsync(ticket);
+
+        await using var session = theStore.IdentitySession();
+
+        var byWrapper = await session.LoadAsync<Ticket>(ticket.Id, TestContext.Current.CancellationToken);
+        var byTypedOverload = await session.LoadAsync<Ticket>(ticket.Id.Value, TestContext.Current.CancellationToken);
+
+        byWrapper.ShouldNotBeNull();
+        ReferenceEquals(byWrapper, byTypedOverload).ShouldBeTrue();
+    }
+
+    /// <remarks>
+    ///     <c>ForTenant</c> returns a <c>NestedTenantSession</c>, which is a separate implementation of
+    ///     the session contract — the shared contract's default implementation would throw
+    ///     <see cref="NotSupportedException" /> here rather than resolve the wrapper.
+    /// </remarks>
+    [Fact]
+    public async Task a_tenant_scoped_session_resolves_a_strong_typed_identity()
+    {
+        var ticket = new Ticket { Id = new TicketId(Guid.NewGuid()), Name = "Tenanted" };
+
+        theSession.ForTenant("tenant-472").Store(ticket);
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var loaded = await theSession.ForTenant("tenant-472")
+            .LoadAsync<Ticket>(ticket.Id, TestContext.Current.CancellationToken);
+
+        loaded.ShouldNotBeNull();
+        loaded.Name.ShouldBe("Tenanted");
+    }
+
+    [Fact]
+    public async Task an_identity_of_the_wrong_type_names_the_document_and_both_id_types()
+    {
+        await using var query = theStore.QuerySession();
+
+        var ex = await Should.ThrowAsync<ArgumentException>(
+            () => query.LoadAsync<Ticket>(new BadgeId("wrong-shape"), TestContext.Current.CancellationToken));
+
+        ex.Message.ShouldContain(nameof(BadgeId));
+        ex.Message.ShouldContain(nameof(Ticket));
+        ex.Message.ShouldContain(nameof(TicketId));
+        ex.ParamName.ShouldBe("id");
+    }
+
+    /// <remarks>
+    ///     Only an <c>object</c>-typed null reaches this overload. A <c>null</c> <i>literal</i> still
+    ///     binds to <c>LoadAsync&lt;T&gt;(string)</c> — <c>string</c> is the more specific of the two
+    ///     applicable members — which is unchanged by this addition and is asserted below so a future
+    ///     change to the overload set cannot move it silently.
+    /// </remarks>
+    [Fact]
+    public async Task a_null_identity_is_rejected()
+    {
+        await using var query = theStore.QuerySession();
+
+        object? nothing = null;
+        await Should.ThrowAsync<ArgumentNullException>(
+            () => query.LoadAsync<Ticket>(nothing!, TestContext.Current.CancellationToken));
+
+        BoundParameterType<Ticket>(s => s.LoadAsync<Ticket>(null!, default)).ShouldBe(typeof(string));
+    }
+
+    /// <remarks>
+    ///     The point of the overload set is that adding <c>object</c> moves no existing call site: a
+    ///     Guid/string/int/long argument still binds to its own member, and only an argument that fits
+    ///     none of them lands on <c>object</c>. An expression tree records what the compiler actually
+    ///     bound, which is the only way to assert overload resolution from a test.
+    /// </remarks>
+    [Fact]
+    public void the_typed_overloads_stay_preferred_by_overload_resolution()
+    {
+        BoundParameterType<PlainTicket>(s => s.LoadAsync<PlainTicket>(Guid.NewGuid(), default))
+            .ShouldBe(typeof(Guid));
+        BoundParameterType<PlainBadge>(s => s.LoadAsync<PlainBadge>("id", default))
+            .ShouldBe(typeof(string));
+        BoundParameterType<PlainTicket>(s => s.LoadAsync<PlainTicket>(1, default))
+            .ShouldBe(typeof(int));
+        BoundParameterType<PlainTicket>(s => s.LoadAsync<PlainTicket>(1L, default))
+            .ShouldBe(typeof(long));
+
+        // ...and a strong-typed identifier, which fits none of them, is what reaches the new member.
+        BoundParameterType<Ticket>(s => s.LoadAsync<Ticket>(new TicketId(Guid.NewGuid()), default))
+            .ShouldBe(typeof(object));
+    }
+
+    private static Type BoundParameterType<T>(Expression<Func<IQuerySession, Task<T?>>> call) where T : notnull
+        => ((MethodCallExpression)call.Body).Method.GetParameters()[0].ParameterType;
+
+    private async Task PersistAsync(params object[] documents)
+    {
+        await using var session = theStore.LightweightSession();
+        session.StoreObjects(documents);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+}

--- a/src/Polecat/IQuerySession.cs
+++ b/src/Polecat/IQuerySession.cs
@@ -144,6 +144,30 @@ public interface IQuerySession : IAsyncDisposable, IDocumentReadOperations
     new Task<T?> LoadAsync<T>(string id, CancellationToken token = default) where T : notnull;
 
     /// <summary>
+    ///     Load a document by an identity resolved at runtime — the overload a
+    ///     <i>strong-typed identifier</i> needs. Returns null if not found.
+    ///     <para>
+    ///     Pass the document's own identity value, boxed: for a document keyed by
+    ///     <c>record struct AlertId(string Id)</c> that means an <c>AlertId</c>, not the string it
+    ///     wraps. Polecat also accepts the wrapped inner value here, exactly as the typed overloads
+    ///     already do, so both spellings resolve the same row.
+    ///     </para>
+    ///     <para>
+    ///     The <see cref="Guid" />, <c>string</c>, <c>int</c> and <c>long</c> overloads stay preferred
+    ///     by overload resolution, so no existing call site moves onto this one. It is reached by an
+    ///     argument that fits none of them — a wrapper — or by a caller holding any identity in an
+    ///     <c>object</c>-typed local, which is why a boxed canonical id has to resolve here too
+    ///     (polecat#472, jasperfx#665).
+    ///     </para>
+    /// </summary>
+    /// <exception cref="ArgumentNullException"><paramref name="id" /> is null.</exception>
+    /// <exception cref="ArgumentException">
+    ///     <paramref name="id" /> is neither <typeparamref name="T" />'s declared id type nor the inner
+    ///     scalar a strong-typed id wraps.
+    /// </exception>
+    new Task<T?> LoadAsync<T>(object id, CancellationToken token = default) where T : notnull;
+
+    /// <summary>
     ///     Load multiple documents by their ids.
     /// </summary>
     Task<IReadOnlyList<T>> LoadManyAsync<T>(IEnumerable<Guid> ids, CancellationToken token = default) where T : class;

--- a/src/Polecat/Internal/NestedTenantSession.cs
+++ b/src/Polecat/Internal/NestedTenantSession.cs
@@ -82,6 +82,10 @@ internal class NestedTenantSession : ITenantOperations
     public Task<T?> LoadAsync<T>(long id, CancellationToken token = default) where T : class
         => _parent.LoadAsync<T>(id, token);
 
+    // polecat#472: the runtime-typed identity overload delegates like every other read here.
+    public Task<T?> LoadAsync<T>(object id, CancellationToken token = default) where T : notnull
+        => _parent.LoadAsync<T>(id, token);
+
     public Task<IReadOnlyList<T>> LoadManyAsync<T>(IEnumerable<Guid> ids, CancellationToken token = default) where T : class
         => _parent.LoadManyAsync<T>(ids, token);
 

--- a/src/Polecat/Internal/QuerySession.cs
+++ b/src/Polecat/Internal/QuerySession.cs
@@ -248,6 +248,25 @@ internal partial class QuerySession : IQuerySession
         return await LoadInternalAsync<T>(id, token);
     }
 
+    /// <summary>
+    ///     polecat#472 / jasperfx#665: the runtime-typed identity overload, the only spelling of a
+    ///     by-id load available to a document keyed by a strong-typed identifier.
+    /// </summary>
+    /// <remarks>
+    ///     It does not open a second load path — <see cref="DocumentMapping.UnwrapIdentity" /> reduces
+    ///     the boxed value to the same inner scalar the typed overloads pass, so this becomes the
+    ///     identical call, identity map included. A boxed Guid/string/int/long therefore resolves
+    ///     exactly as its own overload would, which the shared compliance suite asserts directly.
+    /// </remarks>
+    public async Task<T?> LoadAsync<T>(object id, CancellationToken token = default) where T : notnull
+    {
+        ArgumentNullException.ThrowIfNull(id);
+        assertNotDisposed();
+
+        var mapping = _providers.GetProvider<T>().Mapping;
+        return await LoadInternalAsync<T>(mapping.UnwrapIdentity(id, nameof(id)), token);
+    }
+
     protected virtual async Task<T?> LoadInternalAsync<T>(object id, CancellationToken token) where T : notnull
     {
         assertNotDisposed();

--- a/src/Polecat/Storage/DocumentMapping.cs
+++ b/src/Polecat/Storage/DocumentMapping.cs
@@ -431,6 +431,37 @@ internal class DocumentMapping
     /// </summary>
     internal object WrapId(object rawId) => _idWrapper is not null ? _idWrapper(rawId) : rawId;
 
+    /// <summary>
+    ///     polecat#472: reduces a runtime-typed identity to the inner scalar (Guid/string/int/long)
+    ///     that every load, delete and identity-map path here already carries, accepting either the
+    ///     declared id type — the strong-typed wrapper, when there is one — or that inner scalar.
+    ///     <para>
+    ///     This is what lets <c>IQuerySession.LoadAsync&lt;T&gt;(object)</c> be *literally the same
+    ///     call* as the typed overload rather than a parallel path: the identity map is keyed on the
+    ///     unwrapped value (see <see cref="GetId" />), so a wrapper handed straight down would miss
+    ///     entries the typed overload put there and hand back a second instance of the same document.
+    ///     </para>
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    ///     <paramref name="id" /> is neither the declared id type nor the inner scalar it wraps.
+    /// </exception>
+    internal object UnwrapIdentity(object id, string parameterName)
+    {
+        var declared = Nullable.GetUnderlyingType(IdType) ?? IdType;
+        var supplied = id.GetType();
+
+        if (supplied == declared) return _idUnwrapper is not null ? _idUnwrapper(id) : id;
+        if (supplied == InnerIdType) return id;
+
+        var accepted = IsStrongTypedId
+            ? $"'{declared.FullName}' or the '{InnerIdType.Name}' it wraps"
+            : $"'{declared.Name}'";
+
+        throw new ArgumentException(
+            $"'{supplied.FullName}' is not a valid identity for document type '{_documentType.FullName}', "
+            + $"whose id is {accepted}.", parameterName);
+    }
+
     public void AssignIdIfMissing(object document, ISequenceSource sequences)
         => _identityAssigner?.AssignIfMissing(document, sequences);
 


### PR DESCRIPTION
Adds `IQuerySession.LoadAsync<T>(object id, CancellationToken)` — the overload a strong typed identifier binds to — and rolls the JasperFx lockstep pins to 2.49.0 for the contract member it satisfies.

## The gap

Before this there was **no spelling of a by-id load** for a document keyed by a wrapper. The wrapper does not compile against the `Guid`/`string`/`int`/`long` overload set:

```csharp
await session.LoadAsync<AlertRecord>(new AlertId("some-id"));  // CS1503 on Polecat 5.15.1
```

and passing the wrapped primitive instead is not a workaround but a *runtime* fault on a store that does not accept it — it compiles cleanly on both stores and ships broken, which is exactly how CritterWatch's MCP `get_alert` tool shipped broken once. Marten already had the `object`-typed overload, so source shared across the two stores had to fall back to a LINQ query standing in for a load, with a paragraph of comment at the call site explaining why.

It is also the store-agnostic spelling: it satisfies `JasperFx.Events.Documents.IDocumentReadOperations.LoadAsync<T>(object, CancellationToken)` (jasperfx#665), so consumers binding to the document abstractions rather than to a store get the load too. The two halves had to land together to retire the workaround, and this is the Polecat half.

## What changed

**`IQuerySession`** gains the member, declared `new` per #455/#465. That is load-bearing here rather than cosmetic: re-declaring it makes the member abstract for Polecat's sessions, so every one of them has to implement it instead of silently inheriting the shared contract's default — which throws `NotSupportedException` for exactly the strong-typed case this exists to serve. Two implementations: `QuerySession` (and so `DocumentSessionBase` / `IdentityMapDocumentSession`) and `NestedTenantSession`.

**Not a parallel load path.** `DocumentMapping.UnwrapIdentity` reduces the boxed value to the same inner scalar the typed overloads already pass, accepting either the declared id type or the inner scalar it wraps, so this becomes the *identical* call — reusing the #457 value-type machinery rather than reimplementing identity resolution beside it.

That matters for more than tidiness. The identity map is keyed on the **unwrapped** value (`DocumentMapping.GetId` unwraps), so an implementation that handed the wrapper straight down would miss entries the typed overload put there and return a second instance of the same document. There is a test for it.

An identity of any other type is rejected with an `ArgumentException` naming the document type and both id types, rather than surfacing later as an opaque cast failure.

## JasperFx 2.48.0 → 2.49.0

Additive. The contract member ships with a **default implementation** — it unboxes a `Guid` or `string`, forwards to the typed overload, and throws `NotSupportedException` naming the implementing type for anything else — so the bump alone is not a compile break, and a store only gains the strong-typed half by overriding it. `JasperFx.RuntimeCompiler` stays on its separate 5.0.0 line.

## What the shared suite now pins

`DocumentLoadAndStoreCompliance` gains three facts:

- `store_and_load_by_strong_typed_identity`
- `load_returns_null_for_a_missing_strong_typed_identity`
- `the_object_overload_resolves_canonical_identities_too`

The third is the interesting one: it pins that a boxed `Guid` or `string` arriving through an `object`-typed local resolves exactly as the typed overload does. The contract's default gets that right for free, but an override that assumes every argument is a wrapper passes the first two and regresses this one. Polecat's document compliance suites go **41 → 45 tests, all green**.

`PolecatDocumentComplianceFixture` replays `config.ValueTypes` onto `StoreOptions.RegisterValueType` alongside the existing `DocumentTypes` loop. **Measured**, that is eager validation rather than a requirement here — Polecat resolves value types on its own, and the three new facts pass with the loop removed — but the fixture honors the configuration the suite declares rather than leaning on discovery, which is also what the seam is for on a store that does not auto-discover.

## Polecat-side coverage

`StrongTypedId/load_by_runtime_typed_identity.cs`, 12 tests, covering what the shared suite does not reach:

- all four inner id types — Polecat's id set (`Guid`/`string`/`int`/`long`) is wider than the contract's `Guid`/`string`
- the inner value accepted alongside its wrapper, resolving the same row
- the identity map treating the two spellings as one identity
- the tenant-scoped session (`ForTenant`), a separate implementation that the contract's default would have thrown in
- the two rejections, wrong type and null
- **that the typed overloads stay preferred by overload resolution**, so no existing call site moved — asserted through expression trees, which record what the compiler actually bound rather than what we hope it bound

One finding worth recording from that last test: a `null` **literal** still binds to `LoadAsync<T>(string)`, since `string` is the more specific of the two applicable members, so only an `object`-typed null reaches the new member. Unchanged by this addition, and now asserted so a future change to the overload set cannot move it silently.

## Docs

`docs/documents/identity.md` previously stated outright that "Polecat has no `LoadAsync<T>(object id)` overload; if you pass the wrapper the call will not compile", and listed it under **Not Currently Supported**. Both corrected, with a new *Loading by the wrapper* section; the remaining gap (`LoadManyAsync` / `Delete` / `CheckExistsAsync` still take the inner value) is stated rather than dropped.

## Verification

- `dotnet build polecat.slnx`: **0 errors** across both TFMs, and **no new warnings** — in particular no CS0108 (the `new` is required) and no CS0109 (it is not redundant)
- Document compliance suites: **45 total, 0 failed**
- `load_by_runtime_typed_identity`: **12 total, 0 failed**
- Full local suite: **2169 total, 0 failed**, 2166 succeeded, 3 skipped (24m). The 5.15.1 baseline is 2154 / 0 / 3, so the delta is exactly **+15** — the 12 new Polecat tests plus the 3 new shared compliance facts, and nothing else moved.
- CI green across all seven checks, including both the default and Azure SQL Edge matrices of the main `Polecat.Tests` suite.

Closes #472. Companion to jasperfx#665 / jasperfx#666.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
