### PR TITLE
gh-498: adapt EF Core tests to the server instead of skipping on it

### DIFF
--- a/src/Polecat.EntityFrameworkCore.Tests/EfCoreEventProjectionTests.cs
+++ b/src/Polecat.EntityFrameworkCore.Tests/EfCoreEventProjectionTests.cs
@@ -17,7 +17,7 @@ public class ef_core_event_projection_tests : IAsyncLifetime
         return ValueTask.CompletedTask;
     }
 
-    [RequiresNativeJsonFact(true)]
+    [Fact]
     public async Task can_project_event_to_ef_core_and_polecat()
     {
         var orderId = Guid.NewGuid();
@@ -43,7 +43,7 @@ public class ef_core_event_projection_tests : IAsyncLifetime
         log.EventType.ShouldBe("OrderPlaced");
     }
 
-    [RequiresNativeJsonFact(true)]
+    [Fact]
     public async Task can_project_multiple_events()
     {
         var orderId = Guid.NewGuid();

--- a/src/Polecat.EntityFrameworkCore.Tests/EfCoreMultiStreamProjectionTests.cs
+++ b/src/Polecat.EntityFrameworkCore.Tests/EfCoreMultiStreamProjectionTests.cs
@@ -19,7 +19,7 @@ public abstract class ef_core_multi_stream_projection_tests_base : IAsyncLifetim
 
     protected virtual Task WaitForProjectionAsync() => Task.CompletedTask;
 
-    [RequiresNativeJsonFact(true)]
+    [Fact]
     public async Task multi_stream_projection_aggregates_across_streams()
     {
         var orderId1 = Guid.NewGuid();
@@ -43,7 +43,7 @@ public abstract class ef_core_multi_stream_projection_tests_base : IAsyncLifetim
         ((decimal)row["total_spent"]!).ShouldBe(300.00m);
     }
 
-    [RequiresNativeJsonFact(true)]
+    [Fact]
     public async Task multi_stream_projection_creates_separate_aggregates_per_identity()
     {
         var orderId1 = Guid.NewGuid();
@@ -74,7 +74,7 @@ public abstract class ef_core_multi_stream_projection_tests_base : IAsyncLifetim
         ((decimal)charlieRow["total_spent"]!).ShouldBe(75.00m);
     }
 
-    [RequiresNativeJsonFact(true)]
+    [Fact]
     public async Task multi_stream_projection_handles_subsequent_appends()
     {
         var orderId1 = Guid.NewGuid();
@@ -134,7 +134,7 @@ public class ef_core_multi_stream_live_tests : IAsyncLifetime
         return ValueTask.CompletedTask;
     }
 
-    [RequiresNativeJsonFact(true)]
+    [Fact]
     public async Task can_store_events_without_error()
     {
         var orderId = Guid.NewGuid();

--- a/src/Polecat.EntityFrameworkCore.Tests/EfCoreSingleStreamProjectionTests.cs
+++ b/src/Polecat.EntityFrameworkCore.Tests/EfCoreSingleStreamProjectionTests.cs
@@ -21,7 +21,7 @@ public abstract class ef_core_single_stream_projection_tests_base : IAsyncLifeti
 
     protected virtual Task WaitForProjectionAsync() => Task.CompletedTask;
 
-    [RequiresNativeJsonFact(true)]
+    [Fact]
     public async Task single_stream_projection_writes_aggregate_on_create()
     {
         var orderId = Guid.NewGuid();
@@ -43,7 +43,7 @@ public abstract class ef_core_single_stream_projection_tests_base : IAsyncLifeti
         ((int)row["item_count"]!).ShouldBe(5);
     }
 
-    [RequiresNativeJsonFact(true)]
+    [Fact]
     public async Task single_stream_projection_evolves_aggregate_with_subsequent_events()
     {
         var orderId = Guid.NewGuid();
@@ -69,7 +69,7 @@ public abstract class ef_core_single_stream_projection_tests_base : IAsyncLifeti
         ((bool)row["is_shipped"]!).ShouldBeTrue();
     }
 
-    [RequiresNativeJsonFact(true)]
+    [Fact]
     public async Task single_stream_projection_handles_multiple_events_in_one_append()
     {
         var orderId = Guid.NewGuid();
@@ -91,7 +91,7 @@ public abstract class ef_core_single_stream_projection_tests_base : IAsyncLifeti
         ((bool)row["is_shipped"]!).ShouldBeTrue();
     }
 
-    [RequiresNativeJsonFact(true)]
+    [Fact]
     public async Task single_stream_projection_writes_ef_core_side_effects()
     {
         var orderId = Guid.NewGuid();
@@ -140,7 +140,7 @@ public class ef_core_single_stream_live_tests : IAsyncLifetime
         return ValueTask.CompletedTask;
     }
 
-    [RequiresNativeJsonFact(true)]
+    [Fact]
     public async Task live_aggregation_builds_aggregate_on_the_fly()
     {
         var orderId = Guid.NewGuid();
@@ -159,7 +159,7 @@ public class ef_core_single_stream_live_tests : IAsyncLifetime
         order.IsShipped.ShouldBeTrue();
     }
 
-    [RequiresNativeJsonFact(true)]
+    [Fact]
     public async Task live_aggregation_returns_null_for_unknown_stream()
     {
         await using var query = _store.QuerySession();

--- a/src/Polecat.EntityFrameworkCore.Tests/EfCoreTenantedSingleStreamProjectionTests.cs
+++ b/src/Polecat.EntityFrameworkCore.Tests/EfCoreTenantedSingleStreamProjectionTests.cs
@@ -13,6 +13,8 @@ public abstract class ef_core_tenanted_single_stream_tests_base : IAsyncLifetime
         {
             opts.ConnectionString = ConnectionSource.ConnectionString;
             opts.AutoCreateSchemaObjects = AutoCreate.All;
+            // #498: see EfCoreTestHelper — adapt to the server rather than skip the whole class.
+            opts.UseNativeJsonType = ConnectionSource.SupportsNativeJson;
             opts.DatabaseSchemaName = $"efcore_ten_{Lifecycle.ToString().ToLowerInvariant()}";
             opts.Events.TenancyStyle = TenancyStyle.Conjoined;
 
@@ -33,7 +35,7 @@ public abstract class ef_core_tenanted_single_stream_tests_base : IAsyncLifetime
 
     protected virtual Task WaitForProjectionAsync() => Task.CompletedTask;
 
-    [RequiresNativeJsonFact(true)]
+    [Fact]
     public async Task tenant_id_is_written_to_ef_core_table()
     {
         var orderId = Guid.NewGuid();
@@ -53,7 +55,7 @@ public abstract class ef_core_tenanted_single_stream_tests_base : IAsyncLifetime
         row["tenant_id"].ShouldBe("tenant-a");
     }
 
-    [RequiresNativeJsonFact(true)]
+    [Fact]
     public async Task different_tenants_get_isolated_data()
     {
         var orderId1 = Guid.NewGuid();
@@ -87,7 +89,7 @@ public abstract class ef_core_tenanted_single_stream_tests_base : IAsyncLifetime
         rowY["tenant_id"].ShouldBe("tenant-y");
     }
 
-    [RequiresNativeJsonFact(true)]
+    [Fact]
     public async Task subsequent_appends_preserve_tenant_id()
     {
         var orderId = Guid.NewGuid();

--- a/src/Polecat.EntityFrameworkCore.Tests/EfCoreTestHelper.cs
+++ b/src/Polecat.EntityFrameworkCore.Tests/EfCoreTestHelper.cs
@@ -72,6 +72,12 @@ public static class EfCoreTestHelper
         {
             opts.ConnectionString = ConnectionSource.ConnectionString;
             opts.AutoCreateSchemaObjects = AutoCreate.All;
+            // #498: adapt to the server instead of skipping on it. The edge matrix leg runs SQL
+            // Server 2022, which has no native `json` type, so a store left on the default
+            // UseNativeJsonType = true dies in the Weasel migration with "Cannot find data type
+            // json". Polecat.Tests has used this idiom for exactly this reason all along; this
+            // project gated its tests off instead and so asserted nothing at all on edge.
+            opts.UseNativeJsonType = ConnectionSource.SupportsNativeJson;
             opts.DatabaseSchemaName = $"efcore_ss_{lifecycle.ToString().ToLowerInvariant()}";
 
             opts.Projections.Add<OrderAggregate, Order, TestDbContext>(
@@ -93,6 +99,12 @@ public static class EfCoreTestHelper
         {
             opts.ConnectionString = ConnectionSource.ConnectionString;
             opts.AutoCreateSchemaObjects = AutoCreate.All;
+            // #498: adapt to the server instead of skipping on it. The edge matrix leg runs SQL
+            // Server 2022, which has no native `json` type, so a store left on the default
+            // UseNativeJsonType = true dies in the Weasel migration with "Cannot find data type
+            // json". Polecat.Tests has used this idiom for exactly this reason all along; this
+            // project gated its tests off instead and so asserted nothing at all on edge.
+            opts.UseNativeJsonType = ConnectionSource.SupportsNativeJson;
             opts.DatabaseSchemaName = $"efcore_ms_{lifecycle.ToString().ToLowerInvariant()}";
 
             opts.Projections.Add<CustomerOrderHistoryProjection, CustomerOrderHistory, string, TestDbContext>(
@@ -115,6 +127,12 @@ public static class EfCoreTestHelper
         {
             opts.ConnectionString = ConnectionSource.ConnectionString;
             opts.AutoCreateSchemaObjects = AutoCreate.All;
+            // #498: adapt to the server instead of skipping on it. The edge matrix leg runs SQL
+            // Server 2022, which has no native `json` type, so a store left on the default
+            // UseNativeJsonType = true dies in the Weasel migration with "Cannot find data type
+            // json". Polecat.Tests has used this idiom for exactly this reason all along; this
+            // project gated its tests off instead and so asserted nothing at all on edge.
+            opts.UseNativeJsonType = ConnectionSource.SupportsNativeJson;
             opts.DatabaseSchemaName = $"efcore_fanout_{lifecycle.ToString().ToLowerInvariant()}";
 
             opts.Projections.Add<PlayerTallyProjection, PlayerTally, string, TestDbContext>(
@@ -136,6 +154,12 @@ public static class EfCoreTestHelper
         {
             opts.ConnectionString = ConnectionSource.ConnectionString;
             opts.AutoCreateSchemaObjects = AutoCreate.All;
+            // #498: adapt to the server instead of skipping on it. The edge matrix leg runs SQL
+            // Server 2022, which has no native `json` type, so a store left on the default
+            // UseNativeJsonType = true dies in the Weasel migration with "Cannot find data type
+            // json". Polecat.Tests has used this idiom for exactly this reason all along; this
+            // project gated its tests off instead and so asserted nothing at all on edge.
+            opts.UseNativeJsonType = ConnectionSource.SupportsNativeJson;
             opts.DatabaseSchemaName = $"efcore_ep_{lifecycle.ToString().ToLowerInvariant()}";
 
             opts.Projections.Add<OrderDetailProjection, TestDbContext>(

--- a/src/Polecat.EntityFrameworkCore.Tests/ef_core_projection_storage_concurrency_tests.cs
+++ b/src/Polecat.EntityFrameworkCore.Tests/ef_core_projection_storage_concurrency_tests.cs
@@ -53,7 +53,7 @@ public class ef_core_projection_storage_concurrency_tests : IAsyncLifetime
     ///     AggregationRunner's concurrent block. Revert IsThreadSafe to true and this fails — the
     ///     probe sees JasperFx.Blocks.Block on the stack.
     /// </summary>
-    [RequiresNativeJsonFact(true)]
+    [Fact]
     public async Task daemon_applies_slices_inline_and_never_through_the_concurrent_block()
     {
         var token = TestContext.Current.CancellationToken;


### PR DESCRIPTION
Closes #498.

## The measured problem

`Polecat.EntityFrameworkCore.Tests` gated every store-building test behind `[RequiresNativeJsonFact(true)]`. On the edge matrix leg — SQL Server 2022, no native `json` type — that meant the project asserted almost nothing while reporting green.

Measured on SQL Server 2022, before this change:

```
total: 39   succeeded: 13   skipped: 26
```

**Two thirds of the suite was dead on that leg**, and the job passed. (#498 estimated 16 from counting attribute sites; the real number is 26 test cases, because the gated tests live on base classes that each have inline/async derived variants.)

## And the trap on top of it

The skipping was also load-bearing. Because *every* test in those classes was skipped on edge, xUnit never constructed the classes, which is the only thing that kept their store-building `InitializeAsync` from running. Nothing enforced that invariant. Add one plain `[Fact]` and the class gets constructed for it, `InitializeAsync` runs, and the Weasel migration dies:

```
SqlException : Column, parameter, or variable #5: Cannot find data type json.
```

That is exactly how #489 broke CI ([job 96585557583](https://github.com/JasperFx/polecat/actions/runs/32418662579/job/96585557583)), and a dev box on SQL Server 2025 cannot reproduce it — nothing skips there, so the class is constructed either way and the suite is green.

## The fix

`Polecat.Tests` has always solved this by adapting rather than skipping:

```csharp
opts.UseNativeJsonType = ConnectionSource.SupportsNativeJson;
```

`StoreOptions.JsonColumnType` then picks `json` or `nvarchar(max)`. That idiom appears **66 times** in `Polecat.Tests` and appeared **zero times** here.

Adopted in the five places that actually run DDL — `EfCoreTestHelper`'s four store factories and the tenanted fixture. All 16 `[RequiresNativeJsonFact(true)]` sites then become unnecessary and are dropped.

`EfCoreSchemaTests` and `EfCoreMultiTenancyValidationTests` are untouched: they build stores but run no DDL, which is why their plain `[Fact]`s already survived edge.

## Verification

Ran the suite against **both** matrix images locally, swapping the container via the same compose override CI uses:

| Server | Before | After |
|---|---|---|
| SQL Server 2025 | 39 run, 0 skipped | **39 run, 0 skipped** |
| SQL Server 2022 (edge) | 13 run, **26 skipped** | **39 run, 0 skipped** |

Confirmed the 2022 run genuinely exercises the fallback rather than quietly doing nothing — the emitted DDL shows `data nvarchar(max)` where 2025 emits `data json`, and `SELECT COUNT(*) FROM sys.types WHERE name='json'` returns 0 on that instance.

Test-only change; no production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)