### PR TITLE
5.19.2

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>5.19.1</Version>
+        <Version>5.19.2</Version>
         <LangVersion>latest</LangVersion>
         <Authors>Jeremy D. Miller</Authors>
         <PackageIcon>logo.png</PackageIcon>


### PR DESCRIPTION
Version bump for the 5.19.2 release.

**Packaging only — no functional changes from 5.19.1.** The assemblies are identical; this exists solely to get the package READMEs onto nuget.org, since a published package cannot be edited after the fact.

- #496 — each package now ships its own README that renders on its nuget.org page. `Polecat`, `Polecat.AspNetCore` and `Polecat.EntityFrameworkCore` each describe that package rather than the project as a whole.

🤖 Generated with [Claude Code](https://claude.com/claude-code)