### PR TITLE
5.18.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>5.17.0</Version>
+        <Version>5.18.0</Version>
         <LangVersion>latest</LangVersion>
         <Authors>Jeremy D. Miller</Authors>
         <PackageIcon>logo.png</PackageIcon>


### PR DESCRIPTION
Minor bump, 5.17.0 → 5.18.0. Clears the whole open tracker on JasperFx 2.51.0.

| Issue | Change |
|---|---|
| #479 | The document compliance fixture honors the stream identity a suite **declares** (jasperfx#672) instead of inferring it from a non-empty `config.EventTypes` |
| #477 | `IDocumentSessionOperations.PendingStreams` (jasperfx#673) — the stream actions a session has queued but not yet committed, readable through the shared document contract |
| #478 | `IAggregateWriteCache` wired into `FetchForWriting` (jasperfx#674) — an opt-in, per-aggregate-type second-level snapshot cache |

Minor rather than patch because #478 adds public surface (`Events.CacheAggregatesForWriting<T>()`, `Events.AggregateWriteCaching`) and #477 adds a contract member. Nothing is a breaking change: the cache is off for every aggregate type unless enrolled, and #477 replaces a member that previously threw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)