### PR TITLE
5.19.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>5.19.0</Version>
+        <Version>5.19.1</Version>
         <LangVersion>latest</LangVersion>
         <Authors>Jeremy D. Miller</Authors>
         <PackageIcon>logo.png</PackageIcon>


### PR DESCRIPTION
Version bump for the 5.19.1 release.

Ships three fixes merged since 5.19.0:

- **#487** ([#491](https://github.com/JasperFx/polecat/pull/491)) — `IQuerySession.Events` declared `new`, clearing the CS0108 that shipped in the 5.18.0 and 5.19.0 publish logs.
- **#492** ([#493](https://github.com/JasperFx/polecat/pull/493)) — `IChangeSet` / `IDeletion` stop hiding their `IDocumentChangeSet` / `IDocumentDeletion` members. With #487 this takes the build to **zero CS0108**.
- **#489** ([#494](https://github.com/JasperFx/polecat/pull/494)) — EF Core projection storage declares itself not thread-safe (jasperfx#683), so the async daemon stops applying slices concurrently over one `DbContext`. Carries the JasperFx family bump **2.52.0 → 2.53.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)