### PR TITLE
gh-477: forward pending stream actions to the shared document contract

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -206,15 +206,42 @@
              implicitly satisfy the contract members. Without the explicit implementations on
              IQuerySession / IDocumentSession this compiles clean and throws at runtime; see
              polecat#475. Also brings BinaryEventSerializationCompliance and
-             DocumentSessionEventsCompliance, both opt-in, which Polecat now enrolls in. -->
-        <PackageVersion Include="JasperFx" Version="2.50.0" />
-        <PackageVersion Include="JasperFx.Events" Version="2.50.0" />
+             DocumentSessionEventsCompliance, both opt-in, which Polecat now enrolls in.
+             JasperFx 2.51.0 — three additions, one per open Polecat issue, and all three opt-in.
+             Nothing in this bump is a compile break: every new contract member carries a throwing
+             default, and the two new compliance suites are enrolled by a store when it is ready.
+             (a) jasperfx#672 — DocumentComplianceConfig.StreamIdentity, nullable and defaulting to
+             null ("leave the store on its own default"). It exists because
+             DocumentSessionEventsCompliance appends by stream KEY throughout with no way to say so,
+             which is exactly the gap the fixture works around today by INFERRING string identity
+             from a non-empty config.EventTypes — see the comment in
+             PolecatDocumentComplianceFixture calling it an upstream gap. This is that gap closed;
+             polecat#479 replaces the inference with the declared value.
+             (b) jasperfx#673 — IDocumentSessionOperations.PendingStreams, the store-agnostic read of
+             the StreamActions a session has queued but not yet committed. Polecat already has the
+             collection one hop away on PendingChanges.Streams and the payload type is already the
+             shared StreamAction, so adoption is a forwarding member; polecat#477. The default
+             THROWS rather than returning empty, deliberately: an empty list is indistinguishable
+             from a session with nothing pending, so a silent default would let a consumer's derived
+             work be discarded with a clean build and green tests.
+             (c) jasperfx#674 — IAggregateWriteCache moves into JasperFx.Events, together with
+             AggregateCacheKey, the bounded node-local RecentlyUsedAggregateWriteCache default,
+             NulloAggregateWriteCache, AggregateWriteCacheOptions and
+             EventRegistry.CacheAggregatesForWriting<T>() — which Polecat's EventGraph already
+             inherits, so the registration surface needs no new code and the work is entirely in the
+             fetch path (polecat#478). Grade 1 semantics only: the cached snapshot is a BASELINE, the
+             stream version and every event after it are still read on every call, and the optimistic
+             concurrency assertion is untouched, so a stale entry costs a larger delta query and
+             never a wrong aggregate. The suites are PendingStreamActionsCompliance and
+             AggregateWriteCacheCompliance. -->
+        <PackageVersion Include="JasperFx" Version="2.51.0" />
+        <PackageVersion Include="JasperFx.Events" Version="2.51.0" />
         <!--
              The shared cross-store event sourcing compliance suites. Source-only package: the
              suites compile inside Polecat.Tests so JasperFx's aggregate source generator binds
              Polecat's own session types.
         -->
-        <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.50.0" />
+        <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.51.0" />
         <!-- Pin the sibling JasperFx packages for parity with Marten 9's matrix
              even though Polecat doesn't currently reference them directly —
              keeps the lockstep matrix coherent when transitive resolution
@@ -222,7 +249,7 @@
              RuntimeCompiler 5.x line is the active continuation of the 4.x
              lineage; do not pin against the parallel stale 2.0.x series. -->
         <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.50.0" />
+        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.51.0" />
         <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
@@ -335,7 +362,7 @@
         <PackageVersion Include="Vogen" Version="7.0.0" />
 
         <!-- Source generators (matched to JasperFx.Events above) -->
-        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.50.0" />
+        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.51.0" />
 
         <!-- Build automation -->
         <PackageVersion Include="Nuke.Common" Version="9.0.4" />

--- a/src/Polecat.Tests/Compliance/PolecatDocumentComplianceFixture.cs
+++ b/src/Polecat.Tests/Compliance/PolecatDocumentComplianceFixture.cs
@@ -21,13 +21,16 @@ public class PolecatDocumentComplianceFixture : DocumentStorageComplianceFixture
         var schemaName = (config.SchemaName ?? "compliance_documents").ToLowerInvariant();
 
         // #475 / jasperfx#669: every document suite declares the SAME schema name, which is harmless
-        // while they are all document-only -- they configure the same tables the same way. The event
-        // suite is not: it needs string stream identity (see below), so its pc_streams.id is
-        // nvarchar where a Guid-identity store's is uniqueidentifier. Sharing one schema makes
-        // whichever suite migrates second try to retype a primary key under a live foreign key, and
-        // Weasel fails with "Could not drop constraint" during fixture init -- all five facts red for
-        // a reason that has nothing to do with the code under test. Separate schema, no interaction.
-        if (config.EventTypes.Count > 0)
+        // while they are all document-only -- they configure the same tables the same way. A suite
+        // that needs string stream identity is not: its pc_streams.id is nvarchar where a
+        // Guid-identity store's is uniqueidentifier. Sharing one schema makes whichever suite
+        // migrates second try to retype a primary key under a live foreign key, and Weasel fails
+        // with "Could not drop constraint" during fixture init -- every fact red for a reason that
+        // has nothing to do with the code under test. Separate schema, no interaction.
+        //
+        // #479: keyed off the DECLARED identity rather than off "this suite has event types",
+        // because it is the identity that changes the column type. The two happen to coincide today.
+        if (config.StreamIdentity == JasperFx.Events.StreamIdentity.AsString)
         {
             schemaName += "_events";
         }
@@ -56,27 +59,33 @@ public class PolecatDocumentComplianceFixture : DocumentStorageComplianceFixture
             options.RegisterValueType(valueType);
         }
 
