### PR TITLE
gh-501: register an IDatabaseSource so db-apply / db-assert / db-dump see the store

### DIFF
--- a/docs/schema/migrations.md
+++ b/docs/schema/migrations.md
@@ -52,3 +52,26 @@ All schema management is delegated to Weasel.SqlServer, which provides:
 - **Safe operations** -- Never drops columns or tables
 - **Idempotent** -- Safe to run multiple times
 - **Transaction safety** -- Schema changes are transactional
+
+## Command Line Schema Management
+
+With `RunJasperFxCommands(args)` on a host that calls `AddPolecat(...)`, both families of schema
+commands see the Polecat database:
+
+```bash
+dotnet run -- db-apply
+```
+
+| Command | Does |
+|---|---|
+| `db-apply` | Apply every outstanding migration |
+| `db-assert` | Fail if the database is out of step with the configuration — useful as a deployment gate |
+| `db-dump` | Write the DDL to a file instead of executing it |
+| `resources setup` | Provision every registered resource, Polecat's schema among them |
+| `resources list` / `resources check` | List or verify registered resources |
+
+The `db-*` commands operate on Weasel databases specifically; `resources *` covers every JasperFx
+resource in the application, so on a Wolverine host it also provisions envelope storage and broker
+topology alongside the Polecat schema. Both work against a single database and against every tenant
+database under separate-database or master-table tenancy, and ancillary stores registered with
+`AddPolecatStore<T>()` are included.

--- a/src/Polecat.Tests/DependencyInjection/database_source_registration_tests.cs
+++ b/src/Polecat.Tests/DependencyInjection/database_source_registration_tests.cs
@@ -1,0 +1,77 @@
+using JasperFx.Descriptors;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Polecat.Storage;
+using Polecat.Tests.Harness;
+using Weasel.Core.CommandLine;
+using Weasel.Core.Migrations;
+
+namespace Polecat.Tests.DependencyInjection;
+
+/// <summary>
+///     #501: Weasel's <c>db-apply</c> / <c>db-assert</c> / <c>db-dump</c> resolve
+///     <see cref="IDatabaseSource" /> out of the container, which Polecat never registered — so all
+///     three failed with "No Weasel databases were registered in this application" on a stock
+///     <c>AddPolecat</c> host, while <c>resources setup</c> worked. That reads as a misconfigured
+///     host rather than an unsupported command.
+///     These drive <see cref="WeaselInput" />'s real discovery path rather than merely asserting a
+///     registration exists, because the registration is only worth having if that path finds it.
+/// </summary>
+public class database_source_registration_tests
+{
+    [Fact]
+    public async Task weasel_cli_discovers_the_polecat_database()
+    {
+        using var host = BuildHost();
+
+        // AllDatabases is what FilterDatabases calls, and FilterDatabases is what threw. Before the
+        // fix this returned an empty list — the "Found 0 databases in 0.0s" from the report.
+        var databases = await new WeaselInput().AllDatabases(host);
+
+        databases.ShouldNotBeEmpty();
+
+        var store = (DocumentStore)host.Services.GetRequiredService<IDocumentStore>();
+        databases.ShouldContain(x => ReferenceEquals(x, store.Database));
+    }
+
+    [Fact]
+    public async Task filter_databases_no_longer_throws()
+    {
+        using var host = BuildHost();
+
+        // The exact call in the stack trace on the issue.
+        var databases = await new WeaselInput().FilterDatabases(host);
+
+        databases.ShouldNotBeEmpty();
+    }
+
+    [Fact]
+    public async Task describes_a_single_database_store_as_single_cardinality()
+    {
+        using var host = BuildHost();
+
+        var source = host.Services.GetServices<IDatabaseSource>().OfType<PolecatDatabaseSource>().Single();
+
+        source.Cardinality.ShouldBe(DatabaseCardinality.Single);
+
+        var usage = await source.DescribeDatabasesAsync(TestContext.Current.CancellationToken);
+
+        usage.Cardinality.ShouldBe(DatabaseCardinality.Single);
+        usage.MainDatabase.ShouldNotBeNull();
+    }
+
+    private static IHost BuildHost()
+    {
+        return new HostBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddPolecat(opts =>
+                {
+                    opts.ConnectionString = ConnectionSource.ConnectionString;
+                    opts.UseNativeJsonType = ConnectionSource.SupportsNativeJson;
+                    opts.DatabaseSchemaName = "database_source_501";
+                });
+            })
+            .Build();
+    }
+}

