### PR TITLE
Bump Weasel to 9.27.1 and drop the QueueSqlCommand batch guard (gh-522)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -480,10 +480,20 @@
              weasel#513 — an index's per-column sort direction was read as a whole-index flag, so
              (a DESC, b) read back as (a, b DESC) and a genuinely different index never reported
              drift. New opt-in DescendingColumns / CompareColumnDirection on SQL Server's
-             IndexDefinition; Polecat does not opt in. -->
-        <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.27.0" />
-        <PackageVersion Include="Weasel.SqlServer" Version="9.27.0" />
-        <PackageVersion Include="Weasel.Storage" Version="9.27.0" />
+             IndexDefinition; Polecat does not opt in.
+             Weasel 9.27.1: weasel#526/#527 — BatchBuilder.AppendWithParameters now materializes the
+             batch command BEFORE writing its text. It previously only created the command as a side
+             effect of appending a PARAMETER, so a statement with no placeholders left _current null
+             and the next StartNewCommand() cleared the builder and discarded the SQL silently. That
+             is polecat#517: a QueueSqlCommand statement was dropped whenever the session also
+             carried a document operation, with SaveChangesAsync reporting success.
+             This bump is what lets polecat#522 remove Polecat's own guard (the empty Append in
+             StorageOperationExecution.Configure), so 9.27.1 is a FLOOR, not a preference — the nine
+             queued_sql_command_tests are the proof it holds, and five of them fail against 9.27.0
+             once the local guard is gone. -->
+        <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.27.1" />
+        <PackageVersion Include="Weasel.SqlServer" Version="9.27.1" />
+        <PackageVersion Include="Weasel.Storage" Version="9.27.1" />
 
         <!-- Strongly typed IDs. Both generators are test-only: they prove Polecat's value-type id
              support against the two libraries Marten's ValueTypeTests exercise. StronglyTypedId emits

--- a/src/Polecat/Internal/Operations/StorageOperationExecution.cs
+++ b/src/Polecat/Internal/Operations/StorageOperationExecution.cs
@@ -14,23 +14,13 @@ internal static class StorageOperationExecution
     internal static void Configure(Weasel.Storage.IStorageOperation op, ICommandBuilder builder,
         Weasel.Storage.IStorageSession? session)
     {
-        // polecat#517: materialize the batch command BEFORE the operation appends anything.
-        //
-        // Weasel's BatchBuilder only creates the underlying SqlBatchCommand as a side effect of
-        // appending a PARAMETER — AppendWithParameters writes its text straight into the shared
-        // StringBuilder and creates nothing when the statement has no placeholders. An operation
-        // that appends no parameters therefore leaves the builder with no current command, and the
-        // caller's next StartNewCommand() hits `if (_current != null)`, skips saving the text, and
-        // then _builder.Clear()s it away. The statement is silently discarded: no exception, no log,
-        // and the rest of the batch commits.
-        //
-        // QueueSqlCommand with a parameterless statement is the reported case — it worked alone
-        // (Compile() creates a command when the batch is empty) and vanished the moment any other
-        // operation was queued behind it. Append(string) does `_current ??= appendCommand()`, so an
-        // empty append is enough to pin the command down. Harmless for every other operation: the
-        // caller has already called StartNewCommand() for i > 0, which leaves _current non-null.
-        builder.Append(string.Empty);
-
+        // polecat#517 was a guard here — an empty Append to materialize the batch command before
+        // the operation wrote any text. Weasel 9.27.1 (weasel#526/#527) fixes the cause:
+        // AppendWithParameters now pins the command down itself, so a parameterless statement is no
+        // longer discarded by the next StartNewCommand(). The guard is removed rather than kept as
+        // belt-and-braces so the invariant lives in one place; the Weasel floor in
+        // Directory.Packages.props is what makes that safe, and queued_sql_command_tests is what
+        // proves it. polecat#522.
         if (op is IStorageOperation bespoke)
         {
             bespoke.ConfigureCommand(builder);


### PR DESCRIPTION
Closes #522.

#519 fixed gh-517 with a guard *in Polecat* — an empty `Append` in `StorageOperationExecution.Configure` to materialize the batch command before each operation wrote any text. That was a workaround for a Weasel bug, not the fix for it.

**Weasel 9.27.1** (weasel#526/#527) fixes the cause: `BatchBuilder`'s two `AppendWithParameters` overloads now pin the command down themselves, in both the SqlServer and Postgresql dialects.

```csharp
// Pin the batch command down *before* any text is written. With zero placeholders
// AppendParameter never runs, and the SQL would be silently discarded by the next
// StartNewCommand(). See weasel#526.
_current ??= appendCommand();
```

With the cause fixed, the guard is removed rather than kept as belt-and-braces, so the invariant lives in exactly one place.

## The floor is verified, not assumed

Dropping a local guard in favour of a dependency's fix is only safe if the pin actually requires the fixed version — and that is the part most easily got wrong, because the tests keep passing locally against a new package while the published floor still allows an old one.

So I checked both directions, with the guard removed:

| Weasel | `queued_sql_command_tests` |
|---|---|
| 9.27.1 | **9 pass** |
| 9.27.0 | **5 fail** — the same five that failed before #519 |

9.27.1 is therefore a floor, not a preference. The `Directory.Packages.props` comment says so explicitly, so a future downgrade cannot quietly reintroduce silent SQL loss.

## Checklist from #522

- [x] Bump the Weasel pins (`Weasel.SqlServer`, `Weasel.Storage`, `Weasel.EntityFrameworkCore`) to 9.27.1
- [x] Remove `builder.Append(string.Empty)` and its comment block from `StorageOperationExecution.Configure`
- [x] Keep all nine `queued_sql_command_tests` — they are now the proof the Weasel-side fix alone is sufficient
- [x] Make sure the Weasel floor actually requires the fixed version

`Weasel.Core` is not pinned directly here; it comes in transitively, and `Weasel.SqlServer` 9.27.1 declares a dependency on `Weasel.Core` 9.27.1.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
