### PR TITLE
Add a README to each NuGet package

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,6 +8,14 @@
         <LangVersion>latest</LangVersion>
         <Authors>Jeremy D. Miller</Authors>
         <PackageIcon>logo.png</PackageIcon>
+        <!--
+          nuget.org renders this on the package page, and pack/push warn without it. Set per-project
+          rather than repo-wide: each packable project carries its OWN README.md so the three package
+          pages describe the three packages, and only projects that actually have one opt in. The
+          root README.md is deliberately NOT reused here — it links ./docs/polecat-logo.png
+          relatively, and relative paths do not resolve on nuget.org.
+        -->
+        <PackageReadmeFile Condition="Exists('$(MSBuildProjectDirectory)/README.md')">README.md</PackageReadmeFile>
         <PackageProjectUrl>https://polecat.netlify.app/</PackageProjectUrl>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <NoWarn>1570;1571;1572;1573;1574;1587;1591;1701;1702;1711;1735;0618</NoWarn>
@@ -51,5 +59,7 @@
 
     <ItemGroup>
         <None Include="$(MSBuildThisFileDirectory)logo.png" Pack="true" PackagePath="" Visible="false" />
+        <None Include="$(MSBuildProjectDirectory)/README.md" Pack="true" PackagePath="" Visible="false"
+              Condition="Exists('$(MSBuildProjectDirectory)/README.md')" />
     </ItemGroup>
 </Project>

