### PR TITLE
gh-489: declare EF Core projection storage not thread-safe

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -255,15 +255,32 @@
              instance; Polecat's own IDeletion is already exactly that pair.
              The session half only — the async daemon's projection batches stay with
              IDaemonChangeListener, which Polecat already serves through IChangeListener. The suite
-             is DocumentCommitListenerCompliance. -->
-        <PackageVersion Include="JasperFx" Version="2.52.0" />
-        <PackageVersion Include="JasperFx.Events" Version="2.52.0" />
+             is DocumentCommitListenerCompliance.
+             JasperFx 2.53.0: jasperfx#683 — IProjectionStorage.IsThreadSafe, the seam that lets a
+             projection storage refuse the daemon's concurrent slice application. AggregationRunner
+             applies every slice in a range through a fixed 10-wide Block over ONE storage instance
+             per tenant group; Polecat.EntityFrameworkCore's EfCoreProjectionStorage wraps a single
+             DbContext, which is not thread-safe, so a multi-stream projection that fans one event
+             into many slices had up to ten threads mutating one change tracker. First reported
+             against Marten (marten#5266) as an InvalidOperationException out of Dictionary.TryInsert
+             and an NRE out of ChangeDetector.DetectChanges; polecat#489.
+             ⚠️ A lock INSIDE the storage is not a substitute and this is the trap worth naming: it
+             serializes each individual call, but between calls the aggregation on one thread still
+             mutates entities that another thread's Entry() is running change detection over — the
+             NRE above. The fan-out itself has to stop, and nothing reachable from inside the
+             storage can stop it, which is why the seam has to be upstream.
+             Additive: the member is a default interface implementation returning true, so every
+             existing storage keeps today's behavior until it opts out. Polecat's SQL Server storage
+             stays on the default (it holds no shared mutable state across slices); only the EF Core
+             storage returns false. -->
+        <PackageVersion Include="JasperFx" Version="2.53.0" />
+        <PackageVersion Include="JasperFx.Events" Version="2.53.0" />
         <!--
              The shared cross-store event sourcing compliance suites. Source-only package: the
              suites compile inside Polecat.Tests so JasperFx's aggregate source generator binds
              Polecat's own session types.
         -->
-        <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.52.0" />
+        <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.53.0" />
         <!-- Pin the sibling JasperFx packages for parity with Marten 9's matrix
              even though Polecat doesn't currently reference them directly —
              keeps the lockstep matrix coherent when transitive resolution
@@ -271,7 +288,7 @@
              RuntimeCompiler 5.x line is the active continuation of the 4.x
              lineage; do not pin against the parallel stale 2.0.x series. -->
         <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.52.0" />
+        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.53.0" />
         <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
@@ -384,7 +401,7 @@
         <PackageVersion Include="Vogen" Version="7.0.0" />
 
         <!-- Source generators (matched to JasperFx.Events above) -->
-        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.52.0" />
+        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.53.0" />
 
         <!-- Build automation -->
         <PackageVersion Include="Nuke.Common" Version="9.0.4" />

--- a/src/Polecat.EntityFrameworkCore.Tests/EfCoreTestHelper.cs
+++ b/src/Polecat.EntityFrameworkCore.Tests/EfCoreTestHelper.cs
@@ -106,6 +106,28 @@ public static class EfCoreTestHelper
     }
 
     /// <summary>
+    ///     #489: a store whose multi-stream projection fans one event into many slices, so the
+    ///     daemon drives one EfCoreProjectionStorage with a whole range of them.
+    /// </summary>
+    public static async Task<DocumentStore> CreateStoreWithFanOutProjection(ProjectionLifecycle lifecycle)
+    {
+        var store = DocumentStore.For(opts =>
+        {
+            opts.ConnectionString = ConnectionSource.ConnectionString;
+            opts.AutoCreateSchemaObjects = AutoCreate.All;
+            opts.DatabaseSchemaName = $"efcore_fanout_{lifecycle.ToString().ToLowerInvariant()}";
+
+            opts.Projections.Add<PlayerTallyProjection, PlayerTally, string, TestDbContext>(
+                opts, new PlayerTallyProjection(), lifecycle);
+        });
+
+        await store.Database.ApplyAllConfiguredChangesToDatabaseAsync();
+        await EnsureEfCoreTablesAsync<TestDbContext>(ConnectionSource.ConnectionString);
+        await CleanEfCoreTablesAsync(ConnectionSource.ConnectionString, "ef_player_tallies");
+        return store;
+    }
+
+    /// <summary>
     ///     Create a DocumentStore configured with an EF Core event projection.
     /// </summary>
     public static async Task<DocumentStore> CreateStoreWithEventProjection(ProjectionLifecycle lifecycle)

