### PR TITLE
5.21.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>5.21.0</Version>
+        <Version>5.21.1</Version>
         <LangVersion>latest</LangVersion>
         <Authors>Jeremy D. Miller</Authors>
         <PackageIcon>logo.png</PackageIcon>


### PR DESCRIPTION
Version bump only — `Directory.Build.props` 5.21.0 → 5.21.1.

## What this release carries

One commit landed since v5.21.0: ad0169c, `gh-526: answer IEventTenancySource so single-stream projections fold a single-tenanted store` (#527), together with the JasperFx family bump 2.57.2 → 2.59.0.

## Why it warrants a release rather than waiting

gh-526 is a silent wrong-read-model bug on the *default* configuration (`Events.TenancyStyle = Single`). An async single-stream projection over a single-tenanted store whose event rows carry inconsistent tenant ids slices per tenant and folds into several partial aggregates — surfacing as an `Apply` that receives an all-defaults document, with no error raised. Inline and live aggregation were unaffected; only the async daemon.

Polecat's half of the fix is a single seam answer — `QuerySession` implements `JasperFx.Events.IEventTenancySource` — but that seam only exists in JasperFx.Events 2.59.0, and the published 5.21.0 package pins 2.57.2. A consumer on 5.21.0 stays exposed no matter which JasperFx version they pull themselves, so the fix genuinely cannot ship without a new Polecat package.

Everything upstream it depended on is closed: jasperfx#722 (the inert-flag fix), jasperfx#723 (hoisting the determination into `JasperFxSingleStreamProjectionBase`), and jasperfx#724 (the compliance fact, now in the 2.59.0 suites that `Polecat.Tests` compiles against).

## Patch, not minor

Matches precedent: 5.19.1 shipped three bug fixes plus a package bump as a patch, and 5.15.1 was a pure JasperFx dependency bump as a patch.

## State at time of opening

- No other open PRs.
- One open issue, #490, blocked on the upstream jasperfx#684 epic — not a next-release item.
- CI green on ad0169c across all four legs (polecat, aspnetcore, efcore, aot-smoke).

Publish via `workflow_dispatch` on publish.yml once this is merged and green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)