### PR TITLE
gh-492: stop IChangeSet and IDeletion hiding their shared-contract members

### DIFF
--- a/src/Polecat/Services/IChangeSet.cs
+++ b/src/Polecat/Services/IChangeSet.cs
@@ -15,17 +15,29 @@ public interface IChangeSet : IDocumentChangeSet
     /// <summary>
     ///     Documents that were updated (Update or Upsert operations) in this unit of work.
     /// </summary>
-    IEnumerable<object> Updated { get; }
+    /// <remarks>
+    ///     #492: <c>new</c> because this narrows <see cref="IDocumentChangeSet.Updated" /> from
+    ///     <see cref="IReadOnlyList{T}" /> to <see cref="IEnumerable{T}" />. The explicit adapter
+    ///     below implements the contract member by materialising a snapshot.
+    /// </remarks>
+    new IEnumerable<object> Updated { get; }
 
     /// <summary>
     ///     Documents that were inserted in this unit of work.
     /// </summary>
-    IEnumerable<object> Inserted { get; }
+    /// <inheritdoc cref="Updated" path="/remarks" />
+    new IEnumerable<object> Inserted { get; }
 
     /// <summary>
     ///     Documents that were deleted in this unit of work.
     /// </summary>
-    IEnumerable<IDeletion> Deleted { get; }
+    /// <remarks>
+    ///     #492: <c>new</c> for the same reason as <see cref="Updated" />, and doubly so — this
+    ///     narrows both the collection (<see cref="IReadOnlyList{T}" /> to
+    ///     <see cref="IEnumerable{T}" />) and the element (<see cref="IDocumentDeletion" /> to
+    ///     <see cref="IDeletion" />).
+    /// </remarks>
+    new IEnumerable<IDeletion> Deleted { get; }
 
     /// <summary>
     ///     #485 / jasperfx#679: the shared contract's view of this change set, so a consumer that
@@ -95,22 +107,23 @@ public interface IChangeSet : IDocumentChangeSet
 ///     Describes a single document deletion within an <see cref="IChangeSet" />.
 /// </summary>
 /// <remarks>
-///     #485 / jasperfx#679: derives from the shared <see cref="IDocumentDeletion" />, which declares
-///     the identical pair. The inheritance is what lets a Polecat <see cref="IDeletion" /> instance
-///     be handed straight to an <see cref="IDocumentCommitListener" /> — but note it does NOT make
-///     <c>IEnumerable&lt;IDeletion&gt;</c> satisfy the contract's
-///     <c>IReadOnlyList&lt;IDocumentDeletion&gt;</c>; see the adapter above.
+///     <para>
+///         #485 / jasperfx#679: derives from the shared <see cref="IDocumentDeletion" />, which
+///         declares the <c>{ DocumentType, Id }</c> pair. The inheritance is what lets a Polecat
+///         <see cref="IDeletion" /> instance be handed straight to an
+///         <see cref="IDocumentCommitListener" /> — but note it does NOT make
+///         <c>IEnumerable&lt;IDeletion&gt;</c> satisfy the contract's
+///         <c>IReadOnlyList&lt;IDocumentDeletion&gt;</c>; see the adapter on
+///         <see cref="IChangeSet" /> above.
+///     </para>
+///     <para>
+///         #492: deliberately declares NO members of its own. It used to re-declare
+///         <c>DocumentType</c> and <c>Id</c>, which were identical to the base's rather than
+///         narrowed — so they hid the inherited members for no benefit and cost two CS0108 in every
+///         consumer build. Unlike <see cref="IChangeSet" />'s three properties, there was nothing
+///         here for a <c>new</c> to document. What remains is Polecat's own NAME for the shared
+///         descriptor, which is worth keeping: it is the element type of
+///         <see cref="IChangeSet.Deleted" /> and part of the public surface.
+///     </para>
 /// </remarks>
-public interface IDeletion : IDocumentDeletion
-{
-    /// <summary>
-    ///     The .NET type of the deleted document.
-    /// </summary>
-    Type DocumentType { get; }
-
-    /// <summary>
-    ///     The identity of the deleted document, when the deletion targeted a single document by id.
-    ///     Null for predicate-based (delete-where) operations.
-    /// </summary>
-    object? Id { get; }
-}
+public interface IDeletion : IDocumentDeletion;


### PR DESCRIPTION
Closes #492.

Clears the last five CS0108 in the build. They arrived with `ac7b932` (gh-485 / jasperfx#679), which added `IDocumentChangeSet` / `IDocumentDeletion` as base interfaces, and shipped in 5.19.0. With #487 already merged, this takes the count to zero.

## The five are not one fix

**Three genuinely narrow the contract → `new`.** `IChangeSet.Updated/Inserted/Deleted` declare `IEnumerable<T>` where the contract declares `IReadOnlyList<T>`, and `Deleted` further narrows the element from `IDocumentDeletion` to `IDeletion`. The narrowing is deliberate, and the explicit adapters immediately below already satisfy the contract by materializing snapshots. Same shape as #487, same one-word fix.

**Two were not narrowed at all → removed.** `IDeletion` re-declared `DocumentType` and `Id`, but they are *identical* to the base's, not narrowed:

| | `IDocumentDeletion` | `IDeletion` (before) |
|---|---|---|
| `DocumentType` | `Type` | `Type` |
| `Id` | `object?` | `object?` |

So they hid the inherited members for no benefit, and `new` would have documented an intent that was not there. `IDeletion` keeps its identity — it is Polecat's name for the shared descriptor and the element type of `IChangeSet.Deleted` — it simply declares nothing of its own now.

## Why removing is safe here

The issue flagged this as the thing to check rather than assume: removing members from a public interface breaks anyone implementing them *explicitly*. Both implementors implement the pair implicitly, so they now satisfy `IDocumentDeletion` directly:

- `ClosedShapeDeletion<TDoc,TId>` — `public Type DocumentType => _documentType;`
- `Deletion` — `internal sealed record Deletion(Type DocumentType, object? Id) : IDeletion;`

Neither uses `Type IDeletion.DocumentType => ...`. An outside explicit implementor would still be affected, which is the tradeoff being taken deliberately in exchange for not carrying a permanent warning; `new` remains the conservative fallback if that is judged too aggressive.

## Verification

Full solution build (`dotnet build` on `polecat.slnx`): **succeeded, zero CS0108, zero errors**. Behavior-neutral — no member changes type, and no call site changes — so no test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)