--- a/src/Polecat.EntityFrameworkCore.Tests/TestDbContext.cs
+++ b/src/Polecat.EntityFrameworkCore.Tests/TestDbContext.cs
@@ -12,6 +12,7 @@ public class TestDbContext : DbContext
     public DbSet<Order> Orders => Set<Order>();
     public DbSet<CustomerOrderHistory> CustomerOrderHistories => Set<CustomerOrderHistory>();
     public DbSet<OrderDetail> OrderDetails => Set<OrderDetail>();
+    public DbSet<PlayerTally> PlayerTallies => Set<PlayerTally>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -45,6 +46,15 @@ public class TestDbContext : DbContext
             entity.Property(e => e.Id).HasColumnName("id").HasMaxLength(200);
             entity.Property(e => e.TotalOrders).HasColumnName("total_orders");
             entity.Property(e => e.TotalSpent).HasColumnName("total_spent").HasColumnType("decimal(18,2)");
+        });
+
+        modelBuilder.Entity<PlayerTally>(entity =>
+        {
+            entity.ToTable("ef_player_tallies");
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Id).HasColumnName("id").HasMaxLength(200);
+            entity.Property(e => e.Points).HasColumnName("points");
+            entity.Property(e => e.Appearances).HasColumnName("appearances");
         });
 
         modelBuilder.Entity<OrderDetail>(entity =>

--- a/src/Polecat.EntityFrameworkCore.Tests/TestEvents.cs
+++ b/src/Polecat.EntityFrameworkCore.Tests/TestEvents.cs
@@ -9,6 +9,11 @@ public record OrderCancelled(Guid OrderId);
 public record CustomerOrderPlaced(Guid OrderId, string CustomerName, decimal Amount);
 public record CustomerOrderCompleted(Guid OrderId, string CustomerName);
 
+// #489: fan-out event — ONE event names many players, so Identities<T> turns it into many slices
+// inside a single tenant group, which is the shape that made AggregationRunner's 10-wide block
+// drive one DbContext from ten threads at once.
+public record TeamScored(Guid GameId, string[] PlayerNames, int Points);
+
 // EF Core entity written as side effect
 public class OrderSummary
 {
@@ -36,6 +41,15 @@ public class CustomerOrderHistory
     public string Id { get; set; } = string.Empty;
     public int TotalOrders { get; set; }
     public decimal TotalSpent { get; set; }
+}
+
+// #489: fan-out aggregate. Points is mutated in place on a snapshot the DbContext is tracking,
+// which is what a concurrent Entry() runs change detection over.
+public class PlayerTally
+{
+    public string Id { get; set; } = string.Empty;
+    public int Points { get; set; }
+    public int Appearances { get; set; }
 }
 
 // Side effect entity for event projection

--- a/src/Polecat.EntityFrameworkCore.Tests/TestProjections.cs
+++ b/src/Polecat.EntityFrameworkCore.Tests/TestProjections.cs
@@ -80,6 +80,64 @@ public class CustomerOrderHistoryProjection
 }
 
 /// <summary>
