### PR TITLE
gh-510: render index paths under the store's naming policy

### DIFF
--- a/docs/documents/indexing/computed-indexes.md
+++ b/docs/documents/indexing/computed-indexes.md
@@ -290,11 +290,30 @@ an orphaned `cc_<clrname>` column and its `ix_<table>_<clrname>` index, both saf
 once you no longer need to roll back.
 :::
 
-::: warning Naming policy
-The index path applies camelCase, the serializer default. A store configured for
-`Casing.SnakeCase` still gets camelCased index paths, which will not match the serialized document —
-the same mismatch the alias case had, tracked as
-[polecat#510](https://github.com/JasperFx/polecat/issues/510). Until that is fixed, put an explicit
-`[JsonPropertyName]` on members you index when using a non-default naming policy: the alias is
-honored verbatim, so the index and the serializer agree again.
+## Naming Policies
+
+The index path follows the store's configured naming policy, so a non-default casing indexes the
+path the serializer actually writes:
+
+```cs
+opts.ConfigureSerialization(casing: Casing.SnakeCase);
+opts.Schema.For<Metric>().Index(x => x.ServiceName);
+```
+
+produces a `cc_service_name` column over `$.service_name`, matching both the document and the
+queries translated against it. Every segment of a nested path is converted, and native
+`JsonIndex(...)` paths follow the same rule.
+
+An explicit `[JsonPropertyName]` still wins verbatim and is **not** put through the policy on top,
+matching how `System.Text.Json` itself behaves.
+
+::: warning Upgrading from before 5.20
+Prior to 5.20 index paths were always camelCased regardless of the configured policy, so on a
+`Casing.SnakeCase` store every computed column read a path the document did not contain — `NULL` for
+every row, and an index that could never match. As with the alias case above, queries returned
+correct results by scanning `data`, so there was nothing to notice.
+
+On upgrade the correctly-named column and index are created additively and the stale ones are left
+in place. Expect an orphaned `cc_<camelCase>` column and its index per affected member, both safe to
+drop by hand once you no longer need to roll back.
 :::

--- a/src/Polecat.Tests/Storage/index_naming_policy_tests.cs
+++ b/src/Polecat.Tests/Storage/index_naming_policy_tests.cs
@@ -1,0 +1,198 @@
+using System.Text.Json.Serialization;
+using Weasel.Core;
+using Polecat.Linq;
+using Polecat.Tests.Harness;
+
+namespace Polecat.Tests.Storage;
+
+/// <summary>
+///     #510. The computed column an index creates has to read the path the SERIALIZER writes. The
+///     index builder hardcoded camelCase while the LINQ translator applied the store's configured
+///     policy, so on a <c>Casing.SnakeCase</c> store the column read <c>$.serviceName</c> while the
+///     document held <c>service_name</c> — NULL for every row, an index that could never match, and
+///     queries silently scanning <c>data</c> instead. Same shape as #507's alias bug, same silence.
+///     These assert the column NAME and its DEFINITION, not just that a query returns the right row:
+///     a query is satisfied by a fallback scan and so cannot tell a live index from a dead one.
+/// </summary>
+public class index_naming_policy_tests : OneOffConfigurationsContext
+{
+    public class SnakeMetric
+    {
+        public Guid Id { get; set; }
+        public string ServiceName { get; set; } = string.Empty;
+        public int RequestCount { get; set; }
+        public Inner NestedThing { get; set; } = new();
+    }
+
+    public class Inner
+    {
+        public string RegionCode { get; set; } = string.Empty;
+    }
+
+    public class AliasedUnderSnake
+    {
+        public Guid Id { get; set; }
+
+        [JsonPropertyName("BucketLabel")]
+        public string Label { get; set; } = string.Empty;
+    }
+
+    [Fact]
+    public async Task snake_case_store_indexes_the_path_the_serializer_writes()
+    {
+        ConfigureStore(opts =>
+        {
+            opts.ConfigureSerialization(casing: Casing.SnakeCase);
+            opts.Schema.For<SnakeMetric>().Index(x => x.ServiceName);
+        });
+
+        var id = Guid.NewGuid();
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Store(new SnakeMetric { Id = id, ServiceName = "checkout" });
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        // The column is named and defined from the serialized path, not the CLR name.
+        var definition = await ComputedColumnDefinitionAsync("pc_doc_snakemetric", "cc_service_name");
+        definition.ShouldNotBeNull("Expected a cc_service_name computed column");
+        definition.ShouldContain("$.service_name");
+
+        // And it actually holds the value — the whole point, since the old column was NULL forever.
+        (await ReadColumnAsync("pc_doc_snakemetric", "cc_service_name", id)).ShouldBe("checkout");
+
+        await using var query = theStore.QuerySession();
+        var found = await query.Query<SnakeMetric>()
+            .Where(x => x.ServiceName == "checkout")
+            .ToListAsync(TestContext.Current.CancellationToken);
+        found.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task snake_case_applies_to_every_segment_of_a_nested_path()
+    {
+        ConfigureStore(opts =>
+        {
+            opts.ConfigureSerialization(casing: Casing.SnakeCase);
+            opts.Schema.For<SnakeMetric>().Index(x => x.NestedThing.RegionCode);
+        });
+
+        var id = Guid.NewGuid();
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Store(new SnakeMetric { Id = id, NestedThing = new Inner { RegionCode = "eu-west" } });
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        var definition = await ComputedColumnDefinitionAsync(
+            "pc_doc_snakemetric", "cc_nested_thing_region_code");
+        definition.ShouldNotBeNull("Expected a cc_nested_thing_region_code computed column");
+        definition.ShouldContain("$.nested_thing.region_code");
+
+        (await ReadColumnAsync("pc_doc_snakemetric", "cc_nested_thing_region_code", id))
+            .ShouldBe("eu-west");
+    }
+
+    [Fact]
+    public async Task a_composite_index_types_each_column_through_the_renamed_path()
+    {
+        // The per-path SqlType overrides are keyed BY PATH, so re-rendering the paths has to carry
+        // them across or a composite index silently loses a column's declared type.
+        ConfigureStore(opts =>
+        {
+            opts.ConfigureSerialization(casing: Casing.SnakeCase);
+            opts.Schema.For<SnakeMetric>().Index(x => new { x.ServiceName, x.RequestCount });
+        });
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Store(new SnakeMetric { Id = Guid.NewGuid(), ServiceName = "a", RequestCount = 3 });
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        (await ComputedColumnDefinitionAsync("pc_doc_snakemetric", "cc_service_name"))
+            .ShouldNotBeNull();
+
+        // The numeric column keeps its CLR-derived int typing through the rename — if
+        // ResolveClrMemberType failed to resolve the snake_case path it would fall back to a string
+        // type here rather than refusing, which is the silent-mistyping mode.
+        var countDefinition = await ComputedColumnDefinitionAsync(
+            "pc_doc_snakemetric", "cc_request_count");
+        countDefinition.ShouldNotBeNull();
+        countDefinition!.ToLowerInvariant().ShouldContain("int");
+    }
+
+    [Fact]
+    public async Task an_explicit_alias_still_wins_over_the_naming_policy()
+    {
+        // STJ does not apply the policy on top of an explicit [JsonPropertyName], so neither may we.
+        // This is also the documented workaround for stores on the old behaviour.
+        ConfigureStore(opts =>
+        {
+            opts.ConfigureSerialization(casing: Casing.SnakeCase);
+            opts.Schema.For<AliasedUnderSnake>().Index(x => x.Label);
+        });
+
+        var id = Guid.NewGuid();
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Store(new AliasedUnderSnake { Id = id, Label = "kept" });
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        // "BucketLabel" verbatim — NOT snake_cased into "bucket_label".
+        var definition = await ComputedColumnDefinitionAsync(
+            "pc_doc_aliasedundersnake", "cc_bucketlabel");
+        definition.ShouldNotBeNull("Expected the alias to be used verbatim, not snake_cased");
+        definition.ShouldContain("$.BucketLabel");
+
+        (await ReadColumnAsync("pc_doc_aliasedundersnake", "cc_bucketlabel", id)).ShouldBe("kept");
+    }
+
+    [Fact]
+    public async Task the_default_camel_case_store_is_unchanged()
+    {
+        // The overwhelming majority of stores are on the default, and they must see byte-identical
+        // DDL to before this change.
+        ConfigureStore(opts => opts.Schema.For<SnakeMetric>().Index(x => x.ServiceName));
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Store(new SnakeMetric { Id = Guid.NewGuid(), ServiceName = "checkout" });
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        var definition = await ComputedColumnDefinitionAsync("pc_doc_snakemetric", "cc_servicename");
+        definition.ShouldNotBeNull("Expected the camelCase column name to be unchanged");
+        definition.ShouldContain("$.serviceName");
+    }
+
+    private async Task<string?> ComputedColumnDefinitionAsync(string table, string column)
+    {
+        await using var conn = await OpenConnectionAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"""
+            SELECT cc.definition
+            FROM sys.computed_columns cc
+            WHERE cc.object_id = OBJECT_ID('[{Schema}].[{table}]') AND cc.name = @column;
+            """;
+        cmd.Parameters.AddWithValue("@column", column);
+
+        var value = await cmd.ExecuteScalarAsync(TestContext.Current.CancellationToken);
+        return value == null || value == DBNull.Value ? null : (string)value;
+    }
+
+    private async Task<string?> ReadColumnAsync(string table, string column, Guid id)
+    {
+        await using var conn = await OpenConnectionAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText =
+            $"SELECT CONVERT(varchar(250), [{column}]) FROM [{Schema}].[{table}] WHERE id = @id;";
+        cmd.Parameters.AddWithValue("@id", id);
+
+        var value = await cmd.ExecuteScalarAsync(TestContext.Current.CancellationToken);
+        return value == DBNull.Value ? null : (string?)value;
+    }
+
+    private string Schema => GetType().Name.ToLowerInvariant();
+}

--- a/src/Polecat/Internal/DocumentProviderRegistry.cs
+++ b/src/Polecat/Internal/DocumentProviderRegistry.cs
@@ -118,6 +118,12 @@ internal class DocumentProviderRegistry
             {
                 foreach (var index in indexes)
                 {
+                    // #510: the paths were rendered with the CamelCase default back in
+                    // DocumentMappingExpression, which holds no StoreOptions. This is the first point
+                    // where the store's serializer policy is reachable, so re-render before the
+                    // index is used for DDL or matched by the LINQ translator. A no-op under the
+                    // default policy.
+                    index.ApplyNamingPolicy(mapping.StoreOptions);
                     mapping.Indexes.Add(index);
                 }
             }
@@ -128,6 +134,8 @@ internal class DocumentProviderRegistry
             {
                 foreach (var jsonIndex in jsonIndexes)
                 {
+                    // #510: same re-render as the computed-column indexes above.
+                    jsonIndex.ApplyNamingPolicy(mapping.StoreOptions);
                     mapping.JsonIndexes.Add(jsonIndex);
                 }
             }

--- a/src/Polecat/Linq/Members/MemberFactory.cs
+++ b/src/Polecat/Linq/Members/MemberFactory.cs
@@ -32,14 +32,10 @@ internal class MemberFactory : IMemberResolver
         // On nvarchar(max) storage the RETURNING clause is a syntax error, so fall back to CAST.
         _useReturning = options.UseNativeJsonType;
 
-        if (options.Serializer is Serializer s)
-        {
-            _namingPolicy = s.Options.PropertyNamingPolicy;
-        }
-        else
-        {
-            _namingPolicy = JsonNamingPolicy.CamelCase;
-        }
+        // #510: one resolver, shared with the index DDL builder. These two worked the policy out
+        // separately and drifted, which is what made a snake_case store's computed columns index a
+        // path the serializer never writes.
+        _namingPolicy = SerializedNames.PolicyFor(options);
     }
 
     public IQueryableMember ResolveMember(MemberExpression expression)

--- a/src/Polecat/Storage/DocumentIndex.cs
+++ b/src/Polecat/Storage/DocumentIndex.cs
@@ -21,7 +21,78 @@ public class DocumentIndex
     /// <summary>
     ///     The JSON paths (e.g., "$.userName", "$.address.city") to index.
     /// </summary>
-    public string[] JsonPaths { get; }
+    /// <remarks>
+    ///     #510: settable because these are re-rendered once the store's naming policy is known —
+    ///     see <see cref="ApplyNamingPolicy" />. Set one by hand and it is left exactly as written.
+    /// </remarks>
+    public string[] JsonPaths { get; set; }
+
+    /// <summary>
+    ///     #510: the member chains the paths were resolved from, when they came from a lambda.
+    ///     Null for a hand-written path or a path with no expression behind it, which is what makes
+    ///     <see cref="ApplyNamingPolicy" /> able to tell the two apart.
+    /// </summary>
+    internal MemberInfo[][]? MemberChains { get; set; }
+
+    /// <summary>
+    ///     #510: member chains behind <see cref="IncludeColumns" />, same contract as
+    ///     <see cref="MemberChains" />.
+    /// </summary>
+    internal MemberInfo[][]? IncludeMemberChains { get; set; }
+
+    /// <summary>
+    ///     #510: re-render the paths under the store's serializer naming policy.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Index paths are resolved at <c>Schema.For&lt;T&gt;().Index(...)</c> time, inside a
+    ///         <c>DocumentMappingExpression&lt;T&gt;</c> that holds no <c>StoreOptions</c> — there is
+    ///         nothing to read the policy from at that point, so the paths are first rendered with
+    ///         the CamelCase default. This runs later, when the index is attached to a
+    ///         <c>DocumentMapping</c> and the options are finally in reach.
+    ///     </para>
+    ///     <para>
+    ///         Only paths that came from a lambda are re-rendered. A hand-written
+    ///         <see cref="JsonPaths" /> entry is left verbatim: the caller wrote the exact path they
+    ///         meant, and second-guessing it would silently retarget the column.
+    ///     </para>
+    ///     <para>
+    ///         Idempotent, and a no-op under the default CamelCase policy — which is the common case,
+    ///         so the overwhelming majority of stores see byte-identical DDL to before.
+    ///     </para>
+    /// </remarks>
+    internal void ApplyNamingPolicy(StoreOptions options)
+    {
+        if (MemberChains is { Length: > 0 })
+        {
+            var rendered = MemberChains.Select(chain => SerializedNames.PathFor(chain, options)).ToArray();
+
+            // Per-path SQL type overrides are keyed by path, so a rename has to carry them across or
+            // a composite index silently loses a column's declared type.
+            RekeySqlTypeOverrides(JsonPaths, rendered);
+            JsonPaths = rendered;
+        }
+
+        if (IncludeMemberChains is { Length: > 0 })
+        {
+            IncludeColumns = IncludeMemberChains
+                .Select(chain => SerializedNames.PathFor(chain, options)).ToArray();
+        }
+    }
+
+    private void RekeySqlTypeOverrides(string[] before, string[] after)
+    {
+        if (SqlTypeByPath.Count == 0) return;
+
+        for (var i = 0; i < before.Length && i < after.Length; i++)
+        {
+            if (before[i] == after[i]) continue;
+            if (SqlTypeByPath.Remove(before[i], out var sqlType))
+            {
+                SqlTypeByPath[after[i]] = sqlType;
+            }
+        }
+    }
 
     /// <summary>
     ///     Optional explicit index name. Auto-generated if null.
@@ -315,6 +386,15 @@ public class DocumentIndex
     ///     several — x => new { x.Prop1, x.Address.City }.
     /// </summary>
     internal static string[] ResolveJsonPaths<T>(Expression<Func<T, object?>> expression)
+        => ResolveMemberChains(expression).Select(MemberChainToJsonPath).ToArray();
+
+    /// <summary>
+    ///     #510: the member chains behind an index expression, outermost member first. Kept so the
+    ///     paths can be re-rendered once the store's naming policy is known — see
+    ///     <see cref="ApplyNamingPolicy" />. Path rendering is a projection of this, never the other
+    ///     way round, so the two cannot disagree.
+    /// </summary>
+    internal static MemberInfo[][] ResolveMemberChains<T>(Expression<Func<T, object?>> expression)
     {
         var body = expression.Body;
 
@@ -327,7 +407,7 @@ public class DocumentIndex
         // Single (possibly nested) member: x => x.Property / x => x.Address.City
         if (body is MemberExpression memberExpr)
         {
-            return [MemberExpressionToJsonPath(memberExpr)];
+            return [MemberChainOf(memberExpr)];
         }
 
         // Anonymous type: x => new { x.Prop1, x.Address.City }
@@ -336,7 +416,7 @@ public class DocumentIndex
             return newExpr.Arguments
                 .Select(UnwrapToMemberExpression)
                 .Where(m => m != null)
-                .Select(m => MemberExpressionToJsonPath(m!))
+                .Select(m => MemberChainOf(m!))
                 .ToArray();
         }
 
@@ -345,6 +425,27 @@ public class DocumentIndex
             "Use a single property (x => x.Prop), a nested property (x => x.Address.City), " +
             "or an anonymous type (x => new {{ x.Prop1, x.Prop2 }}).");
     }
