### PR TITLE
Bump JasperFx to 2.61.0 and Weasel to 9.29.0 (5.22.0)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>5.21.2</Version>
+        <Version>5.22.0</Version>
         <LangVersion>latest</LangVersion>
         <Authors>Jeremy D. Miller</Authors>
         <PackageIcon>logo.png</PackageIcon>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>5.21.1</Version>
+        <Version>5.21.2</Version>
         <LangVersion>latest</LangVersion>
         <Authors>Jeremy D. Miller</Authors>
         <PackageIcon>logo.png</PackageIcon>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -323,15 +323,41 @@
              registrations, and a Block no longer running its action on the publisher's thread.
              Both are Wolverine-side; inert for Polecat, carried along by the version bump.
              Weasel stays at 9.27.0 — already the latest, and its JasperFx.Events floor (2.46.0) is
-             satisfied by this line, so the matrix stays coherent without a lockstep bump. -->
-        <PackageVersion Include="JasperFx" Version="2.59.0" />
-        <PackageVersion Include="JasperFx.Events" Version="2.59.0" />
+             satisfied by this line, so the matrix stays coherent without a lockstep bump.
+
+             JasperFx 2.61.0 (from 2.59.0, spanning 2.60.0):
+             (a) jasperfx#728/#729 — a `projection-run` CLI command, and jasperfx#734, which is why
+             this pin is 2.61.0 and not 2.60.0. The command shipped in 2.60.0 resolving as
+             `projectionrun`: CommandFactory.CommandNameFor only strips the "Command" suffix and
+             lowercases, so ProjectionRunCommand never got its PascalCase split. 2.61.0 names it
+             explicitly. Polecat already implements every member the command calls
+             (ReadStreamAsync and QueryByTagsAsync in DocumentStore.EventStoreExplorer.cs,
+             RunMultiStreamProjectionAsync in DocumentStore.ProjectionReplay.cs), so the floor lift
+             alone is what puts the command in a consuming app's `help` output — under the name it
+             is documented by.
+             (b) jasperfx#730/#731 — [BoundaryAggregate] is honored on the Evolve path rather than
+             failing silently. Adjacent to Polecat's own #521, which fixed the identity-less
+             boundary aggregate throw; this closes the Evolve half upstream.
+             (c) jasperfx#733/#735 — event constructors fold into the self-aggregating
+             DetermineAction switch.
+
+             Weasel 9.29.0 (from 9.27.1, spanning 9.28.0). 9.28 is a SQLite release and its upgrade
+             guide's `numeric`/`decimal` migration warning does not reach this store — SQL Server
+             emits no SQLite DDL. Two changes here are NOT provider-inert, though, and are the
+             reason this bump wants a full CI pass rather than a glance:
+             (a) weasel#540 — foreign key cycle creation, which edits Weasel.SqlServer's Table and
+             TableDelta and SqlServerMigrator alongside Weasel.Core's SchemaMigration and Migrator.
+             Polecat creates foreign keys on document tables, so this is live schema-management code.
+             (b) weasel#538/#542 — AssertPatchingIsValid lets a rebuildable Invalid delta through,
+             in Weasel.Core.SchemaMigration and ISchemaObject. Core, so every provider sees it. -->
+        <PackageVersion Include="JasperFx" Version="2.61.0" />
+        <PackageVersion Include="JasperFx.Events" Version="2.61.0" />
         <!--
              The shared cross-store event sourcing compliance suites. Source-only package: the
              suites compile inside Polecat.Tests so JasperFx's aggregate source generator binds
              Polecat's own session types.
         -->
-        <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.59.0" />
+        <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.61.0" />
         <!-- Pin the sibling JasperFx packages for parity with Marten 9's matrix
              even though Polecat doesn't currently reference them directly —
              keeps the lockstep matrix coherent when transitive resolution
@@ -339,7 +365,7 @@
              RuntimeCompiler 5.x line is the active continuation of the 4.x
              lineage; do not pin against the parallel stale 2.0.x series. -->
         <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.59.0" />
+        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.61.0" />
         <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
