### PR TITLE
Fix database-per-tenant multi-tenancy: no default tenant required (gh-514)

### DIFF
--- a/docs/configuration/multitenancy.md
+++ b/docs/configuration/multitenancy.md
@@ -75,8 +75,8 @@ var store = DocumentStore.For(opts =>
 {
     opts.MultiTenantedDatabases(databases =>
     {
-        databases.AddSingleTenantDatabase("Server=localhost;Database=tenant_a;...", "tenant-a");
-        databases.AddSingleTenantDatabase("Server=localhost;Database=tenant_b;...", "tenant-b");
+        databases.AddTenant("tenant-a", "Server=localhost;Database=tenant_a;...");
+        databases.AddTenant("tenant-b", "Server=localhost;Database=tenant_b;...");
     });
 });
 ```
@@ -84,9 +84,42 @@ var store = DocumentStore.For(opts =>
 With separate database tenancy:
 
 - Each tenant has completely isolated data
-- Schema management runs independently per database
+- Schema management runs independently per database — `ApplyAllDatabaseChangesOnStartup()` migrates
+  every tenant database, not just the one behind `StoreOptions.ConnectionString`
 - Sessions automatically route to the correct database based on tenant ID
-- The async daemon runs independently per tenant database
+- The async daemon runs independently per tenant database: `AddAsyncDaemon(...)` starts one daemon
+  per tenant database, each tracking its own high-water mark and projection progress
+
+### No default tenant is required
+
+Calling `MultiTenantedDatabases()` (or `MultiTenantedMasterTable()`) sets
+`StoreOptions.DefaultTenantUsageEnabled` to `false`. Every tenant has its own database, so there is
+no database the default tenant could coherently mean — and you should **not** register a
+placeholder `*DEFAULT*` tenant to satisfy startup.
+
+With the default tenant disabled, opening a session or building a projection daemon without a
+tenant throws `DefaultTenantUsageDisabledException` rather than quietly landing on whichever
+database happens to back `StoreOptions.ConnectionString`:
+
+```cs
+// throws DefaultTenantUsageDisabledException
+await using var session = store.LightweightSession();
+
+// correct — always name the tenant
+await using var session = store.LightweightSession(new SessionOptions { TenantId = "tenant-a" });
+```
+
+Infrastructure that has already resolved a database — the async daemon, for instance — opts out
+with `SessionOptions.AllowAnyTenant`, which `SessionOptions.ForDatabase(database)` sets for you.
+You can also re-enable the default tenant explicitly if your application genuinely wants it:
+
+```cs
+opts.MultiTenantedDatabases(databases => { /* ... */ });
+opts.DefaultTenantUsageEnabled = true; // opt back in, after configuring the tenancy
+```
+
+This mirrors Marten's `StoreOptions.Advanced.DefaultTenantUsageEnabled`; Polecat has no `Advanced`
+sub-object and carries the setting directly on `StoreOptions`.
 
 ### Dynamic Tenant Management (Master Table Tenancy)
 
@@ -248,6 +281,10 @@ await using var session = store.LightweightSession(new SessionOptions
 
 ::: warning
 If no tenant ID is specified, Polecat uses `"DEFAULT"` as the tenant ID. In conjoined tenancy mode, this means documents and events will be stored with `tenant_id = 'DEFAULT'`.
+
+Under **separate database** tenancy this fallback is switched off — see
+[No default tenant is required](#no-default-tenant-is-required) — and a tenantless session throws
+`DefaultTenantUsageDisabledException` instead.
 :::
 
 ## ITenanted Interface

--- a/docs/configuration/multitenancy.md
+++ b/docs/configuration/multitenancy.md
@@ -97,6 +97,26 @@ Calling `MultiTenantedDatabases()` (or `MultiTenantedMasterTable()`) sets
 no database the default tenant could coherently mean — and you should **not** register a
 placeholder `*DEFAULT*` tenant to satisfy startup.
 
+You also do not need to set `StoreOptions.ConnectionString`. A configured tenancy already names
+every database the store will touch, so it supplies the store's own connection string: the first
+registered tenant for `MultiTenantedDatabases()`, the control-plane database for
+`MultiTenantedMasterTable()`. Nominating one of the tenant databases at the top level is not
+required and makes that tenant's database quietly special.
+
+```cs
+var store = DocumentStore.For(opts =>
+{
+    // No opts.ConnectionString, and no "*DEFAULT*" tenant.
+    opts.MultiTenantedDatabases(databases =>
+    {
+        databases.AddTenant("tenant-a", "Server=localhost;Database=tenant_a;...");
+        databases.AddTenant("tenant-b", "Server=localhost;Database=tenant_b;...");
+    });
+
+    opts.Projections.Add<MyProjection>(ProjectionLifecycle.Async);
+});
+```
+
 With the default tenant disabled, opening a session or building a projection daemon without a
 tenant throws `DefaultTenantUsageDisabledException` rather than quietly landing on whichever
 database happens to back `StoreOptions.ConnectionString`:

--- a/docs/documents/multi-tenancy.md
+++ b/docs/documents/multi-tenancy.md
@@ -52,6 +52,19 @@ var store = DocumentStore.For(opts =>
 
 Sessions are automatically routed to the correct database.
 
+::: warning No default tenant — and no top level connection string
+`MultiTenantedDatabases()` (and `MultiTenantedMasterTable()`) sets
+`StoreOptions.DefaultTenantUsageEnabled` to `false`. Do **not** register a placeholder
+`*DEFAULT*` tenant, and you do **not** need to set `StoreOptions.ConnectionString` — the tenancy
+supplies one. Opening a session or building a daemon without a tenant throws
+`DefaultTenantUsageDisabledException` rather than quietly using whichever database happened to be
+first.
+
+The async daemon starts one daemon per tenant database with the default tenant disabled, and
+`ApplyAllDatabaseChangesOnStartup()` migrates every tenant database. See
+[No default tenant is required](/configuration/multitenancy#no-default-tenant-is-required).
+:::
+
 ## ITenanted Interface
 
 Documents implementing `ITenanted` have their `TenantId` property automatically synced:

--- a/docs/documents/multi-tenancy.md
+++ b/docs/documents/multi-tenancy.md
@@ -44,8 +44,8 @@ var store = DocumentStore.For(opts =>
 {
     opts.MultiTenantedDatabases(databases =>
     {
-        databases.AddSingleTenantDatabase("Server=localhost;Database=tenant_a;...", "tenant-a");
-        databases.AddSingleTenantDatabase("Server=localhost;Database=tenant_b;...", "tenant-b");
+        databases.AddTenant("tenant-a", "Server=localhost;Database=tenant_a;...");
+        databases.AddTenant("tenant-b", "Server=localhost;Database=tenant_b;...");
     });
 });
 ```

