### PR TITLE
gh-485: implement IDocumentCommitListener (jasperfx#679)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -233,15 +233,37 @@
              stream version and every event after it are still read on every call, and the optimistic
              concurrency assertion is untouched, so a stale entry costs a larger delta query and
              never a wrong aggregate. The suites are PendingStreamActionsCompliance and
-             AggregateWriteCacheCompliance. -->
-        <PackageVersion Include="JasperFx" Version="2.51.0" />
-        <PackageVersion Include="JasperFx.Events" Version="2.51.0" />
+             AggregateWriteCacheCompliance.
+             JasperFx 2.52.0: jasperfx#679 — IDocumentCommitListener, the store-agnostic post-commit
+             session hook, plus the IDocumentChangeSet / IDocumentDeletion pair it hands over. All
+             three products already declare
+             Task AfterCommitAsync(IDocumentSession, IChangeSet, CancellationToken) and differ only
+             in the store-local types they name, so this closes a naming gap rather than a
+             capability gap; polecat#485.
+             ⚠️ NOT the same failure mode as 2.50.0 above. No member of this contract carries a
+             default implementation, so a near-miss is CS0535 at build time rather than a member
+             silently bound to a throwing default — IEnumerable&lt;object&gt; Inserted does not
+             satisfy IReadOnlyList&lt;object&gt; Inserted and the compiler says so. What the compiler
+             cannot see is the WIRING: a store that declares both interfaces perfectly and never
+             invokes a listener compiles clean and passes every other suite, which is why
+             DocumentCommitListenerCompliance is the only evidence this contract is satisfied.
+             IReadOnlyList rather than IEnumerable throughout is load-bearing — the collections are
+             SNAPSHOTS, so Polecat's ChangeSet materialises them once into fields instead of
+             re-running the lazy LINQ chains over the operation list on every access.
+             Deleted is IReadOnlyList&lt;IDocumentDeletion&gt; ({ DocumentType, Id }) and not a
+             collection of document instances, because only Marten's change set holds the deleted
+             instance; Polecat's own IDeletion is already exactly that pair.
+             The session half only — the async daemon's projection batches stay with
+             IDaemonChangeListener, which Polecat already serves through IChangeListener. The suite
+             is DocumentCommitListenerCompliance. -->
+        <PackageVersion Include="JasperFx" Version="2.52.0" />
+        <PackageVersion Include="JasperFx.Events" Version="2.52.0" />
         <!--
              The shared cross-store event sourcing compliance suites. Source-only package: the
              suites compile inside Polecat.Tests so JasperFx's aggregate source generator binds
              Polecat's own session types.
         -->
-        <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.51.0" />
+        <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.52.0" />
         <!-- Pin the sibling JasperFx packages for parity with Marten 9's matrix
              even though Polecat doesn't currently reference them directly —
              keeps the lockstep matrix coherent when transitive resolution
@@ -249,7 +271,7 @@
              RuntimeCompiler 5.x line is the active continuation of the 4.x
              lineage; do not pin against the parallel stale 2.0.x series. -->
         <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.51.0" />
+        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.52.0" />
         <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
@@ -362,7 +384,7 @@
         <PackageVersion Include="Vogen" Version="7.0.0" />
 
         <!-- Source generators (matched to JasperFx.Events above) -->
-        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.51.0" />
+        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.52.0" />
 
         <!-- Build automation -->
         <PackageVersion Include="Nuke.Common" Version="9.0.4" />

--- a/src/Polecat.Tests/Compliance/PolecatDocumentComplianceFixture.cs
+++ b/src/Polecat.Tests/Compliance/PolecatDocumentComplianceFixture.cs
@@ -88,6 +88,21 @@ public class PolecatDocumentComplianceFixture : DocumentStorageComplianceFixture
             options.Events.AddEventType(eventType);
         }
 
+        // #485 / jasperfx#679: the post-commit listeners the suite registered, replayed onto the
+        // store's own collection. The one config member that is not a Type, because a listener is
+        // registered as an INSTANCE and the suite has to hold the very instance it registered in
+        // order to read back what the store handed it.
+        //
+        // No adapter here, which is the point: Polecat's StoreOptions.CommitListeners takes
+        // IDocumentCommitListener directly rather than making every consumer wrap one in an
+        // IDocumentSessionListener. If this loop is dropped, DocumentCommitListenerCompliance does
+        // not skip -- every fact in it fails, because a listener that was never registered and a
+        // store that never invokes listeners are the same observable failure.
+        foreach (var listener in config.CommitListeners)
+        {
+            options.CommitListeners.Add(listener);
+        }
+
         _store = new DocumentStore(options);
 
         // Polecat applies schema changes explicitly rather than lazily, and the suite's very first