--- a/src/Polecat/PolecatServiceCollectionExtensions.cs
+++ b/src/Polecat/PolecatServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@ using JasperFx.MultiTenancy;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Polecat.Internal;
+using Polecat.Storage;
 
 namespace Polecat;
 
@@ -125,6 +126,15 @@ public static class PolecatServiceCollectionExtensions
         // The "resources" CLI commands also discover the Polecat database through this.
         services.AddSingleton<ISystemPart>(sp =>
             new PolecatSystemPart(sp.GetRequiredService<IDocumentStore>()));
+
+        // #501: the OTHER half of the same seam. "resources setup/list/check" go through the
+        // ISystemPart above, but Weasel's db-apply / db-assert / db-dump resolve IDatabaseSource
+        // instead — so on Polecat they found nothing and failed with "No Weasel databases were
+        // registered in this application". Marten satisfies both because its ITenancy IS an
+        // IDatabaseSource; Polecat's is adapted rather than widened, since ITenancy is public and
+        // has outside implementers. See PolecatDatabaseSource.
+        services.AddSingleton<Weasel.Core.Migrations.IDatabaseSource>(sp =>
+            new PolecatDatabaseSource(sp.GetRequiredService<IDocumentStore>));
 
         // Bridge so monitoring tools (CritterWatch / Wolverine
         // ServiceCapabilities.readDocumentStores) can discover this store via

--- a/src/Polecat/PolecatStoreServiceCollectionExtensions.cs
+++ b/src/Polecat/PolecatStoreServiceCollectionExtensions.cs
@@ -92,6 +92,12 @@ public static class PolecatStoreServiceCollectionExtensions
         services.AddSingleton<JasperFx.Documents.IDocumentStoreDiagnostics>(sp =>
             (JasperFx.Documents.IDocumentStoreDiagnostics)sp.GetRequiredService<T>());
 
+        // #501: and the db-apply / db-assert / db-dump half, so an ancillary store's databases are
+        // migrated by those commands too. Marten registers IDatabaseSource for its ancillary stores
+        // on the same line of reasoning (MartenServiceCollectionExtensions, AddMartenStore<T>).
+        services.AddSingleton<Weasel.Core.Migrations.IDatabaseSource>(sp =>
+            new Polecat.Storage.PolecatDatabaseSource(() => sp.GetRequiredService<T>()));
+
         return new PolecatStoreExpression<T>(services);
     }
 

--- a/src/Polecat/Storage/PolecatDatabaseSource.cs
+++ b/src/Polecat/Storage/PolecatDatabaseSource.cs
@@ -1,0 +1,77 @@
+using JasperFx.Descriptors;
+using Weasel.Core.Migrations;
+
+namespace Polecat.Storage;
+
+/// <summary>
+///     Adapts Polecat's <see cref="ITenancy" /> to Weasel's <see cref="IDatabaseSource" /> so the
+///     <c>db-apply</c> / <c>db-assert</c> / <c>db-dump</c> CLI commands discover the Polecat
+///     database(s). #501.
+/// </summary>
+/// <remarks>
+///     <para>
+///         Weasel's CLI resolves <see cref="IDatabaseSource" /> out of the container
+///         (<c>WeaselInput.FilterDatabases</c>). Marten satisfies this because its own
+///         <c>ITenancy</c> extends <c>IDatabaseSource</c> directly. Polecat's does not, and
+///         registering nothing meant every <c>db-*</c> command failed with "No Weasel databases were
+///         registered in this application" — which reads as a misconfigured host rather than an
+///         unsupported command, especially to anyone carrying a Marten habit.
+///     </para>
+///     <para>
+///         This is an adapter rather than widening <see cref="ITenancy" /> to extend
+///         <c>IDatabaseSource</c> the way Marten's does. <see cref="ITenancy" /> is public and has
+///         implementers outside this repo, so extending it is a breaking change — and it would pull
+///         Weasel's migration contract into Polecat's tenancy abstraction for what is purely a CLI
+///         concern. The pieces needed are already here: <see cref="PolecatDatabase" /> extends
+///         <c>DatabaseBase&lt;SqlConnection&gt;</c> and is therefore already a Weasel
+///         <see cref="IDatabase" />, and <see cref="ITenancy.BuildDatabasesAsync" /> already
+///         enumerates every tenant database including the dynamic <c>MasterTableTenancy</c> case.
+///     </para>
+///     <para>
+///         The store is resolved lazily, not injected, for the same reason
+///         <c>PolecatSystemPart</c> is: the <c>IConfigurePolecat</c> chain has to have run before the
+///         tenancy is meaningful, and that only happens on first <c>IDocumentStore</c> resolution.
+///     </para>
+/// </remarks>
+internal class PolecatDatabaseSource : IDatabaseSource
+{
+    private readonly Func<IDocumentStore> _store;
+
+    public PolecatDatabaseSource(Func<IDocumentStore> store)
+    {
+        _store = store;
+    }
+
+    private ITenancy Tenancy => _store().Options.Tenancy!;
+
+    public DatabaseCardinality Cardinality => Tenancy.Cardinality;
+
+    public async ValueTask<IReadOnlyList<IDatabase>> BuildDatabases()
+    {
+        var databases = await Tenancy.BuildDatabasesAsync().ConfigureAwait(false);
+        return databases;
+    }
+
+    public async ValueTask<DatabaseUsage> DescribeDatabasesAsync(CancellationToken token)
+    {
+        var tenancy = Tenancy;
+        var databases = await tenancy.BuildDatabasesAsync(token).ConfigureAwait(false);
+
+        if (tenancy.Cardinality == DatabaseCardinality.Single)
+        {
+            return new DatabaseUsage
+            {
+                Cardinality = DatabaseCardinality.Single,
+                MainDatabase = databases.Count == 1
+                    ? databases[0].Describe()
+                    : tenancy.GetDatabase(tenancy.DefaultTenantId).Describe()
+            };
+        }
+
+        return new DatabaseUsage
+        {
+            Cardinality = tenancy.Cardinality,
+            Databases = databases.Select(x => x.Describe()).ToList()
+        };
+    }
+}


