### PR TITLE
DCB: honour [BoundaryAggregate] on identity-less aggregates (gh-521)

### DIFF
--- a/docs/documents/querying/linq/operators.md
+++ b/docs/documents/querying/linq/operators.md
@@ -99,6 +99,26 @@ Polecat supports the `GroupBy()` LINQ operator for grouping documents by one or 
 ### Simple Key with Aggregates
 
 <!-- snippet: sample_polecat_group_by_simple_key_with_count -->
+<a id='snippet-sample_polecat_group_by_simple_key_with_count'></a>
+```cs
+[Fact]
+public async Task group_by_simple_key_with_count()
+{
+    await StoreSeedDataAsync();
+
+    await using var query = theStore.QuerySession();
+    var results = await query.Query<LinqTarget>()
+        .GroupBy(x => x.Color)
+        .Select(g => new { Color = g.Key, Count = g.Count() })
+        .ToListAsync(TestContext.Current.CancellationToken);
+
+    results.Count.ShouldBe(3);
+    results.Single(x => x.Color == TargetColor.Blue).Count.ShouldBe(2);
+    results.Single(x => x.Color == TargetColor.Green).Count.ShouldBe(3);
+    results.Single(x => x.Color == TargetColor.Red).Count.ShouldBe(1);
+}
+```
+<sup><a href='https://github.com/JasperFx/polecat/blob/main/src/Polecat.Tests/Linq/group_by_operator.cs#L22-L41' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_polecat_group_by_simple_key_with_count' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### Composite Key