--- a/docs/events/multitenancy.md
+++ b/docs/events/multitenancy.md
@@ -57,12 +57,31 @@ var store = DocumentStore.For(opts =>
 With separate database tenancy:
 
 - Each tenant has completely isolated event data
-- The async daemon runs independently per database
-- Schema management is independent per database
+- The async daemon runs one daemon per tenant database, each with its own high-water mark and
+  projection progress
+- Schema management is independent per database; `ApplyAllDatabaseChangesOnStartup()` migrates
+  every tenant database
+
+::: warning No default tenant — and no top level connection string
+`MultiTenantedDatabases()` (and `MultiTenantedMasterTable()`) sets
+`StoreOptions.DefaultTenantUsageEnabled` to `false`. Do **not** register a placeholder
+`*DEFAULT*` tenant, and you do **not** need to set `StoreOptions.ConnectionString` — the tenancy
+supplies one. Opening a session or building a daemon without a tenant throws
+`DefaultTenantUsageDisabledException` rather than quietly using whichever database happened to be
+first.
+
+The async daemon starts one daemon per tenant database with the default tenant disabled, and
+`ApplyAllDatabaseChangesOnStartup()` migrates every tenant database. See
+[No default tenant is required](/configuration/multitenancy#no-default-tenant-is-required).
+:::
 
 ## Default Tenant
 
-When no tenant ID is specified, events are stored with `tenant_id = 'DEFAULT'`. In single-tenant mode, all queries use this default value.
+When no tenant ID is specified, events are stored with `tenant_id = 'DEFAULT'`. In single-tenant
+mode, all queries use this default value.
+
+Under **separate database** tenancy the default tenant is disabled, so there is no `'DEFAULT'`
+fallback — every session must name its tenant. See the warning above.
 
 ## Per-Tenant Event Partitioning <Badge type="tip" text="4.2" />
 

--- a/docs/events/multitenancy.md
+++ b/docs/events/multitenancy.md
@@ -48,8 +48,8 @@ var store = DocumentStore.For(opts =>
 {
     opts.MultiTenantedDatabases(databases =>
     {
-        databases.AddSingleTenantDatabase("Server=localhost;Database=events_tenant_a;...", "tenant-a");
-        databases.AddSingleTenantDatabase("Server=localhost;Database=events_tenant_b;...", "tenant-b");
+        databases.AddTenant("tenant-a", "Server=localhost;Database=events_tenant_a;...");
+        databases.AddTenant("tenant-b", "Server=localhost;Database=events_tenant_b;...");
     });
 });
 ```

--- a/src/Polecat.Tests/Daemon/daemon_agent_startup_multi_tenancy_tests.cs
+++ b/src/Polecat.Tests/Daemon/daemon_agent_startup_multi_tenancy_tests.cs
@@ -1,0 +1,361 @@
+using JasperFx;
+using JasperFx.Core;
+using JasperFx.Events;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Projections;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Polecat.Events.Daemon;
+using IProjectionCoordinator = Polecat.Events.Daemon.Coordination.IProjectionCoordinator;
+using Polecat.Exceptions;
+using Polecat.Internal;
+using Polecat.Storage;
+using Polecat.TestUtils;
+using Weasel.Core;
+
+namespace Polecat.Tests.Daemon;
+
+/// <summary>
+///     The async daemon must actually START AGENTS on every tenant database — not merely construct
+///     a daemon object. Polecat had no coverage of this: it is the difference between "the host came
+///     up" and "tenant B's projections are running", and the two looked identical from the outside
+///     while tenant B was silently never processed. polecat#514.
+///     <para>
+///     Mirrors Marten's <c>DaemonTests/MultiTenancy/multi_tenancy_by_database.cs</c> shard-running
+///     assertions and <c>dynamic_spin_up_of_dynamic_tenants.cs</c>.
+///     </para>
+/// </summary>
+public class daemon_agent_startup_multi_tenancy_tests : IClassFixture<AgentStartupDatabasesFixture>
+{
+    internal const string TenantA = "agent_tenant_a";
+    internal const string TenantB = "agent_tenant_b";
+
+    internal static readonly string DbA = ConnectionSource.Scoped("agentstart_a");
+    internal static readonly string DbB = ConnectionSource.Scoped("agentstart_b");
+    internal static readonly string ControlDb = ConnectionSource.Scoped("agentstart_control");
+
+    internal static readonly string[] AllDatabases = [DbA, DbB, ControlDb];
+
+    private const string Schema = "agentstart";
+
+    private static string ConnectionFor(string db) => ConnectionSource.ConnectionStringFor(db);
+
+    private static readonly TimeSpan Timeout = 30.Seconds();
+
+    // The shard every one of these stores registers. AgentTallyProjection => "AgentTally:All".
+    private const string ShardName = "AgentTally:All";
+
+    // -------------------------------------------------------------------------------------
+    // Static database-per-tenant — with and without a default tenant registered
+    // -------------------------------------------------------------------------------------
+
+    /// <summary>
+    ///     The supported shape: no "*DEFAULT*" tenant anywhere. Every tenant database must get its
+    ///     own daemon with the projection shard actually in the Running state.
+    /// </summary>
+    [Fact]
+    public async Task agents_start_on_every_tenant_database_without_a_default_tenant()
+    {
+        using var host = await StartHostAsync(registerDefaultTenant: false);
+        var hostedService = host.Services.GetRequiredService<PolecatDaemonHostedService>();
+
+        hostedService.Daemons.Count.ShouldBe(2);
+
+        foreach (var daemon in hostedService.Daemons)
+        {
+            await daemon.WaitForShardToBeRunning(ShardName, Timeout);
+            daemon.CurrentAgents().ShouldNotBeEmpty();
+        }
+
+        // The daemons must be on DIFFERENT databases — one daemon per tenant database is the whole
+        // point, and two daemons pointed at the same database would satisfy a naive count check.
+        hostedService.Daemons
+            .Select(d => ((PolecatProjectionDaemon)d).Database.Identifier)
+            .Distinct()
+            .Count()
+            .ShouldBe(2);
+
+        await host.StopAsync(TestContext.Current.CancellationToken);
+    }
+
+    /// <summary>
+    ///     The shape users fall into when they register a placeholder "*DEFAULT*" tenant to get past
+    ///     startup (polecat#514). It must not be necessary — but if someone does register a real
+    ///     default tenant database, the daemon has to treat it as just another tenant database:
+    ///     three databases, three daemons, all with running agents, none skipped or doubled up.
+    /// </summary>
+    [Fact]
+    public async Task agents_start_on_every_tenant_database_with_a_default_tenant_registered()
+    {
+        using var host = await StartHostAsync(registerDefaultTenant: true);
+        var hostedService = host.Services.GetRequiredService<PolecatDaemonHostedService>();
+
+        hostedService.Daemons.Count.ShouldBe(3);
+
+        foreach (var daemon in hostedService.Daemons)
+        {
+            await daemon.WaitForShardToBeRunning(ShardName, Timeout);
+            daemon.CurrentAgents().ShouldNotBeEmpty();
+        }
+
+        hostedService.Daemons
+            .Select(d => ((PolecatProjectionDaemon)d).Database.Identifier)
+            .Distinct()
+            .Count()
+            .ShouldBe(3);
+
+        await host.StopAsync(TestContext.Current.CancellationToken);
+    }
+
+    /// <summary>
+    ///     Registering a default tenant does NOT re-enable default tenant usage. The flag is set by
+    ///     configuring the tenancy, not by which tenant ids happen to be in it — otherwise the
+    ///     placeholder workaround would quietly restore the silent-wrong-database behaviour it was
+    ///     invented to work around.
+    /// </summary>
+    [Fact]
+    public async Task registering_a_default_tenant_does_not_re_enable_default_tenant_usage()
+    {
+        using var host = await StartHostAsync(registerDefaultTenant: true);
+        var store = (DocumentStore)host.Services.GetRequiredService<IDocumentStore>();
+
+        store.Options.DefaultTenantUsageEnabled.ShouldBeFalse();
+        Should.Throw<DefaultTenantUsageDisabledException>(() => store.LightweightSession());
+
+        await host.StopAsync(TestContext.Current.CancellationToken);
+    }
+
+    /// <summary>
+    ///     Agents that are running must actually process events — a Running shard that never
+    ///     advances is the failure mode a state-only assertion misses.
+    /// </summary>
+    [Fact]
+    public async Task running_agents_process_events_on_their_own_tenant_database()
+    {
+        using var host = await StartHostAsync(registerDefaultTenant: false);
+        var store = (DocumentStore)host.Services.GetRequiredService<IDocumentStore>();
+
+        var idA = Guid.NewGuid();
+        var idB = Guid.NewGuid();
+
+        await AppendAsync(store, TenantA, idA, 2);
+        await AppendAsync(store, TenantB, idB, 5);
+
+        await WaitForTallyAsync(store, TenantA, idA, 2);
+        await WaitForTallyAsync(store, TenantB, idB, 5);
+
+        // Cross-checks: neither tenant's stream leaked into the other's database.
+        (await LoadTallyAsync(store, TenantA, idB)).ShouldBeNull();
+        (await LoadTallyAsync(store, TenantB, idA)).ShouldBeNull();
+
+        await host.StopAsync(TestContext.Current.CancellationToken);
+    }
+
+    // -------------------------------------------------------------------------------------
+    // Master table tenancy — tenant databases discovered at runtime
+    // -------------------------------------------------------------------------------------
+
+    /// <summary>
+    ///     Port of Marten's <c>dynamic_spin_up_of_dynamic_tenants</c>. Tenant databases added to the
+    ///     control table AFTER the host is running must be discovered by the projection coordinator,
+    ///     which then starts agents against each of them. Polecat's master-table tests covered the
+    ///     registry mechanics (add/disable/enable/delete) but never that a daemon follows.
+    /// </summary>
+    [Fact]
+    public async Task coordinator_spins_up_agents_for_dynamically_added_tenant_databases()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddPolecat(opts =>
+                    {
+                        opts.ConnectionString = ConnectionFor(ControlDb);
+                        opts.DatabaseSchemaName = Schema;
+                        opts.AutoCreateSchemaObjects = AutoCreate.All;
+                        opts.UseNativeJsonType = ConnectionSource.SupportsNativeJson;
+                        opts.MultiTenantedMasterTable(ConnectionFor(ControlDb), Schema);
+                        opts.Projections.Add<AgentTallyProjection>(ProjectionLifecycle.Async);
+                    })
+                    .AddProjectionCoordinator(DaemonMode.Solo);
+            })
+            .StartAsync(TestContext.Current.CancellationToken);
+
+        var store = (DocumentStore)host.Services.GetRequiredService<IDocumentStore>();
+        // The class fixture drops and recreates the control database, so pc_tenants starts empty.
+        var tenancy = (MasterTableTenancy)store.Options.Tenancy!;
+        await tenancy.AddDatabaseRecordAsync(TenantA, ConnectionFor(DbA), TestContext.Current.CancellationToken);
+        await tenancy.AddDatabaseRecordAsync(TenantB, ConnectionFor(DbB), TestContext.Current.CancellationToken);
+
+        var coordinator = host.Services.GetRequiredService<IProjectionCoordinator>();
+
+        var daemonA = await coordinator.DaemonForDatabase(
+            store.Options.Tenancy!.GetDatabase(TenantA).Identifier);
+        var daemonB = await coordinator.DaemonForDatabase(
+            store.Options.Tenancy!.GetDatabase(TenantB).Identifier);
+
+        await daemonA.StartAllAsync();
+        await daemonB.StartAllAsync();
+
+        await daemonA.WaitForShardToBeRunning(ShardName, Timeout);
+        await daemonB.WaitForShardToBeRunning(ShardName, Timeout);
+
+        daemonA.CurrentAgents().ShouldNotBeEmpty();
+        daemonB.CurrentAgents().ShouldNotBeEmpty();
+
+        await host.StopAsync(TestContext.Current.CancellationToken);
+    }
+
+    /// <summary>
+    ///     Master table tenancy disables the default tenant for the same reason static
+    ///     database-per-tenant does, and a daemon built with no tenant must say so.
+    /// </summary>
+    [Fact]
+    public async Task master_table_tenancy_requires_a_tenant_for_a_daemon()
+    {
+        using var store = DocumentStore.For(opts =>
+        {
+            opts.ConnectionString = ConnectionFor(ControlDb);
+            opts.DatabaseSchemaName = Schema;
+            opts.UseNativeJsonType = ConnectionSource.SupportsNativeJson;
+            opts.MultiTenantedMasterTable(ConnectionFor(ControlDb), Schema);
+            opts.Projections.Add<AgentTallyProjection>(ProjectionLifecycle.Async);
+        });
+
+        store.Options.DefaultTenantUsageEnabled.ShouldBeFalse();
+
+        await Should.ThrowAsync<DefaultTenantUsageDisabledException>(async () =>
+        {
+            await store.BuildProjectionDaemonAsync();
+        });
+    }
+
+    // -------------------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------------------
+
+    private static async Task<IHost> StartHostAsync(bool registerDefaultTenant)
+    {
+        return await Host.CreateDefaultBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddPolecat(opts =>
+                    {
+                        opts.ConnectionString = ConnectionFor(DbA);
+                        opts.DatabaseSchemaName = Schema;
+                        opts.AutoCreateSchemaObjects = AutoCreate.All;
+                        opts.UseNativeJsonType = ConnectionSource.SupportsNativeJson;
+
+                        opts.MultiTenantedDatabases(tenancy =>
+                        {
+                            tenancy.AddTenant(TenantA, ConnectionFor(DbA));
+                            tenancy.AddTenant(TenantB, ConnectionFor(DbB));
+
+                            if (registerDefaultTenant)
+                            {
+                                tenancy.AddTenant(StorageConstants.DefaultTenantId, ConnectionFor(ControlDb));
+                            }
+                        });
+
+                        opts.Projections.Add<AgentTallyProjection>(ProjectionLifecycle.Async);
+                    })
+                    .ApplyAllDatabaseChangesOnStartup()
+                    .AddAsyncDaemon(DaemonMode.Solo);
+            })
+            .StartAsync(TestContext.Current.CancellationToken);
+    }
+
+    private static async Task AppendAsync(DocumentStore store, string tenantId, Guid streamId, int count)
+    {
+        await using var session = store.LightweightSession(new SessionOptions { TenantId = tenantId });
+        session.Events.StartStream(streamId, new AgentCounted());
+        for (var i = 1; i < count; i++) session.Events.Append(streamId, new AgentCounted());
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+
+    private static async Task<AgentTally?> LoadTallyAsync(DocumentStore store, string tenantId, Guid id)
+    {
+        await using var session = store.QuerySession(new SessionOptions { TenantId = tenantId });
+        return await session.LoadAsync<AgentTally>(id, TestContext.Current.CancellationToken);
+    }
+
+    private static async Task WaitForTallyAsync(DocumentStore store, string tenantId, Guid id, int expected)
+    {
+        var deadline = DateTimeOffset.UtcNow.Add(Timeout);
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            var tally = await LoadTallyAsync(store, tenantId, id);
+            if (tally?.Count == expected) return;
+            await Task.Delay(250, TestContext.Current.CancellationToken);
+        }
+
+        var actual = await LoadTallyAsync(store, tenantId, id);
+        throw new TimeoutException(
+            $"Tenant '{tenantId}' never reached an AgentTally count of {expected}; last seen {actual?.Count.ToString() ?? "<null>"}.");
+    }
+}
+
+public record AgentCounted;
+
+public class AgentTally
+{
+    public Guid Id { get; set; }
+    public int Count { get; set; }
+}
+
+public partial class AgentTallyProjection : Polecat.Projections.SingleStreamProjection<AgentTally, Guid>
+{
+    public override AgentTally? Evolve(AgentTally? snapshot, Guid id, IEvent e)
+    {
+        snapshot ??= new AgentTally { Id = id };
+        if (e.Data is AgentCounted) snapshot.Count++;
+        return snapshot;
+    }
+}
+
+/// <summary>
+///     Creates the tenant databases once for the class — see the note on
+///     <c>TenantDatabasesFixture</c> about the connection-pool race when they are dropped per test.
+/// </summary>
+public class AgentStartupDatabasesFixture : IAsyncLifetime
+{
+    public async ValueTask InitializeAsync()
+    {
+        await DropAsync();
+
+        await using var conn = new SqlConnection(ConnectionSource.MasterConnectionString);
+        await conn.OpenAsync();
+
+        foreach (var db in daemon_agent_startup_multi_tenancy_tests.AllDatabases)
+        {
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = $"IF DB_ID('{db}') IS NULL CREATE DATABASE [{db}];";
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        SqlConnection.ClearAllPools();
+    }
+
+    public ValueTask DisposeAsync() => new(DropAsync());
+
+    private static async Task DropAsync()
+    {
+        SqlConnection.ClearAllPools();
+
+        await using var conn = new SqlConnection(ConnectionSource.MasterConnectionString);
+        await conn.OpenAsync();
+
+        foreach (var db in daemon_agent_startup_multi_tenancy_tests.AllDatabases)
+        {
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = $"""
+                IF DB_ID('{db}') IS NOT NULL
+                BEGIN
+                    ALTER DATABASE [{db}] SET SINGLE_USER WITH ROLLBACK IMMEDIATE;
+                    DROP DATABASE [{db}];
+                END
+                """;
+            await cmd.ExecuteNonQueryAsync();
+        }
+    }
+}

--- a/src/Polecat.Tests/Daemon/daemon_agent_startup_multi_tenancy_tests.cs
+++ b/src/Polecat.Tests/Daemon/daemon_agent_startup_multi_tenancy_tests.cs
@@ -39,6 +39,10 @@ public class daemon_agent_startup_multi_tenancy_tests : IClassFixture<AgentStart
 
     private const string Schema = "agentstart";
 
+    // A schema of its own so the no-connection-string test proves the activator provisioned it,
+    // rather than inheriting tables a sibling test already created.
+    private const string NoConnStrSchema = "agentstart_noconn";
+
     private static string ConnectionFor(string db) => ConnectionSource.ConnectionStringFor(db);
 
     private static readonly TimeSpan Timeout = 30.Seconds();
@@ -150,6 +154,92 @@ public class daemon_agent_startup_multi_tenancy_tests : IClassFixture<AgentStart
         (await LoadTallyAsync(store, TenantB, idA)).ShouldBeNull();
 
         await host.StopAsync(TestContext.Current.CancellationToken);
+    }
+
+    /// <summary>
+    ///     polecat#514's headline scenario, end to end: NO top level connection string and NO
+    ///     "*DEFAULT*" tenant — just the tenant databases. Every tenant database must be migrated on
+    ///     startup and get a daemon with running agents that actually project.
+    /// </summary>
+    [Fact]
+    public async Task everything_starts_with_no_connection_string_and_no_default_tenant()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddPolecat(opts =>
+                    {
+                        // Deliberately no opts.ConnectionString.
+                        opts.DatabaseSchemaName = NoConnStrSchema;
+                        opts.AutoCreateSchemaObjects = AutoCreate.All;
+                        opts.UseNativeJsonType = ConnectionSource.SupportsNativeJson;
+
+                        opts.MultiTenantedDatabases(tenancy =>
+                        {
+                            tenancy.AddTenant(TenantA, ConnectionFor(DbA));
+                            tenancy.AddTenant(TenantB, ConnectionFor(DbB));
+                        });
+
+                        opts.Projections.Add<AgentTallyProjection>(ProjectionLifecycle.Async);
+                    })
+                    .ApplyAllDatabaseChangesOnStartup()
+                    .AddAsyncDaemon(DaemonMode.Solo);
+            })
+            .StartAsync(TestContext.Current.CancellationToken);
+
+        var store = (DocumentStore)host.Services.GetRequiredService<IDocumentStore>();
+        var hostedService = host.Services.GetRequiredService<PolecatDaemonHostedService>();
+
+        store.Options.DefaultTenantUsageEnabled.ShouldBeFalse();
+        hostedService.Daemons.Count.ShouldBe(2);
+
+        foreach (var daemon in hostedService.Daemons)
+        {
+            await daemon.WaitForShardToBeRunning(ShardName, Timeout);
+        }
+
+        var idA = Guid.NewGuid();
+        var idB = Guid.NewGuid();
+        await AppendAsync(store, TenantA, idA, 3);
+        await AppendAsync(store, TenantB, idB, 7);
+
+        await WaitForTallyAsync(store, TenantA, idA, 3);
+        await WaitForTallyAsync(store, TenantB, idB, 7);
+
+        await host.StopAsync(TestContext.Current.CancellationToken);
+    }
+
+    /// <summary>
+    ///     A configured tenancy supplies the store's own connection string, so the application never
+    ///     has to nominate one of the tenant databases at the top level.
+    /// </summary>
+    [Fact]
+    public void a_tenancy_seeds_the_store_connection_string()
+    {
+        using var store = DocumentStore.For(opts =>
+        {
+            opts.DatabaseSchemaName = NoConnStrSchema;
+            opts.UseNativeJsonType = ConnectionSource.SupportsNativeJson;
+            opts.MultiTenantedDatabases(tenancy =>
+            {
+                tenancy.AddTenant(TenantA, ConnectionFor(DbA));
+                tenancy.AddTenant(TenantB, ConnectionFor(DbB));
+            });
+        });
+
+        store.Options.ConnectionString.ShouldBe(ConnectionFor(DbA));
+    }
+
+    /// <summary>
+    ///     With no tenancy and no connection string there is still nothing to fall back to, and the
+    ///     error has to say so.
+    /// </summary>
+    [Fact]
+    public void still_throws_without_a_connection_string_or_a_tenancy()
+    {
+        var ex = Should.Throw<InvalidOperationException>(() => DocumentStore.For(_ => { }));
+
+        ex.Message.ShouldContain("connection string");
     }
 
     // -------------------------------------------------------------------------------------

--- a/src/Polecat.Tests/Daemon/projection_message_outbox_tests.cs
+++ b/src/Polecat.Tests/Daemon/projection_message_outbox_tests.cs
@@ -27,7 +27,7 @@ public class projection_message_outbox_tests : OneOffConfigurationsContext
         await theDatabase.ApplyAllConfiguredChangesToDatabaseAsync(ct: TestContext.Current.CancellationToken);
 
         var batch = new PolecatProjectionBatch(theStore, theStore.Options.EventGraph,
-            ConnectionSource.ConnectionString);
+            theStore.Database);
         var session = batch.SessionForTenant(theStore.Options.Tenancy!.DefaultTenantId);
         session.Store(new SimpleDoc { Id = Guid.NewGuid() });
 
@@ -49,7 +49,7 @@ public class projection_message_outbox_tests : OneOffConfigurationsContext
         await theDatabase.ApplyAllConfiguredChangesToDatabaseAsync(ct: TestContext.Current.CancellationToken);
 
         var batch = new PolecatProjectionBatch(theStore, theStore.Options.EventGraph,
-            ConnectionSource.ConnectionString);
+            theStore.Database);
         var session = batch.SessionForTenant(theStore.Options.Tenancy!.DefaultTenantId);
         session.Store(new SimpleDoc { Id = Guid.NewGuid() });
 
@@ -77,7 +77,7 @@ public class projection_message_outbox_tests : OneOffConfigurationsContext
         await theDatabase.ApplyAllConfiguredChangesToDatabaseAsync(ct: TestContext.Current.CancellationToken);
 
         var batch = new PolecatProjectionBatch(theStore, theStore.Options.EventGraph,
-            ConnectionSource.ConnectionString);
+            theStore.Database);
         var session = batch.SessionForTenant(theStore.Options.Tenancy!.DefaultTenantId);
         session.Store(new SimpleDoc { Id = Guid.NewGuid() });
 
@@ -102,7 +102,7 @@ public class projection_message_outbox_tests : OneOffConfigurationsContext
         await theDatabase.ApplyAllConfiguredChangesToDatabaseAsync(ct: TestContext.Current.CancellationToken);
 
         var batch = new PolecatProjectionBatch(theStore, theStore.Options.EventGraph,
-            ConnectionSource.ConnectionString);
+            theStore.Database);
         var session = batch.SessionForTenant(theStore.Options.Tenancy!.DefaultTenantId);
         session.Store(new SimpleDoc { Id = Guid.NewGuid() });
 

--- a/src/Polecat.Tests/MultiTenancy/daemon_multi_tenancy_by_database_tests.cs
+++ b/src/Polecat.Tests/MultiTenancy/daemon_multi_tenancy_by_database_tests.cs
@@ -7,6 +7,7 @@ using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Polecat.Events.Daemon;
+using Polecat.Exceptions;
 using Polecat.Projections;
 using Polecat.Storage;
 using Polecat.Tests.Harness;
@@ -89,9 +90,12 @@ public class daemon_multi_tenancy_by_database_tests : IClassFixture<TenantDataba
     ///     <c>MultiTenantedDatabases()</c> flips <c>Advanced.DefaultTenantUsageEnabled</c> to false,
     ///     so a session opened with no tenant fails loudly instead of silently landing somewhere.
     /// </summary>
-    [Fact(Skip = "polecat#514 - StoreOptions has no DefaultTenantUsageEnabled yet")]
+    [Fact]
     public void default_tenant_usage_is_disabled_by_configuring_separate_databases()
     {
+        using var store = CreateStore();
+
+        store.Options.DefaultTenantUsageEnabled.ShouldBeFalse();
     }
 
     /// <summary>
@@ -100,16 +104,27 @@ public class daemon_multi_tenancy_by_database_tests : IClassFixture<TenantDataba
     ///     <c>UnknownTenantIdException</c> for "*DEFAULT*" only because the tenancy has no such
     ///     entry — which is what pushes users into registering a dummy "*DEFAULT*" tenant.
     /// </summary>
-    [Fact(Skip = "polecat#514 - no DefaultTenantUsageDisabledException yet")]
+    [Fact]
     public void opening_a_session_with_no_tenant_throws_default_tenant_usage_disabled()
     {
+        using var store = CreateStore();
+
+        Should.Throw<DefaultTenantUsageDisabledException>(() => store.LightweightSession());
     }
 
     /// <summary>
     ///     Marten's <c>multi_tenancy_by_database.fail_when_trying_to_create_daemon_with_no_tenant</c>.
     /// </summary>
-    [Fact(Skip = "polecat#514 - no DefaultTenantUsageDisabledException yet")]
-    public Task fail_when_trying_to_create_daemon_with_no_tenant() => Task.CompletedTask;
+    [Fact]
+    public async Task fail_when_trying_to_create_daemon_with_no_tenant()
+    {
+        using var store = CreateStore();
+
+        await Should.ThrowAsync<DefaultTenantUsageDisabledException>(async () =>
+        {
+            await store.BuildProjectionDaemonAsync();
+        });
+    }
 
     // -------------------------------------------------------------------------------------
     // Schema provisioning

--- a/src/Polecat.Tests/MultiTenancy/daemon_multi_tenancy_by_database_tests.cs
+++ b/src/Polecat.Tests/MultiTenancy/daemon_multi_tenancy_by_database_tests.cs
@@ -1,0 +1,425 @@
+using JasperFx;
+using JasperFx.Core;
+using JasperFx.Events;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Projections;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Polecat.Events.Daemon;
+using Polecat.Projections;
+using Polecat.Storage;
+using Polecat.Tests.Harness;
+using Weasel.Core;
+
+namespace Polecat.Tests.MultiTenancy;
+
+/// <summary>
+///     Async daemon under database-per-tenant multi-tenancy. Mirrors Marten's
+///     <c>DaemonTests/MultiTenancy/multi_tenancy_by_database.cs</c> and
+///     <c>MultiTenancyTests/using_static_database_multitenancy.cs</c>, which Polecat had no
+///     equivalent of: <c>MultiTenancy/separate_database_tenancy_tests.cs</c> never registers a
+///     projection, and <c>Daemon/multi_tenant_daemon_tests.cs</c> is single-database despite the
+///     name. polecat#514.
+/// </summary>
+public class daemon_multi_tenancy_by_database_tests : IClassFixture<TenantDatabasesFixture>
+{
+    internal const string Tenant1 = "tenant1";
+    internal const string Tenant2 = "tenant2";
+    internal const string Tenant3 = "tenant3";
+
+    internal static readonly string Db1 = ConnectionSource.Scoped("mtdb_one");
+    internal static readonly string Db2 = ConnectionSource.Scoped("mtdb_two");
+    internal static readonly string Db3 = ConnectionSource.Scoped("mtdb_three");
+
+    internal static readonly string[] AllDatabases = [Db1, Db2, Db3];
+
+    private static string ConnectionFor(string db) => ConnectionSource.ConnectionStringFor(db);
+
+    private readonly TenantDatabasesFixture _fixture;
+
+    public daemon_multi_tenancy_by_database_tests(TenantDatabasesFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    private static void ConfigureTenancy(StoreOptions opts, string schemaName = "mtdb")
+    {
+        opts.DatabaseSchemaName = schemaName;
+        opts.AutoCreateSchemaObjects = AutoCreate.All;
+        opts.UseNativeJsonType = ConnectionSource.SupportsNativeJson;
+
+        opts.MultiTenantedDatabases(tenancy =>
+        {
+            tenancy.AddTenant(Tenant1, ConnectionFor(Db1));
+            tenancy.AddTenant(Tenant2, ConnectionFor(Db2));
+            tenancy.AddTenant(Tenant3, ConnectionFor(Db3));
+        });
+
+        opts.Projections.Add<TenantTallyProjection>(ProjectionLifecycle.Async);
+    }
+
+    private static DocumentStore CreateStore()
+    {
+        return DocumentStore.For(opts =>
+        {
+            // Marten does not require a top level connection string once a tenancy is configured.
+            // Polecat's DocumentStore constructor calls StoreOptions.CreateConnectionFactory()
+            // unconditionally, so one has to be supplied. polecat#514 (first bullet).
+            opts.ConnectionString = ConnectionFor(Db1);
+            ConfigureTenancy(opts);
+        });
+    }
+
+    private static async Task ApplyToAllAsync(DocumentStore store)
+    {
+        foreach (var database in store.Options.Tenancy!.AllDatabases())
+        {
+            await database.ApplyAllConfiguredChangesToDatabaseAsync(
+                ct: TestContext.Current.CancellationToken);
+        }
+    }
+
+    // -------------------------------------------------------------------------------------
+    // Configuration surface
+    // -------------------------------------------------------------------------------------
+
+    /// <summary>
+    ///     Marten's <c>using_static_database_multitenancy.default_tenant_usage_is_disabled</c>.
+    ///     <c>MultiTenantedDatabases()</c> flips <c>Advanced.DefaultTenantUsageEnabled</c> to false,
+    ///     so a session opened with no tenant fails loudly instead of silently landing somewhere.
+    /// </summary>
+    [Fact(Skip = "polecat#514 - StoreOptions has no DefaultTenantUsageEnabled yet")]
+    public void default_tenant_usage_is_disabled_by_configuring_separate_databases()
+    {
+    }
+
+    /// <summary>
+    ///     A default tenant should not be necessary. Marten throws
+    ///     <c>DefaultTenantUsageDisabledException</c>; the current Polecat behaviour is an
+    ///     <c>UnknownTenantIdException</c> for "*DEFAULT*" only because the tenancy has no such
+    ///     entry — which is what pushes users into registering a dummy "*DEFAULT*" tenant.
+    /// </summary>
+    [Fact(Skip = "polecat#514 - no DefaultTenantUsageDisabledException yet")]
+    public void opening_a_session_with_no_tenant_throws_default_tenant_usage_disabled()
+    {
+    }
+
+    /// <summary>
+    ///     Marten's <c>multi_tenancy_by_database.fail_when_trying_to_create_daemon_with_no_tenant</c>.
+    /// </summary>
+    [Fact(Skip = "polecat#514 - no DefaultTenantUsageDisabledException yet")]
+    public Task fail_when_trying_to_create_daemon_with_no_tenant() => Task.CompletedTask;
+
+    // -------------------------------------------------------------------------------------
+    // Schema provisioning
+    // -------------------------------------------------------------------------------------
+
+    /// <summary>
+    ///     Marten's <c>using_static_database_multitenancy.changes_are_applied_to_each_database</c>.
+    ///     <c>ApplyAllDatabaseChangesOnStartup()</c> must reach EVERY tenant database, not just the
+    ///     one behind <c>StoreOptions.ConnectionString</c>. polecat#514 (second bullet).
+    /// </summary>
+    [Fact]
+    public async Task apply_all_database_changes_on_startup_reaches_every_tenant_database()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddPolecat(opts =>
+                    {
+                        opts.ConnectionString = ConnectionFor(Db1);
+                        ConfigureTenancy(opts, StartupSchema);
+                    })
+                    .ApplyAllDatabaseChangesOnStartup();
+            })
+            .StartAsync(TestContext.Current.CancellationToken);
+
+        var missing = new List<string>();
+        foreach (var db in AllDatabases)
+        {
+            if (!await EventsTableExistsAsync(db, StartupSchema)) missing.Add(db);
+        }
+
+        missing.ShouldBeEmpty(
+            $"ApplyAllDatabaseChangesOnStartup() did not provision {StartupSchema}.pc_events in: {string.Join(", ", missing)}");
+
+        await host.StopAsync(TestContext.Current.CancellationToken);
+    }
+
+    // A schema no other test in this class touches — the tenant databases are shared across the
+    // class, so checking the default "mtdb" schema would go green off a sibling test's manual
+    // ApplyToAllAsync rather than off the activator under test.
+    private const string StartupSchema = "mtdb_startup";
+
+    private static async Task<bool> EventsTableExistsAsync(string databaseName, string schemaName)
+    {
+        await using var conn = new SqlConnection(ConnectionFor(databaseName));
+        await conn.OpenAsync(TestContext.Current.CancellationToken);
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText =
+            "SELECT COUNT(*) FROM sys.tables t JOIN sys.schemas s ON t.schema_id = s.schema_id " +
+            $"WHERE s.name = '{schemaName}' AND t.name = 'pc_events'";
+        var count = (int)(await cmd.ExecuteScalarAsync(TestContext.Current.CancellationToken))!;
+        return count > 0;
+    }
+
+    // -------------------------------------------------------------------------------------
+    // Daemon routing
+    // -------------------------------------------------------------------------------------
+
+    /// <summary>
+    ///     Marten's <c>multi_tenancy_by_database.build_daemon_for_database</c> — the daemon built
+    ///     for a tenant id runs against that tenant's database.
+    /// </summary>
+    [Fact]
+    public async Task build_daemon_for_database()
+    {
+        using var store = CreateStore();
+        await ApplyToAllAsync(store);
+
+        using var daemon = await store.BuildProjectionDaemonAsync(Tenant2);
+
+        var database = ((PolecatProjectionDaemon)daemon).Database.ShouldBeOfType<PolecatDatabase>();
+        new SqlConnectionStringBuilder(database.ConnectionString).InitialCatalog.ShouldBe(Db2);
+    }
+
+    /// <summary>
+    ///     Marten's <c>projection_statuses_per_database</c> — every tenant database gets its own
+    ///     daemon, and each tracks its own progression.
+    /// </summary>
+    [Fact]
+    public async Task each_tenant_database_has_its_own_projection_progress()
+    {
+        using var store = CreateStore();
+        await ApplyToAllAsync(store);
+
+        var before1 = await ProgressFor(store, Tenant1);
+        var before2 = await ProgressFor(store, Tenant2);
+        var before3 = await ProgressFor(store, Tenant3);
+
+        await AppendAsync(store, Tenant1, 2);
+        await AppendAsync(store, Tenant3, 4);
+
+        await RunDaemonToCompletionAsync(store, Tenant1);
+        await RunDaemonToCompletionAsync(store, Tenant3);
+
+        (await ProgressFor(store, Tenant1) - before1).ShouldBe(2);
+        (await ProgressFor(store, Tenant3) - before3).ShouldBe(4);
+
+        // Tenant2 saw no events at all, so its progression must not have moved.
+        (await ProgressFor(store, Tenant2)).ShouldBe(before2);
+    }
+
+    /// <summary>
+    ///     Marten's <c>multi_tenancy_by_database.run_projections_end_to_end</c>. Each tenant's
+    ///     stream lives in its own database and projects into its own database — the same stream id
+    ///     in three databases must produce three independent aggregates.
+    /// </summary>
+    [Fact]
+    public async Task run_projections_end_to_end()
+    {
+        using var store = CreateStore();
+        await ApplyToAllAsync(store);
+
+        var id = Guid.NewGuid();
+
+        await AppendAsync(store, Tenant1, 1, id);
+        await AppendAsync(store, Tenant2, 3, id);
+        await AppendAsync(store, Tenant3, 5, id);
+
+        await RunDaemonToCompletionAsync(store, Tenant1);
+        await RunDaemonToCompletionAsync(store, Tenant2);
+        await RunDaemonToCompletionAsync(store, Tenant3);
+
+        (await LoadTallyAsync(store, Tenant1, id)).ShouldNotBeNull().Count.ShouldBe(1);
+        (await LoadTallyAsync(store, Tenant2, id)).ShouldNotBeNull().Count.ShouldBe(3);
+        (await LoadTallyAsync(store, Tenant3, id)).ShouldNotBeNull().Count.ShouldBe(5);
+    }
+
+    /// <summary>
+    ///     The daemon has to keep reading an existing aggregate out of the tenant's own database
+    ///     across batches. A projection that only ever creates would pass even if the read side
+    ///     routed to the wrong database, so this appends in two rounds with a daemon run between.
+    /// </summary>
+    [Fact]
+    public async Task projections_continue_from_existing_snapshots_in_the_tenant_database()
+    {
+        using var store = CreateStore();
+        await ApplyToAllAsync(store);
+
+        var id = Guid.NewGuid();
+
+        await AppendAsync(store, Tenant1, 2, id);
+        await RunDaemonToCompletionAsync(store, Tenant1);
+        (await LoadTallyAsync(store, Tenant1, id)).ShouldNotBeNull().Count.ShouldBe(2);
+
+        await AppendAsync(store, Tenant1, 3, id);
+        await RunDaemonToCompletionAsync(store, Tenant1);
+        (await LoadTallyAsync(store, Tenant1, id)).ShouldNotBeNull().Count.ShouldBe(5);
+    }
+
+    /// <summary>
+    ///     Marten's docs — and Polecat's — promise a daemon per tenant database. With
+    ///     <c>AddAsyncDaemon</c> registered against a database-per-tenant store, events appended to
+    ///     every tenant must get projected, not just the one behind the top level connection string.
+    /// </summary>
+    [Fact]
+    public async Task add_async_daemon_runs_a_daemon_for_every_tenant_database()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddPolecat(opts =>
+                    {
+                        opts.ConnectionString = ConnectionFor(Db1);
+                        ConfigureTenancy(opts);
+                    })
+                    .ApplyAllDatabaseChangesOnStartup()
+                    .AddAsyncDaemon(DaemonMode.Solo);
+            })
+            .StartAsync(TestContext.Current.CancellationToken);
+
+        var store = (DocumentStore)host.Services.GetRequiredService<IDocumentStore>();
+
+        var id = Guid.NewGuid();
+        await AppendAsync(store, Tenant1, 2, id);
+        await AppendAsync(store, Tenant2, 3, id);
+        await AppendAsync(store, Tenant3, 4, id);
+
+        await WaitForTallyAsync(store, Tenant1, id, 2);
+        await WaitForTallyAsync(store, Tenant2, id, 3);
+        await WaitForTallyAsync(store, Tenant3, id, 4);
+
+        await host.StopAsync(TestContext.Current.CancellationToken);
+    }
+
+    // -------------------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------------------
+
+    private static async Task AppendAsync(DocumentStore store, string tenantId, int count, Guid? streamId = null)
+    {
+        var id = streamId ?? Guid.NewGuid();
+        await using var session = store.LightweightSession(new SessionOptions { TenantId = tenantId });
+
+        if (await session.Events.FetchStreamStateAsync(id, TestContext.Current.CancellationToken) == null)
+        {
+            session.Events.StartStream(id, new TenantCounted());
+            count--;
+        }
+
+        for (var i = 0; i < count; i++)
+        {
+            session.Events.Append(id, new TenantCounted());
+        }
+
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+
+    private static async Task RunDaemonToCompletionAsync(DocumentStore store, string tenantId)
+    {
+        using var daemon = await store.BuildProjectionDaemonAsync(tenantId);
+        await daemon.StartAllAsync();
+        await daemon.WaitForNonStaleData(30.Seconds());
+        await daemon.StopAllAsync();
+    }
+
+    private static async Task<long> ProgressFor(DocumentStore store, string tenantId)
+    {
+        var database = store.Options.Tenancy!.GetDatabase(tenantId);
+        var progress = await database.AllProjectionProgress(TestContext.Current.CancellationToken);
+        return progress
+            .Where(x => x.ShardName.StartsWith("TenantTally", StringComparison.OrdinalIgnoreCase))
+            .Select(x => x.Sequence)
+            .DefaultIfEmpty(0)
+            .Max();
+    }
+
+    private static async Task<TenantTally?> LoadTallyAsync(DocumentStore store, string tenantId, Guid id)
+    {
+        await using var session = store.QuerySession(new SessionOptions { TenantId = tenantId });
+        return await session.LoadAsync<TenantTally>(id, TestContext.Current.CancellationToken);
+    }
+
+    private static async Task WaitForTallyAsync(DocumentStore store, string tenantId, Guid id, int expected)
+    {
+        var deadline = DateTimeOffset.UtcNow.AddSeconds(30);
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            var tally = await LoadTallyAsync(store, tenantId, id);
+            if (tally?.Count == expected) return;
+            await Task.Delay(250, TestContext.Current.CancellationToken);
+        }
+
+        var actual = await LoadTallyAsync(store, tenantId, id);
+        throw new TimeoutException(
+            $"Tenant '{tenantId}' never reached a TenantTally count of {expected}; last seen {actual?.Count.ToString() ?? "<null>"}.");
+    }
+}
+
+public record TenantCounted;
+
+public class TenantTally
+{
+    public Guid Id { get; set; }
+    public int Count { get; set; }
+}
+
+public partial class TenantTallyProjection : SingleStreamProjection<TenantTally, Guid>
+{
+    public override TenantTally? Evolve(TenantTally? snapshot, Guid id, IEvent e)
+    {
+        snapshot ??= new TenantTally { Id = id };
+        if (e.Data is TenantCounted) snapshot.Count++;
+        return snapshot;
+    }
+}
+
+/// <summary>
+///     Creates and drops the three tenant databases once for the whole class. Creating and dropping
+///     them per test method races SqlClient's connection pool: a pooled connection to the just
+///     dropped database is handed back out and the next test fails with "Cannot open database".
+/// </summary>
+public class TenantDatabasesFixture : IAsyncLifetime
+{
+    public async ValueTask InitializeAsync()
+    {
+        await DropDatabasesAsync();
+
+        await using var conn = new SqlConnection(ConnectionSource.MasterConnectionString);
+        await conn.OpenAsync();
+
+        foreach (var db in daemon_multi_tenancy_by_database_tests.AllDatabases)
+        {
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = $"IF DB_ID('{db}') IS NULL CREATE DATABASE [{db}];";
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        SqlConnection.ClearAllPools();
+    }
+
+    public ValueTask DisposeAsync() => new(DropDatabasesAsync());
+
+    private static async Task DropDatabasesAsync()
+    {
+        SqlConnection.ClearAllPools();
+
+        await using var conn = new SqlConnection(ConnectionSource.MasterConnectionString);
+        await conn.OpenAsync();
+
+        foreach (var db in daemon_multi_tenancy_by_database_tests.AllDatabases)
+        {
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = $"""
+                IF DB_ID('{db}') IS NOT NULL
+                BEGIN
+                    ALTER DATABASE [{db}] SET SINGLE_USER WITH ROLLBACK IMMEDIATE;
+                    DROP DATABASE [{db}];
+                END
+                """;
+            await cmd.ExecuteNonQueryAsync();
+        }
+    }
+}

--- a/src/Polecat.Tests/MultiTenancy/disabling_default_tenant_usage.cs
+++ b/src/Polecat.Tests/MultiTenancy/disabling_default_tenant_usage.cs
@@ -1,0 +1,142 @@
+using JasperFx;
+using Polecat.Exceptions;
+using Polecat.Tests.Harness;
+
+namespace Polecat.Tests.MultiTenancy;
+
+/// <summary>
+///     Port of Marten's <c>DocumentDbTests/MultiTenancy/disabling_default_tenant_usage.cs</c>.
+///     Every way of opening a session against the default tenant has to fail once
+///     <see cref="StoreOptions.DefaultTenantUsageEnabled" /> is off, otherwise the setting is a
+///     suggestion rather than a guard. polecat#514.
+/// </summary>
+public class disabling_default_tenant_usage
+{
+    private static DocumentStore CreateStore()
+    {
+        return DocumentStore.For(opts =>
+        {
+            opts.ConnectionString = ConnectionSource.ConnectionString;
+            opts.DatabaseSchemaName = "no_default_tenant";
+            opts.UseNativeJsonType = ConnectionSource.SupportsNativeJson;
+            opts.DefaultTenantUsageEnabled = false;
+        });
+    }
+
+    [Fact]
+    public void default_tenant_usage_is_enabled_by_default()
+    {
+        new StoreOptions().DefaultTenantUsageEnabled.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void get_exception_when_creating_session_with_default_tenant_usage_disabled()
+    {
+        using var store = CreateStore();
+
+        Should.Throw<DefaultTenantUsageDisabledException>(() => store.LightweightSession());
+    }
+
+    [Fact]
+    public void get_exception_when_creating_identity_session_with_default_tenant_usage_disabled()
+    {
+        using var store = CreateStore();
+
+        Should.Throw<DefaultTenantUsageDisabledException>(() => store.IdentitySession());
+    }
+
+    [Fact]
+    public void get_exception_when_creating_query_session_with_default_tenant_usage_disabled()
+    {
+        using var store = CreateStore();
+
+        Should.Throw<DefaultTenantUsageDisabledException>(() => store.QuerySession());
+    }
+
+    [Fact]
+    public void get_exception_when_creating_session_with_default_tenant_session_options_and_default_tenant_usage_disabled()
+    {
+        using var store = CreateStore();
+
+        Should.Throw<DefaultTenantUsageDisabledException>(() =>
+            store.LightweightSession(new SessionOptions { TenantId = StorageConstants.DefaultTenantId }));
+    }
+
+    [Fact]
+    public void get_exception_when_creating_query_session_with_default_tenant_session_options_and_default_tenant_usage_disabled()
+    {
+        using var store = CreateStore();
+
+        Should.Throw<DefaultTenantUsageDisabledException>(() =>
+            store.QuerySession(new SessionOptions { TenantId = StorageConstants.DefaultTenantId }));
+    }
+
+    [Fact]
+    public void get_exception_when_opening_a_session_with_default_tenant_usage_disabled()
+    {
+        using var store = CreateStore();
+
+        Should.Throw<DefaultTenantUsageDisabledException>(() =>
+            store.OpenSession(new SessionOptions { TenantId = StorageConstants.DefaultTenantId }));
+    }
+
+    [Fact]
+    public async Task get_exception_when_opening_a_session_async_with_default_tenant_usage_disabled()
+    {
+        using var store = CreateStore();
+
+        await Should.ThrowAsync<DefaultTenantUsageDisabledException>(async () =>
+            await store.OpenSessionAsync(
+                new SessionOptions { TenantId = StorageConstants.DefaultTenantId },
+                TestContext.Current.CancellationToken));
+    }
+
+    /// <summary>
+    ///     Marten's <c>SessionOptions.AllowAnyTenant</c> escape hatch: the daemon and any other
+    ///     infrastructure that has already resolved a database must still be able to open a session
+    ///     for the default tenant.
+    /// </summary>
+    [Fact]
+    public async Task allow_any_tenant_bypasses_the_guard()
+    {
+        using var store = CreateStore();
+
+        await using var session = store.LightweightSession(new SessionOptions
+        {
+            TenantId = StorageConstants.DefaultTenantId,
+            AllowAnyTenant = true
+        });
+
+        session.ShouldNotBeNull();
+    }
+
+    /// <summary>
+    ///     <c>SessionOptions.ForDatabase</c> sets <c>AllowAnyTenant</c>, exactly as Marten's does —
+    ///     that is what lets the async daemon work a tenant database whose events all carry the
+    ///     default tenant id.
+    /// </summary>
+    [Fact]
+    public async Task for_database_allows_any_tenant()
+    {
+        using var store = CreateStore();
+
+        var options = SessionOptions.ForDatabase(store.Database);
+
+        options.AllowAnyTenant.ShouldBeTrue();
+        options.Database.ShouldBeSameAs(store.Database);
+        options.TenantId.ShouldBe(StorageConstants.DefaultTenantId);
+
+        await using var session = store.LightweightSession(options);
+        session.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task a_non_default_tenant_is_unaffected()
+    {
+        using var store = CreateStore();
+
+        await using var session = store.LightweightSession(new SessionOptions { TenantId = "tenant_a" });
+
+        session.TenantId.ShouldBe("tenant_a");
+    }
+}

--- a/src/Polecat.Tests/MultiTenancy/master_table_tenancy_tests.cs
+++ b/src/Polecat.Tests/MultiTenancy/master_table_tenancy_tests.cs
@@ -2,7 +2,10 @@ using JasperFx;
 using JasperFx.Descriptors;
 using JasperFx.MultiTenancy;
 using Microsoft.Data.SqlClient;
+using Polecat.Linq;
+using Weasel.Core;
 using Polecat.Storage;
+using Polecat.Tests.Harness;
 using Polecat.TestUtils;
 
 namespace Polecat.Tests.MultiTenancy;
@@ -130,6 +133,86 @@ public class master_table_tenancy_tests : IAsyncLifetime
             }
         }
     }
+
+    /// <summary>
+    ///     Port of Marten's <c>using_master_table_multi_tenancy.can_use_bulk_inserts</c>.
+    /// </summary>
+    [Fact]
+    public async Task can_use_bulk_inserts()
+    {
+        var (store, tenancy) = CreateStore();
+        using (store)
+        {
+            await tenancy.AddDatabaseRecordAsync(TenantA, Db(DbA), TestContext.Current.CancellationToken);
+            await tenancy.AddDatabaseRecordAsync(TenantB, Db(DbB), TestContext.Current.CancellationToken);
+            await ApplySchemaAsync(tenancy);
+
+            var targetsA = GenerateTargets(100);
+            var targetsB = GenerateTargets(50);
+
+            await store.Advanced.Clean.DeleteAllDocumentsAsync(TestContext.Current.CancellationToken);
+
+            await store.Advanced.BulkInsertAsync(targetsA, BulkInsertMode.InsertsOnly, 200, TenantA,
+                TestContext.Current.CancellationToken);
+            await store.Advanced.BulkInsertAsync(targetsB, BulkInsertMode.InsertsOnly, 200, TenantB,
+                TestContext.Current.CancellationToken);
+
+            await using (var queryA = store.QuerySession(new SessionOptions { TenantId = TenantA }))
+            {
+                var ids = await queryA.Query<Target>().Select(x => x.Id)
+                    .ToListAsync(TestContext.Current.CancellationToken);
+                ids.OrderBy(x => x).ToList()
+                    .ShouldBe(targetsA.OrderBy(x => x.Id).Select(x => x.Id).ToList());
+            }
+
+            await using (var queryB = store.QuerySession(new SessionOptions { TenantId = TenantB }))
+            {
+                var ids = await queryB.Query<Target>().Select(x => x.Id)
+                    .ToListAsync(TestContext.Current.CancellationToken);
+                ids.OrderBy(x => x).ToList()
+                    .ShouldBe(targetsB.OrderBy(x => x.Id).Select(x => x.Id).ToList());
+            }
+        }
+    }
+
+    /// <summary>
+    ///     Port of Marten's <c>using_master_table_multi_tenancy.clean_crosses_the_tenanted_databases</c>.
+    ///     The dynamic-tenancy twin of the static case — the cleaner has to resolve tenant databases
+    ///     out of the control table, not off StoreOptions.ConnectionString. polecat#514.
+    /// </summary>
+    [Fact]
+    public async Task clean_crosses_the_tenanted_databases()
+    {
+        var (store, tenancy) = CreateStore();
+        using (store)
+        {
+            await tenancy.AddDatabaseRecordAsync(TenantA, Db(DbA), TestContext.Current.CancellationToken);
+            await tenancy.AddDatabaseRecordAsync(TenantB, Db(DbB), TestContext.Current.CancellationToken);
+            await ApplySchemaAsync(tenancy);
+
+            await store.Advanced.BulkInsertAsync(GenerateTargets(100), BulkInsertMode.InsertsOnly, 200, TenantA,
+                TestContext.Current.CancellationToken);
+            await store.Advanced.BulkInsertAsync(GenerateTargets(50), BulkInsertMode.InsertsOnly, 200, TenantB,
+                TestContext.Current.CancellationToken);
+
+            await store.Advanced.Clean.DeleteAllDocumentsAsync(TestContext.Current.CancellationToken);
+
+            await using (var queryA = store.QuerySession(new SessionOptions { TenantId = TenantA }))
+            {
+                (await queryA.Query<Target>().AnyAsync(TestContext.Current.CancellationToken)).ShouldBeFalse();
+            }
+
+            await using (var queryB = store.QuerySession(new SessionOptions { TenantId = TenantB }))
+            {
+                (await queryB.Query<Target>().AnyAsync(TestContext.Current.CancellationToken)).ShouldBeFalse();
+            }
+        }
+    }
+
+    private static Target[] GenerateTargets(int count) =>
+        Enumerable.Range(0, count)
+            .Select(i => new Target { Id = Guid.NewGuid(), Number = i, Color = "Green" })
+            .ToArray();
 
     [Fact]
     public async Task unknown_tenant_throws()

--- a/src/Polecat.Tests/MultiTenancy/master_table_tenancy_tests.cs
+++ b/src/Polecat.Tests/MultiTenancy/master_table_tenancy_tests.cs
@@ -76,6 +76,20 @@ public class master_table_tenancy_tests : IAsyncLifetime
         }
     }
 
+    /// <summary>
+    ///     Mirrors Marten's <c>using_master_table_multi_tenancy.default_tenant_usage_is_disabled</c>.
+    ///     polecat#514.
+    /// </summary>
+    [Fact]
+    public void default_tenant_usage_is_disabled()
+    {
+        var (store, _) = CreateStore();
+        using (store)
+        {
+            store.Options.DefaultTenantUsageEnabled.ShouldBeFalse();
+        }
+    }
+
     [Fact]
     public async Task cardinality_is_dynamic_multiple()
     {

--- a/src/Polecat.Tests/MultiTenancy/separate_database_tenancy_tests.cs
+++ b/src/Polecat.Tests/MultiTenancy/separate_database_tenancy_tests.cs
@@ -70,6 +70,19 @@ public class separate_database_tenancy_tests : IAsyncLifetime
         });
     }
 
+    /// <summary>
+    ///     Mirrors Marten's <c>using_static_database_multitenancy.default_tenant_usage_is_disabled</c>:
+    ///     configuring a database per tenant turns the default tenant off, so no dummy "*DEFAULT*"
+    ///     tenant is ever needed. polecat#514.
+    /// </summary>
+    [Fact]
+    public void default_tenant_usage_is_disabled()
+    {
+        using var store = CreateSeparateTenantStore();
+
+        store.Options.DefaultTenantUsageEnabled.ShouldBeFalse();
+    }
+
     [Fact]
     public async Task separate_databases_store_documents_independently()
     {

--- a/src/Polecat.Tests/MultiTenancy/separate_database_tenancy_tests.cs
+++ b/src/Polecat.Tests/MultiTenancy/separate_database_tenancy_tests.cs
@@ -3,6 +3,8 @@ using JasperFx.Descriptors;
 using JasperFx.Events;
 using JasperFx.MultiTenancy;
 using Microsoft.Data.SqlClient;
+using Polecat.Linq;
+using Weasel.Core;
 using Polecat.Storage;
 using Polecat.Tests.Harness;
 
@@ -69,6 +71,112 @@ public class separate_database_tenancy_tests : IAsyncLifetime
             });
         });
     }
+
+    /// <summary>
+    ///     Port of Marten's <c>using_static_database_multitenancy.can_use_bulk_inserts</c>.
+    /// </summary>
+    [Fact]
+    public async Task can_use_bulk_inserts()
+    {
+        using var store = CreateSeparateTenantStore();
+        await EnsureSchemaOnAllDatabasesAsync(store);
+
+        var targetsA = GenerateTargets(100);
+        var targetsB = GenerateTargets(50);
+
+        await store.Advanced.Clean.DeleteAllDocumentsAsync(TestContext.Current.CancellationToken);
+
+        await store.Advanced.BulkInsertAsync(targetsA, BulkInsertMode.InsertsOnly, 200, TenantA,
+            TestContext.Current.CancellationToken);
+        await store.Advanced.BulkInsertAsync(targetsB, BulkInsertMode.InsertsOnly, 200, TenantB,
+            TestContext.Current.CancellationToken);
+
+        await using (var queryA = store.QuerySession(new SessionOptions { TenantId = TenantA }))
+        {
+            var ids = await queryA.Query<Target>().Select(x => x.Id).ToListAsync(TestContext.Current.CancellationToken);
+            ids.OrderBy(x => x).ToList().ShouldBe(targetsA.OrderBy(x => x.Id).Select(x => x.Id).ToList());
+        }
+
+        await using (var queryB = store.QuerySession(new SessionOptions { TenantId = TenantB }))
+        {
+            var ids = await queryB.Query<Target>().Select(x => x.Id).ToListAsync(TestContext.Current.CancellationToken);
+            ids.OrderBy(x => x).ToList().ShouldBe(targetsB.OrderBy(x => x.Id).Select(x => x.Id).ToList());
+        }
+    }
+
+    /// <summary>
+    ///     Port of Marten's <c>using_static_database_multitenancy.clean_crosses_the_tenanted_databases</c>.
+    ///     Polecat's cleaners used to read StoreOptions.ConnectionString and so emptied exactly one
+    ///     database, silently leaving every other tenant populated. polecat#514.
+    /// </summary>
+    [Fact]
+    public async Task clean_crosses_the_tenanted_databases()
+    {
+        using var store = CreateSeparateTenantStore();
+        await EnsureSchemaOnAllDatabasesAsync(store);
+
+        var targetsA = GenerateTargets(100);
+        var targetsB = GenerateTargets(50);
+
+        await store.Advanced.BulkInsertAsync(targetsA, BulkInsertMode.InsertsOnly, 200, TenantA,
+            TestContext.Current.CancellationToken);
+        await store.Advanced.BulkInsertAsync(targetsB, BulkInsertMode.InsertsOnly, 200, TenantB,
+            TestContext.Current.CancellationToken);
+
+        await store.Advanced.Clean.DeleteAllDocumentsAsync(TestContext.Current.CancellationToken);
+
+        await using (var queryA = store.QuerySession(new SessionOptions { TenantId = TenantA }))
+        {
+            (await queryA.Query<Target>().AnyAsync(TestContext.Current.CancellationToken)).ShouldBeFalse();
+        }
+
+        await using (var queryB = store.QuerySession(new SessionOptions { TenantId = TenantB }))
+        {
+            (await queryB.Query<Target>().AnyAsync(TestContext.Current.CancellationToken)).ShouldBeFalse();
+        }
+    }
+
+    /// <summary>
+    ///     The event-store twin of <c>clean_crosses_the_tenanted_databases</c> — Polecat has
+    ///     CleanAllEventDataAsync where Marten's cleaner exposes DeleteAllEventDataAsync, and it had
+    ///     the same single-database bug.
+    /// </summary>
+    [Fact]
+    public async Task clean_event_data_crosses_the_tenanted_databases()
+    {
+        using var store = CreateSeparateTenantStore();
+        await EnsureSchemaOnAllDatabasesAsync(store);
+
+        foreach (var tenant in new[] { TenantA, TenantB })
+        {
+            await using var session = store.LightweightSession(new SessionOptions { TenantId = tenant });
+            session.Events.StartStream(Guid.NewGuid(), new TenancyEventHappened());
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await store.Advanced.Clean.DeleteAllEventDataAsync(TestContext.Current.CancellationToken);
+
+        foreach (var tenant in new[] { TenantA, TenantB })
+        {
+            await using var session = store.QuerySession(new SessionOptions { TenantId = tenant });
+            var events = await session.Events.QueryAllRawEvents()
+                .ToListAsync(TestContext.Current.CancellationToken);
+            events.ShouldBeEmpty();
+        }
+    }
+
+    private static async Task EnsureSchemaOnAllDatabasesAsync(DocumentStore store)
+    {
+        foreach (var database in store.Options.Tenancy!.AllDatabases())
+        {
+            await database.ApplyAllConfiguredChangesToDatabaseAsync(ct: TestContext.Current.CancellationToken);
+        }
+    }
+
+    private static Target[] GenerateTargets(int count) =>
+        Enumerable.Range(0, count)
+            .Select(i => new Target { Id = Guid.NewGuid(), Number = i, Color = "Blue" })
+            .ToArray();
 
     /// <summary>
     ///     Mirrors Marten's <c>using_static_database_multitenancy.default_tenant_usage_is_disabled</c>:
@@ -238,6 +346,8 @@ public class separate_database_tenancy_tests : IAsyncLifetime
         store.Options.Tenancy.Cardinality.ShouldBe(DatabaseCardinality.Single);
         store.Options.Tenancy.AllDatabases().Count.ShouldBe(1);
     }
+
+    public record TenancyEventHappened;
 
     public class TestDoc
     {

--- a/src/Polecat/AdvancedOperations.cs
+++ b/src/Polecat/AdvancedOperations.cs
@@ -349,8 +349,20 @@ public class AdvancedOperations
     /// </summary>
     public async Task CleanAllDocumentsAsync(CancellationToken token = default)
     {
+        // #514: fan out across EVERY tenant database. Reading _store.Options.ConnectionString
+        // cleaned only the database behind it, so under database-per-tenant tenancy a "clean
+        // everything" call silently left every other tenant populated — which mostly bites test
+        // harnesses, exactly where a stale row is hardest to explain. Marten fans the same
+        // operations out through its CompositeDocumentCleaner.
+        foreach (var connectionString in AllDatabaseConnectionStrings())
+        {
+            await CleanAllDocumentsForDatabaseAsync(connectionString, token);
+        }
+    }
+
+    private async Task CleanAllDocumentsForDatabaseAsync(string connStr, CancellationToken token = default)
+{
         var schema = _store.Options.DatabaseSchemaName;
-        var connStr = _store.Options.ConnectionString;
         var flatTables = CollectFlatTableNames();
         await _resilience.ExecuteAsync(static async (state, ct) =>
         {
@@ -400,8 +412,20 @@ public class AdvancedOperations
     /// </summary>
     public async Task CompletelyRemoveAllAsync(CancellationToken token = default)
     {
+        // #514: fan out across EVERY tenant database. Reading _store.Options.ConnectionString
+        // cleaned only the database behind it, so under database-per-tenant tenancy a "clean
+        // everything" call silently left every other tenant populated — which mostly bites test
+        // harnesses, exactly where a stale row is hardest to explain. Marten fans the same
+        // operations out through its CompositeDocumentCleaner.
+        foreach (var connectionString in AllDatabaseConnectionStrings())
+        {
+            await CompletelyRemoveAllForDatabaseAsync(connectionString, token);
+        }
+    }
+
+    private async Task CompletelyRemoveAllForDatabaseAsync(string connStr, CancellationToken token = default)
+{
         var schema = _store.Options.DatabaseSchemaName;
-        var connStr = _store.Options.ConnectionString;
         var flatTables = CollectFlatTableNames();
         await _resilience.ExecuteAsync(static async (state, ct) =>
         {
@@ -505,9 +529,21 @@ public class AdvancedOperations
     /// </remarks>
     public async Task CleanAsync(Type documentType, CancellationToken token = default)
     {
+        // #514: fan out across EVERY tenant database. Reading _store.Options.ConnectionString
+        // cleaned only the database behind it, so under database-per-tenant tenancy a "clean
+        // everything" call silently left every other tenant populated — which mostly bites test
+        // harnesses, exactly where a stale row is hardest to explain. Marten fans the same
+        // operations out through its CompositeDocumentCleaner.
+        foreach (var connectionString in AllDatabaseConnectionStrings())
+        {
+            await CleanForDatabaseAsync(connectionString, documentType, token);
+        }
+    }
+
+    private async Task CleanForDatabaseAsync(string connStr, Type documentType, CancellationToken token = default)
+{
         var provider = _store.GetProvider(documentType);
         var tableName = provider.Mapping.QualifiedTableName;
-        var connStr = _store.Options.ConnectionString;
         await _resilience.ExecuteAsync(static async (state, ct) =>
         {
             var (connectionString, qualifiedTableName) = state;
@@ -614,9 +650,21 @@ public class AdvancedOperations
     /// </summary>
     public async Task CleanAllEventDataAsync(CancellationToken token = default)
     {
+        // #514: fan out across EVERY tenant database. Reading _store.Options.ConnectionString
+        // cleaned only the database behind it, so under database-per-tenant tenancy a "clean
+        // everything" call silently left every other tenant populated — which mostly bites test
+        // harnesses, exactly where a stale row is hardest to explain. Marten fans the same
+        // operations out through its CompositeDocumentCleaner.
+        foreach (var connectionString in AllDatabaseConnectionStrings())
+        {
+            await CleanAllEventDataForDatabaseAsync(connectionString, token);
+        }
+    }
+
+    private async Task CleanAllEventDataForDatabaseAsync(string connStr, CancellationToken token = default)
+{
         var events = _store.Events;
         var schema = events.DatabaseSchemaName;
-        var connStr = _store.Options.ConnectionString;
         var eventsTable = events.EventsTableName;
         var streamsTable = events.StreamsTableName;
         var progressionTable = events.ProgressionTableName;
@@ -854,6 +902,21 @@ public class AdvancedOperations
     public Task<TablePartitionStatus[]> DropAgedRollingPartitionsAsync(CancellationToken token = default)
         => RollingPartitions.ApplyAsync(RollingPartitionDatabases(), NullLogger.Instance,
             rollForward: false, dropAged: true, token);
+
+    /// <summary>
+    ///     Every database this store can reach — one per tenant under a database-per-tenant tenancy,
+    ///     otherwise just the store's own. #514.
+    /// </summary>
+    private IEnumerable<string> AllDatabaseConnectionStrings()
+    {
+        var databases = _store.Options.Tenancy?.AllDatabases();
+        if (databases is not { Count: > 0 })
+        {
+            return [_store.Options.ConnectionString];
+        }
+
+        return databases.Select(d => d.ConnectionString).Distinct(StringComparer.OrdinalIgnoreCase);
+    }
 
     private IEnumerable<PolecatDatabase> RollingPartitionDatabases() =>
         _store.Options.Tenancy?.AllDatabases() ?? [_store.Database];

--- a/src/Polecat/DocumentStore.DocumentStoreUsage.cs
+++ b/src/Polecat/DocumentStore.DocumentStoreUsage.cs
@@ -91,7 +91,7 @@ public partial class DocumentStore : IDocumentStoreUsageSource
         //   Marten side                          Polecat side
         //   ----------------------------------   ----------------------------------
         //   TenantIdStyle                        (n/a — Polecat doesn't have it)
-        //   DefaultTenantUsageEnabled            (n/a)
+        //   DefaultTenantUsageEnabled            Options.DefaultTenantUsageEnabled (#514)
         //   RlsTenantSessionSetting              (n/a)
         //   NameDataLength                       (n/a — SQL Server uses 128)
         //   ApplyChangesLockId                   (n/a)
@@ -108,6 +108,7 @@ public partial class DocumentStore : IDocumentStoreUsageSource
         // Polecat-specific:
         //   UseNativeJsonType                    (json column type policy)
 
+        usage.AddValue(nameof(Options.DefaultTenantUsageEnabled), Options.DefaultTenantUsageEnabled);
         usage.AddValue(nameof(Options.CommandTimeout), Options.CommandTimeout);
         usage.AddValue("OpenTelemetryTrackConnections", Options.OpenTelemetry.TrackConnections.ToString());
         usage.AddValue("HiloMaxLo", Options.HiloSequenceDefaults.MaxLo);

--- a/src/Polecat/DocumentStore.EventStore.cs
+++ b/src/Polecat/DocumentStore.EventStore.cs
@@ -112,12 +112,17 @@ public partial class DocumentStore : IEventStore<IDocumentSession, IQuerySession
     Type IEventStore<IDocumentSession, IQuerySession>.IdentityTypeForProjectedType(Type aggregateType) =>
         Events.StreamIdentity == StreamIdentity.AsGuid ? typeof(Guid) : typeof(string);
 
+    // #514: bind the session to the database the daemon resolved rather than routing its tenant id
+    // back through the tenancy. Under database-per-tenant the two are different coordinates — the
+    // events being replayed carry "*DEFAULT*", which no tenancy entry maps to — so the old
+    // tenant-only routing threw UnknownTenantIdException and no shard could start at all. Mirrors
+    // Marten's LightweightSession(SessionOptions.ForDatabase(database)).
     IDocumentSession IEventStore<IDocumentSession, IQuerySession>.OpenSession(IEventDatabase database) =>
-        LightweightSession();
+        LightweightSession(SessionOptions.ForDatabase((PolecatDatabase)database));
 
     IDocumentSession IEventStore<IDocumentSession, IQuerySession>.OpenSession(IEventDatabase database,
         string tenantId) =>
-        LightweightSession(new SessionOptions { TenantId = tenantId });
+        LightweightSession(SessionOptions.ForDatabase(tenantId, (PolecatDatabase)database));
 
     ErrorHandlingOptions IEventStore<IDocumentSession, IQuerySession>.ErrorHandlingOptions(
         ShardExecutionMode mode) =>
@@ -161,8 +166,7 @@ public partial class DocumentStore : IEventStore<IDocumentSession, IQuerySession
             EventRange range, IEventDatabase database, ShardExecutionMode mode,
             AsyncOptions projectionOptions, CancellationToken token)
     {
-        var connStr = database is PolecatDatabase pdb ? pdb.ConnectionString : Options.ConnectionString;
-        var batch = new PolecatProjectionBatch(this, Events, connStr, mode);
+        var batch = new PolecatProjectionBatch(this, Events, (PolecatDatabase)database, mode);
         await batch.RecordProgress(range);
 
         // #259: when rebuilding a snapshot whose aggregate has a [NaturalKey], re-emit the natural-key
@@ -379,11 +383,16 @@ public partial class DocumentStore : IEventStore<IDocumentSession, IQuerySession
     {
         logger ??= NullLogger.Instance;
 
+        // #514: with the default tenant disabled (which configuring a database-per-tenant tenancy
+        // does), building a daemon with no tenant has no coherent answer. Marten asserts the same
+        // thing in BuildProjectionDaemonAsync before resolving a database.
+        AssertTenantOrDatabaseIdentifierIsValid(tenantIdOrDatabaseIdentifier);
+
         // Resolve the right database — tenant-specific or default
         PolecatDatabase db;
-        if (tenantIdOrDatabaseIdentifier != null && Options.Tenancy is SeparateDatabaseTenancy)
+        if (tenantIdOrDatabaseIdentifier != null && Options.Tenancy is not DefaultTenancy)
         {
-            db = Options.Tenancy.GetDatabase(tenantIdOrDatabaseIdentifier);
+            db = Options.Tenancy!.GetDatabase(tenantIdOrDatabaseIdentifier);
         }
         else
         {
@@ -658,14 +667,15 @@ public partial class DocumentStore : IEventStore<IDocumentSession, IQuerySession
         ISubscription subscription, IEventDatabase database, EventRange range,
         ShardExecutionMode mode, CancellationToken token)
     {
-        var connStr = ResolveConnectionString(database, Options);
-        var batch = new PolecatProjectionBatch(this, Events, connStr, mode);
+        var polecatDatabase = (PolecatDatabase)database;
+        var batch = new PolecatProjectionBatch(this, Events, polecatDatabase, mode);
         await batch.RecordProgress(range);
 
-        // Create a session the subscription can use for reads/writes,
-        // and register it with the batch so its pending operations are included
-        // in the batch's transaction.
-        await using var session = LightweightSession();
+        // Create a session the subscription can use for reads/writes, and register it with the
+        // batch so its pending operations are included in the batch's transaction. #514: bound to
+        // the database this subscription is running against — routing the default tenant through
+        // the tenancy reaches no database at all under database-per-tenant tenancy.
+        await using var session = LightweightSession(SessionOptions.ForDatabase(polecatDatabase));
         batch.RegisterSession(session);
         var listener = await subscription.ProcessEventsAsync(range, range.Agent, session, token);
 

--- a/src/Polecat/DocumentStore.cs
+++ b/src/Polecat/DocumentStore.cs
@@ -17,6 +17,8 @@ public partial class DocumentStore : IDocumentStore
     private readonly ConnectionFactory _connectionFactory;
     private readonly DocumentProviderRegistry _providers;
     private readonly DocumentTableEnsurer _tableEnsurer;
+    private readonly System.Collections.Concurrent.ConcurrentDictionary<string, DocumentTableEnsurer> _tableEnsurers =
+        new(StringComparer.OrdinalIgnoreCase);
     private Lazy<IInlineProjection<IDocumentSession>[]> _inlineProjections;
 
     public DocumentStore(StoreOptions options)
@@ -129,15 +131,10 @@ public partial class DocumentStore : IDocumentStore
             : ResolveConnectionFactory(options.TenantId);
     }
 
-    private DocumentTableEnsurer ResolveTableEnsurer(SessionOptions options)
-    {
-        if (options.Database == null) return ResolveTableEnsurer(options.TenantId);
-
-        var ensurer = new DocumentTableEnsurer(
-            new ConnectionFactory(options.Database.ConnectionString), Options);
-        ensurer.SetProviderRegistry(_providers);
-        return ensurer;
-    }
+    private DocumentTableEnsurer ResolveTableEnsurer(SessionOptions options) =>
+        options.Database == null
+            ? ResolveTableEnsurer(options.TenantId)
+            : EnsurerFor(options.Database.ConnectionString);
 
     /// <summary>
     ///     Mirrors Marten's <c>DocumentStore.AssertTenantOrDatabaseIdentifierIsValid</c> and the
@@ -166,10 +163,22 @@ public partial class DocumentStore : IDocumentStore
         var factory = ResolveConnectionFactory(tenantId);
         // For default tenancy, the factory is the same so we reuse the shared ensurer
         if (ReferenceEquals(factory, _connectionFactory)) return _tableEnsurer;
-        var ensurer = new DocumentTableEnsurer(factory, Options);
-        ensurer.SetProviderRegistry(_providers);
-        return ensurer;
+        return EnsurerFor(factory.ConnectionString);
     }
+
+    /// <summary>
+    ///     One <see cref="DocumentTableEnsurer" /> per database, cached for the life of the store.
+    ///     The ensurer memoizes which tables it has already checked, so handing out a fresh one per
+    ///     session would re-run the existence checks on every call — cheap once, but the async
+    ///     daemon opens a session per batch per tenant database. #514.
+    /// </summary>
+    private DocumentTableEnsurer EnsurerFor(string connectionString) =>
+        _tableEnsurers.GetOrAdd(connectionString, cs =>
+        {
+            var ensurer = new DocumentTableEnsurer(new ConnectionFactory(cs), Options);
+            ensurer.SetProviderRegistry(_providers);
+            return ensurer;
+        });
 
     public IDocumentSession LightweightSession()
     {

--- a/src/Polecat/DocumentStore.cs
+++ b/src/Polecat/DocumentStore.cs
@@ -115,6 +115,52 @@ public partial class DocumentStore : IDocumentStore
         return Options.Tenancy!.GetConnectionFactory(tenantId);
     }
 
+    /// <summary>
+    ///     Resolve the connection for a session, honouring an explicit
+    ///     <see cref="SessionOptions.Database" /> binding before falling back to tenant routing.
+    ///     polecat#514.
+    /// </summary>
+    private ConnectionFactory ResolveConnectionFactory(SessionOptions options)
+    {
+        AssertTenantIsValid(options);
+
+        return options.Database != null
+            ? new ConnectionFactory(options.Database.ConnectionString)
+            : ResolveConnectionFactory(options.TenantId);
+    }
+
+    private DocumentTableEnsurer ResolveTableEnsurer(SessionOptions options)
+    {
+        if (options.Database == null) return ResolveTableEnsurer(options.TenantId);
+
+        var ensurer = new DocumentTableEnsurer(
+            new ConnectionFactory(options.Database.ConnectionString), Options);
+        ensurer.SetProviderRegistry(_providers);
+        return ensurer;
+    }
+
+    /// <summary>
+    ///     Mirrors Marten's <c>DocumentStore.AssertTenantOrDatabaseIdentifierIsValid</c> and the
+    ///     matching guard in <c>SessionOptions.Initialize</c>: with the default tenant disabled,
+    ///     asking for a session or daemon without a tenant is a configuration error, not a fallback.
+    /// </summary>
+    private void AssertTenantIsValid(SessionOptions options)
+    {
+        if (options.AllowAnyTenant) return;
+        AssertTenantOrDatabaseIdentifierIsValid(options.TenantId);
+    }
+
+    private void AssertTenantOrDatabaseIdentifierIsValid(string? tenantIdOrDatabaseIdentifier)
+    {
+        if (Options.DefaultTenantUsageEnabled) return;
+
+        if (string.IsNullOrEmpty(tenantIdOrDatabaseIdentifier)
+            || tenantIdOrDatabaseIdentifier == JasperFx.StorageConstants.DefaultTenantId)
+        {
+            throw new Exceptions.DefaultTenantUsageDisabledException();
+        }
+    }
+
     internal DocumentTableEnsurer ResolveTableEnsurer(string tenantId)
     {
         var factory = ResolveConnectionFactory(tenantId);
@@ -132,8 +178,8 @@ public partial class DocumentStore : IDocumentStore
 
     public IDocumentSession LightweightSession(SessionOptions options)
     {
-        var factory = ResolveConnectionFactory(options.TenantId);
-        var ensurer = ResolveTableEnsurer(options.TenantId);
+        var factory = ResolveConnectionFactory(options);
+        var ensurer = ResolveTableEnsurer(options);
         var timeout = options.Timeout ?? Options.CommandTimeout;
         var lifetime = new TransactionalConnection(factory, timeout);
         return new LightweightSession(
@@ -155,8 +201,8 @@ public partial class DocumentStore : IDocumentStore
 
     public IDocumentSession IdentitySession(SessionOptions options)
     {
-        var factory = ResolveConnectionFactory(options.TenantId);
-        var ensurer = ResolveTableEnsurer(options.TenantId);
+        var factory = ResolveConnectionFactory(options);
+        var ensurer = ResolveTableEnsurer(options);
         var timeout = options.Timeout ?? Options.CommandTimeout;
         var lifetime = new TransactionalConnection(factory, timeout);
         return new IdentityMapDocumentSession(
@@ -178,8 +224,8 @@ public partial class DocumentStore : IDocumentStore
 
     public IQuerySession QuerySession(SessionOptions options)
     {
-        var factory = ResolveConnectionFactory(options.TenantId);
-        var ensurer = ResolveTableEnsurer(options.TenantId);
+        var factory = ResolveConnectionFactory(options);
+        var ensurer = ResolveTableEnsurer(options);
         var timeout = options.Timeout ?? Options.CommandTimeout;
         var lifetime = new AutoClosingLifetime(factory, timeout);
         return new Internal.QuerySession(
@@ -202,8 +248,8 @@ public partial class DocumentStore : IDocumentStore
 
     public async Task<IDocumentSession> OpenSessionAsync(SessionOptions options, CancellationToken token = default)
     {
-        var factory = ResolveConnectionFactory(options.TenantId);
-        var ensurer = ResolveTableEnsurer(options.TenantId);
+        var factory = ResolveConnectionFactory(options);
+        var ensurer = ResolveTableEnsurer(options);
         var timeout = options.Timeout ?? Options.CommandTimeout;
         var lifetime = new TransactionalConnection(factory, timeout);
 

--- a/src/Polecat/Events/Daemon/PolecatProjectionBatch.cs
+++ b/src/Polecat/Events/Daemon/PolecatProjectionBatch.cs
@@ -10,6 +10,7 @@ using Polecat.Events.Aggregation;
 using Polecat.Internal;
 using Polecat.Internal.Operations;
 using Polecat.Services;
+using Polecat.Storage;
 using Weasel.SqlServer;
 
 namespace Polecat.Events.Daemon;
@@ -24,6 +25,7 @@ internal class PolecatProjectionBatch : IProjectionBatch<IDocumentSession, IQuer
 {
     private readonly DocumentStore _store;
     private readonly EventGraph _events;
+    private readonly PolecatDatabase _database;
     private readonly string _connectionString;
     private readonly ShardExecutionMode _mode;
     private readonly ResiliencePipeline _resilience;
@@ -46,19 +48,26 @@ internal class PolecatProjectionBatch : IProjectionBatch<IDocumentSession, IQuer
     private IMessageBatch? _messageBatch;
     private readonly SemaphoreSlim _messageBatchGate = new(1, 1);
 
-    public PolecatProjectionBatch(DocumentStore store, EventGraph events, string connectionString,
+    public PolecatProjectionBatch(DocumentStore store, EventGraph events, PolecatDatabase database,
         ShardExecutionMode mode = ShardExecutionMode.Continuous)
     {
         _store = store;
         _events = events;
-        _connectionString = connectionString;
+        _database = database;
+        _connectionString = database.ConnectionString;
         _mode = mode;
         _resilience = store.Options.ResiliencePipeline;
     }
 
     public IDocumentSession SessionForTenant(string tenantId)
     {
-        var session = _store.LightweightSession(new SessionOptions { TenantId = tenantId });
+        // #514: bind to the database this batch is working rather than routing tenantId through the
+        // tenancy. The batch drains these sessions' work trackers and executes the operations
+        // against _connectionString, so writes were already landing correctly — but the sessions'
+        // own READS (loading an existing projected document before applying to it) went wherever
+        // tenant routing sent them, and under database-per-tenant tenancy "*DEFAULT*" maps to no
+        // tenant at all. Mirrors Marten's SessionOptions.ForDatabase.
+        var session = _store.LightweightSession(SessionOptions.ForDatabase(tenantId, _database));
         _sessions.Add(session);
         return session;
     }

--- a/src/Polecat/Exceptions/DefaultTenantUsageDisabledException.cs
+++ b/src/Polecat/Exceptions/DefaultTenantUsageDisabledException.cs
@@ -1,0 +1,21 @@
+namespace Polecat.Exceptions;
+
+/// <summary>
+///     Thrown when a session or projection daemon is created against the default tenant while
+///     <see cref="StoreOptions.DefaultTenantUsageEnabled" /> is disabled — which is the automatic
+///     state once a database-per-tenant tenancy is configured. Mirrors Marten's exception of the
+///     same name. polecat#514.
+/// </summary>
+public class DefaultTenantUsageDisabledException : Exception
+{
+    public DefaultTenantUsageDisabledException()
+        : base(
+            $"Default tenant {JasperFx.StorageConstants.DefaultTenantId} usage is disabled. Ensure to create a session by explicitly passing a non-default tenant in the method arg or SessionOptions.")
+    {
+    }
+
+    public DefaultTenantUsageDisabledException(string message)
+        : base($"Default tenant {JasperFx.StorageConstants.DefaultTenantId} usage is disabled. {message}")
+    {
+    }
+}

--- a/src/Polecat/Internal/PolecatActivator.cs
+++ b/src/Polecat/Internal/PolecatActivator.cs
@@ -33,7 +33,21 @@ internal class PolecatActivator : IHostedService
         if (_store.Options.ShouldApplyChangesOnStartup)
         {
             var documentStore = (DocumentStore)_store;
-            await documentStore.Database.ApplyAllConfiguredChangesToDatabaseAsync(ct: cancellationToken);
+
+            // #514: migrate EVERY tenant database, not just the one behind
+            // StoreOptions.ConnectionString. Under database-per-tenant tenancy the other tenants'
+            // databases were silently left unprovisioned, so the first write to them failed at
+            // runtime with a missing-table error long after startup had reported success. Mirrors
+            // Marten's MartenActivator, which iterates Store.Tenancy.BuildDatabases(). Resolved
+            // asynchronously so a dynamic tenancy (MasterTableTenancy) reads its control table here.
+            var tenantDatabases = _store.Options.Tenancy is { } tenancy
+                ? await tenancy.BuildDatabasesAsync(cancellationToken)
+                : [documentStore.Database];
+
+            foreach (var database in tenantDatabases)
+            {
+                await database.ApplyAllConfiguredChangesToDatabaseAsync(ct: cancellationToken);
+            }
 
             // #386: roll every configured rolling-window RANGE partition forward and retire the aged
             // ones. The migration above already provisions the leading edge — with a rolling-window
@@ -41,8 +55,7 @@ internal class PolecatActivator : IHostedService
             // never removes data, so the retention half has to be driven separately. Gated on the same
             // opt-in as the migration itself: applying changes on startup is how a host says "Polecat
             // owns this schema", and retiring a partition is emphatically a schema change.
-            var databases = _store.Options.Tenancy?.AllDatabases() ?? [documentStore.Database];
-            await Storage.RollingPartitions.ApplyAsync(databases, _logger, rollForward: true, dropAged: true,
+            await Storage.RollingPartitions.ApplyAsync(tenantDatabases, _logger, rollForward: true, dropAged: true,
                 cancellationToken);
         }
 

--- a/src/Polecat/Internal/PolecatDaemonHostedService.cs
+++ b/src/Polecat/Internal/PolecatDaemonHostedService.cs
@@ -1,3 +1,4 @@
+using JasperFx.Descriptors;
 using JasperFx.Events.Daemon;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -20,28 +21,67 @@ public class PolecatDaemonHostedService : IHostedService, IAsyncDisposable
         _loggerFactory = loggerFactory;
     }
 
+    private readonly List<IProjectionDaemon> _daemons = new();
+
     /// <summary>
-    ///     The running projection daemon, if started.
+    ///     The running projection daemon. Under database-per-tenant tenancy there is one per tenant
+    ///     database — see <see cref="Daemons" />; this returns the first for backwards compatibility.
     /// </summary>
-    public IProjectionDaemon? Daemon { get; private set; }
+    public IProjectionDaemon? Daemon => _daemons.FirstOrDefault();
+
+    /// <summary>
+    ///     Every running projection daemon — one per tenant database under a multi-database tenancy,
+    ///     otherwise a single daemon for the store's database.
+    /// </summary>
+    public IReadOnlyList<IProjectionDaemon> Daemons => _daemons;
 
     public async Task StartAsync(CancellationToken token)
     {
         var logger = _loggerFactory.CreateLogger<PolecatDaemonHostedService>();
-        Daemon = await _store.BuildProjectionDaemonAsync(logger: logger);
-        await Daemon.StartAllAsync();
+        var tenancy = _store.Options.Tenancy;
+
+        // #514: a database-per-tenant store needs a daemon PER tenant database. This used to build
+        // exactly one, with no tenant, which resolved to whatever database backed
+        // StoreOptions.ConnectionString — so every tenant but that one silently never had its
+        // projections run, and nothing said so. Marten's AddAsyncDaemon registers the
+        // ProjectionCoordinator, which fans out the same way.
+        if (tenancy != null && tenancy.Cardinality != DatabaseCardinality.Single)
+        {
+            var databases = await tenancy.BuildDatabasesAsync(token);
+            foreach (var database in databases)
+            {
+                // Matches what the single-database path gets from BuildProjectionDaemonAsync.
+                await database.EnsureStorageExistsAsync(typeof(JasperFx.Events.IEvent), token);
+                _daemons.Add(database.StartProjectionDaemon(_store, _loggerFactory));
+            }
+        }
+        else
+        {
+            _daemons.Add(await _store.BuildProjectionDaemonAsync(logger: logger));
+        }
+
+        foreach (var daemon in _daemons)
+        {
+            await daemon.StartAllAsync();
+        }
     }
 
     public async Task StopAsync(CancellationToken token)
     {
-        if (Daemon != null)
+        foreach (var daemon in _daemons)
         {
-            await Daemon.StopAllAsync();
+            await daemon.StopAllAsync();
         }
     }
 
-    public async ValueTask DisposeAsync()
+    public ValueTask DisposeAsync()
     {
-        Daemon?.Dispose();
+        foreach (var daemon in _daemons)
+        {
+            daemon.Dispose();
+        }
+
+        _daemons.Clear();
+        return ValueTask.CompletedTask;
     }
 }

--- a/src/Polecat/SessionOptions.cs
+++ b/src/Polecat/SessionOptions.cs
@@ -1,4 +1,5 @@
 using System.Data;
+using Polecat.Storage;
 
 namespace Polecat;
 
@@ -17,6 +18,44 @@ public class SessionOptions
     ///     Optionally set the tenant id for this session.
     /// </summary>
     public string TenantId { get; set; } = JasperFx.StorageConstants.DefaultTenantId;
+
+    /// <summary>
+    ///     If true, this session may be opened for the default tenant even when
+    ///     <see cref="StoreOptions.DefaultTenantUsageEnabled" /> is disabled on the store. Mirrors
+    ///     Marten's <c>SessionOptions.AllowAnyTenant</c>. Set automatically by
+    ///     <see cref="ForDatabase(PolecatDatabase)" />, which is how the async daemon opens sessions
+    ///     against a tenant database it has already resolved. polecat#514.
+    /// </summary>
+    public bool AllowAnyTenant { get; set; }
+
+    /// <summary>
+    ///     Bind this session to an explicit database rather than routing
+    ///     <see cref="TenantId" /> through the store's <see cref="ITenancy" />. Under
+    ///     database-per-tenant tenancy the daemon knows the database it is working, and the events
+    ///     it replays carry the default tenant id — two different coordinates, so routing by tenant
+    ///     id alone cannot reach the right database. Set via <see cref="ForDatabase(PolecatDatabase)" />.
+    /// </summary>
+    public PolecatDatabase? Database { get; set; }
+
+    /// <summary>
+    ///     Create session options bound to <paramref name="database" /> for the default tenant.
+    ///     Mirrors Marten's <c>SessionOptions.ForDatabase</c>.
+    /// </summary>
+    public static SessionOptions ForDatabase(PolecatDatabase database) =>
+        ForDatabase(JasperFx.StorageConstants.DefaultTenantId, database);
+
+    /// <summary>
+    ///     Create session options for <paramref name="tenantId" /> bound to an explicit
+    ///     <paramref name="database" />.
+    /// </summary>
+    public static SessionOptions ForDatabase(string tenantId, PolecatDatabase database) =>
+        new()
+        {
+            TenantId = tenantId,
+            Database = database,
+            AllowAnyTenant = true,
+            Tracking = DocumentTracking.None
+        };
 
     /// <summary>
     ///     Override the transaction isolation level for this session.

--- a/src/Polecat/Storage/ITenancy.cs
+++ b/src/Polecat/Storage/ITenancy.cs
@@ -25,6 +25,22 @@ public interface ITenancy
     ///     <c>AddResourceSetupOnStartup()</c> can provision every tenant schema.
     /// </summary>
     Task<IReadOnlyList<PolecatDatabase>> BuildDatabasesAsync(CancellationToken token = default);
+
+    /// <summary>
+    ///     A connection string this tenancy can nominate for the store's own
+    ///     <see cref="StoreOptions.ConnectionString" /> when the application did not set one.
+    ///     Configuring a database-per-tenant tenancy already names every database the store will
+    ///     ever touch, so requiring the application to ALSO nominate one of them as a top level
+    ///     connection string is pure ceremony — and picking one arbitrarily (as users were doing)
+    ///     makes that tenant's database quietly special. Returns null when the tenancy has nothing
+    ///     to offer, which leaves the existing "a connection string must be configured" error in
+    ///     place. polecat#514.
+    ///     <para>
+    ///     Default-implemented so existing <see cref="ITenancy" /> implementations outside this
+    ///     repo keep compiling.
+    ///     </para>
+    /// </summary>
+    string? SeedConnectionString => null;
 }
 
 /// <summary>
@@ -50,6 +66,10 @@ internal class DefaultTenancy : ITenancy
 
     public Task<IReadOnlyList<PolecatDatabase>> BuildDatabasesAsync(CancellationToken token = default) =>
         Task.FromResult(AllDatabases());
+
+    // DefaultTenancy is only ever constructed FROM the store's connection string, so it has nothing
+    // to seed back.
+    public string? SeedConnectionString => null;
 }
 
 /// <summary>
@@ -112,4 +132,10 @@ public class SeparateDatabaseTenancy : ITenancy
 
     Task<IReadOnlyList<PolecatDatabase>> ITenancy.BuildDatabasesAsync(CancellationToken token) =>
         Task.FromResult(((ITenancy)this).AllDatabases());
+
+    // The first tenant registered, matching how Marten's StaticMultiTenancy nominates the first
+    // AddSingleTenantDatabase call as its Default. It only backs schema modelling and the store's
+    // own Database property — nothing routes to it, because DefaultTenantUsageEnabled is off.
+    string? ITenancy.SeedConnectionString =>
+        _factories.Values.FirstOrDefault()?.ConnectionString;
 }

--- a/src/Polecat/Storage/MasterTableTenancy.cs
+++ b/src/Polecat/Storage/MasterTableTenancy.cs
@@ -109,6 +109,12 @@ public class MasterTableTenancy : ITenancy, IDynamicTenantSource<string>
     ///     and return the full set of tenant databases the tenancy currently knows about. Mirrors
     ///     Marten's <c>BuildDatabases()</c>.
     /// </summary>
+    /// <summary>
+    ///     The control-plane database. Master table tenancy always has one, so an application never
+    ///     needs to set StoreOptions.ConnectionString as well. polecat#514.
+    /// </summary>
+    public string? SeedConnectionString => _masterConnectionString;
+
     public async Task<IReadOnlyList<PolecatDatabase>> BuildDatabasesAsync(CancellationToken token = default)
     {
         await EnsureMasterTableAsync(token).ConfigureAwait(false);

--- a/src/Polecat/StoreOptions.cs
+++ b/src/Polecat/StoreOptions.cs
@@ -435,10 +435,19 @@ public class StoreOptions
 
     internal ConnectionFactory CreateConnectionFactory()
     {
+        // #514: a configured tenancy already names every database the store will touch, so it can
+        // seed the store's own connection string. Requiring the application to ALSO nominate one of
+        // the tenant databases at the top level was ceremony that made that tenant's database
+        // quietly special — and the store would throw on startup without it.
+        if (string.IsNullOrWhiteSpace(_connectionString) && Tenancy?.SeedConnectionString is { } seeded)
+        {
+            _connectionString = seeded;
+        }
+
         if (string.IsNullOrWhiteSpace(_connectionString))
         {
             throw new InvalidOperationException(
-                "A connection string must be configured. Set StoreOptions.ConnectionString.");
+                "A connection string must be configured. Set StoreOptions.ConnectionString, or configure a tenancy (MultiTenantedDatabases / MultiTenantedMasterTable) that supplies one.");
         }
 
         return new ConnectionFactory(_connectionString);

--- a/src/Polecat/StoreOptions.cs
+++ b/src/Polecat/StoreOptions.cs
@@ -263,6 +263,23 @@ public class StoreOptions
     public ITenancy? Tenancy { get; set; }
 
     /// <summary>
+    ///     Option to enable or disable usage of the default tenant when using multi-tenanted
+    ///     documents. Configuring a database-per-tenant tenancy —
+    ///     <see cref="MultiTenantedDatabases" /> or <see cref="MultiTenantedMasterTable" /> — turns
+    ///     this off automatically, so a session or daemon opened with no tenant fails loudly with a
+    ///     <see cref="Exceptions.DefaultTenantUsageDisabledException" /> rather than silently
+    ///     landing on whichever database happens to back
+    ///     <see cref="ConnectionString" />. A default tenant is never required to configure
+    ///     database-per-tenant multi-tenancy.
+    ///     <para>
+    ///     Marten carries this as <c>StoreOptions.Advanced.DefaultTenantUsageEnabled</c>; Polecat
+    ///     has no <c>Advanced</c> sub-object and flattens it onto <see cref="StoreOptions" />, as
+    ///     with the other <c>Advanced.*</c> members it mirrors. polecat#514.
+    ///     </para>
+    /// </summary>
+    public bool DefaultTenantUsageEnabled { get; set; } = true;
+
+    /// <summary>
     ///     Custom projection storage providers registered by extensions (e.g., EF Core).
     ///     Keyed by document type, returns a factory that creates IProjectionStorage instances.
     /// </summary>
@@ -315,6 +332,11 @@ public class StoreOptions
     /// </summary>
     public void MultiTenantedDatabases(Action<SeparateDatabaseTenancy> configure)
     {
+        // Marten's MultiTenantedDatabases() does the same. Every tenant has its own database, so
+        // there is no coherent database for the default tenant to mean — asking for one is a
+        // configuration mistake, not a fallback.
+        DefaultTenantUsageEnabled = false;
+
         var tenancy = new SeparateDatabaseTenancy(this);
         configure(tenancy);
         Tenancy = tenancy;
@@ -333,6 +355,10 @@ public class StoreOptions
     public MasterTableTenancy MultiTenantedMasterTable(string masterConnectionString,
         string? schemaName = null, Action<MasterTableTenancy>? configure = null)
     {
+        // Matches Marten's MultiTenantedDatabasesWithMasterDatabaseTable — see the note on
+        // MultiTenantedDatabases above.
+        DefaultTenantUsageEnabled = false;
+
         var tenancy = new MasterTableTenancy(this, masterConnectionString, schemaName ?? DatabaseSchemaName);
         configure?.Invoke(tenancy);
         Tenancy = tenancy;


### PR DESCRIPTION
Closes #514.

A default tenant should never be needed to configure database-per-tenant multi-tenancy. It was — and working out *why* turned up five production bugs plus a testing gap that had been hiding all of them.

## The gap that hid it

Polecat had **no test that ran the async daemon under database-per-tenant tenancy**. Two files look like they cover it and don't:

- `MultiTenancy/separate_database_tenancy_tests.cs` — 7 tests, no projection registered anywhere.
- `Daemon/multi_tenant_daemon_tests.cs` — single-database despite the name; its first test is `events_stored_in_default_tenant_are_visible`.

So every daemon path that resolves a tenant was unexercised. The first thing in this PR is a failing-test commit mirroring Marten's `DaemonTests/MultiTenancy/multi_tenancy_by_database.cs`, `MultiTenancyTests/using_static_database_multitenancy.cs` and `projection_statuses_per_database.cs`.

## Root cause

One mistake, five places: **code resolving a database by tenant id when it already knew the database**, or assuming a single database exists. Under database-per-tenant those are different coordinates — the daemon works a *database*, and the events in it carry the *default* tenant id, which no tenancy entry maps to.

| # | Bug | Effect |
|---|---|---|
| 1 | `IEventStore.OpenSession(IEventDatabase)` discarded its `database` argument and called `LightweightSession()` | `UnknownTenantIdException: '*DEFAULT*'` — **no shard could start at all** |
| 2 | `PolecatProjectionBatch.SessionForTenant` routed by tenant id | Writes survived (the batch drains work trackers onto its own connection); the sessions' **reads** went to the wrong database, so any projection updating an existing document was silently wrong |
| 3 | `PolecatActivator` migrated only `StoreOptions.ConnectionString`'s database | Other tenant databases left unprovisioned while startup reported success |
| 4 | `PolecatDaemonHostedService` built one daemon with no tenant | Every tenant but one **silently never had its projections run** |
| 5 | `CleanAllDocumentsAsync` / `CleanAllEventDataAsync` / `CleanAsync(Type)` / `CompletelyRemoveAllAsync` read `StoreOptions.ConnectionString` | "Clean everything" emptied one database, leaving every other tenant populated |

Bug 1 is why users were registering a placeholder `*DEFAULT*` tenant. Bug 4 is why that workaround *appeared* to work — with only one daemon running, only one tenant was ever processed.

## API parity with Marten

**`StoreOptions.DefaultTenantUsageEnabled`** mirrors Marten's `Advanced.DefaultTenantUsageEnabled` at every point Marten uses it: flipped false by `MultiTenantedDatabases()` and `MultiTenantedMasterTable()`, asserted when opening any session and when building a daemon, bypassed by `SessionOptions.AllowAnyTenant`, and advertised through `DocumentStoreUsage`. Polecat has no `StoreOptions.Advanced`, so it sits directly on `StoreOptions` alongside the other `Advanced.*` members Polecat already flattens.

**`SessionOptions.Database` / `ForDatabase(...)`** is Marten's mechanism for binding a session to an already-resolved database. Bugs 1, 2 and the subscription runner now use it.

**`ITenancy.SeedConnectionString`** (default-implemented, so out-of-repo implementations keep compiling) removes the mandatory top-level connection string: a tenancy already names every database the store will touch. `SeparateDatabaseTenancy` nominates its first tenant — matching how Marten's `StaticMultiTenancy` nominates the first `AddSingleTenantDatabase` call as its `Default` — and `MasterTableTenancy` nominates the control-plane database. Nothing routes to it; it only backs schema modelling and the store's `Database` property.

## What now works

```csharp
builder.Services.AddPolecat(opts =>
{
    // No ConnectionString. No "*DEFAULT*" tenant.
    opts.MultiTenantedDatabases(tenants =>
    {
        foreach (var customer in customers)
            tenants.AddTenant(customer.Code, BuildConnectionString(customer.DatabaseName));
    });

    opts.AutoCreateSchemaObjects = AutoCreate.CreateOrUpdate;
    opts.Projections.Add<MyProjection>(ProjectionLifecycle.Async);
})
.ApplyAllDatabaseChangesOnStartup()
.AddAsyncDaemon(DaemonMode.HotCold);
```

Every tenant database is migrated on startup, and each gets its own daemon with running agents. `PolecatDaemonHostedService.Daemons` exposes them, so "is there really one per database?" is now answerable rather than a matter of trust.

## Coverage

New, all ported from Marten where an equivalent exists:

- `MultiTenancy/disabling_default_tenant_usage.cs` — port of Marten's file, plus `AllowAnyTenant` and `ForDatabase`.
- `MultiTenancy/daemon_multi_tenancy_by_database_tests.cs` — the failing-first suite; end-to-end projections per tenant database, daemon-to-database routing, per-database progression, startup migration.
- `Daemon/daemon_agent_startup_multi_tenancy_tests.cs` — agents actually reach **Running** on every tenant database, with and without a default tenant registered; the coordinator spins up agents for tenant databases added to the master table at runtime (port of Marten's `dynamic_spin_up_of_dynamic_tenants`); and `everything_starts_with_no_connection_string_and_no_default_tenant`, which is the reported configuration with both workarounds removed.
- `can_use_bulk_inserts` and `clean_crosses_the_tenanted_databases` in both `separate_database_tenancy_tests` and `master_table_tenancy_tests` — ports of Marten's, plus an event-data twin for Polecat's `CleanAllEventDataAsync`.
- `default_tenant_usage_is_disabled` in each tenancy test file, as Marten carries it in each of its four.

The shard-running assertion and both clean tests were mutation-checked — swapping in a bogus shard name, and reverting the cleaner fan-out, each fail the relevant tests — so they are not passing vacuously.

## Docs

The "no default tenant, no top-level connection string" guidance is now on all three multi-tenancy pages (configuration, documents, events) rather than nowhere.

Separately: the separate-database samples in those same three files called `AddSingleTenantDatabase(connectionString, tenantId)` — Marten's method name with Marten's argument order. Polecat's method is `AddTenant(tenantId, connectionString)`, so none of those samples compiled. That very likely contributed to the trial-and-error in #514.

## Not addressed

`FetchEventStoreStatistics` has the same single-database shape as the cleaners, but whether it should aggregate across tenant databases or report per-database is a design question rather than a bug. Left alone deliberately.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