--- a/src/Polecat.AspNetCore/README.md
+++ b/src/Polecat.AspNetCore/README.md
@@ -1,0 +1,39 @@
+# Polecat.AspNetCore
+
+ASP.NET Core helpers for applications built on [Polecat](https://www.nuget.org/packages/Polecat/), the
+SQL Server-backed event store in the Critter Stack.
+
+## Install
+
+```
+dotnet add package Polecat.AspNetCore
+```
+
+## What it gives you
+
+**Write event streams straight to the response.** `WriteStreamState` and `WriteEvents` serialize a
+stream's aggregate or its raw events using the store's own serializer, so the wire format matches
+what Polecat persists:
+
+```csharp
+app.MapGet("/orders/{id:guid}", (Guid id, HttpContext context, IQuerySession session)
+    => context.Response.WriteStreamState<Order>(session, id));
+```
+
+**ETag helpers for optimistic concurrency.** `ETagHelpers` formats a stream version — `Guid` or
+`long` — as an HTTP ETag and checks incoming `If-None-Match` headers, so a caller can be told
+`304 Not Modified` without you reloading the aggregate.
+
+**MCP endpoints.** `MapPolecatMcp` exposes the event store over the Model Context Protocol for
+agent-driven exploration of streams and events.
+
+## Requirements
+
+- .NET 9 or .NET 10
+- A configured Polecat `IDocumentStore` — see the [Polecat package](https://www.nuget.org/packages/Polecat/)
+
+## Links
+
+- [Documentation](https://polecat.jasperfx.net/)
+- [GitHub](https://github.com/JasperFx/polecat)
+- [Discord](https://discord.gg/WMxrvegf8H)

--- a/src/Polecat.EntityFrameworkCore/README.md
+++ b/src/Polecat.EntityFrameworkCore/README.md
@@ -1,0 +1,62 @@
+# Polecat.EntityFrameworkCore
+
+Entity Framework Core integration for [Polecat](https://www.nuget.org/packages/Polecat/) projections.
+
+Project your event streams into EF Core entities instead of Polecat documents, and have both written
+in the same transaction. Useful when a read model already belongs to an existing `DbContext`, or when
+you want EF Core's mapping and migrations over a projected table.
+
+## Install
+
+```
+dotnet add package Polecat.EntityFrameworkCore
+```
+
+## Projection base classes
+
+Derive from the base that matches your projection shape and override `ApplyEvent`:
+
+```csharp
+public class OrderProjection : EfCoreSingleStreamProjection<Order, MyDbContext>
+{
+    public OrderProjection() => IncludeType<OrderPlaced>();
+
+    protected override Order? ApplyEvent(Order? snapshot, Guid identity, IEvent @event,
+        MyDbContext dbContext, IQuerySession session)
+        => @event.Data switch
+        {
+            OrderPlaced placed => new Order { Id = placed.OrderId, Customer = placed.CustomerName },
+            _ => snapshot
+        };
+}
+```
+
+Register it against the store, choosing a lifecycle:
+
+```csharp
+opts.Projections.Add<OrderProjection, Order, MyDbContext>(
+    opts, new OrderProjection(), ProjectionLifecycle.Async);
+```
+
+Three shapes are available:
+
+- `EfCoreSingleStreamProjection<TDoc, TDbContext>` — one aggregate per stream
+- `EfCoreMultiStreamProjection<TDoc, TId, TDbContext>` — aggregate across streams via `Identity` / `Identities`
+- `EfCoreEventProjection<TDbContext>` — free-form per-event side effects, into EF Core and Polecat alike
+
+## Transactions
+
+The `DbContext` enlists in the Polecat session's unit of work, so `SaveChangesAsync` flushes the
+event append and the EF Core changes together — there is no window where one landed and the other
+did not.
+
+## Requirements
+
+- .NET 9 or .NET 10
+- A configured Polecat `IDocumentStore` — see the [Polecat package](https://www.nuget.org/packages/Polecat/)
+
+## Links
+
+- [Documentation](https://polecat.jasperfx.net/)
+- [GitHub](https://github.com/JasperFx/polecat)
+- [Discord](https://discord.gg/WMxrvegf8H)

--- a/src/Polecat/README.md
+++ b/src/Polecat/README.md
@@ -1,0 +1,63 @@
+# Polecat
+
+SQL Server-backed event store and lightweight document database for the [Critter Stack](https://jasperfx.net/).
+
+Polecat is "Marten for SQL Server" — the same API shape, on SQL Server 2025. It leans on the native
+`json` column type, and stores events, streams and documents in `pc_`-prefixed tables it manages for you.
+
+## Install
+
+```
+dotnet add package Polecat
+```
+
+## Getting started
+
+```csharp
+builder.Services.AddPolecat(opts =>
+{
+    opts.ConnectionString = connectionString;
+    opts.DatabaseSchemaName = "myapp";
+});
+```
+
+Then take a session and append events:
+
+```csharp
+await using var session = store.LightweightSession();
+
+var streamId = Guid.NewGuid();
+session.Events.StartStream(streamId, new OrderPlaced(streamId, "Alice", 100m));
+await session.SaveChangesAsync();
+
+var events = await session.Events.FetchStreamAsync(streamId);
+```
+
+Documents work the same way:
+
+```csharp
+session.Store(new Customer { Id = customerId, Name = "Alice" });
+await session.SaveChangesAsync();
+
+var customer = await session.LoadAsync<Customer>(customerId);
+```
+
+## What's in the box
+
+- Event sourcing — streams keyed by `Guid` or `string`, live aggregation, snapshots
+- Projections — inline and async, single-stream, multi-stream, event, flat-table and composite
+- Async daemon — high water mark tracking, rebuilds, subscriptions
+- Document storage — LINQ querying, patching, bulk insert, soft deletes, optimistic concurrency
+- Multi-tenancy — conjoined (per-row) and separate-database, with optional table partitioning
+
+## Requirements
+
+- .NET 9 or .NET 10
+- SQL Server 2025 (the native `json` type is used for event data, document bodies and snapshots)
+
+## Links
+
+- [Documentation](https://polecat.jasperfx.net/)
+- [GitHub](https://github.com/JasperFx/polecat)
+- [Discord](https://discord.gg/WMxrvegf8H)
+- [Commercial support](https://jasperfx.net/support-plans/)


### PR DESCRIPTION
Every pack and push logged `The package X is missing a readme`, and the three package pages on nuget.org showed nothing beyond their one-line `<Description>`.

## Per-package, not shared

Each packable project now carries its **own** `README.md`. `Polecat`, `Polecat.AspNetCore` and `Polecat.EntityFrameworkCore` describe three different things, so one shared file would have been wrong for two of them.

The root `README.md` is deliberately **not** reused. It embeds `./docs/polecat-logo.png` as a relative path, and relative links do not resolve on nuget.org — it would render with a broken image. The per-package files use absolute URLs only.

Content is grounded in the actual public surface (`AddPolecat`, `LightweightSession`, `Events.StartStream`/`FetchStreamAsync`, the three `EfCore*Projection` bases, `WriteStreamState`/`WriteEvents`, `ETagHelpers`, `MapPolecatMcp`) rather than invented.

## Wiring

Mirrors the existing `logo.png` pattern in `Directory.Build.props`, but guarded on the project directory so only projects that actually have a README opt in:

```xml
<PackageReadmeFile Condition="Exists('$(MSBuildProjectDirectory)/README.md')">README.md</PackageReadmeFile>
...
<None Include="$(MSBuildProjectDirectory)/README.md" Pack="true" PackagePath="" Visible="false"
      Condition="Exists('$(MSBuildProjectDirectory)/README.md')" />
```

Test projects and other non-packable projects are untouched. A future packable project gets this for free by dropping a `README.md` next to its csproj.

## Verification

Packed all three in Release:

- No `missing a readme` warning on any of them
- Each `.nupkg` contains its own `README.md` — 1882 / 1338 / 2107 bytes, i.e. three distinct files, not one copied three times
- Each nuspec declares `<readme>README.md</readme>` alongside the existing `<icon>logo.png</icon>`

Full solution build succeeds.

## Timing

This lands after 5.19.1 shipped, so the already-published 5.19.1 packages keep their empty readme — NuGet does not allow editing a published package. It takes effect with the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)