### PR TITLE
gh-526: answer IEventTenancySource so single-stream projections fold a single-tenanted store

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -324,14 +324,14 @@
              Both are Wolverine-side; inert for Polecat, carried along by the version bump.
              Weasel stays at 9.27.0 — already the latest, and its JasperFx.Events floor (2.46.0) is
              satisfied by this line, so the matrix stays coherent without a lockstep bump. -->
-        <PackageVersion Include="JasperFx" Version="2.57.2" />
-        <PackageVersion Include="JasperFx.Events" Version="2.57.2" />
+        <PackageVersion Include="JasperFx" Version="2.59.0" />
+        <PackageVersion Include="JasperFx.Events" Version="2.59.0" />
         <!--
              The shared cross-store event sourcing compliance suites. Source-only package: the
              suites compile inside Polecat.Tests so JasperFx's aggregate source generator binds
              Polecat's own session types.
         -->
-        <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.57.2" />
+        <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.59.0" />
         <!-- Pin the sibling JasperFx packages for parity with Marten 9's matrix
              even though Polecat doesn't currently reference them directly —
              keeps the lockstep matrix coherent when transitive resolution
@@ -339,7 +339,7 @@
              RuntimeCompiler 5.x line is the active continuation of the 4.x
              lineage; do not pin against the parallel stale 2.0.x series. -->
         <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.57.2" />
+        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.59.0" />
         <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
@@ -503,7 +503,7 @@
         <PackageVersion Include="Vogen" Version="7.0.0" />
 
         <!-- Source generators (matched to JasperFx.Events above) -->
-        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.57.2" />
+        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.59.0" />
 
         <!-- Build automation -->
         <PackageVersion Include="Nuke.Common" Version="9.0.4" />

--- a/src/Polecat/Internal/QuerySession.cs
+++ b/src/Polecat/Internal/QuerySession.cs
@@ -23,7 +23,7 @@ namespace Polecat.Internal;
     Justification = "Class-level (all partials): routes load/query operations through ISerializer.FromJson and per-document DocumentProvider reflection. Document types T flow in from caller registration (Schema.For<T>() / session.Load<T>) and are preserved per the AOT publishing guide.")]
 [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
     Justification = "Class-level (all partials): ISerializer.FromJson is annotated RDC; AOT consumers supply a source-generator-backed ISerializer impl.")]
-internal partial class QuerySession : IQuerySession
+internal partial class QuerySession : IQuerySession, JasperFx.Events.IEventTenancySource
 {
     internal readonly IConnectionLifetime _lifetime;
     private readonly ResiliencePipeline _resilience;
@@ -122,6 +122,21 @@ internal partial class QuerySession : IQuerySession
     }
 
     internal StoreOptions Options { get; }
+
+    /// <summary>
+    ///     The event store's tenancy style, for the shared single-stream projection base.
+    /// </summary>
+    /// <remarks>
+    ///     <b>gh-526.</b> <c>JasperFxSingleStreamProjectionBase.BuildSlicer</c> reads this to decide
+    ///     whether to set <c>ForceSingleTenancy</c> on the slicer it builds. On a single-tenanted store,
+    ///     events whose <c>tenant_id</c> values disagree must still fold into one aggregate rather than
+    ///     being sliced per tenant — wolverine#2053 / marten#4085, which only ever bit the async daemon.
+    ///     Marten got that fix by overriding <c>BuildSlicer</c> in its own subclass; ours is an empty
+    ///     class body, so we went without it until jasperfx#723 moved the decision into the base.
+    ///     Answering here is the whole of our side.
+    /// </remarks>
+    public TenancyStyle EventTenancyStyle => Options.Events.TenancyStyle;
+
     internal DocumentProviderRegistry Providers => _providers;
     public string TenantId { get; }
     public ISerializer Serializer { get; }


### PR DESCRIPTION
Closes #526.

## What was wrong

On a **single-tenanted** store, events whose `tenant_id` values disagree must still fold into one aggregate rather than being sliced per tenant. Polecat sliced them per tenant, splitting one stream into several partial documents — each having seen only part of its own history.

This is wolverine#2053, transferred to [marten#4085](https://github.com/JasperFx/marten/issues/4085). It only ever bit the **async daemon**; live and inline aggregation fold the same events correctly, which is exactly why it stayed invisible.

## Why Polecat had it

The fix is `ForceSingleTenancy` on `TenantedEventSlicer`, set when the projection builds its slicer. Marten set it by overriding `BuildSlicer` in its own `SingleStreamProjection<TDoc,TId>`. Ours is an empty class body, so we inherited the base's slicer without it — and `EventStoreOptions.TenancyStyle` defaults to `Single`, so the precondition is the default configuration.

It stayed latent because the flag was inert on the async path in JasperFx.Events itself until jasperfx#721/#722. Once that landed, Marten got the fix and Polecat did not.

## The change

jasperfx#723 moved the decision into `JasperFxSingleStreamProjectionBase`, which resolves it from `IEventTenancySource` on the session — the only thing `BuildSlicer` is handed. Polecat's whole side is answering that member:

```csharp
public TenancyStyle EventTenancyStyle => Options.Events.TenancyStyle;
```

On `QuerySession`, which `DocumentSessionBase` derives from, so every session type gets it.

**One wrinkle worth knowing if this seam is adopted elsewhere in Polecat:** the interface is fully qualified rather than imported. Adding `using JasperFx.Events;` to `QuerySession.cs` makes `IQueryEventStore` ambiguous against `Polecat.Events.IQueryEventStore`, breaking the `IQuerySession.Events` implementation.

Also rolls JasperFx 2.57.2 → 2.59.0, which is the release the seam ships in.

## Verification

Library and `Polecat.Tests` both build clean on 2.59.0. Targeted runs against SQL Server on the areas this touches:

| Namespace | Result |
|---|---|
| `Polecat.Tests.MultiTenancy` | 52 passed, 0 failed (3m 39s) |
| `Polecat.Tests.Daemon` | 138 passed, 3 skipped, 0 failed (2m 02s) |
| `Polecat.Tests.Compliance` | 329 passed, 0 failed (1m 37s) |

Not the full suite, which runs ~2 hours — CI covers the remainder. The three namespaces above are where a tenancy-slicing change would surface, and `Compliance` in particular recompiles the shared suites against 2.59.0.

Note that **no test here yet asserts the fixed behaviour**. jasperfx#724 adds `SingleTenantedEventSlicingCompliance` for exactly this, and it is opt-in; enrolling it is the natural follow-up and is what would keep this from regressing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)