### PR DESCRIPTION
Closes #501.

## What was wrong

Weasel's CLI resolves `IDatabaseSource` out of the container (`WeaselInput.FilterDatabases`). Polecat registered **none**, so on a stock `AddPolecat(...)` host every `db-*` command reported `Found 0 databases` and threw:

```
System.InvalidOperationException: No Weasel databases were registered in this application
```

`resources setup` / `list` / `check` worked the whole time, because those go through `ISystemPart` instead. Having one seam and not the other is what makes the failure read as a misconfigured host rather than an unsupported command.

## Adapter, not a widened `ITenancy`

The issue offered two options. This takes the adapter.

Marten satisfies Weasel because `Marten.Storage.ITenancy` extends `IDatabaseSource` directly. Doing the same here would be a **breaking change** to a public interface with implementers outside this repo, and it would pull Weasel's migration contract into Polecat's tenancy abstraction for what is purely a CLI concern.

Everything needed was already present, as the issue notes:

- `PolecatDatabase` extends `DatabaseBase<SqlConnection>`, so it is already a Weasel `IDatabase`
- `ITenancy.BuildDatabasesAsync` already enumerates every tenant database, including the dynamic `MasterTableTenancy` case

Only `DescribeDatabasesAsync` is genuinely new. The store is resolved lazily for the same reason `PolecatSystemPart` does it: the `IConfigurePolecat` chain has to have run before the tenancy means anything.

Registered for ancillary stores too, matching `AddMartenStore<T>`, which registers `IDatabaseSource` per store on the same reasoning.

## Tests drive the real path

Rather than assert "a registration exists", the tests call `WeaselInput.AllDatabases(host)` and `WeaselInput.FilterDatabases(host)` — the exact call in the reported stack trace. A registration is only worth having if that path finds it.

Removing the registration and re-running:

```
Xunit.MicrosoftTestingPlatform.XunitException:
  System.InvalidOperationException : No Weasel databases were registered in this application
  failed: 3   succeeded: 0
```

With it: `total: 3  failed: 0`.

## Docs

`docs/events/binary-serialization.md:158` referenced `db-apply`. That reference is now **accurate** rather than wrong, so it stays. `docs/schema/migrations.md` gains a "Command Line Schema Management" section covering both command families and when each applies — the gap the issue points at.

## Verification

All three CI legs, net10, fresh SQL Server 2025 (RTM-CU5):

| Leg | Result |
|---|---|
| `Polecat.Tests` | 2223 total — 0 failed, 3 skipped |
| `Polecat.EntityFrameworkCore.Tests` | 39 total — 0 failed |
| `Polecat.AspNetCore.Testing` | 80 total — 0 failed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)