### PR TITLE
gh-500: serialize the progression upserts with UPDLOCK, HOLDLOCK

### DIFF
--- a/src/Polecat.Tests/Daemon/Bug_500_concurrent_high_water_mark.cs
+++ b/src/Polecat.Tests/Daemon/Bug_500_concurrent_high_water_mark.cs
@@ -1,0 +1,119 @@
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Logging.Abstractions;
+using Polecat.Events.Daemon;
+using Polecat.Tests.Harness;
+
+namespace Polecat.Tests.Daemon;
+
+/// <summary>
+///     #500. On a cold start every async agent kicks high-water detection, and each detection ends
+///     in <c>MarkHighWaterAsync</c> writing the one <c>HighWaterMark</c> row. Before the fix that
+///     upsert was a bare <c>MERGE</c>: with no row yet, concurrent writers all probed, all missed,
+///     and all took the INSERT branch, so every loser got
+///     "Violation of PRIMARY KEY constraint 'pkey_pc_event_progression_name'".
+///     Reported against a Wolverine-managed fleet where four agents started at once; the retry
+///     succeeded, so the visible cost was a warn-with-stack on every boot rather than a failure.
+/// </summary>
+[Collection("integration")]
+public class Bug_500_concurrent_high_water_mark : IntegrationContext
+{
+    public Bug_500_concurrent_high_water_mark(DefaultStoreFixture fixture) : base(fixture)
+    {
+    }
+
+    public override async ValueTask InitializeAsync()
+    {
+        await base.InitializeAsync();
+
+        // The cold-start shape is the whole point: no HighWaterMark row for anyone to match on.
+        await using var conn = await OpenConnectionAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = "DELETE FROM [dbo].[pc_event_progression];";
+        await cmd.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task concurrent_cold_start_marks_do_not_collide()
+    {
+        var token = TestContext.Current.CancellationToken;
+        var detector = CreateDetector();
+
+        // Well above the four agents in the report. The race window is one autocommit statement
+        // wide, so the writers have to arrive genuinely together to land inside it.
+        const int writers = 32;
+        const int rounds = 8;
+
+        for (var round = 0; round < rounds; round++)
+        {
+            // Warm the connection pool BEFORE the timed section. Without this the first few
+            // OpenAsync calls pay pool creation and the writers trickle in one at a time, each
+            // finding the row the previous one just committed — the test then passes against a
+            // bare MERGE and guards nothing.
+            await WarmPoolAsync(writers, token);
+
+            // Back to the cold-start shape: no HighWaterMark row for anyone to match on.
+            await DeleteHighWaterRowAsync(token);
+
+            using var gate = new SemaphoreSlim(0, writers);
+            var marks = Enumerable.Range(1, writers).Select(async i =>
+            {
+                await gate.WaitAsync(token);
+                await detector.MarkHighWaterAsync(i, token);
+            }).ToArray();
+
+            gate.Release(writers);
+
+            // The assertion is that nothing threw. A PK violation (2627) is the reported bug; a
+            // deadlock (1205) is the bug that HOLDLOCK-without-UPDLOCK trades it for.
+            await Task.WhenAll(marks);
+
+            // And the upsert converges on one row rather than a pile.
+            (await CountHighWaterRowsAsync(token)).ShouldBe(1);
+        }
+    }
+
+    private async Task WarmPoolAsync(int connections, CancellationToken token)
+    {
+        // Open them all at once and hold them open together, so the pool actually grows to
+        // `connections` rather than handing the same one back serially.
+        var open = await Task.WhenAll(Enumerable.Range(0, connections).Select(async _ =>
+        {
+            var conn = new SqlConnection(theStore.Options.ConnectionString);
+            await conn.OpenAsync(token);
+            return conn;
+        }));
+
+        foreach (var conn in open)
+        {
+            await conn.DisposeAsync();
+        }
+    }
+
+    private async Task DeleteHighWaterRowAsync(CancellationToken token)
+    {
+        await using var conn = await OpenConnectionAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText =
+            "DELETE FROM [dbo].[pc_event_progression] WHERE name = 'HighWaterMark';";
+        await cmd.ExecuteNonQueryAsync(token);
+    }
+
+    private async Task<int> CountHighWaterRowsAsync(CancellationToken token)
+    {
+        await using var conn = await OpenConnectionAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText =
+            "SELECT COUNT(*) FROM [dbo].[pc_event_progression] WHERE name = 'HighWaterMark';";
+        return (int)(await cmd.ExecuteScalarAsync(token))!;
+    }
+
+    private PolecatHighWaterDetector CreateDetector()
+    {
+        return new PolecatHighWaterDetector(
+            theStore.Database.Events,
+            theStore.Options.ConnectionString,
+            theStore.Options.DaemonSettings,
+            NullLogger<PolecatHighWaterDetector>.Instance,
+            theStore.Options.ResiliencePipeline);
+    }
+}

--- a/src/Polecat/DocumentStore.EventStore.cs
+++ b/src/Polecat/DocumentStore.EventStore.cs
@@ -495,8 +495,10 @@ public partial class DocumentStore : IEventStore<IDocumentSession, IQuerySession
             else
             {
                 await using var cmd = conn.CreateCommand();
+                // HOLDLOCK: concurrent rewinds of the same shard would otherwise both miss the row
+                // and both insert. See PolecatHighWaterDetector.MarkHighWaterAsync (#500).
                 cmd.CommandText = $"""
-                    MERGE {progressionTable} AS target
+                    MERGE {progressionTable} WITH (UPDLOCK, HOLDLOCK) AS target
                     USING (SELECT @name AS name) AS source ON target.name = source.name
                     WHEN MATCHED THEN UPDATE SET last_seq_id = @seq, last_updated = SYSDATETIMEOFFSET()
                     WHEN NOT MATCHED THEN INSERT (name, last_seq_id, last_updated)
@@ -521,8 +523,9 @@ public partial class DocumentStore : IEventStore<IDocumentSession, IQuerySession
             await conn.OpenAsync(ct);
 
             await using var cmd = conn.CreateCommand();
+            // HOLDLOCK: see the sibling upsert above and #500.
             cmd.CommandText = $"""
-                MERGE {progressionTable} AS target
+                MERGE {progressionTable} WITH (UPDLOCK, HOLDLOCK) AS target
                 USING (SELECT @name AS name) AS source ON target.name = source.name
                 WHEN MATCHED THEN UPDATE SET last_seq_id = @seq, last_updated = SYSDATETIMEOFFSET()
                 WHEN NOT MATCHED THEN INSERT (name, last_seq_id, last_updated)

--- a/src/Polecat/Events/Daemon/PolecatHighWaterDetector.cs
+++ b/src/Polecat/Events/Daemon/PolecatHighWaterDetector.cs
@@ -224,8 +224,31 @@ internal class PolecatHighWaterDetector : IHighWaterDetector
             await conn.OpenAsync(ct);
 
             await using var cmd = conn.CreateCommand();
+            // WITH (UPDLOCK, HOLDLOCK) is load-bearing, not decoration — #500. A bare MERGE takes no
+            // lasting lock over the key it probed, so two detectors racing on a cold start (no
+            // HighWaterMark row yet) both match nothing and both take the INSERT branch: "Violation
+            // of PRIMARY KEY constraint 'pkey_pc_event_progression_name'".
+            // Why both hints rather than HOLDLOCK alone. HOLDLOCK makes the probe hold its range
+            // lock to end of statement, which is what closes the probe/probe/insert/insert window.
+            // UPDLOCK additionally makes that a RangeS-U rather than a RangeS-S: two RangeS-U locks
+            // are mutually incompatible, so the loser blocks at the probe and re-reads into the
+            // MATCHED branch, instead of both sides holding a shared lock and then needing to
+            // convert it to an insert lock the other side blocks — the documented lock-conversion
+            // deadlock (1205) that a bare HOLDLOCK upsert is prone to.
+            // Measured, so the comment does not overstate it: against Bug_500's reproducer the bare
+            // MERGE fails with 2627 every run, and BOTH hinted forms pass — the conversion deadlock
+            // did not reproduce here. UPDLOCK is kept because it forecloses that failure mode at no
+            // cost on a row this cold (one write per detection cycle), not because it was observed
+            // to be load-bearing. Do not "simplify" it away on the grounds that HOLDLOCK passes.
+            // The document upserts in SqlServerDocumentStorageDescriptorBuilder carry HOLDLOCK alone
+            // and are deliberately left alone: they contend on distinct document ids, where two
+            // sessions rarely probe the SAME key. Every agent here contends on the one literal
+            // 'HighWaterMark' row, so this is the maximal-contention case.
+            // JasperFx 2.56.0 (jasperfx#709) collapses N concurrent agent starts in ONE process into
+            // a single priming Detect(), which is what produced the reported trace — but a second
+            // process still races, so the guard has to be here, server-side.
             cmd.CommandText = $"""
-                MERGE {events.ProgressionTableName} AS target
+                MERGE {events.ProgressionTableName} WITH (UPDLOCK, HOLDLOCK) AS target
                 USING (SELECT 'HighWaterMark' AS name) AS source ON target.name = source.name
                 WHEN MATCHED THEN UPDATE SET last_seq_id = @mark, last_updated = SYSDATETIMEOFFSET()
                 WHEN NOT MATCHED THEN INSERT (name, last_seq_id, last_updated)

--- a/src/Polecat/Events/Projections/NaturalKeyUpsertOperation.cs
+++ b/src/Polecat/Events/Projections/NaturalKeyUpsertOperation.cs
@@ -37,10 +37,12 @@ internal class NaturalKeyUpsertOperation : Polecat.Internal.IStorageOperation
     {
         var streamColumn = _isGuidStream ? "stream_id" : "stream_key";
 
+        // HOLDLOCK on both branches: two sessions first-writing the same natural key would
+        // otherwise both probe, both miss, and both insert against the unique key. See #500.
         if (_isConjoined)
         {
             builder.Append($"""
-                MERGE {_tableName} AS target
+                MERGE {_tableName} WITH (UPDLOCK, HOLDLOCK) AS target
                 USING (VALUES (
                 """);
             builder.AppendParameter(_naturalKeyValue);
@@ -58,7 +60,7 @@ internal class NaturalKeyUpsertOperation : Polecat.Internal.IStorageOperation
         else
         {
             builder.Append($"""
-                MERGE {_tableName} AS target
+                MERGE {_tableName} WITH (UPDLOCK, HOLDLOCK) AS target
                 USING (VALUES (
                 """);
             builder.AppendParameter(_naturalKeyValue);

--- a/src/Polecat/Internal/Operations/RecordProgressionOperation.cs
+++ b/src/Polecat/Internal/Operations/RecordProgressionOperation.cs
@@ -46,8 +46,10 @@ internal class RecordProgressionOperation : IStorageOperation
                 ? "@name, @seq, SYSDATETIMEOFFSET(), SYSDATETIMEOFFSET()"
                 : "@name, @seq, SYSDATETIMEOFFSET()";
 
+            // HOLDLOCK: this is the Floor == 0 path, where the row does not exist yet and two
+            // agents starting together both take the INSERT branch without it. See #500.
             builder.Append($"""
-                MERGE {_progressionTableName} AS target
+                MERGE {_progressionTableName} WITH (UPDLOCK, HOLDLOCK) AS target
                 USING (SELECT @name AS name) AS source ON target.name = source.name
                 WHEN MATCHED THEN UPDATE SET {set}
                 WHEN NOT MATCHED THEN INSERT ({columns})

--- a/src/Polecat/Projections/Flattened/StatementMap.cs
+++ b/src/Polecat/Projections/Flattened/StatementMap.cs
@@ -166,8 +166,10 @@ public class StatementMap<TEvent> : IFlatTableEventHandler
         var insertCols = string.Join(", ", insertColumns);
         var insertVals = string.Join(", ", insertValues);
 
+        // HOLDLOCK: the daemon applies slices concurrently, so two slices touching the same flat
+        // table row race the probe and both insert on the PK without it. See #500.
         _compiledSql = $"""
-            MERGE {SqlEscaping.QualifiedName(table.Identifier.Schema, table.Identifier.Name)} AS target
+            MERGE {SqlEscaping.QualifiedName(table.Identifier.Schema, table.Identifier.Name)} WITH (UPDLOCK, HOLDLOCK) AS target
             USING (SELECT @p0 AS {SqlEscaping.QuoteIdentifier(pkColumn)}) AS source ON target.{SqlEscaping.QuoteIdentifier(pkColumn)} = source.{SqlEscaping.QuoteIdentifier(pkColumn)}
             WHEN MATCHED THEN UPDATE SET {updateSet}
             WHEN NOT MATCHED THEN INSERT ({insertCols}) VALUES ({insertVals});


### PR DESCRIPTION
Closes #500.

## The diagnosis on the issue is close but not quite right

The report reads `MarkHighWaterAsync` as doing "a plain `INSERT`". It has actually been a `MERGE` since well before 5.19.2 — the missing piece was the **lock hint**, not the statement.

A bare `MERGE` takes no lasting lock over the key it probed. Two writers arriving on a row that does not exist yet both probe, both miss, and both take the `INSERT` branch. Every loser gets `Violation of PRIMARY KEY constraint 'pkey_pc_event_progression_name'`.

## What changed

Five upsert `MERGE`s lacked the hint:

| Site | Case |
|---|---|
| `PolecatHighWaterDetector.MarkHighWaterAsync` | the reported bug |
| `DocumentStore.EventStore.cs` (×2) | shard progression rewinds |
| `RecordProgressionOperation` | the `Floor == 0` insert path |
| `NaturalKeyUpsertOperation` (×2) | first write of a natural key |
| `StatementMap` | flat table projection upserts |

The document upserts in `SqlServerDocumentStorageDescriptorBuilder` and `PolecatDocumentStorage` already carry `HOLDLOCK` and are **deliberately left alone** — they contend on distinct document ids. The progression rows are the opposite case: every agent contends on the one literal `'HighWaterMark'` row, so this is the maximal-contention shape.

## Why `UPDLOCK` as well as `HOLDLOCK` — measured, not assumed

`HOLDLOCK` alone holds the probe's range lock to end of statement, which is what closes the window. `UPDLOCK` additionally makes that a `RangeS-U` rather than a `RangeS-S`; two `RangeS-U` locks are mutually incompatible, so the loser blocks at the probe instead of both sides holding a shared lock and then needing to convert it to an insert lock the other blocks — the lock-conversion deadlock a bare `HOLDLOCK` upsert is prone to.

I predicted that deadlock and then measured it, and **it did not reproduce**:

| Variant | Result against the new reproducer |
|---|---|
| `MERGE … AS target` (pre-fix) | ❌ fails — `Violation of PRIMARY KEY constraint`, every run |
| `MERGE … WITH (HOLDLOCK)` | ✅ passes |
| `MERGE … WITH (UPDLOCK, HOLDLOCK)` | ✅ passes |

`UPDLOCK` is kept because it forecloses that failure mode at no cost on a row written once per detection cycle — **not** because it was observed to be load-bearing. The comment in the detector states this explicitly so nobody later "simplifies" it away on the grounds that `HOLDLOCK` alone passes.

## The test needed real contention to be worth anything

The first version of the regression test **passed against the bare MERGE** — connection-pool warmup staggered the writers enough that each found the row the previous one had just committed. It was a vacuous guard.

It now warms the pool before the timed section, then runs 8 rounds of 32 writers released together against a freshly emptied row. That fails on the pre-fix code every run.

## Relationship to #504

This is the **server-side** half. JasperFx 2.56.0 (jasperfx#709, [#504](https://github.com/JasperFx/polecat/pull/504)) collapses N concurrent agent starts in one process into a single priming `Detect()`, which is what produced the reported trace. A second *process* still races the upsert, so both halves are needed. The two PRs are independent and touch different files.

## Verification

`Polecat.Tests` — 2221 total, **0 failed**, 3 skipped, against a fresh SQL Server 2025 (RTM-CU5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)