+
+    private static MemberInfo[] MemberChainOf(MemberExpression expression)
+    {
+        var chain = new List<MemberInfo>();
+        var current = expression;
+
+        while (current != null)
+        {
+            chain.Insert(0, current.Member);
+
+            if (current.Expression is ParameterExpression)
+                break;
+
+            current = current.Expression as MemberExpression;
+        }
+
+        return chain.ToArray();
+    }
+
+    private static string MemberChainToJsonPath(MemberInfo[] chain)
+        => "$." + string.Join(".", chain.Select(SerializedName));
 
     /// <summary>
     ///     Strips a Convert wrapper (value-type members boxed to object in some anonymous-type

--- a/src/Polecat/Storage/DocumentMapping.cs
+++ b/src/Polecat/Storage/DocumentMapping.cs
@@ -170,10 +170,13 @@ internal class DocumentMapping
             // type, so the computed column is silently mistyped rather than refused.
             // The CLR-name comparison is kept as a fallback so a path written by hand (JsonPaths and
             // SqlTypeByPath are both settable) still resolves the way it always did.
+            // #510: match under the store's ACTUAL policy. Hardcoding CamelCase here would fail to
+            // resolve a snake_case path, and the caller answers an unresolved member by falling back
+            // to a default SQL type — a silently mistyped column rather than a refused one.
             var props = current.GetProperties(BindingFlags.Public | BindingFlags.Instance);
             var prop = Array.Find(props,
-                           p => string.Equals(JsonPathHelper.FormatMember(p, JsonNamingPolicy.CamelCase),
-                               segment, StringComparison.Ordinal))
+                           p => string.Equals(SerializedNames.For(p, StoreOptions), segment,
+                               StringComparison.Ordinal))
                        ?? Array.Find(props,
                            p => string.Equals(p.Name, segment, StringComparison.OrdinalIgnoreCase));
             if (prop == null) return null;