+///     #489: multi-stream projection whose grouping fans ONE event out into many slices, so the
+///     async daemon hands a whole rangeful of slices to a single EfCoreProjectionStorage. That is
+///     the shape marten#5266 reported, and the reason that storage declares IsThreadSafe => false.
+/// </summary>
+public class PlayerTallyProjection
+    : EfCoreMultiStreamProjection<PlayerTally, string, TestDbContext>
+{
+    /// <summary>
+    ///     #489 probe. Records how the async daemon dispatched each slice application: through
+    ///     AggregationRunner's 10-wide <c>Block</c>, or inline. Only the storage's IsThreadSafe answer
+    ///     decides that, so it is the one observable that actually distinguishes fixed from unfixed.
+    /// </summary>
+    public static bool ProbeEnabled;
+
+    public static int ProbedCalls;
+
+    public static bool SawBlockDispatch;
+
+    public PlayerTallyProjection()
+    {
+        Identities<TeamScored>(e => e.PlayerNames);
+    }
+
+    public static void ResetProbe()
+    {
+        ProbedCalls = 0;
+        SawBlockDispatch = false;
+        ProbeEnabled = true;
+    }
+
+    protected override PlayerTally? ApplyEvent(PlayerTally? snapshot,
+        string identity, IEvent @event, TestDbContext dbContext)
+    {
+        snapshot ??= new PlayerTally { Id = identity };
+
+        // Sampled — a StackTrace per call over a whole rebuild would dominate the test's runtime, and
+        // the dispatch route is a property of the storage, not of any individual slice.
+        if (ProbeEnabled && Interlocked.Increment(ref ProbedCalls) <= 50)
+        {
+            if (new System.Diagnostics.StackTrace(false).ToString().Contains("JasperFx.Blocks.Block"))
+            {
+                SawBlockDispatch = true;
+            }
+        }
+
+        if (@event.Data is TeamScored scored)
+        {
+            // Mutating a snapshot the DbContext is already tracking (on a rebuild it was loaded,
+            // not constructed) is precisely what a concurrent Entry() would run DetectChanges over.
+            snapshot.Points += scored.Points;
+            snapshot.Appearances++;
+        }
+
+        return snapshot;
+    }
+}
+
+/// <summary>
 ///     Event projection: dual-writes to both EF Core (OrderDetail) and Polecat (OrderLog).
 /// </summary>
 public class OrderDetailProjection : EfCoreEventProjection<TestDbContext>