@@ -491,9 +517,9 @@
              StorageOperationExecution.Configure), so 9.27.1 is a FLOOR, not a preference — the nine
              queued_sql_command_tests are the proof it holds, and five of them fail against 9.27.0
              once the local guard is gone. -->
-        <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.27.1" />
-        <PackageVersion Include="Weasel.SqlServer" Version="9.27.1" />
-        <PackageVersion Include="Weasel.Storage" Version="9.27.1" />
+        <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.29.0" />
+        <PackageVersion Include="Weasel.SqlServer" Version="9.29.0" />
+        <PackageVersion Include="Weasel.Storage" Version="9.29.0" />
 
         <!-- Strongly typed IDs. Both generators are test-only: they prove Polecat's value-type id
              support against the two libraries Marten's ValueTypeTests exercise. StronglyTypedId emits
@@ -503,7 +529,7 @@
         <PackageVersion Include="Vogen" Version="7.0.0" />
 
         <!-- Source generators (matched to JasperFx.Events above) -->
-        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.59.0" />
+        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.61.0" />
 
         <!-- Build automation -->
         <PackageVersion Include="Nuke.Common" Version="9.0.4" />


### PR DESCRIPTION
Supersedes #530. Dependency pins only — no Polecat code changes.

## Why 2.61.0 rather than 2.60.0

#530 lifted the JasperFx floor to 2.60.0 so the `projection-run` CLI command would reach Polecat users. That command shipped in 2.60.0 resolving as **`projectionrun`** — `CommandFactory.CommandNameFor` strips the `Command` suffix and lowercases, but never splits PascalCase, so `ProjectionRunCommand` never got its hyphen. JasperFx/jasperfx#734 names it explicitly, and its own commit message calls out why it was worth a point release: Polecat and Fisher were about to pin a floor specifically to surface this command, and pinning 2.60.0 would have shipped it under a name neither the docs nor the help text use.

Polecat already implements every member the command calls — `ReadStreamAsync` and `QueryByTagsAsync` in `DocumentStore.EventStoreExplorer.cs`, `RunMultiStreamProjectionAsync` in `DocumentStore.ProjectionReplay.cs` — so the floor lift alone is what puts it in a consuming app's `help` output.

## Lockstep correction

All **five** lockstep JasperFx pins move together here: `JasperFx`, `JasperFx.Events`, `JasperFx.Events.ComplianceTests`, `JasperFx.SourceGenerator`, `JasperFx.Events.SourceGenerator`. #530 moved three, which would have left both source generators at 2.59.0 against a 2.60.0 runtime. `JasperFx.RuntimeCompiler` stays on its own 5.0.0 line, as always.

Also in the 2.59 → 2.61 range: jasperfx#730/#731 honors `[BoundaryAggregate]` on the Evolve path instead of failing silently (adjacent to Polecat's own #521), and jasperfx#733/#735 folds event constructors into the self-aggregating `DetermineAction` switch.

## Weasel 9.27.1 → 9.29.0 is not inert here

9.28 is a SQLite release, and its upgrade guide's `numeric`/`decimal` first-migration warning does **not** reach this store — SQL Server emits no SQLite DDL. But two changes in the range are provider-general and touch code Polecat runs:

- **weasel#540** (foreign key cycle creation) edits `Weasel.SqlServer`'s `Table` and `TableDelta` and `SqlServerMigrator`, alongside `Weasel.Core`'s `SchemaMigration` and `Migrator`. Polecat creates foreign keys on document tables.
- **weasel#538/#542** changes `Weasel.Core.SchemaMigration.AssertPatchingIsValid` to let a rebuildable `Invalid` delta through — core, so every provider sees it.

That is why this wants a full CI pass rather than a glance at the build.

## Version

`5.21.1` -> **`5.22.0`**, a minor.

No Polecat code moves, but the JasperFx 2.61.0 floor makes the `projection-run` command appear in consuming applications' help output, and a new user-visible capability is a minor even when the diff is nine pins. This is the reasoning from the superseded #530, applied to the PR that replaced it.

## Verification

`dotnet restore` and `dotnet build -c Release` clean against the new pins on both target frameworks — 0 errors, and the warning set is unchanged from the 5.21.1 publish log. Full suite is CI's job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