@@ -632,12 +635,15 @@ internal class DocumentMapping
             var indexAttr = prop.GetCustomAttribute<IndexAttribute>();
             if (indexAttr == null) continue;
 
-            var jsonPath = DocumentIndex.MemberToJsonPath(prop);
+            // #510: StoreOptions is assigned before this runs, so an attribute index can be
+            // rendered under the real policy immediately rather than re-rendered later.
+            var jsonPath = "$." + SerializedNames.For(prop, StoreOptions);
             var index = new DocumentIndex([jsonPath])
             {
                 IndexName = indexAttr.IndexName,
                 SortOrder = indexAttr.SortOrder,
-                Casing = indexAttr.Casing
+                Casing = indexAttr.Casing,
+                MemberChains = [[prop]]
             };
             if (indexAttr.SqlType != null) index.SqlType = indexAttr.SqlType;
             Indexes.Add(index);
@@ -655,10 +661,12 @@ internal class DocumentMapping
         {
             var members = group.ToList();
             var firstAttr = members[0].Attr!;
-            var jsonPaths = members.Select(m => DocumentIndex.MemberToJsonPath(m.Property)).ToArray();
+            var jsonPaths = members
+                .Select(m => "$." + SerializedNames.For(m.Property, StoreOptions)).ToArray();
 
             var index = new DocumentIndex(jsonPaths)
             {
+                MemberChains = members.Select(m => new[] { (MemberInfo)m.Property }).ToArray(),
                 IsUnique = true,
                 IndexName = firstAttr.IndexName,
                 TenancyScope = firstAttr.TenancyScope,

--- a/src/Polecat/Storage/DocumentMappingExpression.cs
+++ b/src/Polecat/Storage/DocumentMappingExpression.cs
@@ -78,9 +78,7 @@ public class DocumentMappingExpression<T>
     public DocumentMappingExpression<T> Index(Expression<Func<T, object?>> expression,
         Action<DocumentIndex>? configure = null, Expression<Func<T, object?>>? include = null)
     {
-        var paths = DocumentIndex.ResolveJsonPaths(expression);
-        var index = new DocumentIndex(paths);
-        if (include != null) index.IncludeColumns = DocumentIndex.ResolveJsonPaths(include);
+        var index = BuildIndex(expression, include, isUnique: false);
         configure?.Invoke(index);
         Indexes.Add(index);
         return this;
@@ -94,12 +92,35 @@ public class DocumentMappingExpression<T>
     public DocumentMappingExpression<T> UniqueIndex(Expression<Func<T, object?>> expression,
         Action<DocumentIndex>? configure = null, Expression<Func<T, object?>>? include = null)
     {
-        var paths = DocumentIndex.ResolveJsonPaths(expression);
-        var index = new DocumentIndex(paths) { IsUnique = true };
-        if (include != null) index.IncludeColumns = DocumentIndex.ResolveJsonPaths(include);
+        var index = BuildIndex(expression, include, isUnique: true);
         configure?.Invoke(index);
         Indexes.Add(index);
         return this;
+    }
+
+    /// <summary>
+    ///     #510: builds the index carrying BOTH the rendered paths and the member chains they came
+    ///     from. The paths are rendered here with the CamelCase default because this expression holds
+    ///     no <c>StoreOptions</c>; the chains let <c>DocumentIndex.ApplyNamingPolicy</c> re-render
+    ///     them once the index is attached to a mapping and the store's policy is in reach.
+    /// </summary>
+    private static DocumentIndex BuildIndex(Expression<Func<T, object?>> expression,
+        Expression<Func<T, object?>>? include, bool isUnique)
+    {
+        var chains = DocumentIndex.ResolveMemberChains(expression);
+        var index = new DocumentIndex(DocumentIndex.ResolveJsonPaths(expression))
+        {
+            IsUnique = isUnique,
+            MemberChains = chains
+        };
+
+        if (include != null)
+        {
+            index.IncludeColumns = DocumentIndex.ResolveJsonPaths(include);
+            index.IncludeMemberChains = DocumentIndex.ResolveMemberChains(include);
+        }
+
+        return index;
     }
 
     /// <summary>
@@ -113,7 +134,10 @@ public class DocumentMappingExpression<T>
         Action<JsonIndex>? configure = null)
     {
         var paths = Storage.JsonIndex.ResolveJsonPaths(expression);
-        var index = new JsonIndex(paths);
+        var index = new JsonIndex(paths)
+        {
+            MemberChains = Storage.JsonIndex.ResolveMemberChains(expression)
+        };
         configure?.Invoke(index);
         JsonIndexes.Add(index);
         return this;

--- a/src/Polecat/Storage/JsonIndex.cs
+++ b/src/Polecat/Storage/JsonIndex.cs
@@ -33,7 +33,31 @@ public class JsonIndex
     ///     The JSON paths to index (e.g. "$.serviceName", "$.address.city"). When empty, the entire
     ///     JSON document is indexed (the <c>FOR</c> clause is omitted).
     /// </summary>
-    public string[] JsonPaths { get; }
+    /// <remarks>
+    ///     #510: settable for the same reason as <see cref="DocumentIndex.JsonPaths" /> — re-rendered
+    ///     once the store's naming policy is known. A hand-written path is left verbatim.
+    /// </remarks>
+    public string[] JsonPaths { get; set; }
+
+    /// <summary>
+    ///     #510: the member chains the paths came from, when they came from a lambda. Null for a
+    ///     hand-written path.
+    /// </summary>
+    internal System.Reflection.MemberInfo[][]? MemberChains { get; set; }
+
+    /// <summary>
+    ///     #510: re-render the paths under the store's serializer naming policy. A JSON index names
+    ///     its paths in a <c>FOR</c> clause, so a camelCased path on a snake_case store indexes
+    ///     something the document does not contain — the same silent miss as
+    ///     <see cref="DocumentIndex" />, and invisible for the same reason.
+    /// </summary>
+    internal void ApplyNamingPolicy(StoreOptions options)
+    {
+        if (MemberChains is { Length: > 0 })
+        {
+            JsonPaths = MemberChains.Select(chain => SerializedNames.PathFor(chain, options)).ToArray();
+        }
+    }
 
     /// <summary>
     ///     Optional explicit index name. Auto-derived from the table name when null.
@@ -100,4 +124,12 @@ public class JsonIndex
     /// </summary>
     internal static string[] ResolveJsonPaths<T>(Expression<Func<T, object?>> expression)
         => DocumentIndex.ResolveJsonPaths(expression);
+
+    /// <summary>
+    ///     #510: member chains behind an expression. Reuses
+    ///     <see cref="DocumentIndex.ResolveMemberChains{T}" />.
+    /// </summary>
+    internal static System.Reflection.MemberInfo[][] ResolveMemberChains<T>(
+        Expression<Func<T, object?>> expression)
+        => DocumentIndex.ResolveMemberChains(expression);
 }

--- a/src/Polecat/Storage/SerializedNames.cs
+++ b/src/Polecat/Storage/SerializedNames.cs
@@ -1,0 +1,55 @@
+using System.Reflection;
+using System.Text.Json;
+using Polecat.Patching;
+using Polecat.Serialization;
+
+namespace Polecat.Storage;
+
+/// <summary>
+///     #507 / #510: the one place that answers "what key does the serializer write for this member".
+/// </summary>
+/// <remarks>
+///     <para>
+///         Three consumers need the same answer and each used to work it out for itself: the LINQ
+///         translator (<c>MemberFactory</c>), the patch path builder (<see cref="JsonPathHelper" />),
+///         and the index DDL builder (<see cref="DocumentIndex" />). They drifted, twice, and both
+///         times the symptom was silent — a computed column over a path the serializer never writes
+///         is <c>NULL</c> for every row, so the index can never match, and queries keep returning
+///         correct results by scanning <c>data</c>. #507 was the <c>[JsonPropertyName]</c> half and
+///         #510 the naming-policy half.
+///     </para>
+///     <para>
+///         The rule itself lives in <see cref="JsonPathHelper.FormatMember" />, matching
+///         System.Text.Json: an explicit <c>[JsonPropertyName]</c> wins verbatim, and the policy is
+///         NOT applied on top of it. This type only resolves which policy is in force.
+///     </para>
+/// </remarks>
+internal static class SerializedNames
+{
+    /// <summary>
+    ///     The naming policy the store's serializer actually applies. Mirrors
+    ///     <c>MemberFactory</c>'s constructor: a custom <c>ISerializer</c> is opaque, so fall back to
+    ///     the CamelCase default rather than guessing.
+    /// </summary>
+    public static JsonNamingPolicy? PolicyFor(StoreOptions options)
+    {
+        return options.Serializer is Serializer s
+            ? s.Options.PropertyNamingPolicy
+            : JsonNamingPolicy.CamelCase;
+    }
+
+    /// <summary>
+    ///     The serialized key for a single member under the store's policy.
+    /// </summary>
+    public static string For(MemberInfo member, StoreOptions options)
+        => JsonPathHelper.FormatMember(member, PolicyFor(options));
+
+    /// <summary>
+    ///     Renders a member chain (outermost first) as a JSON path, e.g. <c>$.address.city</c>.
+    /// </summary>
+    public static string PathFor(IReadOnlyList<MemberInfo> chain, StoreOptions options)
+    {
+        var policy = PolicyFor(options);
+        return "$." + string.Join(".", chain.Select(m => JsonPathHelper.FormatMember(m, policy)));
+    }
+}


### PR DESCRIPTION
Closes #510. The naming-policy half of #507.

## The bug

`DocumentIndex` hardcoded camelCase while the LINQ translator applied the store's **configured** policy. On a `Casing.SnakeCase` store:

| | |
|---|---|
| document holds | `{"service_name": "checkout"}` |
| computed column reads | `JSON_VALUE(data, '$.serviceName')` → **NULL** |

`NULL` for every row, an index that can never match, and queries silently scanning `data`. Same shape and same silence as the alias bug.

## Why it needed a different fix than #507

`[JsonPropertyName]` lives on the member and is available statically, so #507 was fixable in place. **The policy is not** — paths resolve at `Schema.For<T>().Index(...)` time inside `DocumentMappingExpression<T>`, which holds no `StoreOptions`. So resolution is now split in two:

- `DocumentIndex` keeps the **member chains** the paths came from. Path rendering is a *projection* of those rather than the source of truth, so the two cannot disagree.
- `ApplyNamingPolicy` re-renders at the first point `StoreOptions` is reachable — `DocumentProviderRegistry`, where indexes are attached to a mapping.
- Attribute-based indexes render correctly outright, since `DocumentMapping` assigns `StoreOptions` before it discovers them.

**Only lambda-derived paths are re-rendered.** A hand-written `JsonPaths` entry is left verbatim — the caller wrote the exact path they meant, and second-guessing it would silently retarget the column.

## Two things that would have broken quietly

- **`SqlTypeByPath` is keyed by path**, so a rename has to carry the overrides across or a composite index loses a column's declared type. Covered by a test.
- **`ResolveClrMemberType`** now matches under the real policy. Hardcoding camelCase there would fail to resolve a snake_case path, and the caller answers an unresolved member by falling back to a default SQL type — a silently *mistyped* column rather than a refused one.

`JsonIndex` had the identical latent bug (its `FOR` clause names the paths) and gets the same treatment.

## The structural point

`MemberFactory`'s own copy of the policy lookup is gone. It and the index builder now share `SerializedNames`, which exists precisely because these two working the answer out separately is what caused **both** #507 and #510. Three consumers, one rule, one place.

## Compatibility

**No-op under the default CamelCase policy**, so the overwhelming majority of stores see byte-identical DDL. Upgrades additively like #507 — the index name derives from the path, so old and new do not collide, and the stale column and index are left in place per Polecat's never-drop policy. Documented, including that the orphans are safe to drop.

## Verification

Confirmed the guards are real — with the re-render removed, **3 of 5 fail**:

```
Expected a cc_service_name computed column
Expected a cc_nested_thing_region_code computed column
  total: 5   failed: 3   succeeded: 2
```

The other two are deliberate no-regression guards: the camelCase default is unchanged, and an explicit alias still beats the policy (STJ does not apply the policy on top of an explicit name, so neither may we).

`Polecat.Tests` — 2234 total, **0 failed**, 3 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)