### PR TITLE
Lift the JasperFx floor to 2.60 so the projection-run CLI reaches Polecat users

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>5.21.1</Version>
+        <Version>5.22.0</Version>
         <LangVersion>latest</LangVersion>
         <Authors>Jeremy D. Miller</Authors>
         <PackageIcon>logo.png</PackageIcon>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -324,14 +324,14 @@
              Both are Wolverine-side; inert for Polecat, carried along by the version bump.
              Weasel stays at 9.27.0 — already the latest, and its JasperFx.Events floor (2.46.0) is
              satisfied by this line, so the matrix stays coherent without a lockstep bump. -->
-        <PackageVersion Include="JasperFx" Version="2.59.0" />
-        <PackageVersion Include="JasperFx.Events" Version="2.59.0" />
+        <PackageVersion Include="JasperFx" Version="2.60.0" />
+        <PackageVersion Include="JasperFx.Events" Version="2.60.0" />
         <!--
              The shared cross-store event sourcing compliance suites. Source-only package: the
              suites compile inside Polecat.Tests so JasperFx's aggregate source generator binds
              Polecat's own session types.
         -->
-        <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.59.0" />
+        <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.60.0" />
         <!-- Pin the sibling JasperFx packages for parity with Marten 9's matrix
              even though Polecat doesn't currently reference them directly —
              keeps the lockstep matrix coherent when transitive resolution


### PR DESCRIPTION
Polecat **already implements every member** the JasperFx.Events `projection-run` command needs:

| member | where |
|---|---|
| `ReadStreamAsync` | `DocumentStore.EventStoreExplorer.cs:80` |
| `QueryByTagsAsync` | `DocumentStore.EventStoreExplorer.cs` |
| `RunMultiStreamProjectionAsync` | `DocumentStore.ProjectionReplay.cs:186` |

The only thing between a Polecat user and that command was the **dependency floor**: at `JasperFx.Events` 2.59.0 the command doesn't exist, so a stock `dotnet add package Polecat` app never sees it in `help` and can't invoke it.

So this is a pin bump and nothing else — no new code, no behaviour change to anything that already worked. Verified by building against 2.60.0.

**5.22.0** rather than a patch: it makes a new CLI command appear in consuming applications, which is a user-visible capability change even though no Polecat code moved.

## Sibling PR

JasperFx/fisher#146 does the same bump for Fisher — but **Fisher needed `ReadStreamAsync` implemented first**, because there the bump alone would have surfaced a command that fails on its first call:

```
Unable to read the source events: ReadStreamAsync is not implemented on this IEventStore.
```

Polecat needs no such work.

⚠️ **On 2.60.0 vs 2.60.1:** JasperFx/jasperfx#734 renames the command from `projectionrun` to `projection-run` and ships as 2.60.1. This pins **2.60.0** because that's what's published and therefore what I could build against. One-line change to 2.60.1 before merge if you'd rather — worth doing, since `projectionrun` is the name users would otherwise learn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EVQ4LcDmK6cmvnY792tUEm