--- a/src/Polecat.Tests/Compliance/polecat_event_store_compliance_wave11.cs
+++ b/src/Polecat.Tests/Compliance/polecat_event_store_compliance_wave11.cs
@@ -1,0 +1,27 @@
+using JasperFx.Events.ComplianceTests;
+
+namespace Polecat.Tests.Compliance;
+
+/*
+ * Wave 11 -- the suite JasperFx 2.52.0 added.
+ *
+ * DocumentCommitListenerCompliance is jasperfx#679 / #485: IDocumentCommitListener, the
+ * store-agnostic post-commit session hook, and the IDocumentChangeSet / IDocumentDeletion pair it
+ * hands over. Not opt-in in the sense the wave 9 and 10 suites are -- it needs nothing but
+ * documents -- but it does need the fixture to replay DocumentComplianceConfig.CommitListeners onto
+ * StoreOptions.CommitListeners, which PolecatDocumentComplianceFixture now does.
+ *
+ * ⚠️ This suite is the ONLY evidence the contract is satisfied, and it is a different situation from
+ * every earlier wave. Nothing in IDocumentChangeSet carries a default implementation, so a Polecat
+ * type that declares it wrongly is a compile error rather than a member silently bound to a throwing
+ * default -- the jasperfx#669 trap cannot bite here. The wiring is what the compiler cannot see: a
+ * store that declares both interfaces perfectly and never invokes a listener from
+ * DocumentSessionBase.SaveChangesAsync builds clean and passes every other suite in the library.
+ *
+ * Two behaviours it deliberately does NOT assert, because the contract permits either answer: a
+ * SaveChangesAsync with nothing enlisted need not raise a callback, and a session enlisted in a
+ * caller's ambient transaction may or may not fire. Polecat's own session tests own those.
+ */
+
+public class polecat_document_commit_listener_compliance
+    : DocumentCommitListenerCompliance<PolecatDocumentComplianceFixture>;

--- a/src/Polecat/DocumentStore.cs
+++ b/src/Polecat/DocumentStore.cs
@@ -144,7 +144,8 @@ public partial class DocumentStore : IDocumentStore
             Events,
             InlineProjections,
             options.TenantId,
-            options.Listeners);
+            options.Listeners,
+            options.CommitListeners);
     }
 
     public IDocumentSession IdentitySession()
@@ -166,7 +167,8 @@ public partial class DocumentStore : IDocumentStore
             Events,
             InlineProjections,
             options.TenantId,
-            options.Listeners);
+            options.Listeners,
+            options.CommitListeners);
     }
 
     public IQuerySession QuerySession()
@@ -213,9 +215,11 @@ public partial class DocumentStore : IDocumentStore
         return options.Tracking switch
         {
             DocumentTracking.IdentityOnly => new IdentityMapDocumentSession(
-                Options, lifetime, _providers, ensurer, Events, InlineProjections, options.TenantId, options.Listeners),
+                Options, lifetime, _providers, ensurer, Events, InlineProjections, options.TenantId, options.Listeners,
+                options.CommitListeners),
             _ => new LightweightSession(
-                Options, lifetime, _providers, ensurer, Events, InlineProjections, options.TenantId, options.Listeners)
+                Options, lifetime, _providers, ensurer, Events, InlineProjections, options.TenantId, options.Listeners,
+                options.CommitListeners)
         };
     }
 

--- a/src/Polecat/Internal/DocumentSessionBase.cs
+++ b/src/Polecat/Internal/DocumentSessionBase.cs
@@ -30,6 +30,7 @@ internal abstract class DocumentSessionBase : QuerySession, IDocumentSession
     private readonly WorkTracker _workTracker = new();
     private readonly IInlineProjection<IDocumentSession>[] _inlineProjections;
     private readonly IReadOnlyList<IDocumentSessionListener> _sessionListeners;
+    private readonly IReadOnlyList<JasperFx.Events.Documents.IDocumentCommitListener> _sessionCommitListeners;
     private readonly IAlwaysConnectedLifetime _transactional;
     private readonly List<ITransactionParticipant> _transactionParticipants = new();
     private EventOperations? _eventOperations;
@@ -42,12 +43,15 @@ internal abstract class DocumentSessionBase : QuerySession, IDocumentSession
         EventGraph eventGraph,
         IInlineProjection<IDocumentSession>[] inlineProjections,
         string tenantId,