-        // #475 / jasperfx#669: DocumentSessionEventsCompliance appends through the session's Events
-        // accessor, so the event types it names have to be registered before the store is built --
-        // otherwise the append writes an event whose type name only resolves by assembly scanning,
-        // and the read back is at the mercy of what happens to be loaded. Only the one document suite
-        // that is also an event-store suite populates this list; it is empty for the other four.
-        if (config.EventTypes.Count > 0)
+        // #479 / jasperfx#672: the stream identity the suite DECLARES, replacing the inference this
+        // fixture used to make.
+        //
+        // The gap the old comment here called out is closed. A suite that appends by stream key --
+        // DocumentSessionEventsCompliance does throughout -- had no way to say so, so this fixture
+        // had to work it out from "the config named event types, and the only suite that does keys
+        // its streams by string". That is a guess about another repository's source: correct on the
+        // day it was written, silently wrong the moment a document suite named an event type without
+        // wanting string identity. It also failed loudly and misleadingly when it was missing, since
+        // Polecat refuses a string-keyed StartStream under AsGuid with
+        // ExistingStreamIdCollisionException, an error naming a stream collision rather than the
+        // identity mismatch that caused it.
+        //
+        // Nullable and null by default, meaning "leave the store on its own default", so this is
+        // inert for every document-only suite and no existing behavior changes.
+        if (config.StreamIdentity.HasValue)
         {
-            // ⚠️ That suite keys every stream by a STRING, and DocumentComplianceConfig carries no
-            // StreamIdentity knob the way ComplianceStoreConfig does -- so the requirement is
-            // implicit in the suite's body rather than declared. Polecat defaults to AsGuid, under
-            // which a string-keyed StartStream is refused, and the failure names a stream collision
-            // rather than an identity mismatch: three of the five facts died with
-            // ExistingStreamIdCollisionException on freshly minted Guids. Inferred from the suite,
-            // not from the config, which is why it is spelled out here. Upstream gap, tracked by the
-            // jasperfx side; do NOT "fix" it by editing the shared suite.
-            options.Events.StreamIdentity = JasperFx.Events.StreamIdentity.AsString;
+            options.Events.StreamIdentity = config.StreamIdentity.Value;
+        }
 
-            foreach (var eventType in config.EventTypes)
-            {
-                options.Events.AddEventType(eventType);
-            }
+        // Event types stay registered from the config: a suite appending through the session's Events
+        // accessor needs its types known before the store is built, or the append writes an event
+        // whose type name only resolves by assembly scanning and the read back is at the mercy of
+        // what happens to be loaded. Empty for the document-only suites.
+        foreach (var eventType in config.EventTypes)
+        {
+            options.Events.AddEventType(eventType);
         }
 
         _store = new DocumentStore(options);

