### PR TITLE
5.21.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>5.20.0</Version>
+        <Version>5.21.0</Version>
         <LangVersion>latest</LangVersion>
         <Authors>Jeremy D. Miller</Authors>
         <PackageIcon>logo.png</PackageIcon>


### PR DESCRIPTION
Version bump for the 5.21.0 release.

| Issue | PR | |
|---|---|---|
| gh-514 | #518 | Database-per-tenant multi-tenancy: no default tenant required |
| gh-517 | #519 | `QueueSqlCommand` stops dropping parameterless statements |
| — | #520 | JasperFx family to 2.57.2 |
| gh-521 | #523 | DCB `[BoundaryAggregate]` honoured on identity-less aggregates |
| gh-522 | #524 | Weasel 9.27.1, and the gh-517 guard removed now the cause is fixed upstream |

Weasel 9.27.1 is a **floor** for this release, not a preference — see #524. With Polecat's local guard removed, five of the nine `queued_sql_command_tests` fail against 9.27.0.

This PR exists to give CI a run over the exact state that ships.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)