-        IReadOnlyList<IDocumentSessionListener>? sessionListeners = null)
+        IReadOnlyList<IDocumentSessionListener>? sessionListeners = null,
+        IReadOnlyList<JasperFx.Events.Documents.IDocumentCommitListener>? sessionCommitListeners = null)
         : base(options, lifetime, providers, tableEnsurer, eventGraph, tenantId)
     {
         _transactional = lifetime;
         _inlineProjections = inlineProjections;
         _sessionListeners = sessionListeners ?? Array.Empty<IDocumentSessionListener>();
+        _sessionCommitListeners = sessionCommitListeners
+                                  ?? Array.Empty<JasperFx.Events.Documents.IDocumentCommitListener>();
     }
 
     public IWorkTracker PendingChanges => _workTracker;
@@ -717,6 +721,31 @@ internal abstract class DocumentSessionBase : QuerySession, IDocumentSession
             }
 
             foreach (var listener in _sessionListeners)
+            {
+                await listener.AfterCommitAsync(this, commit, token);
+            }
+
+            // #485 / jasperfx#679: the store-agnostic post-commit listeners, after the store-native
+            // ones and on the SAME `commit` snapshot taken above -- so a consumer holding both kinds
+            // sees one consistent view of the unit of work, and the shared contract cannot observe a
+            // commit the native listeners did not.
+            //
+            // ⚠️ THIS LOOP is where the contract silently no-ops. Nothing about declaring
+            // IDocumentChangeSet on ChangeSet is visible to a consumer until a listener is actually
+            // invoked, and a store that declares every interface perfectly and never reaches here
+            // compiles clean and passes every other compliance suite. That is what
+            // DocumentCommitListenerCompliance exists to catch.
+            //
+            // Inside the `try`, after `await tx.CommitAsync`, and deliberately NOT in the `finally`
+            // below: the contract requires the callback if and only if the commit succeeded, and a
+            // rolled-back transaction that announced its writes is the one failure the suite pins
+            // explicitly.
+            foreach (var listener in Options.CommitListeners)
+            {
+                await listener.AfterCommitAsync(this, commit, token);
+            }
+
+            foreach (var listener in _sessionCommitListeners)
             {
                 await listener.AfterCommitAsync(this, commit, token);
             }

--- a/src/Polecat/Internal/IdentityMapDocumentSession.cs
+++ b/src/Polecat/Internal/IdentityMapDocumentSession.cs
@@ -20,8 +20,10 @@ internal class IdentityMapDocumentSession : DocumentSessionBase
         EventGraph eventGraph,
         IInlineProjection<IDocumentSession>[] inlineProjections,
         string tenantId,
-        IReadOnlyList<IDocumentSessionListener>? sessionListeners = null)
-        : base(options, lifetime, providers, tableEnsurer, eventGraph, inlineProjections, tenantId, sessionListeners)
+        IReadOnlyList<IDocumentSessionListener>? sessionListeners = null,
+        IReadOnlyList<JasperFx.Events.Documents.IDocumentCommitListener>? sessionCommitListeners = null)
+        : base(options, lifetime, providers, tableEnsurer, eventGraph, inlineProjections, tenantId, sessionListeners,
+            sessionCommitListeners)
     {
     }
 

--- a/src/Polecat/Internal/LightweightSession.cs
+++ b/src/Polecat/Internal/LightweightSession.cs
@@ -17,8 +17,10 @@ internal class LightweightSession : DocumentSessionBase
         EventGraph eventGraph,
         IInlineProjection<IDocumentSession>[] inlineProjections,
         string tenantId,
-        IReadOnlyList<IDocumentSessionListener>? sessionListeners = null)
-        : base(options, lifetime, providers, tableEnsurer, eventGraph, inlineProjections, tenantId, sessionListeners)
+        IReadOnlyList<IDocumentSessionListener>? sessionListeners = null,
+        IReadOnlyList<JasperFx.Events.Documents.IDocumentCommitListener>? sessionCommitListeners = null)
+        : base(options, lifetime, providers, tableEnsurer, eventGraph, inlineProjections, tenantId, sessionListeners,
+            sessionCommitListeners)
     {
     }
 }

--- a/src/Polecat/Internal/WorkTracker.cs
+++ b/src/Polecat/Internal/WorkTracker.cs
@@ -1,5 +1,6 @@
 using JasperFx.Events;
 using System.Collections.Immutable;
+using JasperFx.Events.Documents;
 using Polecat.Services;
 
 namespace Polecat.Internal;
