### PR TITLE
Implement the broadened EventQuery (jasperfx#737) and enroll EventQueryCompliance

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -349,15 +349,23 @@
              TableDelta and SqlServerMigrator alongside Weasel.Core's SchemaMigration and Migrator.
              Polecat creates foreign keys on document tables, so this is live schema-management code.
              (b) weasel#538/#542 — AssertPatchingIsValid lets a rebuildable Invalid delta through,
-             in Weasel.Core.SchemaMigration and ISchemaObject. Core, so every provider sees it. -->
-        <PackageVersion Include="JasperFx" Version="2.61.0" />
-        <PackageVersion Include="JasperFx.Events" Version="2.61.0" />
+             in Weasel.Core.SchemaMigration and ISchemaObject. Core, so every provider sees it.
+
+             JasperFx 2.62.0 (#532, jasperfx#737): the broadened EventQuery — multi-type
+             union via CombinedEventTypeNames(), inclusive timestamp and sequence windows, folded
+             EventTagQuerySpec tag conditions, EventQueryFilters + AssertFiltersAreSupported (the
+             honor-or-refuse guard rail), the EventQueryCompliance suite (and two EventQuery facts
+             on the conjoined tenancy suite), and the SetUserName / EnableUserNameTracking fixture
+             seams. Also carries jasperfx#739, the fix for the suite's
+             paging_composes_with_filtering seed arithmetic that this enrollment surfaced. -->
+        <PackageVersion Include="JasperFx" Version="2.62.0" />
+        <PackageVersion Include="JasperFx.Events" Version="2.62.0" />
         <!--
              The shared cross-store event sourcing compliance suites. Source-only package: the
              suites compile inside Polecat.Tests so JasperFx's aggregate source generator binds
              Polecat's own session types.
         -->
-        <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.61.0" />
+        <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.62.0" />
         <!-- Pin the sibling JasperFx packages for parity with Marten 9's matrix
              even though Polecat doesn't currently reference them directly —
              keeps the lockstep matrix coherent when transitive resolution
@@ -365,7 +373,7 @@
              RuntimeCompiler 5.x line is the active continuation of the 4.x
              lineage; do not pin against the parallel stale 2.0.x series. -->
         <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.61.0" />
+        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.62.0" />
         <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
@@ -529,7 +537,7 @@
         <PackageVersion Include="Vogen" Version="7.0.0" />
 
         <!-- Source generators (matched to JasperFx.Events above) -->
-        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.61.0" />
+        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.62.0" />
 
         <!-- Build automation -->
         <PackageVersion Include="Nuke.Common" Version="9.0.4" />

--- a/src/Polecat.Tests/CommandLine/event_query_command_end_to_end.cs
+++ b/src/Polecat.Tests/CommandLine/event_query_command_end_to_end.cs
@@ -1,0 +1,181 @@
+using System.Text.Json;
+using JasperFx;
+using JasperFx.Events.CommandLine;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Polecat.TestUtils;
+using Shouldly;
+
+namespace Polecat.Tests.CommandLine;
+
+/// <summary>
+/// #532 (jasperfx#737): end-to-end coverage of the <c>event-query</c> CLI command against a REAL
+/// Polecat store — upstream carries only input-mapping unit tests, so until this class nothing
+/// anywhere executed <see cref="EventQueryCommand"/> against a live event store. The command is
+/// driven exactly as the CLI runtime drives it: a real <see cref="EventQueryInput"/> with its
+/// <c>HostBuilder</c> set (the command builds and disposes the host itself, resolves the store
+/// from DI via <c>GetServices&lt;IEventStore&gt;()</c> — the registration AddPolecat makes), stdout
+/// captured and parsed as the JSON report agents and scripts consume.
+///
+/// Three facts: a filtered query returning exact expected events + totalCount; the honesty case
+/// where a filter matches nothing (totalCount 0 printed as a REAL answer, success return); and the
+/// guard-rail case where a supplied filter the store does not capture is refused with a report
+/// naming the field and a failure return — never an unfiltered result that reads as filtered.
+/// </summary>
+public class event_query_command_end_to_end
+{
+    private const string Schema = "event_query_cli";
+
+    public record OrderPlaced(int OrderId);
+
+    public record OrderShipped(int OrderId);
+
+    private static StoreOptions ConfigureOptions(StoreOptions opts)
+    {
+        opts.ConnectionString = ConnectionSource.ConnectionString;
+        opts.DatabaseSchemaName = Schema;
+        opts.AutoCreateSchemaObjects = AutoCreate.All;
+        opts.UseNativeJsonType = ConnectionSource.SupportsNativeJson;
+        // Deliberately NOT enabling the metadata columns (EnableUserName etc.) — the refusal fact
+        // depends on the store genuinely not capturing user_name.
+        return opts;
+    }
+
+    private static async Task DropSchemaAsync()
+    {
+        await using var conn = new Microsoft.Data.SqlClient.SqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync(TestContext.Current.CancellationToken);
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"""
+            IF OBJECT_ID('[{Schema}].[pc_events]','U') IS NOT NULL DROP TABLE [{Schema}].[pc_events];
+            IF OBJECT_ID('[{Schema}].[pc_streams]','U') IS NOT NULL DROP TABLE [{Schema}].[pc_streams];
+            """;
+        await cmd.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+    }
+
+    /// <summary>
+    /// Five events over two streams, one save each so the global sequence is deterministic:
+    /// Placed(1), Shipped(1), Placed(2), Shipped(2), Placed(3).
+    /// </summary>
+    private static async Task SeedAsync()
+    {
+        await DropSchemaAsync();
+
+        await using var store = DocumentStore.For(opts => ConfigureOptions(opts));
+
+        var streamOne = Guid.NewGuid();
+        var streamTwo = Guid.NewGuid();
+        foreach (var @event in new object[]
+                 {
+                     new OrderPlaced(1), new OrderShipped(1), new OrderPlaced(2),
+                     new OrderShipped(2), new OrderPlaced(3)
+                 })
+        {
+            await using var session = store.LightweightSession();
+            session.Events.Append(@event is OrderPlaced ? streamOne : streamTwo, @event);
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+    }
+
+    /// <summary>
+    /// Run the command the way the CLI runtime does — <c>Execute(input)</c> against a host built
+    /// from the input's own HostBuilder — capturing stdout and parsing the JSON report.
+    /// </summary>
+    private static async Task<(bool Success, JsonElement Report)> ExecuteAsync(EventQueryInput input)
+    {
+        input.HostBuilder = Host.CreateDefaultBuilder()
+            .ConfigureServices(services => services.AddPolecat(opts => ConfigureOptions(opts)));
+
+        var original = Console.Out;
+        var writer = new StringWriter();
+        Console.SetOut(writer);
+        bool success;
+        try
+        {
+            success = await new EventQueryCommand().Execute(input);
+        }
+        finally
+        {
+            Console.SetOut(original);
+        }
+
+        var output = writer.ToString();
+        var start = output.IndexOf('{');
+        start.ShouldBeGreaterThanOrEqualTo(0, $"expected a JSON report on stdout, got: {output}");
+
+        using var doc = JsonDocument.Parse(output[start..]);
+        return (success, doc.RootElement.Clone());
+    }
+
+    [Fact]
+    public async Task a_filtered_query_returns_the_exact_events_and_total()
+    {
+        await SeedAsync();
+
+        var (success, report) = await ExecuteAsync(new EventQueryInput
+        {
+            EventTypeFlag = "order_placed",
+            PageSizeFlag = 50
+        });
+
+        success.ShouldBeTrue();
+        report.GetProperty("totalCount").GetInt32().ShouldBe(3);
+        report.GetProperty("pageNumber").GetInt32().ShouldBe(1);
+        report.GetProperty("pageSize").GetInt32().ShouldBe(50);
+        report.GetProperty("hasMore").GetBoolean().ShouldBeFalse();
+        report.TryGetProperty("error", out _).ShouldBeFalse();
+
+        var events = report.GetProperty("events").EnumerateArray().ToList();
+        events.Count.ShouldBe(3);
+        events.ShouldAllBe(e => e.GetProperty("eventType").GetString() == "order_placed");
+
+        // Exact membership in seed order — the filter demonstrably filtered (the two
+        // order_shipped events are absent) and the ordering is the store-global sequence.
+        events.Select(e => e.GetProperty("data").GetProperty("OrderId").GetInt32())
+            .ShouldBe([1, 2, 3]);
+        var sequences = events.Select(e => e.GetProperty("sequence").GetInt64()).ToList();
+        sequences.ShouldBe(sequences.OrderBy(x => x).ToList());
+        sequences.Distinct().Count().ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task a_filter_matching_nothing_is_a_real_answer_not_a_failure()
+    {
+        await SeedAsync();
+
+        var (success, report) = await ExecuteAsync(new EventQueryInput
+        {
+            EventTypeFlag = "no_such_event_type",
+            PageSizeFlag = 50
+        });
+
+        // totalCount 0 with no error, and a success return: "nothing matched" must stay
+        // distinguishable from "the run failed".
+        success.ShouldBeTrue();
+        report.GetProperty("totalCount").GetInt32().ShouldBe(0);
+        report.GetProperty("events").GetArrayLength().ShouldBe(0);
+        report.TryGetProperty("error", out _).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task a_filter_the_store_does_not_capture_is_refused_by_name()
+    {
+        await SeedAsync();
+
+        var (success, report) = await ExecuteAsync(new EventQueryInput
+        {
+            UserNameFlag = "whoever",
+            PageSizeFlag = 50
+        });
+
+        // The jasperfx#737 guard rail surfaced through the CLI: the store does not capture
+        // user_name, so the run FAILS with a report naming the refused field — it must never
+        // return unfiltered events that read as filtered.
+        success.ShouldBeFalse();
+        var error = report.GetProperty("error").GetString();
+        error.ShouldNotBeNull();
+        error.ShouldContain("EventQuery.UserName");
+        report.GetProperty("totalCount").GetInt32().ShouldBe(0);
+        report.GetProperty("events").GetArrayLength().ShouldBe(0);
+    }
+}

--- a/src/Polecat.Tests/Compliance/PolecatComplianceFixture.cs
+++ b/src/Polecat.Tests/Compliance/PolecatComplianceFixture.cs
@@ -49,6 +49,12 @@ public class PolecatComplianceFixture : EventStoreComplianceFixture<IDocumentSes
             options.Events.EnableCausationId = true;
         }
 
+        // jasperfx#737: opt-in like correlation — the event query suite filters on user_name.
+        if (config.EnableUserNameTracking)
+        {
+            options.Events.EnableUserName = true;
+        }
+
         if (config.EnableHeaders)
         {
             options.Events.EnableHeaders = true;
@@ -113,6 +119,11 @@ public class PolecatComplianceFixture : EventStoreComplianceFixture<IDocumentSes
 
     public override void SetCorrelationId(IDocumentSession session, string? correlationId)
         => session.CorrelationId = correlationId;
+
+    // jasperfx#737: the event query suite filters on the user_name column, which Polecat stamps
+    // from the session's LastModifiedBy (#237/#239) when EnableUserName is on.
+    public override void SetUserName(IDocumentSession session, string? userName)
+        => session.LastModifiedBy = userName;
 
     public override IEventStore EventStore => _store;
 

--- a/src/Polecat.Tests/Compliance/polecat_event_store_compliance_wave12.cs
+++ b/src/Polecat.Tests/Compliance/polecat_event_store_compliance_wave12.cs
@@ -1,0 +1,37 @@
+using JasperFx.Events.ComplianceTests;
+
+namespace Polecat.Tests.Compliance;
+
+/*
+ * Wave 12 -- the suite JasperFx.Events 2.62.0 added (jasperfx#737, polecat#532).
+ *
+ * EventQueryCompliance is the cross-stream query surface -- IReadOnlyEventStore.QueryEventsAsync
+ * over the broadened EventQuery: every filter field (multi-type union, inclusive timestamp and
+ * sequence windows, folded DCB tag conditions, the metadata trio), the sequence-ascending
+ * ordering contract, and the paging/TotalCount contract. Every fact asserts the filter actually
+ * FILTERED -- exact membership and totals -- never that the call succeeded, because the failure
+ * mode the design refuses is a silently-ignored filter reading as a filtered result. Polecat's
+ * declaration lives in QueryEventStore.SupportedEventQueryFilters(): everything structural always,
+ * the metadata filters exactly when the store captures the column (EnableCorrelationId /
+ * EnableCausationId / EnableUserName), refused via EventQuery.AssertFiltersAreSupported otherwise.
+ *
+ * The suite turns on ComplianceStoreConfig.EnableUserNameTracking (the jasperfx#737 fixture seam,
+ * mapped to Events.EnableUserName) and drives the user_name column through the fixture's
+ * SetUserName -> session.LastModifiedBy. Tag conditions ride Polecat's existing DCB tag tables:
+ * each EventTagQuerySpec condition compiles to the same correlated seq_id IN (SELECT ... FROM
+ * pc_event_tag_*) subquery as the HasTag() LINQ path, OR'd per condition, AND-combined with the
+ * rest of the query.
+ *
+ * The EventQuery.TenantId filter is deliberately NOT here -- its two facts live in
+ * ConjoinedEventTenancyCompliance (wave 8), which owns the conjoined store configuration.
+ *
+ * Enrolling this suite surfaced an upstream defect in the suite itself, fixed before the pin
+ * landed here: paging_composes_with_filtering originally seeded with `i % 3 == 0` over i = 0..9
+ * (four CargoLoaded, six CargoInspected) while asserting seven matches per its own "Seven
+ * Inspected events interleaved with three Loaded" intent. Polecat correctly answered 6. Fixed in
+ * jasperfx PR #739, included in the published JasperFx.Events.ComplianceTests 2.62.0 this repo
+ * pins, so the suite runs 41/41 here.
+ */
+
+public class polecat_event_query_compliance
+    : EventQueryCompliance<PolecatComplianceFixture, IDocumentSession, IQuerySession>;

--- a/src/Polecat.Tests/Metadata/event_metadata_filter_tests.cs
+++ b/src/Polecat.Tests/Metadata/event_metadata_filter_tests.cs
@@ -10,6 +10,9 @@ namespace Polecat.Tests.Metadata;
 /// (parity with the JasperFx EventQuery surface). CorrelationId / CausationId / UserName are honored only
 /// when the option is set AND the event store captures that column (EnableCorrelationId / EnableCausationId /
 /// EnableUserName, #237). UserName is sourced from the session's LastModifiedBy (#237/#239).
+/// #532 (jasperfx#737): a supplied metadata filter whose column is NOT captured is now REFUSED with a
+/// NotSupportedException naming the field, via EventQuery.AssertFiltersAreSupported — never silently
+/// dropped, because unfiltered results read as filtered.
 ///
 /// Seeding: 8 single-event streams covering every combination of correlation ∈ {c0,c1} ×
 /// causation ∈ {u0,u1} × user ∈ {b0,b1}, indexed 0..7 by the (corr,caus,user) binary tuple.
@@ -110,12 +113,14 @@ public class event_metadata_filter_tests
     }
 
     [Theory]
-    [InlineData(false, true, true, "correlation")]
-    [InlineData(true, false, true, "causation")]
-    [InlineData(true, true, false, "username")]
-    public async Task filter_is_silently_ignored_when_its_column_is_disabled(
-        bool enableCorr, bool enableCaus, bool enableUser, string which)
+    [InlineData(false, true, true, "correlation", nameof(EventQuery.CorrelationId))]
+    [InlineData(true, false, true, "causation", nameof(EventQuery.CausationId))]
+    [InlineData(true, true, false, "username", nameof(EventQuery.UserName))]
+    public async Task filter_is_refused_when_its_column_is_disabled(
+        bool enableCorr, bool enableCaus, bool enableUser, string which, string expectedFieldName)
     {
+        // jasperfx#737 guard rail: an unsupported-but-supplied filter must throw naming the field,
+        // never be silently dropped (this test used to pin the old drop-it behavior — TotalCount 8).
         await using var store = await CreateStoreAsync($"evt256_off_{which}", enableCorr, enableCaus, enableUser);
         await SeedMatrixAsync(store);
 
@@ -126,24 +131,34 @@ public class event_metadata_filter_tests
             _ => new EventQuery { PageSize = 50, UserName = "b0" }
         };
 
-        var result = await QueryAsync(store, query);
-
-        result.TotalCount.ShouldBe(8); // disabled column → filter dropped → all events
+        var ex = await Should.ThrowAsync<NotSupportedException>(() => QueryAsync(store, query));
+        ex.Message.ShouldContain($"{nameof(EventQuery)}.{expectedFieldName}");
     }
 
     [Fact]
-    public async Task disabled_filter_does_not_suppress_an_enabled_one()
+    public async Task a_disabled_filter_in_a_mixed_query_refuses_the_whole_query()
     {
-        // causation disabled, correlation + user enabled.
+        // causation disabled, correlation + user enabled: the query carries one refusable filter,
+        // so the whole call throws rather than answering with the other two applied — a partially
+        // filtered answer would read as the fully filtered one (jasperfx#737).
         await using var store = await CreateStoreAsync("evt256_mixed", enableCorr: true, enableCaus: false, enableUser: true);
         await SeedMatrixAsync(store);
 
+        var ex = await Should.ThrowAsync<NotSupportedException>(() => QueryAsync(store, new EventQuery
+        {
+            PageSize = 50,
+            CorrelationId = "c0", // capturable
+            CausationId = "u0",   // NOT captured → refusal
+            UserName = "b0"       // capturable
+        }));
+        ex.Message.ShouldContain($"{nameof(EventQuery)}.{nameof(EventQuery.CausationId)}");
+
+        // And the capturable filters still work on their own against the same store.
         var result = await QueryAsync(store, new EventQuery
         {
             PageSize = 50,
-            CorrelationId = "c0", // honored
-            CausationId = "u0",    // ignored (disabled)
-            UserName = "b0"        // honored
+            CorrelationId = "c0",
+            UserName = "b0"
         });
 
         result.TotalCount.ShouldBe(2); // c0 ∩ b0

--- a/src/Polecat/Events/QueryEventStore.cs
+++ b/src/Polecat/Events/QueryEventStore.cs
@@ -1,6 +1,8 @@
 using System.Collections.Concurrent;
+using System.Linq.Expressions;
 using System.Reflection;
 using JasperFx.Events;
+using JasperFx.Events.Tags;
 using JasperFx.Events.Projections;
 using Microsoft.Data.SqlClient;
 using Polecat.Events.Internal;
@@ -49,14 +51,21 @@ internal class QueryEventStore : IQueryEventStore, IReadOnlyEventStore
     }
 
     /// <summary>
-    ///     #256: query events across all streams with exact-match metadata filters and pagination
-    ///     (the JasperFx <see cref="EventQuery" /> surface). The correlation/causation/user-name
-    ///     filters are honored only when the option is set AND the event store actually captures that
-    ///     metadata column (the <c>Enable*</c> flag), since a disabled column isn't populated. v1 is
-    ///     exact-match, AND-combined; headers and timestamp ranges are deferred.
+    ///     #256 / #532 (jasperfx#737): query events across all streams with metadata filters,
+    ///     inclusive timestamp/sequence windows, multi-type union, DCB tag conditions, and
+    ///     pagination — the full JasperFx <see cref="EventQuery" /> surface. All supplied filters
+    ///     AND-combine; results are ordered by the store-global sequence ascending and
+    ///     <see cref="PagedEvents.TotalCount" /> is the match count across every page.
+    ///     The correlation/causation/user-name filters are honored only when the event store
+    ///     actually captures that metadata column (the <c>Enable*</c> flag), since a disabled
+    ///     column isn't populated — a query supplying one of those against a store that does not
+    ///     capture it is REFUSED by <see cref="EventQuery.AssertFiltersAreSupported" /> (never
+    ///     silently ignored; unfiltered results would read as filtered).
     /// </summary>
     public async Task<PagedEvents> QueryEventsAsync(EventQuery query, CancellationToken token = default)
     {
+        query.AssertFiltersAreSupported(SupportedEventQueryFilters());
+
         IQueryable<IEvent> queryable = QueryAllRawEvents();
 
         // #353 / jasperfx#555 — honour the tenant scope the Event Explorer sets. On a conjoined
@@ -69,9 +78,18 @@ internal class QueryEventStore : IQueryEventStore, IReadOnlyEventStore
             queryable = queryable.TenantIsOneOf(query.TenantId);
         }
 
-        if (query.EventTypeName != null)
+        // jasperfx#737: EventTypeName and EventTypeNames union through CombinedEventTypeNames(),
+        // so both spellings share one code path and the single/plural semantics stay upstream.
+        var eventTypeNames = query.CombinedEventTypeNames();
+        if (eventTypeNames.Count == 1)
         {
-            queryable = queryable.Where(e => e.EventTypeName == query.EventTypeName);
+            var single = eventTypeNames[0];
+            queryable = queryable.Where(e => e.EventTypeName == single);
+        }
+        else if (eventTypeNames.Count > 1)
+        {
+            var names = eventTypeNames.ToArray();
+            queryable = queryable.Where(e => e.EventTypeName.IsOneOf(names));
         }
 
         if (query.StreamId != null)
@@ -86,20 +104,54 @@ internal class QueryEventStore : IQueryEventStore, IReadOnlyEventStore
             }
         }
 
-        var options = _events.EventOptions;
-        if (query.CorrelationId != null && options.EnableCorrelationId)
+        // The Enable* capture guards live in SupportedEventQueryFilters(): a supplied metadata
+        // filter against a store that doesn't capture the column was already refused above, so
+        // reaching here means the column exists and the filter is applied unconditionally.
+        if (query.CorrelationId != null)
         {
             queryable = queryable.Where(e => e.CorrelationId == query.CorrelationId);
         }
 
-        if (query.CausationId != null && options.EnableCausationId)
+        if (query.CausationId != null)
         {
             queryable = queryable.Where(e => e.CausationId == query.CausationId);
         }
 
-        if (query.UserName != null && options.EnableUserName)
+        if (query.UserName != null)
         {
             queryable = queryable.Where(e => e.UserName == query.UserName);
+        }
+
+        // jasperfx#737: inclusive at both ends; a half-open window (one bound null) is valid, and
+        // an inverted window is a well-formed range containing nothing — the SQL comparisons
+        // produce exactly that (empty page, TotalCount 0), never an error.
+        if (query.TimestampFrom.HasValue)
+        {
+            var timestampFrom = query.TimestampFrom.Value;
+            queryable = queryable.Where(e => e.Timestamp >= timestampFrom);
+        }
+
+        if (query.TimestampTo.HasValue)
+        {
+            var timestampTo = query.TimestampTo.Value;
+            queryable = queryable.Where(e => e.Timestamp <= timestampTo);
+        }
+
+        if (query.SequenceFloor.HasValue)
+        {
+            var sequenceFloor = query.SequenceFloor.Value;
+            queryable = queryable.Where(e => e.Sequence >= sequenceFloor);
+        }
+
+        if (query.SequenceCeiling.HasValue)
+        {
+            var sequenceCeiling = query.SequenceCeiling.Value;
+            queryable = queryable.Where(e => e.Sequence <= sequenceCeiling);
+        }
+
+        if (query.TagConditions != null)
+        {
+            queryable = ApplyTagConditions(queryable, query.TagConditions);
         }
 
         var pageNumber = query.PageNumber <= 0 ? 1 : query.PageNumber;
@@ -120,6 +172,83 @@ internal class QueryEventStore : IQueryEventStore, IReadOnlyEventStore
             PageNumber = pageNumber,
             PageSize = pageSize
         };
