### PR TITLE
gh-478: wire the shared aggregate write cache into FetchForWriting

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -206,15 +206,42 @@
              implicitly satisfy the contract members. Without the explicit implementations on
              IQuerySession / IDocumentSession this compiles clean and throws at runtime; see
              polecat#475. Also brings BinaryEventSerializationCompliance and
-             DocumentSessionEventsCompliance, both opt-in, which Polecat now enrolls in. -->
-        <PackageVersion Include="JasperFx" Version="2.50.0" />
-        <PackageVersion Include="JasperFx.Events" Version="2.50.0" />
+             DocumentSessionEventsCompliance, both opt-in, which Polecat now enrolls in.
+             JasperFx 2.51.0 — three additions, one per open Polecat issue, and all three opt-in.
+             Nothing in this bump is a compile break: every new contract member carries a throwing
+             default, and the two new compliance suites are enrolled by a store when it is ready.
+             (a) jasperfx#672 — DocumentComplianceConfig.StreamIdentity, nullable and defaulting to
+             null ("leave the store on its own default"). It exists because
+             DocumentSessionEventsCompliance appends by stream KEY throughout with no way to say so,
+             which is exactly the gap the fixture works around today by INFERRING string identity
+             from a non-empty config.EventTypes — see the comment in
+             PolecatDocumentComplianceFixture calling it an upstream gap. This is that gap closed;
+             polecat#479 replaces the inference with the declared value.
+             (b) jasperfx#673 — IDocumentSessionOperations.PendingStreams, the store-agnostic read of
+             the StreamActions a session has queued but not yet committed. Polecat already has the
+             collection one hop away on PendingChanges.Streams and the payload type is already the
+             shared StreamAction, so adoption is a forwarding member; polecat#477. The default
+             THROWS rather than returning empty, deliberately: an empty list is indistinguishable
+             from a session with nothing pending, so a silent default would let a consumer's derived
+             work be discarded with a clean build and green tests.
+             (c) jasperfx#674 — IAggregateWriteCache moves into JasperFx.Events, together with
+             AggregateCacheKey, the bounded node-local RecentlyUsedAggregateWriteCache default,
+             NulloAggregateWriteCache, AggregateWriteCacheOptions and
+             EventRegistry.CacheAggregatesForWriting<T>() — which Polecat's EventGraph already
+             inherits, so the registration surface needs no new code and the work is entirely in the
+             fetch path (polecat#478). Grade 1 semantics only: the cached snapshot is a BASELINE, the
+             stream version and every event after it are still read on every call, and the optimistic
+             concurrency assertion is untouched, so a stale entry costs a larger delta query and
+             never a wrong aggregate. The suites are PendingStreamActionsCompliance and
+             AggregateWriteCacheCompliance. -->
+        <PackageVersion Include="JasperFx" Version="2.51.0" />
+        <PackageVersion Include="JasperFx.Events" Version="2.51.0" />
         <!--
              The shared cross-store event sourcing compliance suites. Source-only package: the
              suites compile inside Polecat.Tests so JasperFx's aggregate source generator binds
              Polecat's own session types.
         -->
-        <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.50.0" />
+        <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.51.0" />
         <!-- Pin the sibling JasperFx packages for parity with Marten 9's matrix
              even though Polecat doesn't currently reference them directly —
              keeps the lockstep matrix coherent when transitive resolution
@@ -222,7 +249,7 @@
              RuntimeCompiler 5.x line is the active continuation of the 4.x
              lineage; do not pin against the parallel stale 2.0.x series. -->
         <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.50.0" />
+        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.51.0" />
         <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
@@ -335,7 +362,7 @@
         <PackageVersion Include="Vogen" Version="7.0.0" />
 
         <!-- Source generators (matched to JasperFx.Events above) -->
-        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.50.0" />
+        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.51.0" />
 
         <!-- Build automation -->
         <PackageVersion Include="Nuke.Common" Version="9.0.4" />

--- a/src/Polecat.Tests/Compliance/PolecatComplianceFixture.cs
+++ b/src/Polecat.Tests/Compliance/PolecatComplianceFixture.cs
@@ -1,6 +1,7 @@
 using JasperFx;
 using JasperFx.Events;
 using JasperFx.Events.ComplianceTests;
+using JasperFx.Events.Fetching;
 using JasperFx.Events.Daemon;
 using JasperFx.Events.Projections;
 using JasperFx.Events.Tags;
@@ -256,6 +257,16 @@ public class PolecatComplianceFixture : EventStoreComplianceFixture<IDocumentSes
 
         public void AddProjection(ProjectionBase projection, ProjectionLifecycle lifecycle)
             => _options.Projections.Add((IProjectionSource<IDocumentSession, IQuerySession>)projection, lifecycle);
+
+        // #478 / jasperfx#674. Both halves are needed and they are different things: the suite's
+        // RecordingAggregateWriteCache has to be the instance the store actually resolves (that is
+        // how the suite counts hits at all), and the type has to be enrolled, because caching is
+        // opt-in per aggregate type rather than store-wide.
+        public void CacheAggregatesForWriting<TDoc>(IAggregateWriteCache cache) where TDoc : class
+        {
+            _options.Events.AggregateWriteCaching.Cache = cache;
+            _options.Events.CacheAggregatesForWriting<TDoc>();
+        }
 
         // Wave 8: the name is pinned to ComplianceSubscription.SubscriptionName rather than left to
         // default, because the products disagree on whether an unnamed subscription takes its short

--- a/src/Polecat.Tests/Compliance/polecat_aggregate_write_cache_compliance.cs
+++ b/src/Polecat.Tests/Compliance/polecat_aggregate_write_cache_compliance.cs
@@ -1,0 +1,19 @@
+using JasperFx.Events.ComplianceTests;
+
+namespace Polecat.Tests.Compliance;
+
+/*
+ * #478 / jasperfx#674 -- the second-level aggregate snapshot cache behind FetchForWriting.
+ *
+ * Opt-in, and the opt-in is the point: a store that ignored it entirely would pass every
+ * correctness fact in this suite vacuously, because an uncached fetch is correct by construction.
+ * That is what the suite's RecordingAggregateWriteCache and its nonzero-hit assertion exist for --
+ * the_cache_is_actually_consulted_when_a_type_opts_in is the fact that separates "implemented" from
+ * "silently ignored", and it is the one to look at first if this file ever goes red.
+ *
+ * The suite deliberately never starts the daemon, so the Async-snapshotted aggregate's stored
+ * snapshot always lags and every fetch has a real delta to fold onto whatever baseline it started
+ * from. Nothing here can pass by accident of the snapshot already being at the head of the stream.
+ */
+public class aggregate_write_cache_compliance
+    : AggregateWriteCacheCompliance<PolecatComplianceFixture, IDocumentSession, IQuerySession>;

--- a/src/Polecat.Tests/Events/aggregate_write_cache_tests.cs
+++ b/src/Polecat.Tests/Events/aggregate_write_cache_tests.cs
@@ -1,0 +1,277 @@
+using System.Diagnostics.CodeAnalysis;
+using JasperFx.Events.Fetching;
+using JasperFx.Events.Projections;
+using Polecat.Projections;
+using Polecat.Tests.Harness;
+using Shouldly;
+
+namespace Polecat.Tests.Events;
+
+public record VaultOpened(string Owner);
+
+public record CoinsAdded(int Amount);
+
+public class Vault
+{
+    public Guid Id { get; set; }
+    public string Owner { get; set; } = string.Empty;
+    public int Coins { get; set; }
+
+    public static Vault Create(VaultOpened e) => new() { Owner = e.Owner };
+
+    public void Apply(CoinsAdded e) => Coins += e.Amount;
+}
+
+public partial class VaultProjection : SingleStreamProjection<Vault, Guid>;
+
+/// <summary>
+///     A cache that records every interaction and can be seeded with an arbitrary baseline, so a test
+///     can prove which events a fetch actually read.
+/// </summary>
+public sealed class RecordingWriteCache : IAggregateWriteCache
+{
+    private readonly Dictionary<AggregateCacheKey, (object Aggregate, long Version)> _entries = new();
+
+    public List<AggregateCacheKey> Takes { get; } = new();
+    public List<(AggregateCacheKey Key, object Aggregate, long Version)> Stores { get; } = new();
+    public int Hits { get; private set; }
+
+    public bool TryTake(AggregateCacheKey key, [NotNullWhen(true)] out object? aggregate, out long version)
+    {
+        Takes.Add(key);
+
+        if (_entries.Remove(key, out var entry))
+        {
+            aggregate = entry.Aggregate;
+            version = entry.Version;
+            Hits++;
+            return true;
+        }
+
+        aggregate = null;
+        version = 0;
+        return false;
+    }
+
+    public void Store(AggregateCacheKey key, object aggregate, long version)
+    {
+        Stores.Add((key, aggregate, version));
+        _entries[key] = (aggregate, version);
+    }
+
+    public void Evict(AggregateCacheKey key) => _entries.Remove(key);
+
+    public void Seed(AggregateCacheKey key, object aggregate, long version) => _entries[key] = (aggregate, version);
+}
+
+/// <summary>
+///     #478 / jasperfx#674, the store-specific half. The cross-store definition is
+///     <c>AggregateWriteCacheCompliance</c> (enrolled in
+///     <c>Compliance/polecat_aggregate_write_cache_compliance.cs</c>) and it deliberately leaves two
+///     things to each store: <b>when</b> an entry is written back, and <b>what version</b> it claims.
+///     Both are decisions here, and both are the kind that fail silently, so they are pinned locally.
+/// </summary>
+public class aggregate_write_cache_tests : OneOffConfigurationsContext
+{
+    private readonly RecordingWriteCache _cache = new();
+
+    private async Task ConfigureAsync(bool enroll = true)
+    {
+        ConfigureStore(opts =>
+        {
+            opts.Projections.Add<VaultProjection>(ProjectionLifecycle.Inline);
+            opts.Events.AggregateWriteCaching.Cache = _cache;
+            if (enroll)
+            {
+                opts.Events.CacheAggregatesForWriting<Vault>();
+            }
+        });
+
+        await theDatabase.ApplyAllConfiguredChangesToDatabaseAsync();
+    }
+
+    private async Task<Guid> AnOpenVaultAsync()
+    {
+        var streamId = Guid.NewGuid();
+
+        await using var session = theStore.LightweightSession();
+        session.Events.StartStream<Vault>(streamId, new VaultOpened("Hilda"), new CoinsAdded(100));
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        return streamId;
+    }
+
+    private async Task WarmAsync(Guid streamId, int amount)
+    {
+        await using var session = theStore.LightweightSession();
+        var stream = await session.Events.FetchForWriting<Vault>(streamId, TestContext.Current.CancellationToken);
+        stream.AppendOne(new CoinsAdded(amount));
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task a_type_nobody_enrolled_never_reaches_the_cache()
+    {
+        await ConfigureAsync(enroll: false);
+        var streamId = await AnOpenVaultAsync();
+
+        await WarmAsync(streamId, 10);
+        await WarmAsync(streamId, 5);
+
+        // ResolveCache hands back the Nullo instance for an unenrolled type, so the store's fetch
+        // path needs no branch of its own -- but it must also not have reached the configured cache.
+        _cache.Takes.ShouldBeEmpty();
+        _cache.Stores.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task the_entry_is_written_back_on_commit_and_not_at_fetch()
+    {
+        await ConfigureAsync();
+        var streamId = await AnOpenVaultAsync();
+
+        await using (var session = theStore.LightweightSession())
+        {
+            var stream = await session.Events
+                .FetchForWriting<Vault>(streamId, TestContext.Current.CancellationToken);
+
+            // Take-on-read is why: storing here would republish the very instance this caller is
+            // still holding, and a concurrent fetch could then take it. The commit is the point at
+            // which this caller is done with it.
+            _cache.Takes.ShouldHaveSingleItem();
+            _cache.Stores.ShouldBeEmpty();
+
+            stream.AppendOne(new CoinsAdded(10));
+            _cache.Stores.ShouldBeEmpty("appending is not committing");
+
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        _cache.Stores.ShouldHaveSingleItem();
+    }
+
+    [Fact]
+    public async Task a_fetch_that_appends_nothing_never_warms_the_cache()
+    {
+        // Not an omission -- a fetch with nothing appended has no work to commit, so
+        // SaveChangesAsync returns before there is a transaction to hang the write-back off. The
+        // shared suite allows either answer here, and this is the one that falls out of writing the
+        // entry back on commit. It costs nothing: a stream nobody writes to is not a stream a write
+        // cache exists for.
+        await ConfigureAsync();
+        var streamId = await AnOpenVaultAsync();
+
+        await using (var session = theStore.LightweightSession())
+        {
+            await session.Events.FetchForWriting<Vault>(streamId, TestContext.Current.CancellationToken);
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        _cache.Takes.ShouldHaveSingleItem();
+        _cache.Stores.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task the_entry_claims_the_version_the_instance_actually_reflects()
+    {
+        // The decision most likely to be got wrong, because jasperfx#674 says to take the version
+        // from the committed StreamAction -- which is right for a store whose inline projection
+        // mutates the instance FetchForWriting handed out. Polecat's does not: it writes its own
+        // document, and the instance stays at the version it was built from. Claiming the committed
+        // version here would make the next fetch skip every event this session appended, and it
+        // would do so silently -- an aggregate quietly missing writes, not an error.
+        await ConfigureAsync();
+        var streamId = await AnOpenVaultAsync(); // version 2
+
+        await using (var session = theStore.LightweightSession())
+        {
+            var stream = await session.Events.FetchForWriting<Vault>(streamId, TestContext.Current.CancellationToken);
+            stream.AppendOne(new CoinsAdded(10)); // commits at version 3
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        var stored = _cache.Stores.ShouldHaveSingleItem();
+        stored.Version.ShouldBe(2, "the cached instance is the aggregate as of the fetch, not the commit");
+        ((Vault)stored.Aggregate).Coins.ShouldBe(100);
+
+        // And the round trip proves the pairing is coherent: the next fetch folds event 3 onto it.
+        await using var next = theStore.LightweightSession();
+        var refetched = await next.Events.FetchForWriting<Vault>(streamId, TestContext.Current.CancellationToken);
+        refetched.Aggregate.ShouldNotBeNull();
+        refetched.Aggregate!.Coins.ShouldBe(110);
+    }
+
+    [Fact]
+    public async Task a_hit_reads_only_the_events_after_the_baseline()
+    {
+        // The saving, asserted directly rather than by timing. Polecat's FetchForWriting
+        // live-aggregates, so what a hit removes is the re-read of the stream from version 1. A
+        // doctored baseline is the cleanest proof: if the fetch had read events 1..2 it could not
+        // possibly answer 1000, and if it ignored the baseline it would answer 100.
+        await ConfigureAsync();
+        var streamId = await AnOpenVaultAsync(); // Coins = 100 at version 2
+
+        await WarmAsync(streamId, 10); // version 3, and the entry lands at version 2
+
+        var key = _cache.Stores[^1].Key;
+        _cache.Seed(key, new Vault { Id = streamId, Owner = "Hilda", Coins = 1000 }, 2);
+
+        await using var session = theStore.LightweightSession();
+        var stream = await session.Events.FetchForWriting<Vault>(streamId, TestContext.Current.CancellationToken);
+
+        stream.Aggregate.ShouldNotBeNull();
+        stream.Aggregate!.Coins.ShouldBe(1010, "events 1 and 2 were replaced by the baseline; event 3 was folded on");
+        stream.StartingVersion.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task publishing_hands_the_instance_off_rather_than_sharing_it()
+    {
+        // With UseIdentityMapForAggregates also on, a published aggregate would otherwise be
+        // reachable from two places at once: the cache, where another session can take it, and this
+        // session's aggregate identity map, where ProjectLatest folds pending events onto whatever
+        // it finds. One mutable object with two live owners is exactly what take-on-read prevents
+        // between sessions, so publishing drops this session's handle.
+        ConfigureStore(opts =>
+        {
+            opts.Projections.Add<VaultProjection>(ProjectionLifecycle.Inline);
+            opts.Projections.UseIdentityMapForAggregates = true;
+            opts.Events.AggregateWriteCaching.Cache = _cache;
+            opts.Events.CacheAggregatesForWriting<Vault>();
+        });
+        await theDatabase.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        var streamId = await AnOpenVaultAsync();
+
+        await using var session = theStore.LightweightSession();
+        var stream = await session.Events.FetchForWriting<Vault>(streamId, TestContext.Current.CancellationToken);
+        stream.AppendOne(new CoinsAdded(10));
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var published = (Vault)_cache.Stores.ShouldHaveSingleItem().Aggregate;
+
+        // Same session, after the hand-off: the identity map no longer answers with the published
+        // instance, so nothing this session does next can mutate what the cache is holding.
+        var latest = await session.Events.FetchLatest<Vault>(streamId, TestContext.Current.CancellationToken);
+        latest.ShouldNotBeNull();
+        latest.ShouldNotBeSameAs(published);
+        latest!.Coins.ShouldBe(110, "and the re-read reflects the commit, which the stale handle would not have");
+    }
+
+    [Fact]
+    public async Task the_key_carries_the_database_the_aggregate_was_read_from()
+    {
+        // In the key because database-per-tenant deployments genuinely have the same tenant id and
+        // stream id in more than one physical database.
+        await ConfigureAsync();
+        var streamId = await AnOpenVaultAsync();
+
+        await WarmAsync(streamId, 10);
+
+        var key = _cache.Stores.ShouldHaveSingleItem().Key;
+        key.DocumentType.ShouldBe(typeof(Vault));
+        key.Id.ShouldBe(streamId);
+        key.TenantId.ShouldBe(theStore.Options.Tenancy!.DefaultTenantId);
+        key.DatabaseIdentifier.ShouldBe(theStore.Database.Identifier);
+    }
+}

--- a/src/Polecat/Events/EventOperations.cs
+++ b/src/Polecat/Events/EventOperations.cs
@@ -6,6 +6,7 @@ using System.Text;
 using JasperFx.Core.Reflection;
 using JasperFx.Events;
 using JasperFx.Events.Aggregation;
+using JasperFx.Events.Fetching;
 using JasperFx.Events.Protected;
 using JasperFx.Events.Tags;
 using Microsoft.Data.SqlClient;
@@ -588,27 +589,7 @@ internal class EventOperations : QueryEventStore, IEventOperations
         T? aggregate = null;
         if (streamExists && version > 0)
         {
-            if (streamId is Guid guidId)
-            {
-                var events = await FetchStreamAsync(guidId, token: cancellation);
-                if (events.Count > 0)
-                {
-                    var aggregator = _sessionBase.Options.Projections.AggregatorFor<T>();
-                    aggregate = await aggregator.BuildAsync(events, _sessionBase, null, cancellation);
-                    if (aggregate != null) QueryEventStore.TrySetIdentity(aggregate, guidId);
-                }
-            }
-            else
-            {
-                var key = (string)streamId;
-                var events = await FetchStreamAsync(key, token: cancellation);
-                if (events.Count > 0)
-                {
-                    var aggregator = _sessionBase.Options.Projections.AggregatorFor<T>();
-                    aggregate = await aggregator.BuildAsync(events, _sessionBase, null, cancellation);
-                    if (aggregate != null) QueryEventStore.TrySetIdentity(aggregate, key);
-                }
-            }
+            aggregate = await buildForWritingAsync<T>(streamId, version, cancellation);
 
             // Cache in session-level aggregate identity map if optimization is enabled
             if (aggregate != null && _events.UseIdentityMapForAggregates)
@@ -667,6 +648,136 @@ internal class EventOperations : QueryEventStore, IEventOperations
             return new EventStream<T>(_sessionBase, _events, (string)streamId, aggregate, cancellation, action);
         }
     }
+
+    /// <summary>
+    ///     Rebuild the aggregate a <c>FetchForWriting</c> hands back, using the second-level
+    ///     aggregate write cache (#478 / jasperfx#674) as a <b>baseline</b> when one is available.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Polecat's <c>FetchForWriting</c> live-aggregates rather than loading a stored
+    ///         snapshot, so what a cache hit removes here is the re-read of every event in the
+    ///         stream from version 1 — it collapses to reading only the events committed after the
+    ///         cached baseline. That is a bigger saving than the snapshot load the contract
+    ///         describes, and it is the same saving in kind: reads per second, not bytes per read.
+    ///     </para>
+    ///     <para>
+    ///         <b>Grade 1 semantics and nothing more.</b> The stream version above was already read
+    ///         from the database on this very call and the concurrency assertion on append is
+    ///         untouched, so a stale entry costs a larger delta query and can never produce a wrong
+    ///         aggregate or suppress a concurrency failure.
+    ///     </para>
+    ///     <para>
+    ///         Every path that cannot trust the baseline discards it and refetches from version 1 —
+    ///         an entry ahead of the stream (a restore or a rollback), and a stream whose events
+    ///         have been archived out from under a baseline. Discarding is always sound because
+    ///         <see cref="IAggregateWriteCache.TryTake" /> has already removed the entry.
+    ///     </para>
+    /// </remarks>
+    private async Task<T?> buildForWritingAsync<T>(object streamId, long version, CancellationToken cancellation)
+        where T : class
+    {
+        // Nullo for any type nobody enrolled, so there is no `if (caching enabled)` branch here:
+        // every take simply misses. `cacheable` exists only to keep the key construction and the
+        // tenancy lookup off the overwhelmingly common uncached path, not to change behavior.
+        var cache = _events.AggregateWriteCaching.ResolveCache(typeof(T));
+        var cacheable = !ReferenceEquals(cache, NulloAggregateWriteCache.Instance);
+
+        T? baseline = null;
+        long baselineVersion = 0;
+        var key = default(AggregateCacheKey);
+
+        if (cacheable)
+        {
+            key = new AggregateCacheKey(typeof(T), databaseIdentifier(), _tenantId, streamId);
+
+            // Take-on-read: the entry is removed in the same atomic step, so exactly one caller can
+            // ever win it. That is a requirement rather than a detail -- an aggregate is commonly
+            // mutable and the fold below mutates the instance it is handed, so two callers holding
+            // one instance would corrupt each other. A loser just misses and takes the path below.
+            if (cache.TryTake(key, out var taken, out var takenVersion) && taken is T typed
+                && takenVersion <= version)
+            {
+                baseline = typed;
+                baselineVersion = takenVersion;
+            }
+        }
+
+        // fromVersion is inclusive, so a baseline at version N reads N+1 and after. With no baseline
+        // this is `fromVersion: 1`, which is the whole stream -- the uncached behavior, unchanged.
+        var events = await fetchForWritingEventsAsync(streamId, baselineVersion + 1, cancellation);
+
+        if (baseline != null && events.Count == 0 && baselineVersion < version)
+        {
+            // The stream says there are events past the baseline and the read returned none, which
+            // means they are archived. Fall back to the uncached read so this behaves exactly as it
+            // did before the cache existed (an archived stream aggregates to null).
+            baseline = null;
+            baselineVersion = 0;
+            events = await fetchForWritingEventsAsync(streamId, 1, cancellation);
+        }
+
+        T? aggregate;
+        if (events.Count > 0)
+        {
+            var aggregator = _sessionBase.Options.Projections.AggregatorFor<T>();
+            aggregate = await aggregator.BuildAsync(events, _sessionBase, baseline, cancellation);
+        }
+        else
+        {
+            // No delta to fold. With a baseline that is the aggregate; without one the stream has no
+            // readable events and the answer is null, as it was before.
+            aggregate = baseline;
+        }
+
+        if (aggregate != null)
+        {
+            if (streamId is Guid guidId)
+            {
+                QueryEventStore.TrySetIdentity(aggregate, guidId);
+            }
+            else
+            {
+                QueryEventStore.TrySetIdentity(aggregate, (string)streamId);
+            }
+        }
+
+        if (cacheable && aggregate != null)
+        {
+            // Deferred to the commit, and stored at the version the instance actually reflects --
+            // `version`, the stream version read at the top of this fetch, NOT the version the
+            // commit lands on. Polecat does not apply appended events to the instance it handed out
+            // (an inline projection writes its own document rather than mutating this one), so
+            // claiming the committed version would silently skip every event this session appended
+            // the next time the entry was used as a baseline.
+            //
+            // Deferring is what makes take-on-read work: storing at fetch time would republish the
+            // very instance this caller is still holding, and a concurrent fetch could then take it.
+            // The commit is the point at which this caller is done with it. It also means a rolled
+            // back commit leaves no entry at all rather than a poisoned one.
+            _sessionBase.RegisterAggregateWriteCacheEntry(cache, key, aggregate, version);
+        }
+
+        return aggregate;
+    }
+
+    private Task<IReadOnlyList<IEvent>> fetchForWritingEventsAsync(object streamId, long fromVersion,
+        CancellationToken cancellation)
+        => streamId is Guid guidId
+            ? FetchStreamAsync(guidId, fromVersion: fromVersion, token: cancellation)
+            : FetchStreamAsync((string)streamId, fromVersion: fromVersion, token: cancellation);
+
+    /// <summary>
+    ///     The physical database this session reads from, for the aggregate cache key.
+    /// </summary>
+    /// <remarks>
+    ///     In the key because database-per-tenant deployments genuinely have the same tenant id and
+    ///     the same stream id in more than one physical database, and a cache shared between them
+    ///     would otherwise hand one database's aggregate to the other. Resolved only for an enrolled
+    ///     type, so the tenancy lookup never runs on the uncached path.
+    /// </remarks>
+    private string databaseIdentifier()
+        => _sessionBase.Options.Tenancy?.GetDatabase(_tenantId).Identifier ?? "Polecat";
 
     /// <summary>
     ///     Unwrap a strong-typed identifier that wraps the stream identity, so the generic

--- a/src/Polecat/Internal/DocumentSessionBase.cs
+++ b/src/Polecat/Internal/DocumentSessionBase.cs
@@ -3,6 +3,7 @@ using System.Linq.Expressions;
 using JasperFx;
 using JasperFx.Events;
 using JasperFx.Events.Daemon;
+using JasperFx.Events.Fetching;
 using JasperFx.Events.Projections;
 using Microsoft.Data.SqlClient;
 using Polecat.Events;
@@ -50,6 +51,55 @@ internal abstract class DocumentSessionBase : QuerySession, IDocumentSession
     }
 
     public IWorkTracker PendingChanges => _workTracker;
+
+    // #478 / jasperfx#674: aggregate snapshots this session's FetchForWriting calls owe back to the
+    // second-level write cache, published once the commit succeeds. Null until an enrolled type is
+    // actually fetched, which is the overwhelmingly common case.
+    private List<PendingAggregateCacheWrite>? _aggregateCacheWrites;
+
+    private readonly record struct PendingAggregateCacheWrite(
+        IAggregateWriteCache Cache,
+        AggregateCacheKey Key,
+        object Aggregate,
+        long Version);
+
+    /// <summary>
+    ///     Enlist an aggregate snapshot to be published to the write cache when this session commits.
+    /// </summary>
+    /// <remarks>
+    ///     Deferred rather than written at fetch time on purpose; see the call site in
+    ///     <see cref="Polecat.Events.EventOperations" /> for why take-on-read requires it.
+    /// </remarks>
+    internal void RegisterAggregateWriteCacheEntry(IAggregateWriteCache cache, AggregateCacheKey key,
+        object aggregate, long version)
+    {
+        _aggregateCacheWrites ??= new List<PendingAggregateCacheWrite>();
+        _aggregateCacheWrites.Add(new PendingAggregateCacheWrite(cache, key, aggregate, version));
+    }
+
+    /// <summary>
+    ///     Publish the enlisted aggregate snapshots. Called only after a successful commit, so a
+    ///     rolled-back unit of work leaves no entry rather than a poisoned one.
+    /// </summary>
+    private void StoreAggregateWriteCacheEntries()
+    {
+        if (_aggregateCacheWrites is not { Count: > 0 }) return;
+
+        foreach (var pending in _aggregateCacheWrites)
+        {
+            pending.Cache.Store(pending.Key, pending.Aggregate, pending.Version);
+
+            // Publishing is a hand-off, so this session gives up its own handle on the instance.
+            // Without this, an aggregate could be reachable from BOTH the cache (where another
+            // session may take it) and this session's aggregate identity map (where ProjectLatest
+            // folds pending events onto whatever it finds) -- two live references to one mutable
+            // object, which is precisely what take-on-read exists to prevent. Only reachable with
+            // UseIdentityMapForAggregates also turned on, and a no-op otherwise.
+            EvictAggregateFromIdentityMap(pending.Key.DocumentType, pending.Key.Id);
+        }
+
+        _aggregateCacheWrites.Clear();
+    }
 
     Polecat.Events.IQueryEventStore IQuerySession.Events => EventOps;
     public new Polecat.Events.IEventOperations Events => EventOps;
@@ -640,6 +690,11 @@ internal abstract class DocumentSessionBase : QuerySession, IDocumentSession
 
             await tx.CommitAsync(token);
 
+            // #478: the aggregate write cache is published here and nowhere else. After the commit,
+            // so a failed one leaves nothing behind; before the tracker is reset, purely to keep it
+            // beside the other post-commit work.
+            StoreAggregateWriteCacheEntries();
+
             // Runtime append observation (polecat#213 / CritterWatch#500) — capture the committed
             // events before the work tracker is reset, then notify best-effort.
             NotifyAppendObserver();
@@ -674,6 +729,11 @@ internal abstract class DocumentSessionBase : QuerySession, IDocumentSession
         finally
         {
             _transactional.Transaction = null;
+
+            // Drop anything a failed commit left enlisted. Harmless either way -- an entry is stored
+            // at the version the instance reflects, so it would still be correct on a later commit --
+            // but a session should not carry a fetch's leftovers past the save that failed.
+            _aggregateCacheWrites?.Clear();
         }
     }
 

--- a/src/Polecat/Internal/QuerySession.cs
+++ b/src/Polecat/Internal/QuerySession.cs
@@ -58,6 +58,26 @@ internal partial class QuerySession : IQuerySession
         }
     }
 
+    /// <summary>
+    ///     Drop a session-level aggregate identity map entry by runtime type and id (#478).
+    /// </summary>
+    /// <remarks>
+    ///     Non-generic because the caller is the aggregate write cache write-back, which holds an
+    ///     <see cref="JasperFx.Events.Fetching.AggregateCacheKey" /> — a <see cref="Type" /> and a
+    ///     boxed id, not a type pair. <c>Dictionary&lt;TId, TDoc&gt;</c> implements the non-generic
+    ///     <see cref="System.Collections.IDictionary" />, whose <c>Remove</c> is a no-op for a key of
+    ///     the wrong type, which is the right answer for the strong-typed-id case the generic
+    ///     <see cref="StoreAggregateInIdentityMap{TDoc,TId}" /> already sidesteps.
+    /// </remarks>
+    internal void EvictAggregateFromIdentityMap(Type documentType, object id)
+    {
+        if (AggregateIdentityMap.TryGetValue(documentType, out var raw)
+            && raw is System.Collections.IDictionary dictionary)
+        {
+            dictionary.Remove(id);
+        }
+    }
+
     internal bool TryGetAggregateFromIdentityMap<TDoc, TId>(TId id, out TDoc? document)
         where TDoc : class where TId : notnull
     {

--- a/src/Polecat/StoreOptions.cs
+++ b/src/Polecat/StoreOptions.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using JasperFx;
 using JasperFx.Events;
 using JasperFx.Events.Daemon;
+using JasperFx.Events.Fetching;
 using JasperFx.Events.Tags;
 using Polly;
 using Polecat.Events;
@@ -541,6 +542,40 @@ public class EventStoreOptions : IEventStoreInstrumentation
     public void AddMaskingRuleForProtectedInformation<T>(Func<T, T> func) where T : notnull
     {
         EventGraph!.AddMaskingRuleForProtectedInformation(func);
+    }
+
+    /// <summary>
+    ///     #478 / jasperfx#674: the second-level cache of aggregate snapshots behind
+    ///     <c>FetchForWriting</c>. Off for every aggregate type by default.
+    /// </summary>
+    /// <remarks>
+    ///     Reach for <see cref="CacheAggregatesForWriting{T}" /> to enroll a type; this is here for
+    ///     the rest of the surface — <c>SizeLimit</c>, and <c>Cache</c> for supplying your own
+    ///     implementation instead of the bounded node-local default.
+    /// </remarks>
+    public AggregateWriteCacheOptions AggregateWriteCaching => EventGraph!.AggregateWriteCaching;
+
+    /// <summary>
+    ///     #478 / jasperfx#674: cache <typeparamref name="T" />'s snapshot across
+    ///     <c>FetchForWriting</c> calls, so a fetch folds only the events committed since the cached
+    ///     baseline instead of re-reading the stream from the beginning.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Per aggregate type rather than store-wide, because the win is proportional to how
+    ///         often one stream is fetched for writing — real on a hot aggregate under high message
+    ///         volume, and only overhead on an aggregate written once.
+    ///     </para>
+    ///     <para>
+    ///         The cached snapshot is a <b>baseline</b> and nothing more: the stream version and
+    ///         every event after the baseline are still read on every call, and optimistic
+    ///         concurrency is untouched. Turning this on is unobservable except in latency.
+    ///     </para>
+    /// </remarks>
+    public EventStoreOptions CacheAggregatesForWriting<T>(int sizeLimit = 1000) where T : class
+    {
+        EventGraph!.CacheAggregatesForWriting<T>(sizeLimit);
+        return this;
     }
 
     /// <summary>


### PR DESCRIPTION
Closes #478. Stacked on [#480](https://github.com/JasperFx/polecat/pull/480) (the 2.51.0 bump) and independent of the other two.

jasperfx#674 moved `IAggregateWriteCache` into `JasperFx.Events` so Marten, Polecat and Fisher share one second-level aggregate snapshot cache. `EventGraph` already inherits the registration surface through `EventRegistry`, so all of the work is in the fetch path.

## What a hit buys here

Polecat's `FetchForWriting` **live-aggregates** rather than loading a stored snapshot — so what a hit removes is not the snapshot load the contract describes, but the re-read of every event in the stream from version 1. It collapses to reading only the events committed after the cached baseline. A bigger saving, and the same saving in kind: reads per second, not bytes per read.

Grade 1 semantics only. The stream version is still read on every call, in the same statement it always was, and the concurrency assertion on append is untouched — so a stale entry costs a larger delta query and can never produce a wrong aggregate or suppress a concurrency failure. Two cases cannot trust a baseline and refetch from version 1 rather than guess: an entry **ahead** of the stream (a restore or a rollback), and a stream whose events were archived out from under it, which preserves today's answer of `null` for an archived stream.

## The two decisions the shared suite leaves to each store

Both fail *silently* if got wrong, so both are pinned by Polecat-local tests in `Events/aggregate_write_cache_tests.cs`.

**When the entry is published — after the commit, not at fetch.** Take-on-read is why: storing at fetch time would republish the very instance the caller is still holding, and a concurrent fetch could then take it, leaving two callers folding events onto one mutable object. The commit is the point at which the caller is done with it, and it also means a rolled-back commit leaves no entry rather than a poisoned one. A consequence worth stating: a fetch that appends nothing never warms the cache, because there is nothing to commit.

**What version it claims — the stream version read at the top of the fetch, not the version the commit landed on.** The issue says to take it from the committed `StreamAction`, which is right for a store whose inline projection mutates the instance `FetchForWriting` handed out. Polecat's does not — it writes its own document — so the instance stays at the version it was built from. Claiming the committed version would make the next fetch skip every event this session appended, silently.

## One hazard found and closed

Publishing is a hand-off, so the session also drops its own aggregate identity map entry for the key. Without that, an aggregate would be reachable from **both** the cache (where another session may take it) and the session's identity map (where `ProjectLatest` folds pending events onto whatever it finds) — two live references to one mutable object, which is exactly what take-on-read prevents between sessions. Only reachable with `UseIdentityMapForAggregates` also on, and a no-op otherwise.

## Cost on the uncached path

None beyond a dictionary lookup. `ResolveCache` returns the Nullo instance for a type nobody enrolled, so there is no `if (caching enabled)` branch in the fold — every take simply misses. Key construction and the tenancy lookup for the database identifier happen only for an enrolled type. The database identifier is in the key because database-per-tenant deployments genuinely have the same tenant id and stream id in more than one physical database.

## Surface

```csharp
opts.Events.CacheAggregatesForWriting<Order>();   // per type; off by default
opts.Events.AggregateWriteCaching.SizeLimit = 5000;
opts.Events.AggregateWriteCaching.Cache = myCache; // or supply your own
```

## Tests

- `AggregateWriteCacheCompliance` enrolled: **14 passed, 0 failed**. Including `the_cache_is_actually_consulted_when_a_type_opts_in`, which is the fact separating "implemented" from "silently ignored" — every correctness fact in that suite is vacuously true of a store that dropped the opt-in.
- `aggregate_write_cache_tests`: **7 passed, 0 failed** — the two store-specific decisions above, the no-cache-for-unenrolled-types path, the key contents, and a doctored-baseline test proving a hit really does skip the earlier events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)