@@ -56,6 +57,76 @@ internal class WorkTracker : IWorkTracker
     public IEnumerable<IEvent> GetEvents() => Streams.SelectMany(x => x.Events);
     public IEnumerable<StreamAction> GetStreams() => Streams;
     public IChangeSet Clone() => new ChangeSet(Operations, Streams);
+
+    // #485 / jasperfx#679: the shared contract's view of the SAME live unit of work. Explicit for
+    // the covariance reason spelled out on IChangeSet -- the three IEnumerable-typed members above
+    // do not satisfy the IReadOnlyList-typed contract members -- and materialised here rather than
+    // left on IChangeSet's default implementations, which would re-run the LINQ chains over the
+    // whole operation list on every access.
+    //
+    // The memo is keyed off the Operations SNAPSHOT INSTANCE rather than cached outright, because
+    // unlike ChangeSet this object is mutable and long-lived: it accumulates operations and is
+    // Reset() and reused after every commit. Operations already invalidates its snapshot on every
+    // mutation, so a snapshot the memo was not built from is exactly the signal to rebuild -- and
+    // no new invalidation has to be threaded through Add / AddStream / Reset / Eject*, which is the
+    // version of this that goes stale the next time someone adds a mutator.
+    //
+    // ⚠️ These are still a view of a LIVE tracker, so they answer the CURRENT unit of work, not a
+    // frozen one. What DocumentSessionBase hands a commit listener is Clone()'s immutable ChangeSet.
+    private IReadOnlyList<Weasel.Storage.IStorageOperation>? _documentViewSource;
+    private IReadOnlyList<object>? _updatedView;
+    private IReadOnlyList<object>? _insertedView;
+    private IReadOnlyList<IDeletion>? _deletedView;
+
+    IReadOnlyList<object> IDocumentChangeSet.Updated
+    {
+        get
+        {
+            lock (_stateLock)
+            {
+                refreshDocumentViews();
+                return _updatedView!;
+            }
+        }
+    }
+
+    IReadOnlyList<object> IDocumentChangeSet.Inserted
+    {
+        get
+        {
+            lock (_stateLock)
+            {
+                refreshDocumentViews();
+                return _insertedView!;
+            }
+        }
+    }
+
+    IReadOnlyList<IDocumentDeletion> IDocumentChangeSet.Deleted
+    {
+        get
+        {
+            lock (_stateLock)
+            {
+                refreshDocumentViews();
+                return _deletedView!;
+            }
+        }
+    }
+
+    private void refreshDocumentViews()
+    {
+        // Operations takes the same lock; it is re-entrant (System.Threading.Lock), and reading it
+        // inside this one is what makes "snapshot taken" and "views built from it" a single atomic
+        // step.
+        var operations = Operations;
+        if (ReferenceEquals(_documentViewSource, operations)) return;
+
+        _updatedView = ChangeSet.UpdatedFrom(operations).ToList();
+        _insertedView = ChangeSet.InsertedFrom(operations).ToList();
+        _deletedView = ChangeSet.DeletedFrom(operations).ToList();
+        _documentViewSource = operations;
+    }
 
     public void Add(Weasel.Storage.IStorageOperation operation)
     {

--- a/src/Polecat/Services/ChangeSet.cs
+++ b/src/Polecat/Services/ChangeSet.cs
@@ -1,4 +1,5 @@
 using JasperFx.Events;
+using JasperFx.Events.Documents;
 using Polecat.Internal;
 using Weasel.Core;
 using IStorageOperation = Polecat.Internal.IStorageOperation;
@@ -17,15 +18,72 @@ internal sealed class ChangeSet : IChangeSet
     private readonly IReadOnlyList<Weasel.Storage.IStorageOperation> _operations;
     private readonly IReadOnlyList<StreamAction> _streams;
 
+    // #485 / jasperfx#679: materialised ONCE, in the constructor, rather than left as the lazy LINQ
+    // chains these used to be. Two reasons, and the first is correctness rather than speed:
+    //
+    //   (a) IDocumentChangeSet promises SNAPSHOTS -- IReadOnlyList and not IEnumerable -- because a
+    //       listener may retain the change set past the commit boundary. A lazy chain is only as
+    //       stable as the list it reads, and PolecatProjectionBatch constructs a change set over a
+    //       plain List<T> it has been accumulating, not over an immutable snapshot.
+    //   (b) A listener that read Inserted/Updated/Deleted re-ran the whole chain, once per property
+    //       per access, on a path that has just done its SQL round trips. Marten's IChangeSet has
+    //       the same shape and the same cost.
+    //
+    // Partitioned in a SINGLE pass rather than by three Where() chains, so this is cheaper than the
+    // lazy version for any listener that reads more than one property and costs one traversal for a
+    // store with no listeners at all. The public IEnumerable-typed members below hand back these
+    // same lists, so nothing walks the operations twice.
+    private readonly IReadOnlyList<object> _updated;
+    private readonly IReadOnlyList<object> _inserted;
+    private readonly IReadOnlyList<IDeletion> _deleted;
+
     public ChangeSet(IReadOnlyList<Weasel.Storage.IStorageOperation> operations, IReadOnlyList<StreamAction> streams)
     {
         _operations = operations;
         _streams = streams;
+
+        List<object>? updated = null;
+        List<object>? inserted = null;
+        List<IDeletion>? deleted = null;
+
+        // foreach rather than an indexed loop: WorkTracker.Operations hands over an ImmutableList,
+        // whose indexer is O(log n).
+        foreach (var operation in operations)
+        {
+            switch (operation.Role())
+            {
+                case OperationRole.Update or OperationRole.Upsert:
+                    if (DocumentOf(operation) is { } document) (updated ??= []).Add(document);
+                    break;
+
+                case OperationRole.Insert:
+                    if (DocumentOf(operation) is { } inserting) (inserted ??= []).Add(inserting);
+                    break;
+
+                case OperationRole.Deletion:
+                    (deleted ??= []).Add(new Deletion(operation.DocumentType, IdentityOf(operation)));
+                    break;
+            }
+        }
+
+        // Empty rather than null throughout, per IDocumentChangeSet, and a shared empty array rather
+        // than a List so the overwhelmingly common "this commit deleted nothing" costs no allocation.
+        _updated = updated ?? (IReadOnlyList<object>)Array.Empty<object>();
+        _inserted = inserted ?? (IReadOnlyList<object>)Array.Empty<object>();
+        _deleted = deleted ?? (IReadOnlyList<IDeletion>)Array.Empty<IDeletion>();
     }
 
-    public IEnumerable<object> Updated => UpdatedFrom(_operations);
-    public IEnumerable<object> Inserted => InsertedFrom(_operations);
-    public IEnumerable<IDeletion> Deleted => DeletedFrom(_operations);
+    public IEnumerable<object> Updated => _updated;
+    public IEnumerable<object> Inserted => _inserted;
+    public IEnumerable<IDeletion> Deleted => _deleted;
+
+    // The shared contract's view (#485). Explicit because IEnumerable<T> does not satisfy an
+    // IReadOnlyList<T> member -- see the commentary on IChangeSet, which carries the default
+    // implementations these override. IReadOnlyList<T> is covariant, so the IDeletion list is
+    // already an IReadOnlyList<IDocumentDeletion>.
+    IReadOnlyList<object> IDocumentChangeSet.Updated => _updated;
+    IReadOnlyList<object> IDocumentChangeSet.Inserted => _inserted;
+    IReadOnlyList<IDocumentDeletion> IDocumentChangeSet.Deleted => _deleted;
 
     public IEnumerable<IEvent> GetEvents() => _streams.SelectMany(x => x.Events);
     public IEnumerable<StreamAction> GetStreams() => _streams;

--- a/src/Polecat/Services/IChangeSet.cs
+++ b/src/Polecat/Services/IChangeSet.cs
@@ -1,4 +1,5 @@
 using JasperFx.Events;
+using JasperFx.Events.Documents;
 
 namespace Polecat.Services;
 
@@ -9,7 +10,7 @@ namespace Polecat.Services;
 ///     post-commit side effects (cache invalidation, messaging, etc.) can see exactly what changed.
 ///     Mirrors Marten's <c>Marten.Services.IChangeSet</c>.
 /// </summary>
-public interface IChangeSet
+public interface IChangeSet : IDocumentChangeSet
 {
     /// <summary>
     ///     Documents that were updated (Update or Upsert operations) in this unit of work.
@@ -25,6 +26,53 @@ public interface IChangeSet
     ///     Documents that were deleted in this unit of work.
     /// </summary>
     IEnumerable<IDeletion> Deleted { get; }
+
+    /// <summary>
+    ///     #485 / jasperfx#679: the shared contract's view of this change set, so a consumer that
+    ///     registered an <see cref="IDocumentCommitListener" /> can read what a commit wrote without
+    ///     naming a Polecat type.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Explicit, and an adapter rather than a rename, for the reason
+    ///         <see cref="IQuerySession" />'s <c>Events</c> member spells out: C# interface
+    ///         implementation is not covariant in a member's type, so the three properties above do
+    ///         not satisfy the contract's. <c>IEnumerable&lt;object&gt; Inserted</c> is not
+    ///         <c>IReadOnlyList&lt;object&gt; Inserted</c>, and <c>IEnumerable&lt;IDeletion&gt;
+    ///         Deleted</c> is not <c>IReadOnlyList&lt;IDocumentDeletion&gt; Deleted</c> even though
+    ///         <see cref="IDeletion" /> and <see cref="IDocumentDeletion" /> declare the same pair.
+    ///     </para>
+    ///     <para>
+    ///         ⚠️ It differs from the jasperfx#669 <c>Events</c> case in exactly one way, and it is
+    ///         the way that matters: <see cref="IDocumentChangeSet" /> carries NO default
+    ///         implementations, so omitting these three is CS0535 at build time rather than a member
+    ///         silently bound to a throwing default. The silent failure for #485 lives in the
+    ///         <em>wiring</em> instead — see <c>DocumentSessionBase.SaveChangesAsync</c>.
+    ///     </para>
+    ///     <para>
+    ///         Declared here as default interface members rather than on the implementing classes so
+    ///         that adding a base interface to a PUBLIC interface is not a breaking change for an
+    ///         outside implementor. Polecat's own two implementations
+    ///         (<c>Polecat.Services.ChangeSet</c> and <c>Polecat.Internal.WorkTracker</c>) override
+    ///         them with memoized fields, because these defaults re-materialise the lazy LINQ chains
+    ///         on every access and <c>SaveChangesAsync</c> is a hot path.
+    ///     </para>
+    ///     <para>
+    ///         The contract requires SNAPSHOTS — <see cref="IReadOnlyList{T}" /> and not
+    ///         <see cref="IEnumerable{T}" /> — because a listener may retain the change set past the
+    ///         commit boundary. <c>.ToList()</c> here is what makes that true of a live change set
+    ///         such as an <see cref="IWorkTracker" />, which is otherwise a view over a unit of work
+    ///         that is <c>Reset()</c> immediately after the listener loop runs.
+    ///     </para>
+    /// </remarks>
+    IReadOnlyList<object> IDocumentChangeSet.Inserted => Inserted as IReadOnlyList<object> ?? Inserted.ToList();
+
+    /// <inheritdoc cref="IDocumentChangeSet.Inserted" />
+    IReadOnlyList<object> IDocumentChangeSet.Updated => Updated as IReadOnlyList<object> ?? Updated.ToList();
+
+    /// <inheritdoc cref="IDocumentChangeSet.Inserted" />
+    IReadOnlyList<IDocumentDeletion> IDocumentChangeSet.Deleted =>
+        Deleted as IReadOnlyList<IDocumentDeletion> ?? Deleted.Cast<IDocumentDeletion>().ToList();
 
     /// <summary>
     ///     All events appended across every stream in this unit of work.
@@ -46,7 +94,14 @@ public interface IChangeSet
 /// <summary>
 ///     Describes a single document deletion within an <see cref="IChangeSet" />.
 /// </summary>
-public interface IDeletion
+/// <remarks>
+///     #485 / jasperfx#679: derives from the shared <see cref="IDocumentDeletion" />, which declares
+///     the identical pair. The inheritance is what lets a Polecat <see cref="IDeletion" /> instance
+///     be handed straight to an <see cref="IDocumentCommitListener" /> — but note it does NOT make
+///     <c>IEnumerable&lt;IDeletion&gt;</c> satisfy the contract's
+///     <c>IReadOnlyList&lt;IDocumentDeletion&gt;</c>; see the adapter above.
+/// </remarks>
+public interface IDeletion : IDocumentDeletion
 {
     /// <summary>
     ///     The .NET type of the deleted document.

--- a/src/Polecat/SessionOptions.cs
+++ b/src/Polecat/SessionOptions.cs
@@ -32,4 +32,13 @@ public class SessionOptions
     ///     Session-specific listeners applied only to this session.
     /// </summary>
     public List<IDocumentSessionListener> Listeners { get; } = new();
+
+    /// <summary>
+    ///     Session-specific store-agnostic post-commit listeners — #485 / jasperfx#679's
+    ///     <see cref="JasperFx.Events.Documents.IDocumentCommitListener" />. The per-session
+    ///     counterpart to <see cref="StoreOptions.CommitListeners" />, exactly as
+    ///     <see cref="Listeners" /> is to <see cref="StoreOptions.Listeners" />; both collections
+    ///     run on a commit, store-level first.
+    /// </summary>
+    public List<JasperFx.Events.Documents.IDocumentCommitListener> CommitListeners { get; } = new();
 }

--- a/src/Polecat/StoreOptions.cs
+++ b/src/Polecat/StoreOptions.cs
@@ -170,6 +170,34 @@ public class StoreOptions
     public List<IDocumentSessionListener> Listeners { get; } = new();
 
     /// <summary>
+    ///     Global store-agnostic post-commit listeners applied to all sessions — #485 /
+    ///     jasperfx#679's <see cref="JasperFx.Events.Documents.IDocumentCommitListener" />.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         A separate collection from <see cref="Listeners" /> rather than a widening of it,
+    ///         because neither type can implement the other. Polecat's
+    ///         <see cref="IDocumentSessionListener" /> also declares <c>BeforeSaveChangesAsync</c>,
+    ///         which the shared contract deliberately does not abstract, and every parameter of the
+    ///         two <c>AfterCommitAsync</c> signatures differs
+    ///         (<see cref="IDocumentSession" /> vs <c>IDocumentSessionOperations</c>,
+    ///         <see cref="IChangeSet" /> vs <c>IDocumentChangeSet</c>). Inheritance cannot bridge
+    ///         that, so the alternative to a second list is asking every consumer to write the same
+    ///         adapter.
+    ///     </para>
+    ///     <para>
+    ///         Registered here on <see cref="StoreOptions" /> rather than swept out of the DI
+    ///         container. A DI sweep would only serve stores built by <c>AddPolecat</c>, and
+    ///         <c>new DocumentStore(options)</c> is a first-class construction path — the document
+    ///         compliance fixture itself uses it — so a container-only registration would leave the
+    ///         contract unreachable for exactly the callers most likely to be embedding Polecat.
+    ///         It would also be a new pattern for Polecat, which does not register
+    ///         <c>IDocumentSessionFactory</c> in DI at all.
+    ///     </para>
+    /// </remarks>
+    public List<JasperFx.Events.Documents.IDocumentCommitListener> CommitListeners { get; } = new();
+
+    /// <summary>
     ///     The store-level logger for SQL command logging and session tracking.
     ///     Defaults to NullPolecatLogger (no-op).
     /// </summary>


### PR DESCRIPTION
Closes #485. Implements `JasperFx.Events.Documents.IDocumentCommitListener` (jasperfx#679 / PR
JasperFx/jasperfx#680), shipped in JasperFx 2.52.0.

## The pins

`JasperFx`, `JasperFx.Events`, `JasperFx.Events.ComplianceTests`, `JasperFx.Events.SourceGenerator`
and the sibling `JasperFx.SourceGenerator` all go 2.51.0 → 2.52.0, with the inline changelog in
`Directory.Packages.props` extended rather than replaced.

## What was implemented

**`IChangeSet : IDocumentChangeSet`, and `IDeletion : IDocumentDeletion`.** An adapter, not a rename.
C# interface implementation is not covariant in a member's type, so `IEnumerable<object> Inserted`
does not satisfy `IReadOnlyList<object> Inserted`, and `IEnumerable<IDeletion> Deleted` does not
satisfy `IReadOnlyList<IDocumentDeletion> Deleted` even though the two deletion interfaces declare
the identical `{ DocumentType, Id }` pair.

The three explicit implementations are **default interface members on `IChangeSet` itself**, matching
the `IQuerySession.Events` / `IDocumentSession.PendingStreams` precedents — and here that placement
also means adding a base interface to a *public* interface is not a breaking change for an outside
implementor. Polecat's own two implementations override them with materialised fields.

**`ChangeSet` materialises once, in the constructor.** `Inserted`/`Updated`/`Deleted` were lazily
evaluated LINQ chains re-run on every access. Two reasons to change that, and the first is
correctness:

- `IDocumentChangeSet` promises **snapshots** — `IReadOnlyList`, not `IEnumerable` — because a
  listener may retain the change set past the commit boundary. A lazy chain is only as stable as the
  list it reads, and `PolecatProjectionBatch` builds a change set over a plain `List<T>` it has been
  accumulating rather than over an immutable snapshot.
- A listener reading all three properties re-ran the whole chain three times, on a path that has just
  done its SQL round trips.

Partitioned in a **single pass** with a `switch` on `Role()` instead of three `Where()` chains, so it
is cheaper than the lazy version for any listener reading more than one property, and costs one
traversal (and zero allocations for each empty category) for a store with no listeners at all.

**`WorkTracker`** is also an `IChangeSet` and is what a pre-commit caller holds, so it gets the same
treatment — but memoised rather than eager, because unlike `ChangeSet` it is mutable, long-lived, and
`Reset()` and reused after every commit. The memo is keyed off the **`Operations` snapshot instance**:
that snapshot is already invalidated on every mutation, so "a snapshot the memo was not built from"
is exactly the rebuild signal, and no new invalidation has to be threaded through
`Add` / `AddStream` / `Reset` / `Eject*` — which is the version of this that goes stale the next time
someone adds a mutator.

**Invocation** is in the existing loop in `DocumentSessionBase.SaveChangesAsync`, after the
store-native listeners and on the **same `commit` snapshot**, so a consumer holding both kinds of
listener sees one consistent view. Inside the `try` after `await tx.CommitAsync` and deliberately not
in the `finally` — the contract requires the callback if and only if the commit succeeded.

`IDocumentSessionListener` is untouched: it carries `BeforeSaveChangesAsync`, which this contract
deliberately does not abstract.

## Registration: `StoreOptions.CommitListeners` + `SessionOptions.CommitListeners`, not a DI sweep

A new `List<IDocumentCommitListener>` on each, beside the existing `Listeners` collections, threaded
into the session constructors alongside the native session listeners.

A separate collection rather than widening `Listeners`, because neither type can implement the other:
Polecat's `IDocumentSessionListener` also declares `BeforeSaveChangesAsync`, and every parameter of
the two `AfterCommitAsync` signatures differs. The alternative to a second list is asking every
consumer to write the same adapter.

Not a DI sweep, for two reasons. A sweep would only serve stores built by `AddPolecat`, and
`new DocumentStore(options)` is a first-class construction path — the document compliance fixture
itself uses it — so a container-only registration would leave the contract unreachable for exactly
the callers most likely to be embedding Polecat. It would also be a genuinely new pattern here:
`AddPolecat` does not register `IDocumentSessionFactory` in DI at all.

## Compliance

`DocumentCommitListenerCompliance` enrolled as wave 11; the fixture replays
`config.CommitListeners` onto `StoreOptions.CommitListeners` with no adapter, which is the point of
taking `IDocumentCommitListener` directly.

**10 of 10 facts pass**, in 4.5s.

⚠️ **Verified non-vacuous by negative control.** With only the invocation loop disabled and
everything else in place, the build still reported **0 errors** and **8 of the 10 facts failed**. That
is the failure mode the contract warns about: unlike jasperfx#669 there is no throwing default for a
near-miss to bind to (a mis-declared member is CS0535 at build time), but the *wiring* is invisible to
the compiler at every point, and a store that declares both interfaces perfectly and never invokes a
listener passes every other suite in the library. The two facts that still passed under the negative
control are the two negative ones — work that was never committed, and the cancelled-commit branch —
which is exactly right.

## The inbound direction

Worth stating explicitly, because it is the half that is easy to get wrong: making the store's own
listener interface satisfy the contract would only cover the **outbound** direction. The direction
the contract exists for is **inbound** — a listener that implements *only* `IDocumentCommitListener`,
knowing nothing about Polecat, has to be registrable.

`StoreOptions.CommitListeners` is typed `List<IDocumentCommitListener>`, i.e. to the contract rather
than to Polecat's own interface, so that listener registers with **no adapter at all**. The
compliance fixture is the proof: `RecordingCommitListener` implements only `IDocumentCommitListener`,
and the fixture's replay is a bare `options.CommitListeners.Add(listener)`.

Correspondingly, `IDocumentSessionListener` is left completely untouched and is *not* made to satisfy
the contract — it carries `BeforeSaveChangesAsync`, which the contract deliberately does not
abstract, and every parameter of the two `AfterCommitAsync` signatures differs anyway.

## Exactly what was run

On this machine, against the local SQL Server (`localhost,11433`), all after the final build:

- `DocumentCommitListenerCompliance` — **10 passed, 0 failed** (4.8s).
- The negative control described above — **8 of 10 failed** with the invocation loop disabled and a
  clean build.
- The whole `Polecat.Tests.Compliance` namespace, i.e. every wave 4→11 — **319 passed, 0 failed,
  0 skipped** (2m 19s).
- `session_listener_tests` + `change_listener_daemon_tests` + `operation_result_set_alignment_tests`,
  the three classes that actually exercise `IChangeSet` — **18 passed, 0 failed** (22s), including
  `after_commit_change_set_reports_inserts_updates_and_deletes`.
- Solution build clean: `Polecat` and `Polecat.Tests`, 0 errors.

**Not** run to completion: the entire `Polecat.Tests` assembly. No failures were observed and none
were baselined away — I simply do not have a full-assembly number to report.
