### PR TITLE
QueueSqlCommand: stop dropping parameterless statements (gh-517)

### DIFF
--- a/src/Polecat.Tests/queued_sql_command_tests.cs
+++ b/src/Polecat.Tests/queued_sql_command_tests.cs
@@ -1,0 +1,199 @@
+using Microsoft.Data.SqlClient;
+using Polecat.Tests.Harness;
+
+namespace Polecat.Tests;
+
+/// <summary>
+///     polecat#517 — a statement queued with <c>QueueSqlCommand</c> was silently discarded whenever
+///     the same session also carried another operation. <c>SaveChangesAsync</c> reported success and
+///     the documents committed, so a caller who queued SQL alongside a document write believed both
+///     had landed.
+///     <para>
+///     The statement was not merely failing to report an error: it never ran at all. Weasel's
+///     BatchBuilder creates the underlying batch command as a side effect of appending a PARAMETER,
+///     so a parameterless statement left no current command and the next <c>StartNewCommand()</c>
+///     cleared its text out of the shared buffer. That is why the parameterized cases below always
+///     worked and the parameterless ones did not, and why the bug was invisible with the queued
+///     command alone on the session.
+///     </para>
+/// </summary>
+public class queued_sql_command_tests : OneOffConfigurationsContext
+{
+    private const string BadSql = "delete from a_table_that_does_not_exist_anywhere";
+
+    // ---- the statement actually runs -------------------------------------------------------
+
+    [Fact]
+    public async Task parameterless_queued_sql_runs_when_it_is_the_only_operation()
+    {
+        await StartAsync();
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.QueueSqlCommand($"insert into {ProbeTable} (note) values ('alone')");
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        (await ProbeCountAsync("alone")).ShouldBe(1);
+    }
+
+    /// <summary>The regression: this one silently did nothing.</summary>
+    [Fact]
+    public async Task parameterless_queued_sql_runs_alongside_a_document()
+    {
+        await StartAsync();
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.QueueSqlCommand($"insert into {ProbeTable} (note) values ('with_doc')");
+            session.Store(new Target { Id = Guid.NewGuid() });
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        (await ProbeCountAsync("with_doc")).ShouldBe(1);
+    }
+
+    /// <summary>
+    ///     Ordering matters to the underlying mechanism, so cover the queued command arriving after
+    ///     the document as well as before it.
+    /// </summary>
+    [Fact]
+    public async Task parameterless_queued_sql_runs_when_queued_after_a_document()
+    {
+        await StartAsync();
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Store(new Target { Id = Guid.NewGuid() });
+            session.QueueSqlCommand($"insert into {ProbeTable} (note) values ('after_doc')");
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        (await ProbeCountAsync("after_doc")).ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task several_parameterless_queued_commands_all_run()
+    {
+        await StartAsync();
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.QueueSqlCommand($"insert into {ProbeTable} (note) values ('multi')");
+            session.QueueSqlCommand($"insert into {ProbeTable} (note) values ('multi')");
+            session.QueueSqlCommand($"insert into {ProbeTable} (note) values ('multi')");
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        (await ProbeCountAsync("multi")).ShouldBe(3);
+    }
+
+    /// <summary>Parameterized statements always worked; kept so a fix cannot regress them.</summary>
+    [Fact]
+    public async Task parameterized_queued_sql_runs_alongside_a_document()
+    {
+        await StartAsync();
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.QueueSqlCommand($"insert into {ProbeTable} (note) values (?)", "parameterized");
+            session.Store(new Target { Id = Guid.NewGuid() });
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        (await ProbeCountAsync("parameterized")).ShouldBe(1);
+    }
+
+    // ---- failures surface, and the batch is atomic -----------------------------------------
+
+    [Fact]
+    public async Task invalid_queued_sql_fails_the_commit_when_it_is_the_only_operation()
+    {
+        await StartAsync();
+
+        await using var session = theStore.LightweightSession();
+        session.QueueSqlCommand(BadSql);
+
+        await Should.ThrowAsync<Exception>(async () =>
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task invalid_queued_sql_fails_the_commit_when_a_document_is_pending()
+    {
+        await StartAsync();
+
+        await using var session = theStore.LightweightSession();
+        session.QueueSqlCommand(BadSql);
+        session.Store(new Target { Id = Guid.NewGuid() });
+
+        await Should.ThrowAsync<Exception>(async () =>
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task the_document_is_not_persisted_when_the_queued_sql_is_invalid()
+    {
+        await StartAsync();
+
+        var id = Guid.NewGuid();
+        await using (var session = theStore.LightweightSession())
+        {
+            session.QueueSqlCommand(BadSql);
+            session.Store(new Target { Id = id });
+            try { await session.SaveChangesAsync(TestContext.Current.CancellationToken); }
+            catch { /* expected */ }
+        }
+
+        await using var query = theStore.QuerySession();
+        (await query.LoadAsync<Target>(id, TestContext.Current.CancellationToken))
+            .ShouldBeNull("the batch contained an invalid statement, so nothing in it should have committed");
+    }
+
+    /// <summary>
+    ///     Unparseable text, not just a missing table — the reporter noted both behave identically,
+    ///     which ruled out deferred name resolution as the explanation.
+    /// </summary>
+    [Fact]
+    public async Task unparseable_queued_sql_fails_the_commit_when_a_document_is_pending()
+    {
+        await StartAsync();
+
+        await using var session = theStore.LightweightSession();
+        session.QueueSqlCommand("this text cannot parse as sql on any engine");
+        session.Store(new Target { Id = Guid.NewGuid() });
+
+        await Should.ThrowAsync<Exception>(async () =>
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken));
+    }
+
+    // ---- harness ---------------------------------------------------------------------------
+
+    private string ProbeTable => $"{theStore.Options.DatabaseSchemaName}.queued_sql_probe";
+
+    private async Task StartAsync()
+    {
+        ConfigureStore(_ => { });
+        await theStore.Database.ApplyAllConfiguredChangesToDatabaseAsync(ct: TestContext.Current.CancellationToken);
+
+        await using var conn = new SqlConnection(theStore.Options.ConnectionString);
+        await conn.OpenAsync(TestContext.Current.CancellationToken);
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"""
+            IF OBJECT_ID('{ProbeTable}', 'U') IS NULL
+                CREATE TABLE {ProbeTable} (id int identity(1,1) primary key, note nvarchar(50));
+            DELETE FROM {ProbeTable};
+            """;
+        await cmd.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+    }
+
+    private async Task<int> ProbeCountAsync(string note)
+    {
+        await using var conn = new SqlConnection(theStore.Options.ConnectionString);
+        await conn.OpenAsync(TestContext.Current.CancellationToken);
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"SELECT COUNT(*) FROM {ProbeTable} WHERE note = @n";
+        cmd.Parameters.AddWithValue("@n", note);
+        return (int)(await cmd.ExecuteScalarAsync(TestContext.Current.CancellationToken))!;
+    }
+}

--- a/src/Polecat/Internal/Operations/StorageOperationExecution.cs
+++ b/src/Polecat/Internal/Operations/StorageOperationExecution.cs
@@ -14,6 +14,23 @@ internal static class StorageOperationExecution
     internal static void Configure(Weasel.Storage.IStorageOperation op, ICommandBuilder builder,
         Weasel.Storage.IStorageSession? session)
     {
+        // polecat#517: materialize the batch command BEFORE the operation appends anything.
+        //
+        // Weasel's BatchBuilder only creates the underlying SqlBatchCommand as a side effect of
+        // appending a PARAMETER — AppendWithParameters writes its text straight into the shared
+        // StringBuilder and creates nothing when the statement has no placeholders. An operation
+        // that appends no parameters therefore leaves the builder with no current command, and the
+        // caller's next StartNewCommand() hits `if (_current != null)`, skips saving the text, and
+        // then _builder.Clear()s it away. The statement is silently discarded: no exception, no log,
+        // and the rest of the batch commits.
+        //
+        // QueueSqlCommand with a parameterless statement is the reported case — it worked alone
+        // (Compile() creates a command when the batch is empty) and vanished the moment any other
+        // operation was queued behind it. Append(string) does `_current ??= appendCommand()`, so an
+        // empty append is enough to pin the command down. Harmless for every other operation: the
+        // caller has already called StartNewCommand() for i > 0, which leaves _current non-null.
+        builder.Append(string.Empty);
+
         if (op is IStorageOperation bespoke)
         {
             bespoke.ConfigureCommand(builder);


### PR DESCRIPTION
Closes #517.

## It was worse than a swallowed error — the statement never ran

The report suspected error handling: `PostprocessAsync` is a no-op, the drain loop might not surface a per-command batch error. It isn't that. Dumping the compiled `SqlBatch` for *one queued command + one document* gives **one** `SqlBatchCommand`, containing only the document upsert. The queued SQL is absent from the batch entirely.

```
### BATCH: 1 commands for 2 operations
###   [0] <<MERGE [schema].[pc_doc_target] ... OUTPUT inserted.id;>>
###   op[0] = ExecuteSqlStorageOperation role=Upsert
###   op[1] = ClosedShapeOperationAdapter role=Upsert
```

A probe with *valid* SQL confirms it independently: `insert into probe_rows ...` queued alone inserts a row; the same statement queued alongside a `Store()` inserts nothing, and `SaveChangesAsync` reports success.

## Root cause

Weasel's `BatchBuilder` creates the underlying `SqlBatchCommand` as a side effect of appending a **parameter**. `AppendWithParameters` writes its text straight into the shared `StringBuilder` and creates nothing when the statement has no placeholders, so `_current` stays null. The caller's next `StartNewCommand()` then does:

```csharp
if (_current != null) { _current.CommandText = _builder.ToString(); }  // skipped
_builder.Clear();                                                      // text discarded
_current = appendCommand();
```

That accounts for every observed symptom, including the ones that looked contradictory:

| Case | Behaviour | Why |
|---|---|---|
| Queued command alone | works | `Compile()` creates a command when the batch is empty, so nothing ever cleared the buffer |
| Queued **before** another operation | **dropped** | `StartNewCommand()` clears the un-saved text |
| Queued **after** another operation | works | `StartNewCommand()` already created the command before the text was appended |
| Queued **with parameters** | works | the first parameter materializes the command |

The parameterized-vs-parameterless split was the decisive test — it was predicted from the mechanism and then confirmed, rather than found by trial.

## Fix

One line, in `StorageOperationExecution.Configure`:

```csharp
builder.Append(string.Empty);
```

`Append(string)` does `_current ??= appendCommand()`, so an empty append pins the command down before the operation writes anything.

Placed at the central dispatch point rather than in `ExecuteSqlStorageOperation`, because it is the single entry for every operation in both batch paths (session commit and the async daemon batch), and *any* parameterless operation is exposed to the same loss — `QueueSqlCommand` is just the one a user can reach directly. It is a no-op for operations the caller has already called `StartNewCommand()` for.

## On the Weasel side

The underlying `BatchBuilder` behaviour is arguably a Weasel bug: any caller of `AppendWithParameters` with no placeholders followed by `StartNewCommand` loses SQL, and the same shape exists in `Weasel.Postgresql`. Worth raising upstream. The guard belongs here regardless, and this way the fix doesn't wait on a Weasel release.

## Tests

`queued_sql_command_tests` — nine tests covering both orderings, several queued commands in one session, the parameterized case that always worked (so a fix can't regress it), and batch atomicity when the queued statement is invalid or unparseable.

**Five of the nine fail without the fix**, verified by reverting it.

The three from the issue are included as written. The rest exist because the original repro could only ever show that *something* was wrong — it asserted on exceptions, which cannot distinguish "the error was swallowed" from "the statement never ran". The `probe_rows` assertions pin down which.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