--- a/docs/events/dcb.md
+++ b/docs/events/dcb.md
@@ -18,6 +18,21 @@ Polecat uses a single append strategy (direct `INSERT` with `OUTPUT inserted.seq
 Tag types are strong-typed identifiers (typically `record` types wrapping a primitive). Register them during store configuration:
 
 <!-- snippet: sample_polecat_dcb_registering_tag_types -->
+<a id='snippet-sample_polecat_dcb_registering_tag_types'></a>
+```cs
+public override async ValueTask InitializeAsync()
+{
+    await StoreOptions(opts =>
+    {
+        // Register tag types -- each gets its own table (pc_event_tag_student, pc_event_tag_course)
+        opts.Events.RegisterTagType<StudentId>("student")
+            .ForAggregate<StudentCourseEnrollment>();
+        opts.Events.RegisterTagType<CourseId>("course")
+            .ForAggregate<StudentCourseEnrollment>();
+    });
+}
+```
+<sup><a href='https://github.com/JasperFx/polecat/blob/main/src/Polecat.Tests/Events/dcb_documentation_samples.cs#L77-L89' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_polecat_dcb_registering_tag_types' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Each tag type gets its own table (`pc_event_tag_student`, `pc_event_tag_course`, etc.) with a composite primary key of `(value, seq_id)`.
@@ -27,6 +42,13 @@ Each tag type gets its own table (`pc_event_tag_student`, `pc_event_tag_course`,
 Tag types should be simple wrapper records around a primitive value:
 
 <!-- snippet: sample_polecat_dcb_tag_type_definitions -->
+<a id='snippet-sample_polecat_dcb_tag_type_definitions'></a>
+```cs
+// Strong-typed tag identifiers
+public record StudentId(Guid Value);
+public record CourseId(Guid Value);
+```
+<sup><a href='https://github.com/JasperFx/polecat/blob/main/src/Polecat.Tests/Events/dcb_documentation_samples.cs#L9-L13' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_polecat_dcb_tag_type_definitions' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Supported inner value types: `Guid`, `string`, `int`, `long`, `short`.
@@ -36,6 +58,14 @@ Supported inner value types: `Guid`, `string`, `int`, `long`, `short`.
 Use `BuildEvent` and `WithTag` to attach tags before appending:
 
 <!-- snippet: sample_polecat_dcb_tagging_events -->
+<a id='snippet-sample_polecat_dcb_tagging_events'></a>
+```cs
+var enrolled = theSession.Events.BuildEvent(new StudentEnrolled("Alice", "Math"));
+enrolled.WithTag(studentId, courseId);
+theSession.Events.Append(streamId, enrolled);
+await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
+```
+<sup><a href='https://github.com/JasperFx/polecat/blob/main/src/Polecat.Tests/Events/dcb_documentation_samples.cs#L98-L103' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_polecat_dcb_tagging_events' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Events can have multiple tags of different types. Tags are persisted to their respective tag tables in the same transaction as the event.
@@ -45,16 +75,39 @@ Events can have multiple tags of different types. Tags are persisted to their re
 Use `EventTagQuery` to build a query, then execute it with `QueryByTagsAsync`:
 
 <!-- snippet: sample_polecat_dcb_query_by_single_tag -->
+<a id='snippet-sample_polecat_dcb_query_by_single_tag'></a>
+```cs
+var query = new EventTagQuery().Or<StudentId>(studentId);
+var events = await session2.Events.QueryByTagsAsync(query, TestContext.Current.CancellationToken);
+```
+<sup><a href='https://github.com/JasperFx/polecat/blob/main/src/Polecat.Tests/Events/dcb_documentation_samples.cs#L106-L109' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_polecat_dcb_query_by_single_tag' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### Multiple Tags (OR)
 
 <!-- snippet: sample_polecat_dcb_query_multiple_tags_or -->
+<a id='snippet-sample_polecat_dcb_query_multiple_tags_or'></a>
+```cs
+var query = new EventTagQuery()
+    .Or<StudentId>(student1)
+    .Or<StudentId>(student2);
+
+var events = await session2.Events.QueryByTagsAsync(query, TestContext.Current.CancellationToken);
+```
+<sup><a href='https://github.com/JasperFx/polecat/blob/main/src/Polecat.Tests/Events/dcb_documentation_samples.cs#L135-L141' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_polecat_dcb_query_multiple_tags_or' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### Filtering by Event Type
 
 <!-- snippet: sample_polecat_dcb_query_by_event_type -->
+<a id='snippet-sample_polecat_dcb_query_by_event_type'></a>
+```cs
+var query = new EventTagQuery()
+    .Or<AssignmentSubmitted, StudentId>(studentId);
+
+var events = await session2.Events.QueryByTagsAsync(query, TestContext.Current.CancellationToken);
+```
+<sup><a href='https://github.com/JasperFx/polecat/blob/main/src/Polecat.Tests/Events/dcb_documentation_samples.cs#L162-L167' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_polecat_dcb_query_by_event_type' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Events are always returned ordered by sequence number (global append order).
@@ -64,6 +117,13 @@ Events are always returned ordered by sequence number (global append order).
 Tag predicates can also compose directly into a LINQ `Where()` over an event query, alongside ordinary event predicates (timestamp, event type, stream). Use the `IEvent.HasTag<TTag>(value)` marker method:
 
 <!-- snippet: sample_polecat_dcb_has_tag_linq -->
+<a id='snippet-sample_polecat_dcb_has_tag_linq'></a>
+```cs
+var events = await session.Events.QueryAllRawEvents()
+    .Where(e => e.HasTag<StudentId>(alice))
+    .ToListAsync(TestContext.Current.CancellationToken);
+```
+<sup><a href='https://github.com/JasperFx/polecat/blob/main/src/Polecat.Tests/Events/dcb_tag_linq_where_tests.cs#L50-L56' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_polecat_dcb_has_tag_linq' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 `HasTag` compiles to the same tag-table subquery that `QueryByTagsAsync` emits (a correlated `seq_id IN (SELECT seq_id FROM pc_event_tag_{suffix} WHERE value = @p)` predicate), and under conjoined tenancy it is automatically tenant-scoped. AND-ing several `HasTag` calls with normal predicates is supported:
@@ -83,11 +143,49 @@ For OR-across-tags or the richer tag/event-type interplay, keep using the `Event
 Build an aggregate from tagged events, similar to `AggregateStreamAsync` but across streams. First define an aggregate that applies the tagged events:
 
 <!-- snippet: sample_polecat_dcb_aggregate -->
+<a id='snippet-sample_polecat_dcb_aggregate'></a>
+```cs
+// Aggregate for DCB
+public partial class StudentCourseEnrollment
+{
+    public Guid Id { get; set; }
+    public string StudentName { get; set; } = "";
+    public string CourseName { get; set; } = "";
+    public List<string> Assignments { get; set; } = new();
+    public bool IsDropped { get; set; }
+
+    public void Apply(StudentEnrolled e)
+    {
+        StudentName = e.StudentName;
+        CourseName = e.CourseName;
+    }
+
+    public void Apply(AssignmentSubmitted e)
+    {
+        Assignments.Add(e.AssignmentName);
+    }
+
+    public void Apply(StudentDropped e)
+    {
+        IsDropped = true;
+    }
+}
+```
+<sup><a href='https://github.com/JasperFx/polecat/blob/main/src/Polecat.Tests/Events/dcb_documentation_samples.cs#L28-L54' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_polecat_dcb_aggregate' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Then aggregate across streams by tag query:
 
 <!-- snippet: sample_polecat_dcb_aggregate_by_tags -->
+<a id='snippet-sample_polecat_dcb_aggregate_by_tags'></a>
+```cs
+var query = new EventTagQuery()
+    .Or<StudentId>(studentId)
+    .Or<CourseId>(courseId);
+
+var aggregate = await session2.Events.AggregateByTagsAsync<StudentCourseEnrollment>(query, TestContext.Current.CancellationToken);
+```
+<sup><a href='https://github.com/JasperFx/polecat/blob/main/src/Polecat.Tests/Events/dcb_documentation_samples.cs#L189-L195' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_polecat_dcb_aggregate_by_tags' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Returns `null` if no matching events are found.
@@ -149,11 +247,49 @@ for SingleStreamProjection<CourseEnrollmentSummary, string>
 `FetchForWritingByTags` loads the aggregate and establishes a consistency boundary. At `SaveChangesAsync` time, Polecat checks whether any new events matching the query have been appended since the read, throwing `DcbConcurrencyException` if so:
 
 <!-- snippet: sample_polecat_dcb_fetch_for_writing_by_tags -->
+<a id='snippet-sample_polecat_dcb_fetch_for_writing_by_tags'></a>
+```cs
+await using var session2 = theStore.LightweightSession();
+var query = new EventTagQuery().Or<StudentId>(studentId);
+var boundary = await session2.Events.FetchForWritingByTags<StudentCourseEnrollment>(query, TestContext.Current.CancellationToken);
+
+// Read current state
+var aggregate = boundary.Aggregate; // may be null if no events yet
+var lastSequence = boundary.LastSeenSequence;
+
+// Append via boundary
+var assignment = session2.Events.BuildEvent(new AssignmentSubmitted("HW1", 95));
+assignment.WithTag(studentId, courseId);
+boundary.AppendOne(assignment);
+
+// Save -- will throw DcbConcurrencyException if another session
+// appended matching events after our read
+await session2.SaveChangesAsync(TestContext.Current.CancellationToken);
+```
+<sup><a href='https://github.com/JasperFx/polecat/blob/main/src/Polecat.Tests/Events/dcb_documentation_samples.cs#L214-L231' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_polecat_dcb_fetch_for_writing_by_tags' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### Handling Concurrency Violations
 
 <!-- snippet: sample_polecat_dcb_handling_concurrency -->
+<a id='snippet-sample_polecat_dcb_handling_concurrency'></a>
+```cs
+public static async Task handling_a_concurrency_violation(IDocumentSession session)
+{
+    try
+    {
+        await session.SaveChangesAsync();
+    }
+    catch (DcbConcurrencyException violation)
+    {
+        // Reload and retry -- the boundary's tag query had new matching events since the read.
+        // violation.Query is the original tag query, violation.LastSeenSequence the sequence
+        // the boundary was read at.
+        Console.WriteLine($"DCB violation on {violation.Query} at {violation.LastSeenSequence}");
+    }
+}
+```
+<sup><a href='https://github.com/JasperFx/polecat/blob/main/src/Polecat.Tests/Events/dcb_documentation_samples.cs#L274-L289' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_polecat_dcb_handling_concurrency' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ::: tip
@@ -173,6 +309,28 @@ boundary -- the common case, and what the sample above shows -- always throws th
 If you only need to know whether any events matching a tag query exist -- without loading or deserializing them -- use `EventsExistAsync`. This is a lightweight existence check that avoids the overhead of fetching and materializing event data:
 
 <!-- snippet: sample_polecat_dcb_events_exist_async -->
+<a id='snippet-sample_polecat_dcb_events_exist_async'></a>
+```cs
+[Fact]
+public async Task events_exist_returns_true_when_matching_events_found()
+{
+    var studentId = new StudentId(Guid.NewGuid());
+    var courseId = new CourseId(Guid.NewGuid());
+    var streamId = Guid.NewGuid();
+
+    var enrolled = theSession.Events.BuildEvent(new StudentEnrolled("Alice", "Math"));
+    enrolled.WithTag(studentId, courseId);
+    theSession.Events.Append(streamId, enrolled);
+    await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+    // Check existence -- lightweight, no event loading
+    await using var session2 = theStore.LightweightSession();
+    var query = new EventTagQuery().Or<StudentId>(studentId);
+    var exists = await session2.Events.EventsExistAsync(query, TestContext.Current.CancellationToken);
+    exists.ShouldBeTrue();
+}
+```
+<sup><a href='https://github.com/JasperFx/polecat/blob/main/src/Polecat.Tests/Events/dcb_documentation_samples.cs#L291-L310' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_polecat_dcb_events_exist_async' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 This is useful for guard clauses and validation logic in DCB workflows where you need to check preconditions before appending new events.

--- a/docs/events/natural-keys.md
+++ b/docs/events/natural-keys.md
@@ -15,6 +15,69 @@ Use natural keys when:
 Mark a property on your aggregate with `[NaturalKey]`, and mark the methods that set or change the key value with `[NaturalKeySource]`:
 
 <!-- snippet: sample_polecat_natural_key_aggregate_types -->
+<a id='snippet-sample_polecat_natural_key_aggregate_types'></a>
+```cs
+public record OrderNumber(string Value);
+
+public partial class OrderAggregate
+{
+    public Guid Id { get; set; }
+
+    [NaturalKey]
+    public OrderNumber OrderNum { get; set; } = null!;
+
+    public decimal TotalAmount { get; set; }
+    public string CustomerName { get; set; } = string.Empty;
+    public bool IsComplete { get; set; }
+
+    [NaturalKeySource]
+    public void Apply(NkOrderCreated e)
+    {
+        OrderNum = e.OrderNumber;
+        CustomerName = e.CustomerName;
+    }
+
+    public void Apply(NkOrderItemAdded e)
+    {
+        TotalAmount += e.Price;
+    }
+
+    [NaturalKeySource]
+    public void Apply(NkOrderNumberChanged e)
+    {
+        OrderNum = e.NewOrderNumber;
+    }
+
+    public void Apply(NkOrderCompleted e)
+    {
+        IsComplete = true;
+    }
+}
+
+public partial class InvoiceAggregate
+{
+    public Guid Id { get; set; }
+
+    [NaturalKey]
+    public string InvoiceCode { get; set; } = string.Empty;
+
+    public decimal Amount { get; set; }
+
+    [NaturalKeySource]
+    public void Apply(NkInvoiceCreated e)
+    {
+        InvoiceCode = e.Code;
+        Amount = e.Amount;
+    }
+}
+
+public record NkOrderCreated(OrderNumber OrderNumber, string CustomerName);
+public record NkOrderItemAdded(string ItemName, decimal Price);
+public record NkOrderNumberChanged(OrderNumber NewOrderNumber);
+public record NkOrderCompleted;
+public record NkInvoiceCreated(string Code, decimal Amount);
+```
+<sup><a href='https://github.com/JasperFx/polecat/blob/main/src/Polecat.Tests/Events/natural_key_tests.cs#L9-L71' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_polecat_natural_key_aggregate_types' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The `[NaturalKeySource]` attribute tells Polecat which `Create` / `Apply` methods produce or change the natural key value. Polecat uses this information to keep the lookup table in sync whenever events are appended.
@@ -78,6 +141,19 @@ Unlike Marten's PostgreSQL-based implementation which uses table partitioning fo
 The primary use case for natural keys is looking up a stream for writing without knowing its stream id:
 
 <!-- snippet: sample_polecat_fetch_for_writing_by_natural_key -->
+<a id='snippet-sample_polecat_fetch_for_writing_by_natural_key'></a>
+```cs
+// FetchForWriting by the business identifier instead of stream id
+var stream = await session2.Events.FetchForWriting<OrderAggregate, OrderNumber>(orderNumber, TestContext.Current.CancellationToken);
+
+stream.Aggregate.ShouldNotBeNull();
+stream.Aggregate!.OrderNum.ShouldBe(orderNumber);
+
+// Append new events through the stream
+stream.AppendOne(new NkOrderItemAdded("Gadget", 19.99m));
+await session2.SaveChangesAsync(TestContext.Current.CancellationToken);
+```
+<sup><a href='https://github.com/JasperFx/polecat/blob/main/src/Polecat.Tests/Events/natural_key_tests.cs#L113-L123' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_polecat_fetch_for_writing_by_natural_key' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 This resolves the natural key to a stream id and fetches the aggregate in a single database round-trip. Polecat uses `WITH (UPDLOCK, HOLDLOCK)` hints to ensure safe concurrent access during the lookup.
@@ -87,6 +163,12 @@ This resolves the natural key to a stream id and fetches the aggregate in a sing
 For read-only access, you can use `FetchLatest` with a natural key:
 
 <!-- snippet: sample_polecat_fetch_latest_by_natural_key -->
+<a id='snippet-sample_polecat_fetch_latest_by_natural_key'></a>
+```cs
+// Read-only access by natural key
+var aggregate = await session2.Events.FetchLatest<OrderAggregate, OrderNumber>(orderNumber, TestContext.Current.CancellationToken);
+```
+<sup><a href='https://github.com/JasperFx/polecat/blob/main/src/Polecat.Tests/Events/natural_key_tests.cs#L169-L172' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_polecat_fetch_latest_by_natural_key' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Mutability

--- a/docs/events/projections/composite.md
+++ b/docs/events/projections/composite.md
@@ -114,6 +114,61 @@ that needs to consult the upstream `Order` that is being projected in the same b
 reach into the upstream stage's in-memory aggregate cache.
 
 <!-- snippet: sample_polecat_try_find_upstream_cache -->
+<a id='snippet-sample_polecat_try_find_upstream_cache'></a>
+```cs
+public partial class OrderShippingNotificationProjection : MultiStreamProjection<OrderShippingNotification, Guid>
+{
+    public OrderShippingNotificationProjection()
+    {
+        Identity<IEvent<CompositeOrderShipped>>(e => e.StreamId);
+    }
+
+    public override Task EnrichEventsAsync(SliceGroup<OrderShippingNotification, Guid> group,
+        IQuerySession querySession, CancellationToken cancellation)
+    {
+        // Ask the upstream CompositeOrderProjection (running earlier in the same composite stage)
+        // for its in-memory aggregate cache. A SQL query for CompositeOrder in this same batch
+        // would return nothing — those writes are still queued on the shared IProjectionBatch
+        // and have not been committed to SQL Server yet.
+        if (!group.TryFindUpstreamCache<Guid, CompositeOrder>(out var upstreamOrders))
+        {
+            return Task.CompletedTask;
+        }
+
+        foreach (var slice in group.Slices)
+        {
+            if (upstreamOrders.TryFind(slice.Id, out var order))
+            {
+                // Stamp a synthetic References<CompositeOrder> event onto the slice so
+                // the Evolve method can read the upstream entity's data.
+                slice.Reference(order);
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public override OrderShippingNotification? Evolve(OrderShippingNotification? snapshot, Guid id, IEvent e)
+    {
+        switch (e.Data)
+        {
+            case CompositeOrderShipped shipped:
+                snapshot ??= new OrderShippingNotification { Id = id };
+                snapshot.Carrier = shipped.Carrier;
+                break;
+
+            case References<CompositeOrder> orderRef:
+                snapshot ??= new OrderShippingNotification { Id = id };
+                snapshot.CustomerId = orderRef.Entity.CustomerId;
+                snapshot.OrderTotal = orderRef.Entity.Total;
+                break;
+        }
+
+        return snapshot;
+    }
+}
+```
+<sup><a href='https://github.com/JasperFx/polecat/blob/main/src/Polecat.Tests/Projections/composite_try_find_upstream_cache_tests.cs#L66-L120' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_polecat_try_find_upstream_cache' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 `TryFindUpstreamCache` returns `false` when no upstream stage of this composite is

--- a/docs/events/projections/flat.md
+++ b/docs/events/projections/flat.md
@@ -118,7 +118,7 @@ public partial class ImportSqlProjection: EventProjection
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/polecat/blob/main/src/Polecat.Tests/Projections/using_event_projection_for_flat_tables.cs#L26-L57' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_polecat_import_sql_event_projection' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/polecat/blob/main/src/Polecat.Tests/Projections/using_event_projection_for_flat_tables.cs#L25-L57' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_polecat_import_sql_event_projection' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 A couple notes about the `EventProjection` approach:

--- a/docs/events/projections/multi-stream-projections.md
+++ b/docs/events/projections/multi-stream-projections.md
@@ -75,16 +75,81 @@ The key technique is using a composite identity that combines the stream ID with
 **Events:**
 
 <!-- snippet: sample_polecat_monthly_account_activity_events -->
+<a id='snippet-sample_polecat_monthly_account_activity_events'></a>
+```cs
+public record AccountOpened(string AccountName);
+public record AccountDebited(decimal Amount, string Description);
+public record AccountCredited(decimal Amount, string Description);
+```
+<sup><a href='https://github.com/JasperFx/polecat/blob/main/src/Polecat.Tests/Projections/time_based_multi_stream_projection_tests.cs#L9-L15' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_polecat_monthly_account_activity_events' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 **Read model document:**
 
 <!-- snippet: sample_polecat_monthly_account_activity_document -->
+<a id='snippet-sample_polecat_monthly_account_activity_document'></a>
+```cs
+public partial class MonthlyAccountActivity
+{
+    public string Id { get; set; } = "";
+    public Guid AccountId { get; set; }
+    public string Month { get; set; } = "";
+    public int TransactionCount { get; set; }
+    public decimal TotalDebits { get; set; }
+    public decimal TotalCredits { get; set; }
+    public decimal NetChange => TotalCredits - TotalDebits;
+}
+```
+<sup><a href='https://github.com/JasperFx/polecat/blob/main/src/Polecat.Tests/Projections/time_based_multi_stream_projection_tests.cs#L17-L30' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_polecat_monthly_account_activity_document' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 **Projection with time-based routing:**
 
 <!-- snippet: sample_polecat_monthly_account_activity_projection -->
+<a id='snippet-sample_polecat_monthly_account_activity_projection'></a>
+```cs
+public partial class MonthlyAccountActivityProjection : MultiStreamProjection<MonthlyAccountActivity, string>
+{
+    public MonthlyAccountActivityProjection()
+    {
+        // Route each event to a document keyed by "{streamId}:{yyyy-MM}"
+        // This segments a single account stream into monthly summaries
+        Identity<IEvent<AccountDebited>>(e =>
+            $"{e.StreamId}:{e.Timestamp:yyyy-MM}");
+        Identity<IEvent<AccountCredited>>(e =>
+            $"{e.StreamId}:{e.Timestamp:yyyy-MM}");
+    }
+
+    public MonthlyAccountActivity Create(IEvent<AccountDebited> e) => new()
+    {
+        AccountId = e.StreamId,
+        Month = e.Timestamp.ToString("yyyy-MM"),
+        TransactionCount = 1,
+        TotalDebits = e.Data.Amount
+    };
+
+    public MonthlyAccountActivity Create(IEvent<AccountCredited> e) => new()
+    {
+        AccountId = e.StreamId,
+        Month = e.Timestamp.ToString("yyyy-MM"),
+        TransactionCount = 1,
+        TotalCredits = e.Data.Amount
+    };
+
+    public void Apply(IEvent<AccountDebited> e, MonthlyAccountActivity view)
+    {
+        view.TransactionCount++;
+        view.TotalDebits += e.Data.Amount;
+    }
+
+    public void Apply(IEvent<AccountCredited> e, MonthlyAccountActivity view)
+    {
+        view.TransactionCount++;
+        view.TotalCredits += e.Data.Amount;
+    }
+}
+```
+<sup><a href='https://github.com/JasperFx/polecat/blob/main/src/Polecat.Tests/Projections/time_based_multi_stream_projection_tests.cs#L32-L75' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_polecat_monthly_account_activity_projection' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Register the projection as inline (for immediate consistency) or async (for eventual consistency):

--- a/docs/events/projections/project-latest.md
+++ b/docs/events/projections/project-latest.md
@@ -50,6 +50,34 @@ identically to `FetchLatest` — it returns the current committed state.
 ## Example
 
 <!-- snippet: sample_polecat_project_latest_example -->
+<a id='snippet-sample_polecat_project_latest_example'></a>
+```cs
+[Fact]
+public async Task includes_pending_events_from_start_stream()
+{
+    var streamId = Guid.NewGuid();
+
+    await using var session = theStore.LightweightSession();
+
+    // Append events without committing
+    session.Events.StartStream(streamId,
+        new ReportCreated("Q1 Report"),
+        new SectionAdded("Revenue"),
+        new SectionAdded("Costs")
+    );
+
+    // ProjectLatest includes the pending events above
+    var report = await session.Events.ProjectLatest<Report>(streamId, TestContext.Current.CancellationToken);
+
+    report.ShouldNotBeNull();
+    report.Title.ShouldBe("Q1 Report");
+    report.SectionCount.ShouldBe(2);
+
+    // SaveChangesAsync can happen later
+    await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+}
+```
+<sup><a href='https://github.com/JasperFx/polecat/blob/main/src/Polecat.Tests/Events/project_latest_tests.cs#L46-L73' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_polecat_project_latest_example' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Merging Committed and Pending Events
@@ -58,6 +86,43 @@ identically to `FetchLatest` — it returns the current committed state.
 are appended in the current session:
 
 <!-- snippet: sample_polecat_project_latest_merge_example -->
+<a id='snippet-sample_polecat_project_latest_merge_example'></a>
+```cs
+[Fact]
+public async Task includes_pending_events_after_committed_events()
+{
+    var streamId = Guid.NewGuid();
+
+    // First, commit some events
+    await using (var session = theStore.LightweightSession())
+    {
+        session.Events.StartStream(streamId,
+            new ReportCreated("Q1 Report"),
+            new SectionAdded("Revenue")
+        );
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+
+    // In a new session, append more events without committing
+    await using (var session = theStore.LightweightSession())
+    {
+        session.Events.Append(streamId,
+            new SectionAdded("Costs"),
+            new SectionAdded("Outlook"),
+            new ReportPublished()
+        );
+
+        // ProjectLatest merges the committed state with pending events
+        var report = await session.Events.ProjectLatest<Report>(streamId, TestContext.Current.CancellationToken);
+
+        report.ShouldNotBeNull();
+        report.Title.ShouldBe("Q1 Report");
+        report.SectionCount.ShouldBe(3);       // 1 committed + 2 pending
+        report.IsPublished.ShouldBeTrue();      // from pending ReportPublished
+    }
+}
+```
+<sup><a href='https://github.com/JasperFx/polecat/blob/main/src/Polecat.Tests/Events/project_latest_tests.cs#L75-L111' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_polecat_project_latest_merge_example' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## String-Keyed Streams

--- a/docs/events/querying.md
+++ b/docs/events/querying.md
@@ -196,6 +196,18 @@ These queries search the entire event table and should be used judiciously. For 
 `AggregateToAsync<T>()` is a LINQ terminal that folds **every** event matched by an event query into a single live aggregate of type `T`, regardless of which stream each event came from. It uses the same conventional `Create`/`Apply` aggregation that `AggregateStreamAsync` uses, but over an arbitrary event query instead of one stream:
 
 <!-- snippet: sample_aggregate_to_async -->
+<a id='snippet-sample_aggregate_to_async'></a>
+```cs
+var questParty = await session.Events
+    .QueryAllRawEvents()
+
+    // You could of course chain all the Linq
+    // Where()/OrderBy()/Take()/Skip() operators
+    // you need here
+
+    .AggregateToAsync<QuestParty>(token: TestContext.Current.CancellationToken);
+```
+<sup><a href='https://github.com/JasperFx/polecat/blob/main/src/Polecat.Tests/Projections/aggregateto_linq_operator_tests.cs#L57-L68' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_aggregate_to_async' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 You can also seed the fold with initial state:
@@ -217,11 +229,43 @@ The aggregate's identity is stamped from the last queried event's stream (`Strea
 Given a multi-stream projection:
 
 <!-- snippet: sample_aggregate_to_many_projection -->
+<a id='snippet-sample_aggregate_to_many_projection'></a>
+```cs
+public record MoneyDeposited(Guid AccountId, int Amount);
+public record AccountFrozen(Guid AccountId);
+
+public class Balance
+{
+    public Guid Id { get; set; }
+    public int Amount { get; set; }
+}
+
+public partial class BalanceProjection : MultiStreamProjection<Balance, Guid>
+{
+    public BalanceProjection()
+    {
+        Identity<MoneyDeposited>(e => e.AccountId);
+        Identity<AccountFrozen>(e => e.AccountId);
+    }
+
+    public void Apply(MoneyDeposited e, Balance b) => b.Amount += e.Amount;
+
+    public bool ShouldDelete(AccountFrozen e) => true;
+}
+```
+<sup><a href='https://github.com/JasperFx/polecat/blob/main/src/Polecat.Tests/Projections/aggregate_to_many_tests.cs#L11-L35' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_aggregate_to_many_projection' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 query any slice of the event store and fan it out to one aggregate per identity:
 
 <!-- snippet: sample_aggregate_to_many -->
+<a id='snippet-sample_aggregate_to_many'></a>
+```cs
+var aggregates = await session.Events.QueryAllRawEvents()
+    .Where(e => e.StreamId == stream1 || e.StreamId == stream2)
+    .AggregateToManyAsync<Balance>(TestContext.Current.CancellationToken);
+```
+<sup><a href='https://github.com/JasperFx/polecat/blob/main/src/Polecat.Tests/Projections/aggregate_to_many_tests.cs#L115-L121' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_aggregate_to_many' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Each returned aggregate has its identity stamped from the projection's slice id. Aggregates whose event slice resolves to a delete (`ShouldDelete`) are omitted, an empty query returns an empty list, and calling it for an aggregate type with no registered projection throws `ArgumentException`.

--- a/src/Polecat.Tests/Events/identity_less_boundary_aggregate_tests.cs
+++ b/src/Polecat.Tests/Events/identity_less_boundary_aggregate_tests.cs
@@ -1,0 +1,197 @@
+using JasperFx.Events;
+using JasperFx.Events.Aggregation;
+using JasperFx.Events.Tags;
+using Polecat.Events;
+using Polecat.Tests.Harness;
+
+namespace Polecat.Tests.Events;
+
+#region sample_polecat_dcb_identity_less_boundary_aggregate
+
+/// <summary>
+///     The aggregate from the "Identity-less Boundary Aggregates" section of docs/events/dcb.md.
+///     It spans streams by tag and is keyed to none, so it has no <c>Id</c> —
+///     <see cref="BoundaryAggregateAttribute" /> is the explicit opt-out that makes the source
+///     generator emit its evolver. Until polecat#521 this type existed only in the markdown, which
+///     is how the documented model shipped broken.
+/// </summary>
+[BoundaryAggregate]
+public partial class CourseEnrollmentSummary
+{
+    public int EnrolledCount { get; private set; }
+    public List<string> Students { get; } = new();
+
+    public void Apply(StudentEnrolled e)
+    {
+        Students.Add(e.StudentName);
+        EnrolledCount++;
+    }
+
+    public void Apply(StudentDropped e)
+    {
+        EnrolledCount--;
+    }
+}
+
+#endregion
+
+/// <summary>
+///     An identity-less aggregate WITHOUT the marker. Kept broken on purpose: the generator emits
+///     nothing for one, and a missing <c>Id</c> is far more often an oversight than a deliberate
+///     boundary aggregate, so this must still fail fast.
+/// </summary>
+public class UnmarkedIdentitylessAggregate
+{
+    public int Count { get; set; }
+
+    public void Apply(StudentEnrolled e) => Count++;
+}
+
+public class identity_less_boundary_aggregate_tests : IntegrationContext
+{
+    public identity_less_boundary_aggregate_tests(DefaultStoreFixture fixture) : base(fixture)
+    {
+    }
+
+    public override async ValueTask InitializeAsync()
+    {
+        await StoreOptions(opts =>
+        {
+            opts.Events.RegisterTagType<CourseId>("course")
+                .ForAggregate<CourseEnrollmentSummary>();
+        });
+    }
+
+    // ---- the aggregator can be built at all -------------------------------------------------
+
+    /// <summary>
+    ///     The unit-level reproduction from polecat#521: this threw before any I/O, because
+    ///     Build&lt;TDoc&gt; resolved the identity through DocumentMapping, which demands an Id.
+    /// </summary>
+    [Fact]
+    public void aggregation_source_can_be_built_for_an_identity_less_boundary_aggregate()
+    {
+        var factory = (IAggregationSourceFactory<IQuerySession>)theStore.Options.EventGraph;
+
+        var source = factory.Build<CourseEnrollmentSummary>();
+
+        source.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void an_identity_less_aggregate_without_the_marker_still_throws()
+    {
+        var factory = (IAggregationSourceFactory<IQuerySession>)theStore.Options.EventGraph;
+
+        var ex = Should.Throw<InvalidOperationException>(() =>
+            factory.Build<UnmarkedIdentitylessAggregate>());
+
+        // The message has to name the marker that would fix it — DocumentMapping's own message is
+        // phrased for documents and never mentions [BoundaryAggregate].
+        ex.Message.ShouldContain("BoundaryAggregate");
+        ex.Message.ShouldContain(nameof(UnmarkedIdentitylessAggregate));
+    }
+
+    // ---- and actually aggregates ------------------------------------------------------------
+
+    /// <summary>
+    ///     The coverage that matters, per polecat#521: FetchForWritingByTags only resolves the
+    ///     aggregator when the query finds events, so a suite that exercises only the empty
+    ///     "this must not exist yet" boundary is green over a model that breaks on first real use.
+    ///     This one has events present.
+    /// </summary>
+    [Fact]
+    public async Task fetch_for_writing_by_tags_aggregates_with_events_present()
+    {
+        var courseId = new CourseId(Guid.NewGuid());
+
+        await AppendEnrollmentAsync(courseId, "Alice");
+        await AppendEnrollmentAsync(courseId, "Bob");
+
+        await using var session = theStore.LightweightSession();
+        var query = new EventTagQuery().Or<CourseId>(courseId);
+        var boundary = await session.Events.FetchForWritingByTags<CourseEnrollmentSummary>(
+            query, TestContext.Current.CancellationToken);
+
+        boundary.Aggregate.ShouldNotBeNull();
+        boundary.Aggregate.EnrolledCount.ShouldBe(2);
+        boundary.Aggregate.Students.OrderBy(x => x).ToList().ShouldBe(new List<string> { "Alice", "Bob" });
+    }
+
+    [Fact]
+    public async Task events_that_decrement_are_applied_too()
+    {
+        var courseId = new CourseId(Guid.NewGuid());
+
+        await AppendEnrollmentAsync(courseId, "Alice");
+        await AppendEnrollmentAsync(courseId, "Bob");
+        await AppendDropAsync(courseId);
+
+        await using var session = theStore.LightweightSession();
+        var query = new EventTagQuery().Or<CourseId>(courseId);
+        var boundary = await session.Events.FetchForWritingByTags<CourseEnrollmentSummary>(
+            query, TestContext.Current.CancellationToken);
+
+        boundary.Aggregate.ShouldNotBeNull().EnrolledCount.ShouldBe(1);
+    }
+
+    /// <summary>
+    ///     The empty case still works — it is the path that was already green, kept so the fix
+    ///     cannot regress it.
+    /// </summary>
+    [Fact]
+    public async Task fetch_for_writing_by_tags_over_no_events_yields_a_null_aggregate()
+    {
+        await using var session = theStore.LightweightSession();
+        var query = new EventTagQuery().Or<CourseId>(new CourseId(Guid.NewGuid()));
+
+        var boundary = await session.Events.FetchForWritingByTags<CourseEnrollmentSummary>(
+            query, TestContext.Current.CancellationToken);
+
+        boundary.Aggregate.ShouldBeNull();
+    }
+
+    /// <summary>
+    ///     The boundary a marked aggregate establishes still enforces concurrency — the marker
+    ///     exempts the type from needing an identity, not from the DCB contract.
+    /// </summary>
+    [Fact]
+    public async Task the_boundary_still_enforces_concurrency()
+    {
+        var courseId = new CourseId(Guid.NewGuid());
+        await AppendEnrollmentAsync(courseId, "Alice");
+
+        await using var session = theStore.LightweightSession();
+        var query = new EventTagQuery().Or<CourseId>(courseId);
+        var boundary = await session.Events.FetchForWritingByTags<CourseEnrollmentSummary>(
+            query, TestContext.Current.CancellationToken);
+
+        // Someone else appends under the same tag after the boundary was captured.
+        await AppendEnrollmentAsync(courseId, "Carol");
+
+        var next = session.Events.BuildEvent(new StudentEnrolled("Dave", "Math"));
+        next.WithTag(courseId);
+        boundary.AppendOne(next);
+
+        await Should.ThrowAsync<DcbConcurrencyException>(
+            () => session.SaveChangesAsync(TestContext.Current.CancellationToken));
+    }
+
+    private async Task AppendEnrollmentAsync(CourseId courseId, string student)
+    {
+        await using var session = theStore.LightweightSession();
+        var e = session.Events.BuildEvent(new StudentEnrolled(student, "Math"));
+        e.WithTag(courseId);
+        session.Events.Append(Guid.NewGuid(), e);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+
+    private async Task AppendDropAsync(CourseId courseId)
+    {
+        await using var session = theStore.LightweightSession();
+        var e = session.Events.BuildEvent(new StudentDropped("moved away"));
+        e.WithTag(courseId);
+        session.Events.Append(Guid.NewGuid(), e);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+}

--- a/src/Polecat/Events/EventGraph.cs
+++ b/src/Polecat/Events/EventGraph.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 using System.Text;
 using JasperFx.Events;
 using JasperFx.Events.Aggregation;
@@ -364,7 +365,7 @@ public class EventGraph : EventRegistry, IAggregationSourceFactory<IQuerySession
         // Falling back to typeof(Guid) / typeof(string) (the underlying stream-identity
         // primitive) misses the wrapper and trips the post-FEC fail-fast in
         // JasperFxAggregationProjectionBase.tryUseAssemblyRegisteredEvolver (JasperFx#276).
-        var idType = new DocumentMapping(typeof(TDoc), _options).IdType;
+        var idType = ResolveAggregateIdType(typeof(TDoc));
         var projectionType = typeof(SingleStreamProjection<,>).MakeGenericType(typeof(TDoc), idType);
 #pragma warning disable CS8714 // notnull constraint mismatch
         var projection = (ProjectionBase)Activator.CreateInstance(projectionType)!;
@@ -373,6 +374,57 @@ public class EventGraph : EventRegistry, IAggregationSourceFactory<IQuerySession
         projection.AssembleAndAssertValidity();
         foreach (var et in projection.IncludedEventTypes) AddEventType(et);
         return projection as IAggregatorSource<IQuerySession>;
+    }
+
+    /// <summary>
+    ///     The identity type to close <see cref="SingleStreamProjection{TDoc,TId}" /> over for a
+    ///     conventionally-aggregated type.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///     <see cref="BoundaryAggregateAttribute" /> is an explicit opt-out of single-stream
+    ///     identity (polecat#521). A DCB boundary aggregate is <em>defined</em> by spanning streams
+    ///     by tag rather than being keyed to one, so demanding an <c>Id</c> asks its author for a
+    ///     member the model has no use for — and Polecat's own DCB docs told them they did not need
+    ///     one. The marker is the source generator's own opt-in: it emits an
+    ///     <c>IGeneratedSyncEvolver&lt;TDoc, string&gt;</c> for a marked identity-less type, so
+    ///     <c>string</c> is the only answer that finds that dispatcher. It is vestigial — nothing on
+    ///     the DCB path reads the id — but it has to agree with what the generator emitted.
+    ///     </para>
+    ///     <para>
+    ///     Not inherited: the generator reads the attribute off the declaring type in its own
+    ///     compilation, so a subclass that merely inherited the marker would resolve to
+    ///     <c>string</c> and then fail to find a dispatcher of its own.
+    ///     </para>
+    ///     <para>
+    ///     An identity-less aggregate WITHOUT the marker still throws, deliberately: the generator
+    ///     emits nothing for one, and a missing <c>Id</c> is far more often an oversight than a
+    ///     boundary aggregate. The message is re-thrown here rather than left to
+    ///     <see cref="DocumentMapping" /> because that one is phrased for documents and never
+    ///     mentions the marker that would fix this case.
+    ///     </para>
+    /// </remarks>
+    private Type ResolveAggregateIdType(Type aggregateType)
+    {
+        if (aggregateType.GetCustomAttribute<BoundaryAggregateAttribute>(false) is not null)
+        {
+            return typeof(string);
+        }
+
+        try
+        {
+            return new DocumentMapping(aggregateType, _options).IdType;
+        }
+        catch (InvalidOperationException e)
+        {
+            throw new InvalidOperationException(
+                $"Aggregate type '{aggregateType.FullName}' has no identity member. Single stream " +
+                "aggregates need a public property named 'Id', or one marked with [Identity], of " +
+                "type Guid, string, int, or long. An aggregate reached only through a DCB tag " +
+                "boundary has no stream to be keyed to — mark it [BoundaryAggregate] " +
+                "(JasperFx.Events.Aggregation) instead of giving it an identity it has no use for.",
+                e);
+        }
     }
 
     public override Type AggregateTypeFor(string aggregateTypeName)


### PR DESCRIPTION
Closes #521.

`docs/events/dcb.md` has a whole *Identity-less Boundary Aggregates* section telling users to mark a pure boundary aggregate with `[BoundaryAggregate]` so it needs no `Id`, closing with "it works identically across the Critter Stack event stores". `BoundaryAggregate` appeared nowhere in `src/`.

## The failure

`EventGraph`'s `IAggregationSourceFactory<IQuerySession>.Build<TDoc>()` resolved the identity with:

```csharp
var idType = new DocumentMapping(typeof(TDoc), _options).IdType;
```

and `DocumentMapping`'s constructor throws unconditionally when `FindIdProperty` returns null. So the documented model threw at the first DCB fetch that found any events:

```
System.InvalidOperationException : Document type 'CourseEnrollmentSummary' must have a public
property named 'Id' or a property marked with [Identity] of type Guid, string, int, or long.
```

## Fix

`Build<TDoc>()` now goes through `ResolveAggregateIdType`, which treats `[BoundaryAggregate]` as an explicit opt-out of single-stream identity and resolves to `typeof(string)` — the vestigial `TId` the source generator already keys its emitted `IGeneratedSyncEvolver<TDoc, string>` on, and therefore the only answer that finds that dispatcher. Read non-inherited, because the generator reads the attribute off the declaring type in its own compilation; a subclass that merely inherited the marker would resolve to `string` and then fail to find a dispatcher of its own.

Mirrors Fisher's `AggregateIdentity.ResolveIdType` (fisher#135), as the issue suggested.

An identity-less aggregate **without** the marker still throws — the generator emits nothing for one, and a missing `Id` is far more often an oversight than a deliberate boundary aggregate. The message is re-thrown naming `[BoundaryAggregate]`, since `DocumentMapping`'s own message is phrased for documents and never mentions the marker that would fix this case.

## Tests

`identity_less_boundary_aggregate_tests`, six tests built around `CourseEnrollmentSummary` — the aggregate the docs section is written around, which until now existed **only in the markdown**. That absence is half of why this shipped broken.

**Four of the six fail without the fix.** The two that still pass are the empty boundary and the unmarked-throws case — and that is exactly the issue's explanation for how it survived: `FetchForWritingByTags` only resolves the aggregator when the query finds events, so a suite exercising only the empty "this must not exist yet" boundary stays green over a model that breaks on first real use. The new coverage has events present, and also checks that the boundary a marked aggregate establishes still enforces concurrency — the marker exempts the type from needing an identity, not from the DCB contract.

## Worth doing separately

The issue's closing suggestion still stands: the shared DCB compliance suite has an identity-less boundary aggregate nowhere, and every DCB aggregate in it happens to have an identity. That is why neither Polecat's nor Fisher's enrollment caught this. Adding one upstream would stop the next store from rediscovering it.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