--- a/src/Polecat.EntityFrameworkCore.Tests/ef_core_projection_storage_concurrency_tests.cs
+++ b/src/Polecat.EntityFrameworkCore.Tests/ef_core_projection_storage_concurrency_tests.cs
@@ -1,0 +1,134 @@
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Projections;
+using Microsoft.EntityFrameworkCore;
+
+namespace Polecat.EntityFrameworkCore.Tests;
+
+/// <summary>
+///     #489 / jasperfx#683. <see cref="EfCoreProjectionStorage{TDoc,TId,TDbContext}" /> wraps one
+///     <see cref="DbContext" />, which is not thread-safe, but AggregationRunner applies every slice
+///     in a range through a fixed 10-wide block over a single storage instance per tenant group. A
+///     multi-stream projection with fan-out grouping therefore put up to ten threads on one change
+///     tracker. Reported against Marten's identically shaped storage as marten#5266
+///     (InvalidOperationException from Dictionary.TryInsert, NullReferenceException from
+///     ChangeDetector.DetectChanges).
+/// </summary>
+/// <remarks>
+///     These tests assert the ROUTING rather than trying to trip the race, and that is deliberate.
+///     The race was never reproduced in Polecat: the block's channel is created with
+///     AllowSynchronousContinuations, so a waiting reader's continuation runs on the posting thread
+///     and slice applications end up serialized anyway under this workload — measured max concurrency
+///     was 1 with the fix reverted, over 19,000 slice applications. A test that "passes" through that
+///     is not evidence of anything, and a probabilistic assertion on top of it would be worse: green
+///     whether or not the storage opted out. What genuinely flips when IsThreadSafe changes is which
+///     dispatch path the runner takes, so that is what is asserted here.
+/// </remarks>
+public class ef_core_projection_storage_concurrency_tests : IAsyncLifetime
+{
+    // Comfortably wider than the runner's 10-wide block, so a range's worth of slices would have
+    // saturated it several times over.
+    private const int PlayersPerEvent = 40;
+    private const int GameCount = 10;
+    private const int PointsPerGame = 3;
+
+    private static readonly string[] Players =
+        Enumerable.Range(0, PlayersPerEvent).Select(i => $"player_{i:D3}").ToArray();
+
+    private DocumentStore _store = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _store = await EfCoreTestHelper.CreateStoreWithFanOutProjection(ProjectionLifecycle.Async);
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        PlayerTallyProjection.ProbeEnabled = false;
+        _store?.Dispose();
+        return ValueTask.CompletedTask;
+    }
+
+    /// <summary>
+    ///     The contract, asserted directly on the storage.
+    /// </summary>
+    [Fact]
+    public void ef_core_storage_declares_itself_not_thread_safe()
+    {
+        var optionsBuilder = new DbContextOptionsBuilder<TestDbContext>();
+        optionsBuilder.UseSqlServer(ConnectionSource.ConnectionString);
+
+        using var dbContext = new TestDbContext(optionsBuilder.Options);
+        var storage = new EfCoreProjectionStorage<PlayerTally, string, TestDbContext>(dbContext, "*DEFAULT*");
+
+        ((IProjectionStorage<PlayerTally, string>)storage).IsThreadSafe.ShouldBeFalse();
+    }
+
+    /// <summary>
+    ///     The regression itself: the daemon must apply this storage's slices inline, never through
+    ///     AggregationRunner's concurrent block. Revert IsThreadSafe to true and this fails — the
+    ///     probe sees JasperFx.Blocks.Block on the stack.
+    /// </summary>
+    [RequiresNativeJsonFact(true)]
+    public async Task daemon_applies_slices_inline_and_never_through_the_concurrent_block()
+    {
+        var token = TestContext.Current.CancellationToken;
+
+        await using (var session = _store.LightweightSession())
+        {
+            for (var i = 0; i < GameCount; i++)
+            {
+                session.Events.StartStream(Guid.NewGuid(),
+                    new TeamScored(Guid.NewGuid(), Players, PointsPerGame));
+            }
+
+            await session.SaveChangesAsync(token);
+        }
+
+        await _store.WaitForProjectionAsync();
+
+        // A rebuild, because it LOADS each snapshot before mutating it — so the aggregation mutates
+        // entities the change tracker is already tracking, which is the shape that made concurrent
+        // dispatch dangerous in the first place.
+        PlayerTallyProjection.ResetProbe();
+
+        var daemon = await _store.BuildProjectionDaemonAsync();
+        await daemon.RebuildProjectionAsync<PlayerTallyProjection>(token);
+
+        PlayerTallyProjection.ProbedCalls.ShouldBeGreaterThan(0);
+        PlayerTallyProjection.SawBlockDispatch.ShouldBeFalse(
+            "EF Core-backed projection storage must be applied inline — it declares IsThreadSafe => false");
+
+        // Deliberately NOT asserting an absolute total. A rebuild does not empty ef_player_tallies —
+        // Polecat's teardown does not own an EF Core table — so tallies accumulate once per pass.
+        //
+        // What holds regardless: every player is named by every event, so all 40 tallies must be
+        // IDENTICAL and each internally consistent. Losing or double-applying a slice breaks that.
+        var rows = new List<(string Player, int Points, int Appearances)>();
+        foreach (var player in Players)
+        {
+            var row = await EfCoreTestHelper.QueryRowAsync(
+                "SELECT points, appearances FROM ef_player_tallies WHERE id = @id",
+                ("@id", player));
+
+            row.ShouldNotBeNull();
+            rows.Add((player, (int)row["points"]!, (int)row["appearances"]!));
+        }
+
+        var expected = rows[0];
+        expected.Appearances.ShouldBeGreaterThan(0);
+        (expected.Appearances % GameCount).ShouldBe(0);
+        expected.Points.ShouldBe(expected.Appearances * PointsPerGame);
+
+        foreach (var row in rows)
+        {
+            row.Appearances.ShouldBe(expected.Appearances,
+                $"{row.Player} diverged from {expected.Player} — a slice was lost or applied twice");
+            row.Points.ShouldBe(expected.Points,
+                $"{row.Player} diverged from {expected.Player} — a slice was lost or applied twice");
+        }
+
+        var rowCount = await EfCoreTestHelper.QueryScalarAsync<int>(
+            "SELECT COUNT(*) FROM ef_player_tallies");
+        rowCount.ShouldBe(PlayersPerEvent);
+    }
+}

--- a/src/Polecat.EntityFrameworkCore.Tests/ef_core_projection_storage_concurrency_tests.cs
+++ b/src/Polecat.EntityFrameworkCore.Tests/ef_core_projection_storage_concurrency_tests.cs
@@ -49,21 +49,6 @@ public class ef_core_projection_storage_concurrency_tests : IAsyncLifetime
     }
 
     /// <summary>
