### PR TITLE
gh-487: declare IQuerySession.Events as `new`

### DIFF
--- a/src/Polecat/IQuerySession.cs
+++ b/src/Polecat/IQuerySession.cs
@@ -101,7 +101,15 @@ public interface IQuerySession : IAsyncDisposable, IDocumentReadOperations
     /// <summary>
     ///     Read-only access to event store queries.
     /// </summary>
-    IQueryEventStore Events { get; }
+    /// <remarks>
+    ///     #487: <c>new</c> because jasperfx#669 added <see cref="IDocumentReadOperations.Events" /> to
+    ///     the shared contract, and this property deliberately hides it to narrow the return type to
+    ///     Polecat's own <see cref="Polecat.Events.IQueryEventStore" />. The explicit forwarder just
+    ///     below implements the contract member and returns this same instance, so which member a
+    ///     caller reaches through is invisible. <see cref="IDocumentSession.Events" /> declares
+    ///     <c>new</c> one tier up for exactly the same reason.
+    /// </remarks>
+    new IQueryEventStore Events { get; }
 
     /// <summary>
     ///     #475 / jasperfx#669: the shared contract's read-tier <c>Events</c> accessor, so a consumer


### PR DESCRIPTION
Closes #487.

`IQuerySession.Events` hides the `IDocumentReadOperations.Events` member JasperFx 2.50.0 (jasperfx#669) added, emitting CS0108 on both target frameworks in every consumer build — including the 5.18.0 and 5.19.0 publish logs.

The hiding is deliberate. The property narrows the shared `JasperFx.Events.IQueryEventStore` to Polecat's own, which is the point of the property, and the explicit `IDocumentReadOperations.Events` forwarder directly below already satisfies the contract member and returns the same instance — so which member a caller reaches through is invisible either way. `IDocumentSession.Events` declares `new` one tier up for exactly the same reason.

One word plus a remark recording why, so it isn't re-litigated later.

## Verification

Built `src/Polecat/Polecat.csproj` before and after:

- **before** — `IQuerySession.cs(104,22): warning CS0108: 'IQuerySession.Events' hides inherited member 'IDocumentReadOperations.Events'`
- **after** — gone

Behavior-neutral, so no test changes.

## Noted, not fixed here

The same build shows five more CS0108 of identical shape in `src/Polecat/Services/IChangeSet.cs` — `IChangeSet.Updated/Inserted/Deleted` hiding `IDocumentChangeSet`, and `IDeletion.DocumentType/Id` hiding `IDocumentDeletion`. They pre-date this change, arriving with ac7b932 (gh-485 / jasperfx#679) and shipping in 5.19.0 — precisely the "next batch" #487 predicts. Left out to keep this PR scoped; worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)