--- a/src/Polecat.Tests/Compliance/polecat_event_store_compliance_wave10.cs
+++ b/src/Polecat.Tests/Compliance/polecat_event_store_compliance_wave10.cs
@@ -1,0 +1,21 @@
+using JasperFx.Events.ComplianceTests;
+
+namespace Polecat.Tests.Compliance;
+
+/*
+ * Wave 10 -- the suites JasperFx 2.51.0 added.
+ *
+ * PendingStreamActionsCompliance is jasperfx#673 / #477: the stream actions a session has queued but
+ * not yet committed, read through the shared document contract. Opt-in for the same reason as
+ * DocumentSessionEventsCompliance in wave 9, whose event types and stream marker it reuses -- there
+ * are no pending stream actions without an event store.
+ *
+ * Its first fact is the one a store still on the contract's throwing default cannot pass: an empty
+ * collection for a session with nothing enlisted. The default throws rather than answering empty
+ * precisely because empty is indistinguishable from a session with nothing pending, so a store that
+ * returned empty instead of implementing the member would pass a suite written the other way round
+ * and still drop every consumer's work.
+ */
+
+public class polecat_pending_stream_actions_compliance
+    : PendingStreamActionsCompliance<PolecatDocumentComplianceFixture>;

--- a/src/Polecat/IDocumentSession.cs
+++ b/src/Polecat/IDocumentSession.cs
@@ -41,6 +41,35 @@ public interface IDocumentSession : IDocumentOperations, IStorageOperations, ITr
     IEventStoreOperations IDocumentSessionOperations.Events => Events;
 
     /// <summary>
+    ///     #477 / jasperfx#673: the <see cref="StreamAction" />s this session has queued but not yet
+    ///     committed, read through the shared contract.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Polecat already had the collection one hop away, and the payload type was already the
+    ///         shared <see cref="StreamAction" /> — only the accessor's NAME diverged between the
+    ///         products (Marten's <c>PendingChanges.Streams()</c>, this <c>PendingChanges.Streams</c>,
+    ///         Fisher's <c>Events.PendingStreams</c>). So this closes a naming gap rather than a
+    ///         capability gap, and a Polecat caller keeps reading
+    ///         <see cref="PendingChanges" />.<see cref="IWorkTracker.Streams" /> directly.
+    ///     </para>
+    ///     <para>
+    ///         It exists for code that did <em>not</em> do the appending — a listener, or a pre-commit
+    ///         hook deciding something from what the session is about to write. Code at the call site
+    ///         already holds the <see cref="StreamAction" />, because <c>StartStream</c> and
+    ///         <c>Append</c> return it.
+    ///     </para>
+    ///     <para>
+    ///         The contract's default <b>throws</b> rather than answering with an empty list, and here
+    ///         that choice matters more than it did for <see cref="Events" />: empty is
+    ///         indistinguishable from a session with nothing pending, so a store left on a silent
+    ///         default would discard whatever a consumer derives from these actions with a clean
+    ///         build and green tests.
+    ///     </para>
+    /// </remarks>
+    IReadOnlyList<StreamAction> IDocumentSessionOperations.PendingStreams => PendingChanges.Streams;
+
+    /// <summary>
     ///     Flush all pending operations to the database in a single transaction.
     /// </summary>
     new Task SaveChangesAsync(CancellationToken token = default);


### PR DESCRIPTION
Closes #477. Stacked on [#481](https://github.com/JasperFx/polecat/pull/481) (#479) → [#480](https://github.com/JasperFx/polecat/pull/480) (the 2.51.0 bump): `PendingStreamActionsCompliance` declares `StreamIdentity.AsString`, so it needs the fixture change in #481 to run at all.

## The member

jasperfx#673 added `IDocumentSessionOperations.PendingStreams` so a store-agnostic consumer — a listener, or a pre-commit hook deciding something from the events a session is about to write — can read the queued `StreamAction`s without naming a store. Polecat already had them one hop away, and the payload type was already the shared `StreamAction`, so this closes a naming gap rather than a capability gap:

```csharp
IReadOnlyList<StreamAction> IDocumentSessionOperations.PendingStreams => PendingChanges.Streams;
```

A default interface member on `IDocumentSession`, matching the two `Events` accessors #475 put beside it. Unlike those, there is no non-covariance trap here — nothing on Polecat's own surface is named `PendingStreams`, so there is no member of a different shape for the contract member to bind past. A Polecat caller keeps reading `PendingChanges.Streams` directly.

## Why the default throws

The contract raises `NotSupportedException` rather than returning an empty list, and that is what makes the suite's first fact meaningful: empty is indistinguishable from a session that genuinely has nothing pending, so a store left on a silent default would discard whatever a consumer derives from these actions — clean build, green tests, no events.

## Tests

`PendingStreamActionsCompliance` enrolled as wave 10: **9 passed, 0 failed**. Covers an empty session, documents-only enlisting nothing, a started stream visible before commit, event order within a stream, several streams together, an append to an existing stream, per-session isolation, that committing clears the collection, and the `Start` vs `Append` distinction.

Document compliance suites alongside it: **50 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)