### PR TITLE
5.20.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>5.19.2</Version>
+        <Version>5.20.0</Version>
         <LangVersion>latest</LangVersion>
         <Authors>Jeremy D. Miller</Authors>
         <PackageIcon>logo.png</PackageIcon>


### PR DESCRIPTION
Version bump for the 5.20.0 release. One line in `Directory.Build.props`.

**Minor rather than patch** for two reasons: `AddPolecat` now registers an `IDatabaseSource` (additive public surface, #501), and Weasel 9.25's SQL Server identifier quoting is observable once on the first run after upgrade.

## What's in this release

**Fixes**

- **#500** — `HighWaterMark` PK violation on cold start. Five progression/upsert `MERGE`s took no lasting lock over the key they probed, so concurrent writers all missed and all inserted. Now `UPDLOCK, HOLDLOCK`.
- **#507** — `Index()` on a `[JsonPropertyName]`-aliased member built a permanently-`NULL` computed column, so the index could never match and queries silently scanned `data`.
- **#510** — the same mismatch for naming policies: index paths were always camelCased, so a `Casing.SnakeCase` store's computed columns indexed a path the document did not contain.

**Features**

- **#501** — `db-apply` / `db-assert` / `db-dump` now discover the Polecat store. Previously all three failed with "No Weasel databases were registered in this application" while `resources setup` worked.

**Dependencies**

- **#502** — JasperFx 2.53.0 → 2.56.0: async daemon high-water reliability (jasperfx#702/#709/#710), and the in-process half of #500.
- Weasel 9.24.0 → 9.27.0: read-back fidelity fixes on partition-aligned indexes, IDENTITY columns and composite primary keys — all paths Polecat drives.

**Tests**

- **#503** — regression guards pinning that a patch leaves an `Index()` computed column consistent with the document. These are what found #507.

## Upgrade notes

#507 and #510 both change generated DDL for affected indexes, and both upgrade **additively** — the correctly-named column and index are created, and the stale ones are left in place per Polecat's never-drop policy. Anyone indexing an aliased member, or running a non-default naming policy, will find one orphaned `cc_*` column and index per affected member, safe to drop by hand. Stores on the default CamelCase policy with no aliases see byte-identical DDL.

Weasel 9.25's identifier quoting means the schema fingerprint stamps re-evaluate once on first run. That is a one-time "everything looks changed" pass, not drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)