### PR TITLE
5.16.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>5.15.1</Version>
+        <Version>5.16.0</Version>
         <LangVersion>latest</LangVersion>
         <Authors>Jeremy D. Miller</Authors>
         <PackageIcon>logo.png</PackageIcon>


### PR DESCRIPTION
Version bump for the 5.16.0 release.

**A minor rather than a patch**, because #473 adds public API surface.

## Contents

| Issue | PR | Change |
|---|---|---|
| #472 | #473 | `IQuerySession.LoadAsync<T>(object id, CancellationToken)` — the overload a strong typed identifier binds to. Also rolls the JasperFx lockstep pins 2.48.0 → 2.49.0. |

Before #473 there was **no spelling of a by-id load** for a document keyed by a wrapper: the wrapper does not compile against the `Guid`/`string`/`int`/`long` overload set, and passing the wrapped primitive instead is a *runtime* id-type fault on a store that does not accept it — it compiles cleanly on both stores and ships broken, which is how CritterWatch's MCP `get_alert` tool shipped broken once. Marten already had the `object`-typed overload, so source shared across the two stores had to fall back to a LINQ query standing in for a load.

It is also the store-agnostic spelling: it satisfies `JasperFx.Events.Documents.IDocumentReadOperations.LoadAsync<T>(object, CancellationToken)` (jasperfx#665, shipped in JasperFx 2.49.0), so consumers binding to the document abstractions rather than to a store get the load too.

Both spellings resolve the same row — `order.Id` and `order.Id.Value` — identity map included, because the overload normalizes through `DocumentMapping.UnwrapIdentity` down to the same inner scalar the typed overloads already pass rather than opening a parallel load path. The typed overloads stay preferred by overload resolution, so **no existing call site moved**; that is asserted through expression trees rather than assumed.

## Verification

- #473 merged with a fully green CI matrix — all seven checks, both the default and Azure SQL Edge matrices
- Full local suite on the merged tree: **2169 total, 0 failed**, 3 skipped. The 5.15.1 baseline is 2154 / 0 / 3, so the delta is exactly **+15** — the 12 new Polecat tests plus the 3 new shared compliance facts, and nothing else moved.
- Document compliance suites: 41 → **45 tests**, all green

**Dependency-and-version only in this PR** — no Polecat source changes here beyond `<Version>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