-    ///     The contract, asserted directly on the storage.
-    /// </summary>
-    [Fact]
-    public void ef_core_storage_declares_itself_not_thread_safe()
-    {
-        var optionsBuilder = new DbContextOptionsBuilder<TestDbContext>();
-        optionsBuilder.UseSqlServer(ConnectionSource.ConnectionString);
-
-        using var dbContext = new TestDbContext(optionsBuilder.Options);
-        var storage = new EfCoreProjectionStorage<PlayerTally, string, TestDbContext>(dbContext, "*DEFAULT*");
-
-        ((IProjectionStorage<PlayerTally, string>)storage).IsThreadSafe.ShouldBeFalse();
-    }
-
-    /// <summary>
     ///     The regression itself: the daemon must apply this storage's slices inline, never through
     ///     AggregationRunner's concurrent block. Revert IsThreadSafe to true and this fails — the
     ///     probe sees JasperFx.Blocks.Block on the stack.
@@ -130,5 +115,34 @@ public class ef_core_projection_storage_concurrency_tests : IAsyncLifetime
         var rowCount = await EfCoreTestHelper.QueryScalarAsync<int>(
             "SELECT COUNT(*) FROM ef_player_tallies");
         rowCount.ShouldBe(PlayersPerEvent);
+    }
+}
+
+/// <summary>
+///     #489, the deterministic half — deliberately in its own class with NO
+///     <see cref="IAsyncLifetime" />.
+/// </summary>
+/// <remarks>
+///     Every other test class in this project gates ALL of its tests behind
+///     <see cref="RequiresNativeJsonFactAttribute" />, so on a SQL Server without the native
+///     <c>json</c> type xUnit skips them all and never constructs the class — which is what keeps
+///     their store-building InitializeAsync from running. A single plain <c>[Fact]</c> alongside a
+///     gated one breaks that: the class gets constructed for the ungated test, InitializeAsync runs,
+///     and store creation dies with "Cannot find data type json" on the edge matrix leg. Hence the
+///     split — this assertion needs no database at all (it opens no connection), so it belongs
+///     nowhere near a fixture.
+/// </remarks>
+public class ef_core_projection_storage_thread_safety_tests
+{
+    [Fact]
+    public void ef_core_storage_declares_itself_not_thread_safe()
+    {
+        var optionsBuilder = new DbContextOptionsBuilder<TestDbContext>();
+        optionsBuilder.UseSqlServer(ConnectionSource.ConnectionString);
+
+        using var dbContext = new TestDbContext(optionsBuilder.Options);
+        var storage = new EfCoreProjectionStorage<PlayerTally, string, TestDbContext>(dbContext, "*DEFAULT*");
+
+        ((IProjectionStorage<PlayerTally, string>)storage).IsThreadSafe.ShouldBeFalse();
     }
 }

--- a/src/Polecat.EntityFrameworkCore/EfCoreProjectionStorage.cs
+++ b/src/Polecat.EntityFrameworkCore/EfCoreProjectionStorage.cs
@@ -48,6 +48,31 @@ internal class EfCoreProjectionStorage<
 
     public string TenantId { get; }
 