+    }
+
+    /// <summary>
+    ///     The jasperfx#737 declaration: every <see cref="EventQuery" /> filter Polecat honors.
+    ///     Structural filters (types, stream, tenant, both windows, tag conditions) are always
+    ///     supported; the metadata filters are supported exactly when the store captures the
+    ///     column, because a disabled column is never populated and filtering on it would return
+    ///     truthful-looking garbage (everything or nothing depending on NULL semantics).
+    /// </summary>
+    private EventQueryFilters SupportedEventQueryFilters()
+    {
+        var supported = EventQueryFilters.EventTypeName
+                        | EventQueryFilters.EventTypeNames
+                        | EventQueryFilters.StreamId
+                        | EventQueryFilters.TenantId
+                        | EventQueryFilters.TimestampWindow
+                        | EventQueryFilters.SequenceWindow
+                        | EventQueryFilters.TagConditions;
+
+        var options = _events.EventOptions;
+        if (options.EnableCorrelationId) supported |= EventQueryFilters.CorrelationId;
+        if (options.EnableCausationId) supported |= EventQueryFilters.CausationId;
+        if (options.EnableUserName) supported |= EventQueryFilters.UserName;
+
+        return supported;
+    }
+
+    private static readonly MethodInfo _hasTagMethod =
+        typeof(LinqExtensions).GetMethod(nameof(LinqExtensions.HasTag))!;
+
+    /// <summary>
+    ///     jasperfx#737: fold the wire-form <see cref="EventTagQuerySpec" /> into the event LINQ
+    ///     query as an OR of <see cref="LinqExtensions.HasTag{TTag}" /> marker calls — each
+    ///     compiling to the same correlated <c>seq_id IN (SELECT seq_id FROM pc_event_tag_*)</c>
+    ///     subquery Polecat's DCB tag path emits (see <see cref="HasTagParser" />), so an event
+    ///     matching several conditions still reads back once and the whole selection AND-combines
+    ///     with every other filter on the query. A type-scoped condition
+    ///     (<c>EventTagQueryConditionSpec.EventType</c>) ANDs an <c>e.type</c> match into its own
+    ///     OR branch, distinct from the query-level event type filter.
+    /// </summary>
+    private IQueryable<IEvent> ApplyTagConditions(IQueryable<IEvent> queryable, EventTagQuerySpec spec)
+    {
+        // Resolve the wire descriptors back to CLR types against the registered tag/event graph;
+        // an unknown type raises UnknownTagQueryTypeException naming the descriptor.
+        var knownTypes = _events.TagTypes.Select(x => x.TagType)
+            .Concat(_events.AllKnownEventTypes().Select(x => x.EventType));
+        var tagQuery = spec.Resolve(EventTagQuerySpec.ResolverFor(knownTypes));
+
+        if (tagQuery.Conditions.Count == 0)
+        {
+            return queryable;
+        }
+
+        var e = Expression.Parameter(typeof(IEvent), "e");
+
+        Expression? body = null;
+        foreach (var condition in tagQuery.Conditions)
+        {
+            Expression branch = Expression.Call(
+                _hasTagMethod.MakeGenericMethod(condition.TagType),
+                e,
+                Expression.Constant(condition.TagValue, condition.TagType));
+
+            if (condition.EventType != null)
+            {
+                var eventTypeName = _events.EventMappingFor(condition.EventType).EventTypeName;
+                branch = Expression.AndAlso(
+                    branch,
+                    Expression.Equal(
+                        Expression.Property(e, typeof(IEvent).GetProperty(nameof(IEvent.EventTypeName))!),
+                        Expression.Constant(eventTypeName)));
+            }
+
+            body = body == null ? branch : Expression.OrElse(body, branch);
+        }
+
+        return queryable.Where(Expression.Lambda<Func<IEvent, bool>>(body!, e));
     }
 
     public async Task<IReadOnlyList<IEvent>> FetchStreamAsync(Guid streamId, long version = 0,


### PR DESCRIPTION
Closes #532. Downstream of jasperfx#737 (merged as jasperfx#738), pinned against the published JasperFx 2.62.0 matched set — which also carries jasperfx#739, the compliance-suite seed fix this enrollment surfaced.

## What QueryEventsAsync now honors

`QueryEventStore.QueryEventsAsync` opens with `query.AssertFiltersAreSupported(SupportedEventQueryFilters())` and implements the full `EventQuery` surface. Declared flags: the structural set unconditionally — `EventTypeName | EventTypeNames | StreamId | TenantId | TimestampWindow | SequenceWindow | TagConditions` — plus `CorrelationId` / `CausationId` / `UserName` exactly when the store captures the column (`Events.EnableCorrelationId` / `EnableCausationId` / `EnableUserName`), i.e. `EventQueryFilters.All` on a fully instrumented store.

### T-SQL translation (through the event LINQ provider over `pc_events`)

- **Multi-type union**: `CombinedEventTypeNames()` → `type = @p` for one name, `type IN (@p1, …)` for several, so the single/plural union semantics stay upstream and duplicates cannot double-count.
- **Windows**: inclusive `timestamp >= @p` / `<= @p` and `seq_id >= @p` / `<= @p`. A half-open window is valid; an inverted window matches nothing (empty page, `TotalCount` 0) by the SQL itself — never an error.
- **Tag conditions**: the wire-form `EventTagQuerySpec` resolves against the registered tag/event graph and folds into the query as OR'd `HasTag()` marker calls, each compiling to the same correlated `seq_id IN (SELECT seq_id FROM pc_event_tag_*)` subquery as the existing DCB tag path (`HasTagParser`), with `AND type = @p` inside the branch for a type-scoped condition. No joins, so an event matching several conditions reads back once, and the whole selection AND-combines with every other filter.
- **Ordering/paging**: `ORDER BY seq_id` + OFFSET/FETCH unchanged and now compliance-pinned; `TotalCount` is the filtered total across every page.

## ⚠️ Behavior change (release-note-worthy)

A supplied `CorrelationId` / `CausationId` / `UserName` filter against a store that does **not** capture that column used to be **silently dropped**, returning unfiltered results that read as filtered. It is now **refused** with a `NotSupportedException` naming the field (the jasperfx#737 guard rail). `event_metadata_filter_tests` was updated from pinning the drop to pinning the refusal — including the mixed-query case, where one refusable filter fails the whole call rather than answering with the others applied.

## Compliance enrollment

- New wave 12: `polecat_event_query_compliance : EventQueryCompliance<…>`.
- Fixture seams: `SetUserName → session.LastModifiedBy`, `ComplianceStoreConfig.EnableUserNameTracking → Events.EnableUserName`.
- The conjoined tenancy suite's two new `EventQuery.TenantId` facts pass on the existing `TenantIsOneOf` scoping.
- Enrolling the suite surfaced an upstream defect in the suite itself (`paging_composes_with_filtering` seeded 6 matches while asserting 7); fixed as jasperfx#739, included in the published 2.62.0 this PR pins.

## CLI end-to-end coverage

Adds the first test anywhere that executes the `event-query` CLI command (jasperfx#737's operator/agent surface) against a real store: a real `EventQueryInput` with its `HostBuilder` pointed at a Polecat host, `EventQueryCommand.Execute` driven directly, stdout captured and the JSON report parsed. Three facts: exact events + `totalCount` for a filtered query (`--event-type` + page size), `totalCount` 0 printed as a real answer when nothing matches (success return, no error), and the unsupported-filter refusal naming `EventQuery.UserName` with a failure return.

## Test counts (published 2.62.0, SQL Server 2025)

| Suite | Result |
|---|---|
| EventQueryCompliance (new, wave 12) | **41/41** on net10.0 and net9.0 |
| ConjoinedEventTenancyCompliance (incl. 2 new EventQuery facts) | 10/10 |
| event_metadata_filter_tests (updated to the refusal contract) | 15/15 |
| event_query_command_end_to_end (new CLI e2e) | 3/3 on net10.0 and net9.0 |
| Whole Compliance namespace | 372/372 real (one transient DDL timeout during the local737 pre-release run, green in isolation) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)