### PR TITLE
gh-507: build index paths from the serialized name, not the CLR name

### DIFF
--- a/docs/documents/indexing/computed-indexes.md
+++ b/docs/documents/indexing/computed-indexes.md
@@ -257,3 +257,44 @@ opts.Schema.For<User>().UniqueIndex(x => x.Email, idx =>
 ```
 
 This includes `tenant_id` in the index columns, allowing the same email across different tenants while enforcing uniqueness within each tenant.
+
+## Serialized Names and `[JsonPropertyName]`
+
+The computed column reads the JSON path the **serializer** writes, not the CLR property name. A
+member carrying `[JsonPropertyName]` is indexed under its alias:
+
+```cs
+public class Metric
+{
+    public Guid Id { get; set; }
+
+    [JsonPropertyName("bucket_label")]
+    public string Label { get; set; } = string.Empty;
+}
+
+opts.Schema.For<Metric>().Index(x => x.Label);
+```
+
+produces a column over `$.bucket_label`, matching what queries on `x.Label` translate to, so the
+index is usable.
+
+::: warning Upgrading from before 5.20
+Prior to 5.20 the index path was built from the CLR member name, so an aliased member got a column
+over a path the serializer never writes — permanently `NULL`, and an index that could never match.
+Queries kept returning correct results by scanning the `data` column, so there was no error to
+notice.
+
+On upgrade the correct column and index are created additively; the stale ones are left in place,
+since Polecat's migrations never drop. For a member previously indexed under an alias you will find
+an orphaned `cc_<clrname>` column and its `ix_<table>_<clrname>` index, both safe to drop by hand
+once you no longer need to roll back.
+:::
+
+::: warning Naming policy
+The index path applies camelCase, the serializer default. A store configured for
+`Casing.SnakeCase` still gets camelCased index paths, which will not match the serialized document —
+the same mismatch the alias case had, tracked as
+[polecat#510](https://github.com/JasperFx/polecat/issues/510). Until that is fixed, put an explicit
+`[JsonPropertyName]` on members you index when using a non-default naming policy: the alias is
+honored verbatim, so the index and the serializer agree again.
+:::

--- a/src/Polecat.Tests/Patching/patching_with_computed_column_index.cs
+++ b/src/Polecat.Tests/Patching/patching_with_computed_column_index.cs
@@ -96,9 +96,7 @@ public class patching_with_computed_column_index : OneOffConfigurationsContext
         (await ReadColumnAsync("pc_doc_simpleindexed", "cc_servicename", id)).ShouldBe("after");
     }
 
-    [Fact(Skip = "polecat#507: Index() builds its path from the CLR member name, so an aliased " +
-                 "member's computed column is permanently NULL. Un-skip with that fix — the test " +
-                 "is correct as written and fails on the column-existence assertion.")]
+    [Fact]
     public async Task patch_keeps_an_indexed_aliased_member_consistent()
     {
         ConfigureStore(opts => opts.Schema.For<AliasedIndexed>().Index(x => x.Label));

--- a/src/Polecat/Patching/JsonPathHelper.cs
+++ b/src/Polecat/Patching/JsonPathHelper.cs
@@ -112,7 +112,13 @@ internal static class JsonPathHelper
     ///     explicit [JsonPropertyName] wins verbatim over the naming policy, otherwise the configured
     ///     naming policy is applied — so a patch targets the same key the document was written with.
     /// </summary>
-    private static string FormatMember(MemberInfo member, JsonNamingPolicy? namingPolicy)
+    /// <remarks>
+    ///     #507: internal rather than private because the index DDL builder needs the SAME answer.
+    ///     It had its own copy that applied a casing transform and never looked at the attribute, so
+    ///     an aliased member got a computed column over a path the serializer never writes.
+    ///     There is one rule and it lives here.
+    /// </remarks>
+    internal static string FormatMember(MemberInfo member, JsonNamingPolicy? namingPolicy)
     {
         var attribute = member.GetCustomAttribute<JsonPropertyNameAttribute>();
         if (attribute != null)

--- a/src/Polecat/Storage/DocumentIndex.cs
+++ b/src/Polecat/Storage/DocumentIndex.cs
@@ -1,6 +1,8 @@
 using System.Linq.Expressions;
 using System.Reflection;
 using Polecat.Internal;
+using Polecat.Patching;
+using System.Text.Json;
 
 namespace Polecat.Storage;
 
@@ -258,16 +260,36 @@ public class DocumentIndex
     /// </summary>
     internal static string MemberToJsonPath(MemberInfo member)
     {
-        var name = member.Name;
-        return "$." + char.ToLowerInvariant(name[0]) + name[1..];
+        return "$." + SerializedName(member);
     }
+
+    /// <summary>
+    ///     #507: the serialized key for a member, which is what the computed column has to read.
+    ///     Delegates to the single rule in <see cref="JsonPathHelper.FormatMember" /> — an explicit
+    ///     <c>[JsonPropertyName]</c> wins verbatim, otherwise the casing transform applies. Before
+    ///     this, the index builders camelCased the CLR name and never consulted the attribute, so an
+    ///     aliased member produced a column over a path the serializer never writes: permanently
+    ///     NULL, and an index that could never match. Queries kept returning correct results by
+    ///     scanning <c>data</c>, so nothing ever errored.
+    /// </summary>
+    /// <remarks>
+    ///     ⚠️ The naming policy is hardcoded to CamelCase, which is the serializer default and what
+    ///     these builders have always assumed. It is NOT read from the store, because index paths are
+    ///     resolved at <c>Schema.For&lt;T&gt;().Index(...)</c> time, where
+    ///     <c>DocumentMappingExpression</c> holds no <c>StoreOptions</c>. A store configured for
+    ///     <c>Casing.SnakeCase</c> therefore still builds camelCased index paths — the same class of
+    ///     mismatch as the alias bug, tracked separately. Fixing it means deferring path resolution
+    ///     to DDL time, where the mapping does have the options.
+    /// </remarks>
+    private static string SerializedName(MemberInfo member)
+        => JsonPathHelper.FormatMember(member, JsonNamingPolicy.CamelCase);
 
     /// <summary>
     ///     Resolves a (possibly nested) member access expression to a JSON path by walking the
     ///     member chain, e.g. x => x.Address.City → "$.address.city". This mirrors the LINQ
     ///     translator's MemberFactory.BuildJsonPath so an index path and the query predicate path
-    ///     are identical (otherwise the computed-column index can never match). Each segment is
-    ///     camelCased, matching the default serializer casing the rest of the index DSL assumes.
+    ///     are identical (otherwise the computed-column index can never match). #507: that claim was
+    ///     false for a member carrying [JsonPropertyName] — see <see cref="SerializedName" />.
     /// </summary>
     internal static string MemberExpressionToJsonPath(MemberExpression expression)
     {
@@ -276,8 +298,7 @@ public class DocumentIndex
 
         while (current != null)
         {
-            var name = current.Member.Name;
-            segments.Insert(0, char.ToLowerInvariant(name[0]) + name[1..]);
+            segments.Insert(0, SerializedName(current.Member));
 
             if (current.Expression is ParameterExpression)
                 break;

--- a/src/Polecat/Storage/DocumentMapping.cs
+++ b/src/Polecat/Storage/DocumentMapping.cs
@@ -9,6 +9,8 @@ using Polecat.Schema.Identity.Sequences;
 using Polecat.Storage.Metadata;
 using Weasel.Core.Identity;
 using Weasel.Core.Sequences;
+using Polecat.Patching;
+using System.Text.Json;
 
 namespace Polecat.Storage;
 
@@ -161,10 +163,19 @@ internal class DocumentMapping
         var current = _documentType;
         foreach (var segment in jsonPath[2..].Split('.'))
         {
-            // Index paths are camelCased property names; match case-insensitively since
-            // camelCasing only changes the first character.
-            var prop = current.GetProperties(BindingFlags.Public | BindingFlags.Instance)
-                .FirstOrDefault(p => string.Equals(p.Name, segment, StringComparison.OrdinalIgnoreCase));
+            // #507: match on the SERIALIZED name, not the CLR name. An index path segment is
+            // whatever the serializer writes, which for a [JsonPropertyName] member is the alias and
+            // bears no relation to the property name — "bucket_label" never matches "Label" however
+            // it is cased. Resolving to null here is not loud: the caller falls back to a default SQL
+            // type, so the computed column is silently mistyped rather than refused.
+            // The CLR-name comparison is kept as a fallback so a path written by hand (JsonPaths and
+            // SqlTypeByPath are both settable) still resolves the way it always did.
+            var props = current.GetProperties(BindingFlags.Public | BindingFlags.Instance);
+            var prop = Array.Find(props,
+                           p => string.Equals(JsonPathHelper.FormatMember(p, JsonNamingPolicy.CamelCase),
+                               segment, StringComparison.Ordinal))
+                       ?? Array.Find(props,
+                           p => string.Equals(p.Name, segment, StringComparison.OrdinalIgnoreCase));
             if (prop == null) return null;
             current = prop.PropertyType;
         }


### PR DESCRIPTION
Closes #507. Depends on nothing, but un-skips a test added by #508 — merge that one first, or this PR's test file simply arrives with it.

## The bug

`DocumentIndex` built its JSON path from the CLR member name with a casing transform and **never consulted `[JsonPropertyName]`**, while `JsonPathHelper` (patching) and `MemberFactory` (LINQ) both honor it:

```
data     | {"id":"aaecaf13…","bucket_label":"before"}
cc_label | <NULL>          ← JSON_VALUE(data, '$.label')
```

The column is `NULL` for every row that will ever exist, and the index can never match.

**Nothing errors.** The translator emits the correct aliased path, so queries return correct results — by scanning `data`. Dead index and false confidence rather than wrong answers, which is exactly why it went unnoticed. Same defect as marten#5290, one consumer over.

The doc comment on `MemberExpressionToJsonPath` already asserted the invariant it was breaking:

> mirrors the LINQ translator's MemberFactory.BuildJsonPath so an index path and the query predicate path are identical (otherwise the computed-column index can never match)

## The fix

`JsonPathHelper.FormatMember` becomes `internal`, and both `DocumentIndex` path builders route through it. **One rule, one place** — rather than two copies that drifted.

`DocumentMapping.ResolveClrMemberType` had to move with it. It walked path segments against CLR property names, and `bucket_label` never matches `Label` however it is cased. Left alone it returns `null`, the caller falls back to a default SQL type, and the column comes back **silently mistyped** rather than refused. It now matches on the serialized name, keeping the CLR-name comparison as a fallback since `JsonPaths` and `SqlTypeByPath` are both settable and a hand-written path must still resolve as before.

Verified after the fix:

```
cc_bucket_label | (json_value([data],'$.bucket_label' RETURNING VARCHAR(250)))
```

The correct `VARCHAR(250)` confirms `ResolveClrMemberType` resolves through the alias too.

## Upgrading is additive, with no special handling

- Index name derives from the JSON path, so `ix_…_label` and `ix_…_bucket_label` **do not collide**
- Column add is `IF COL_LENGTH(…) IS NULL ALTER TABLE ADD`
- Index create is `IF NOT EXISTS (…) CREATE INDEX`

An existing deployment gains the correct column and index and keeps a dead `cc_label` plus its index — consistent with Polecat's migrations never dropping. Documented, including that the orphans are safe to drop by hand once rollback is no longer wanted.

## What this does NOT fix — #510

The **naming-policy** half of the same mismatch: a `Casing.SnakeCase` store still gets camelCased index paths. Filed as [#510](https://github.com/JasperFx/polecat/issues/510).

It cannot be fixed in place. `[JsonPropertyName]` lives on the member and is available statically; the naming policy is not — index paths resolve at `Schema.For<T>().Index(...)` time, inside `DocumentMappingExpression<T>`, which holds no `StoreOptions`. Fixing it means deferring path resolution to DDL time, where the mapping does have the options, and that touches `JsonPaths` / `IncludeColumns` / `SqlTypeByPath`.

The hardcoded `CamelCase` is now a single visible, greppable argument rather than an inlined transform, and the workaround — an explicit `[JsonPropertyName]` on indexed members — is documented.

## Verification

| Leg | Result |
|---|---|
| `Polecat.Tests` | 2225 total — **0 failed**, 3 skipped (the alias test now runs) |
| `Polecat.EntityFrameworkCore.Tests` | 39 total — 0 failed |
| `Polecat.AspNetCore.Testing` | 80 total — 0 failed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)