+    /// <summary>
+    ///     #489 / jasperfx#683: this storage cannot take concurrently applied slices, so the async
+    ///     daemon must apply them one at a time.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///     <see cref="AggregationRunner{TDoc,TId,TOperations,TQuerySession}" /> applies every slice in
+    ///     a range through a fixed 10-wide block, and hands every slice in a tenant group this same
+    ///     storage instance. This one wraps a single <see cref="DbContext" />, which is not
+    ///     thread-safe, so a multi-stream projection with custom grouping — where one event fans out
+    ///     into many slices — otherwise has up to ten threads calling <c>Entry()</c> / <c>Find</c>
+    ///     against one change tracker. Reported against Marten's identically shaped storage as
+    ///     marten#5266: an <see cref="InvalidOperationException" /> out of <c>Dictionary.TryInsert</c>
+    ///     and a <see cref="NullReferenceException" /> out of <c>ChangeDetector.DetectChanges</c>.
+    ///     </para>
+    ///     <para>
+    ///     ⚠️ <see cref="_dbContextLock" /> does not make this <see langword="true" />. It serializes
+    ///     each individual member, but between calls the aggregation on one thread mutates entities
+    ///     that another thread's <c>Entry()</c> is running change detection over — which is the
+    ///     <c>ChangeDetector</c> failure above. The fan-out itself has to stop, and only the runner
+    ///     can stop it. The lock stays as protection for any non-daemon caller.
+    ///     </para>
+    /// </remarks>
+    public bool IsThreadSafe => false;
+
     public void SetIdentity(TDoc document, TId identity)
     {
         _dbContextLock.Wait();

--- a/src/Polecat.EntityFrameworkCore/Polecat.EntityFrameworkCore.csproj
+++ b/src/Polecat.EntityFrameworkCore/Polecat.EntityFrameworkCore.csproj
@@ -17,6 +17,12 @@
     </ItemGroup>
 
     <ItemGroup>
+        <!-- #489: so the tests can assert EfCoreProjectionStorage.IsThreadSafe directly. Mirrors the
+             InternalsVisibleTo Polecat.csproj already declares for its own test project. -->
+        <InternalsVisibleTo Include="Polecat.EntityFrameworkCore.Tests" />
+    </ItemGroup>
+
+    <ItemGroup>
         <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
         <PackageReference Include="Weasel.EntityFrameworkCore" />
     </ItemGroup>


### PR DESCRIPTION
Closes #489. Adopts JasperFx/jasperfx#683.

`AggregationRunner` applies every slice in a range through a fixed 10-wide `Block` and hands every slice in a tenant group the *same* `IProjectionStorage` instance. `EfCoreProjectionStorage` wraps a single `DbContext`, which is not thread-safe, so a multi-stream projection with fan-out grouping put up to ten threads on one change tracker. Reported against Marten's identically shaped storage as JasperFx/marten#5266.

## Changes

- **JasperFx family 2.52.0 → 2.53.0**, which carries `IProjectionStorage.IsThreadSafe` as a default interface member. Weasel 9.24.0's floor is JasperFx.Events 2.46.0, so no lockstep Weasel bump is needed. Polecat's SQL Server storage stays on the default `true`; only the EF Core storage opts out.
- **`EfCoreProjectionStorage.IsThreadSafe => false`.** The pre-existing `_dbContextLock` is *not* a substitute and stays only as protection for non-daemon callers: it serializes each individual call, but between calls the aggregation on one thread mutates entities another thread's `Entry()` is running change detection over — which is the reported `ChangeDetector` NRE.
- **Regression coverage**, plus `InternalsVisibleTo` on `Polecat.EntityFrameworkCore` so the tests can reach the storage (mirrors what `Polecat.csproj` already declares for its own test project).

## The tests assert routing, not the race — deliberately

Worth reading before reviewing, because it is a departure from what the issue asked for.

**The race does not reproduce in Polecat.** My first attempt at the probabilistic test the issue describes passed **5/5 with the fix reverted** — it was testing nothing. Instrumenting the projection showed why: measured **max concurrency of 1 across 19,000 slice applications** with `IsThreadSafe = true`. The block's channel is created with `AllowSynchronousContinuations`, so a waiting reader's continuation runs on the posting thread and applications serialize anyway under this workload.

Stack traces confirmed the seam itself works, flipping cleanly between the two paths:

- `IsThreadSafe => false` → `AggregationRunner.applyInlineAsync`
- `IsThreadSafe => true` → `JasperFx.Blocks.Block.processAsync`

So the dispatch route is what actually distinguishes fixed from unfixed, and that is what is asserted. A probabilistic assertion layered on top would have been green either way — worse than no test, because it would read as coverage.

**Verified in both directions:** both tests fail with `IsThreadSafe` reverted to `true`, and pass with it `false`.

If you would rather also carry the Marten-style probabilistic test as a canary against upstream changes to the block's behavior, say so and I will add it alongside.

## Verification

- Full `Polecat.EntityFrameworkCore.Tests`: **39/39 pass**
- Full `Polecat.Tests` (net10.0), for the dependency bump: **2220 total, 0 failed**, 2217 succeeded, 3 skipped, 25m09s

🤖 Generated with [Claude Code](https://claude.com/claude-code)