### PR TITLE
IQueryable<StreamState> + CompactedVersion watermark (jasperfx#740), enroll StreamStateQueryCompliance

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -357,15 +357,21 @@
              honor-or-refuse guard rail), the EventQueryCompliance suite (and two EventQuery facts
              on the conjoined tenancy suite), and the SetUserName / EnableUserNameTracking fixture
              seams. Also carries jasperfx#739, the fix for the suite's
-             paging_composes_with_filtering seed arithmetic that this enrollment surfaced. -->
-        <PackageVersion Include="JasperFx" Version="2.62.0" />
-        <PackageVersion Include="JasperFx.Events" Version="2.62.0" />
+             paging_composes_with_filtering seed arithmetic that this enrollment surfaced.
+
+             JasperFx 2.63.0 (#534, jasperfx#740): IReadOnlyEventStore.QueryStreamStates —
+             the streams table as a real IQueryable<StreamState> executed through the shared
+             JasperFx.Events.Documents terminators — plus the StreamState.CompactedVersion
+             compaction watermark, the StreamStateQueryCompliance suite (and a tenancy fact on the
+             conjoined suite), and the stream-query CLI command. -->
+        <PackageVersion Include="JasperFx" Version="2.63.0" />
+        <PackageVersion Include="JasperFx.Events" Version="2.63.0" />
         <!--
              The shared cross-store event sourcing compliance suites. Source-only package: the
              suites compile inside Polecat.Tests so JasperFx's aggregate source generator binds
              Polecat's own session types.
         -->
-        <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.62.0" />
+        <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.63.0" />
         <!-- Pin the sibling JasperFx packages for parity with Marten 9's matrix
              even though Polecat doesn't currently reference them directly —
              keeps the lockstep matrix coherent when transitive resolution
@@ -373,7 +379,7 @@
              RuntimeCompiler 5.x line is the active continuation of the 4.x
              lineage; do not pin against the parallel stale 2.0.x series. -->
         <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.62.0" />
+        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.63.0" />
         <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
@@ -537,7 +543,7 @@
         <PackageVersion Include="Vogen" Version="7.0.0" />
 
         <!-- Source generators (matched to JasperFx.Events above) -->
-        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.62.0" />
+        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.63.0" />
 
         <!-- Build automation -->
         <PackageVersion Include="Nuke.Common" Version="9.0.4" />

--- a/src/Polecat.Tests/CommandLine/stream_query_command_end_to_end.cs
+++ b/src/Polecat.Tests/CommandLine/stream_query_command_end_to_end.cs
@@ -1,0 +1,193 @@
+using System.Text.Json;
+using JasperFx;
+using JasperFx.Events.CommandLine;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Polecat.TestUtils;
+using Shouldly;
+
+namespace Polecat.Tests.CommandLine;
+
+#region CLI stream query aggregate
+
+public record CliShipLaunched(string Name);
+
+public record CliShipDocked(string Port);
+
+/// <summary>
+/// Top-level and uniquely named on purpose: <c>StreamQueryInput.ResolveAggregateType</c> scans the
+/// loaded assemblies by simple name, so a nested or generic type would not resolve and a common
+/// name could be ambiguous across test assemblies.
+/// </summary>
+public partial class CliCargoShip
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public int Dockings { get; set; }
+
+    public static CliCargoShip Create(CliShipLaunched e) => new() { Name = e.Name };
+
+    public void Apply(CliShipDocked _) => Dockings++;
+}
+
+#endregion
+
+/// <summary>
+/// #534 (jasperfx#740): end-to-end coverage of the <c>stream-query</c> CLI command against a REAL
+/// Polecat store, the pattern the event-query wave established (see
+/// <c>event_query_command_end_to_end</c>) — a real <see cref="StreamQueryInput"/> with its
+/// <c>HostBuilder</c> set, <see cref="StreamQueryCommand.Execute"/> driven directly, stdout
+/// captured and the JSON report parsed. The happy path pins the compaction-policy question the
+/// command exists to answer — aggregate type + un-compacted growth — including the exact
+/// <c>versionsSinceCompaction</c> arithmetic off the watermark CompactStreamAsync wrote; the two
+/// honesty facts pin the truthful empty answer and the tenant refusal naming the problem.
+/// </summary>
+public class stream_query_command_end_to_end
+{
+    private const string Schema = "stream_query_cli";
+
+    private static StoreOptions ConfigureOptions(StoreOptions opts)
+    {
+        opts.ConnectionString = ConnectionSource.ConnectionString;
+        opts.DatabaseSchemaName = Schema;
+        opts.AutoCreateSchemaObjects = AutoCreate.All;
+        opts.UseNativeJsonType = ConnectionSource.SupportsNativeJson;
+        // Deliberately NOT conjoined — the tenant-refusal fact depends on it.
+        return opts;
+    }
+
+    private static async Task DropSchemaAsync()
+    {
+        await using var conn = new Microsoft.Data.SqlClient.SqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync(TestContext.Current.CancellationToken);
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"""
+            IF OBJECT_ID('[{Schema}].[pc_events]','U') IS NOT NULL DROP TABLE [{Schema}].[pc_events];
+            IF OBJECT_ID('[{Schema}].[pc_streams]','U') IS NOT NULL DROP TABLE [{Schema}].[pc_streams];
+            """;
+        await cmd.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+    }
+
+    /// <summary>
+    /// Three streams: an overgrown compacted ship (version 9, compacted through 5 → growth 4), a
+    /// small never-compacted ship (version 2, growth 2), and an untyped stream — the decoy for a
+    /// dropped aggregate-type filter.
+    /// </summary>
+    private static async Task<(Guid Overgrown, Guid Small)> SeedAsync()
+    {
+        await DropSchemaAsync();
+
+        await using var store = DocumentStore.For(opts => ConfigureOptions(opts));
+
+        var overgrown = Guid.NewGuid();
+        var small = Guid.NewGuid();
+
+        await using (var session = store.LightweightSession())
+        {
+            var events = new object[] { new CliShipLaunched("Overgrown") }
+                .Concat(Enumerable.Range(0, 8).Select(object (i) => new CliShipDocked($"Port {i}")))
+                .ToArray();
+            session.Events.StartStream<CliCargoShip>(overgrown, events);
+            session.Events.StartStream<CliCargoShip>(small, new CliShipLaunched("Small"), new CliShipDocked("Kiel"));
+            session.Events.StartStream(Guid.NewGuid(), new CliShipLaunched("Untyped"));
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using (var session = store.LightweightSession())
+        {
+            await session.Events.CompactStreamAsync<CliCargoShip>(overgrown, x => x.Version = 5);
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        return (overgrown, small);
+    }
+
+    private static async Task<(bool Success, JsonElement Report)> ExecuteAsync(StreamQueryInput input)
+    {
+        input.HostBuilder = Host.CreateDefaultBuilder()
+            .ConfigureServices(services => services.AddPolecat(opts => ConfigureOptions(opts)));
+
+        var original = Console.Out;
+        var writer = new StringWriter();
+        Console.SetOut(writer);
+        bool success;
+        try
+        {
+            success = await new StreamQueryCommand().Execute(input);
+        }
+        finally
+        {
+            Console.SetOut(original);
+        }
+
+        var output = writer.ToString();
+        var start = output.IndexOf('{');
+        start.ShouldBeGreaterThanOrEqualTo(0, $"expected a JSON report on stdout, got: {output}");
+
+        using var doc = JsonDocument.Parse(output[start..]);
+        return (success, doc.RootElement.Clone());
+    }
+
+    [Fact]
+    public async Task the_compaction_policy_question_answers_with_exact_streams()
+    {
+        var (overgrown, _) = await SeedAsync();
+
+        var (success, report) = await ExecuteAsync(new StreamQueryInput
+        {
+            AggregateTypeFlag = nameof(CliCargoShip),
+            VersionAboveCompactedFlag = 3
+        });
+
+        // The small ship (growth 2) fails the growth filter, the untyped stream fails the type
+        // filter — only the overgrown ship answers, with the watermark arithmetic exact.
+        success.ShouldBeTrue(report.ToString());
+        report.GetProperty("totalCount").GetInt32().ShouldBe(1);
+        report.GetProperty("hasMore").GetBoolean().ShouldBeFalse();
+        report.TryGetProperty("error", out _).ShouldBeFalse();
+
+        var stream = report.GetProperty("streams").EnumerateArray().ShouldHaveSingleItem();
+        stream.GetProperty("streamId").GetString().ShouldBe(overgrown.ToString());
+        stream.GetProperty("version").GetInt64().ShouldBe(9);
+        stream.GetProperty("compactedVersion").GetInt64().ShouldBe(5);
+        stream.GetProperty("versionsSinceCompaction").GetInt64().ShouldBe(4);
+        stream.GetProperty("aggregateType").GetString().ShouldBe(typeof(CliCargoShip).FullName);
+        stream.GetProperty("isArchived").GetBoolean().ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task a_filter_matching_nothing_is_a_real_answer_not_a_failure()
+    {
+        await SeedAsync();
+
+        var (success, report) = await ExecuteAsync(new StreamQueryInput
+        {
+            AggregateTypeFlag = nameof(CliCargoShip),
+            MinVersionFlag = 1000
+        });
+
+        success.ShouldBeTrue(report.ToString());
+        report.GetProperty("totalCount").GetInt32().ShouldBe(0);
+        report.GetProperty("streams").GetArrayLength().ShouldBe(0);
+        report.TryGetProperty("error", out _).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task a_tenant_on_a_tenantless_store_is_refused_by_the_report()
+    {
+        await SeedAsync();
+
+        var (success, report) = await ExecuteAsync(new StreamQueryInput
+        {
+            TenantFlag = "tenant-a"
+        });
+
+        // The jasperfx#740 refusal surfaced through the CLI: this store has no tenant dimension,
+        // so the run FAILS with a report saying so — never unscoped rows dressed as a tenant's.
+        success.ShouldBeFalse();
+        var error = report.GetProperty("error").GetString();
+        error.ShouldNotBeNull();
+        error.ShouldContain("tenant");
+        report.GetProperty("streams").GetArrayLength().ShouldBe(0);
+    }
+}

--- a/src/Polecat.Tests/Compliance/polecat_event_store_compliance_wave13.cs
+++ b/src/Polecat.Tests/Compliance/polecat_event_store_compliance_wave13.cs
@@ -1,0 +1,30 @@
+using JasperFx.Events.ComplianceTests;
+
+namespace Polecat.Tests.Compliance;
+
+/*
+ * Wave 13 -- the suite the jasperfx#740 wave added (polecat#534), sibling of wave 12's
+ * EventQueryCompliance.
+ *
+ * StreamStateQueryCompliance is IReadOnlyEventStore.QueryStreamStates(): the pc_streams table as a
+ * real IQueryable<StreamState>, executed through the shared JasperFx.Events.Documents terminators
+ * (Polecat's StreamStateLinqQueryProvider implements IDocumentQueryExecutor, the same hook the
+ * document read tier uses). One Where() fact per public get member -- including the
+ * x.AggregateType == typeof(X) form, translated to the stored aggregate-type alias via
+ * EventGraph.AggregateAliasFor, and the new CompactedVersion watermark, which Polecat's
+ * CompactStreamAsync now WRITES (SetCompactedVersionOperation: partial compaction records the
+ * cutoff version, full compaction the stream version, never-compacted reads the column's
+ * DEFAULT 0) -- plus the compaction-policy shape itself
+ * (AggregateType == typeof(X) && Version - CompactedVersion > N && !IsArchived), the stated
+ * ordering (Created ascending, Id tiebreak) with Skip/Take paging, and truthful empty answers.
+ *
+ * Two refusal shapes the suite deliberately CANNOT pin (both current stores translate everything)
+ * live in Polecat's own stream_state_query_refusals tests instead: an untranslatable member throws
+ * naming it, and a tenantId on a store without conjoined tenancy is refused.
+ *
+ * The tenant-scoped overload's happy path lives in ConjoinedEventTenancyCompliance (wave 8), which
+ * owns the conjoined store configuration.
+ */
+
+public class polecat_stream_state_query_compliance
+    : StreamStateQueryCompliance<PolecatComplianceFixture, IDocumentSession, IQuerySession>;

--- a/src/Polecat.Tests/Events/stream_state_query_refusals.cs
+++ b/src/Polecat.Tests/Events/stream_state_query_refusals.cs
@@ -1,0 +1,87 @@
+using JasperFx;
+using JasperFx.Events;
+using Polecat.Linq;
+using Polecat.TestUtils;
+using Shouldly;
+
+namespace Polecat.Tests.Events;
+
+/// <summary>
+/// #534 (jasperfx#740): the two refusal shapes StreamStateQueryCompliance deliberately cannot pin,
+/// because both enrolled stores translate every StreamState member and both have a tenant
+/// dimension available. The contract's rule is the jasperfx#737 one: a predicate or scope the
+/// store cannot honor must THROW naming it, never silently match all rows — an ignored clause
+/// returns unfiltered streams that read as filtered.
+/// </summary>
+public class stream_state_query_refusals
+{
+    private const string Schema = "stream_query_refusals";
+
+    private static async Task<DocumentStore> CreateStoreAsync()
+    {
+        await using (var conn = new Microsoft.Data.SqlClient.SqlConnection(ConnectionSource.ConnectionString))
+        {
+            await conn.OpenAsync(TestContext.Current.CancellationToken);
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = $"""
+                IF OBJECT_ID('[{Schema}].[pc_events]','U') IS NOT NULL DROP TABLE [{Schema}].[pc_events];
+                IF OBJECT_ID('[{Schema}].[pc_streams]','U') IS NOT NULL DROP TABLE [{Schema}].[pc_streams];
+                """;
+            await cmd.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+        }
+
+        var store = DocumentStore.For(opts =>
+        {
+            opts.ConnectionString = ConnectionSource.ConnectionString;
+            opts.DatabaseSchemaName = Schema;
+            opts.AutoCreateSchemaObjects = AutoCreate.All;
+            opts.UseNativeJsonType = ConnectionSource.SupportsNativeJson;
+            // Deliberately NOT conjoined: the tenant-refusal fact depends on this store having no
+            // tenant dimension.
+        });
+
+        // One stream, so a silently-ignored clause would have something to wrongly return.
+        await using var session = store.LightweightSession();
+        session.Events.StartStream(Guid.NewGuid(), new ShipmentNoted("crates"));
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        return store;
+    }
+
+    public record ShipmentNoted(string Cargo);
+
+    [Fact]
+    public async Task a_member_the_provider_cannot_translate_is_refused_by_name()
+    {
+        await using var store = await CreateStoreAsync();
+
+        var streams = ((IEventStore)store).OpenReadOnlyEventStore().QueryStreamStates();
+
+        // AggregateType.Name reaches THROUGH a translatable member into one Polecat has no column
+        // for — the realistic near-miss of the supported typeof-equality form.
+        var ex = await Should.ThrowAsync<NotSupportedException>(
+            () => streams.Where(x => x.AggregateType!.Name == "Whatever")
+                .ToListAsync(TestContext.Current.CancellationToken));
+
+        ex.Message.ShouldContain("Name");
+        ex.Message.ShouldContain(nameof(StreamState));
+    }
+
+    [Fact]
+    public async Task a_tenant_scope_on_a_store_without_a_tenant_dimension_is_refused()
+    {
+        await using var store = await CreateStoreAsync();
+
+        var readOnly = ((IEventStore)store).OpenReadOnlyEventStore();
+
+        // Refused at the call, not at execution: unscoped rows must never come back dressed as a
+        // tenant's.
+        var ex = Should.Throw<NotSupportedException>(() => readOnly.QueryStreamStates("tenant-a"));
+
+        ex.Message.ShouldContain("tenant");
+
+        // And the null form still answers on the same store.
+        var all = await readOnly.QueryStreamStates().ToListAsync(TestContext.Current.CancellationToken);
+        all.ShouldHaveSingleItem();
+    }
+}

--- a/src/Polecat/DocumentStore.EventStoreExplorer.cs
+++ b/src/Polecat/DocumentStore.EventStoreExplorer.cs
@@ -143,14 +143,15 @@ public partial class DocumentStore
         // #57: share the pc_streams column projection + row read with the
         // other two stream-reading sites via PcStreamsRowReader. The JOIN'd
         // first_event_at column is appended after the canonical projection
-        // (index 7) and threaded into ReadStreamMetadata explicitly.
+        // (index 8, following jasperfx#740's compacted_version at 7) and
+        // threaded into ReadStreamMetadata explicitly.
         cmd.CommandText = $"""
             SELECT {PcStreamsRowReader.SelectColumnsWithAlias("s")},
                    MIN(e.timestamp) AS first_event_at
             FROM {Events.StreamsTableName} s
             LEFT JOIN {Events.EventsTableName} e ON e.stream_id = s.id AND e.tenant_id = s.tenant_id
             WHERE s.id = @id
-            GROUP BY s.id, s.type, s.version, s.created, s.timestamp, s.tenant_id, s.is_archived;
+            GROUP BY s.id, s.type, s.version, s.created, s.timestamp, s.tenant_id, s.is_archived, s.compacted_version;
             """;
         cmd.Parameters.AddIdParameter("@id", resolvedStreamId);
 
@@ -160,9 +161,9 @@ public partial class DocumentStore
             return null;
         }
 
-        var firstEventAt = reader.IsDBNull(7)
+        var firstEventAt = reader.IsDBNull(8)
             ? (DateTimeOffset?)null
-            : reader.GetFieldValue<DateTimeOffset>(7);
+            : reader.GetFieldValue<DateTimeOffset>(8);
 
         return PcStreamsRowReader.ReadStreamMetadata(reader, JasperFx.StorageConstants.DefaultTenantId, firstEventAt);
     }

--- a/src/Polecat/Events/Internal/PcStreamsRowReader.cs
+++ b/src/Polecat/Events/Internal/PcStreamsRowReader.cs
@@ -30,14 +30,15 @@ internal static class PcStreamsRowReader
     ///     reads. When this changes, every call site that composes its SELECT
     ///     from this constant adjusts automatically.
     /// </summary>
-    internal const string SelectColumns = "id, type, version, created, timestamp, tenant_id, is_archived";
+    internal const string SelectColumns =
+        "id, type, version, created, timestamp, tenant_id, is_archived, compacted_version";
 
     /// <summary>
     ///     Same column list with a table alias prefix, for queries that join
     ///     <c>pc_streams</c> against other tables.
     /// </summary>
     internal static string SelectColumnsWithAlias(string alias) =>
-        $"{alias}.id, {alias}.type, {alias}.version, {alias}.created, {alias}.timestamp, {alias}.tenant_id, {alias}.is_archived";
+        $"{alias}.id, {alias}.type, {alias}.version, {alias}.created, {alias}.timestamp, {alias}.tenant_id, {alias}.is_archived, {alias}.compacted_version";
 
     /// <summary>
     ///     Read the row the reader is positioned on into a
@@ -63,7 +64,11 @@ internal static class PcStreamsRowReader
             Version = reader.GetInt64(2),
             Created = reader.GetFieldValue<DateTimeOffset>(3),
             LastTimestamp = reader.GetFieldValue<DateTimeOffset>(4),
-            IsArchived = reader.GetBoolean(6)
+            IsArchived = reader.GetBoolean(6),
+            // jasperfx#740: the compaction watermark, appended LAST in SelectColumns so the
+            // positional reads above (and ReadStreamSummary / ReadStreamMetadata) keep their
+            // ordinals across the schema addition.
+            CompactedVersion = reader.GetInt64(7)
         };
 
         if (!reader.IsDBNull(1))

--- a/src/Polecat/Events/Linq/StreamStateLinqQueryProvider.cs
+++ b/src/Polecat/Events/Linq/StreamStateLinqQueryProvider.cs
@@ -1,0 +1,256 @@
+using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq.Expressions;
+using JasperFx.Events;
+using Microsoft.Data.SqlClient;
+using Polecat.Events.Internal;
+using Polecat.Internal;
+using Polecat.Linq;
+using Polecat.Linq.Parsing;
+using Polecat.Linq.QueryHandlers;
+using Polecat.Linq.SqlGeneration;
+using Weasel.SqlServer;
+
+namespace Polecat.Events.Linq;
+
+/// <summary>
+///     IQueryProvider for <see cref="QueryEventStore.QueryStreamStates"/> (jasperfx#740): LINQ
+///     queries over the <c>pc_streams</c> table hydrating <see cref="StreamState"/> rows through
+///     the canonical <see cref="PcStreamsRowReader"/>. Implements the shared
+///     <see cref="JasperFx.Events.Documents.IDocumentQueryExecutor"/> hook by delegating to
+///     Polecat's own terminators, so the JasperFx.Events.Documents extension terminators
+///     (<c>ToListAsync</c>, <c>CountAsync</c>, <c>AnyAsync</c>, <c>FirstOrDefaultAsync</c>) and
+///     <see cref="PolecatQueryableExtensions"/> are the same execution path.
+/// </summary>
+/// <remarks>
+///     Unlike the events queryable there is NO implicit <c>is_archived = 0</c> filter here:
+///     archived streams are first-class rows of this surface (<c>Where(x =&gt; x.IsArchived)</c> is
+///     part of the contract), and the compaction-policy predicate composes <c>!x.IsArchived</c>
+///     explicitly.
+/// </remarks>
+internal class StreamStateLinqQueryProvider : IPolecatAsyncQueryProvider,
+    JasperFx.Events.Documents.IDocumentQueryExecutor
+{
+    private readonly QuerySession _session;
+    private readonly EventGraph _events;
+    private readonly string? _tenantId;
+    private readonly StreamStateMemberFactory _memberFactory;
+
+    /// <param name="tenantId">
+    ///     Explicit tenant scope from <c>QueryStreamStates(tenantId)</c>, already validated by the
+    ///     caller (a non-null tenant on a store with no tenant dimension was refused there). Null
+    ///     falls back to the session's own tenant, matching every other pc_streams read.
+    /// </param>
+    public StreamStateLinqQueryProvider(QuerySession session, EventGraph events, string? tenantId)
+    {
+        _session = session;
+        _events = events;
+        _tenantId = tenantId;
+        _memberFactory = new StreamStateMemberFactory(events);
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2046",
+        Justification = "IQueryProvider.CreateQuery(Expression) lacks RUC; the AOT-safe entry is the generic CreateQuery<TElement>(Expression).")]
+    [UnconditionalSuppressMessage("AOT", "IL3051",
+        Justification = "IQueryProvider.CreateQuery(Expression) lacks RDC; the AOT-safe entry is the generic CreateQuery<TElement>(Expression).")]
+    [RequiresDynamicCode("Closes PolecatLinqQueryable<> over the element type via Type.MakeGenericType. AOT consumers should call CreateQuery<TElement>(Expression) instead.")]
+    [RequiresUnreferencedCode("Activator.CreateInstance reflects over the constructor of PolecatLinqQueryable<>.")]
+    public IQueryable CreateQuery(Expression expression)
+    {
+        return CreateQuery<StreamState>(expression);
+    }
+
+    public IQueryable<TElement> CreateQuery<TElement>(Expression expression)
+    {
+        return new PolecatLinqQueryable<TElement>(this, expression);
+    }
+
+    public object? Execute(Expression expression)
+    {
+        throw new NotSupportedException(
+            "Polecat does not support synchronous LINQ execution. Use async methods (ToListAsync, etc.) instead.");
+    }
+
+    public TResult Execute<TResult>(Expression expression)
+    {
+        throw new NotSupportedException(
+            "Polecat does not support synchronous LINQ execution. Use async methods (ToListAsync, etc.) instead.");
+    }
+
+    public async Task<TResult> ExecuteAsync<TResult>(Expression expression, CancellationToken token)
+    {
+        var parser = new LinqQueryParser(_memberFactory, _events.StreamsTableName);
+        parser.Parse(expression);
+
+        ApplySingleValueMode(parser);
+
+        // Tenant scope: the explicit QueryStreamStates(tenantId) argument wins; otherwise the
+        // session's own tenant, exactly like FetchStreamStateAsync — unless the query opted out
+        // via AnyTenant()/TenantIsOneOf().
+        if (!parser.IsAnyTenant)
+        {
+            if (parser.TenantIds != null)
+            {
+                parser.Statement.Wheres.Add(new TenantInFilter(parser.TenantIds));
+            }
+            else
+            {
+                parser.Statement.Wheres.Add(
+                    new ComparisonFilter("tenant_id", "=", _tenantId ?? _session.TenantId));
+            }
+        }
+
+        // The stream-query CLI's stated ordering tiebreaks by Id THEN Key so it is deterministic
+        // on either identity style — but both members are the one id column here, and SQL Server
+        // refuses a column named twice in ORDER BY. Deduping by locator (first occurrence wins) is
+        // semantically identity: ordering twice by the same column cannot change the order.
+        var seenOrderBys = new HashSet<string>();
+        parser.Statement.OrderBys.RemoveAll(orderBy => !seenOrderBys.Add(orderBy.Item1));
+
+        var isScalar = parser.ValueMode is SingleValueMode.Count or SingleValueMode.LongCount
+            or SingleValueMode.Any;
+
+        if (!isScalar && parser.SelectExpression == null)
+        {
+            parser.Statement.SelectColumns = PcStreamsRowReader.SelectColumns;
+        }
+
+        await using var batch = new SqlBatch();
+        var builder = new BatchBuilder(batch);
+        parser.Statement.Apply(builder);
+        builder.Compile();
+
+        await using var reader = await _session.ExecuteReaderAsync(batch, token);
+
+        return await HandleResultAsync<TResult>(reader, parser, token);
+    }
+
+    private async Task<TResult> HandleResultAsync<TResult>(
+        DbDataReader reader, LinqQueryParser parser, CancellationToken token)
+    {
+        switch (parser.ValueMode)
+        {
+            case null:
+                return (TResult)(object)await ReadStreamStatesAsync(reader, token);
+
+            case SingleValueMode.First:
+            case SingleValueMode.Single:
+            case SingleValueMode.Last:
+                return await SingleStreamStateAsync<TResult>(reader, token, canBeNull: false);
+
+            case SingleValueMode.FirstOrDefault:
+            case SingleValueMode.SingleOrDefault:
+            case SingleValueMode.LastOrDefault:
+                return await SingleStreamStateAsync<TResult>(reader, token, canBeNull: true);
+
+            case SingleValueMode.Count:
+            case SingleValueMode.LongCount:
+                var scalarHandler = new ScalarHandler<TResult>();
+                return await scalarHandler.HandleAsync(reader, token);
+
+            case SingleValueMode.Any:
+                var anyHandler = new AnyHandler();
+                var anyResult = await anyHandler.HandleAsync(reader, token);
+                return (TResult)(object)anyResult;
+
+            default:
+                throw new NotSupportedException(
+                    $"Unsupported operation over a stream state query: {parser.ValueMode}");
+        }
+    }
+
+    private async Task<IReadOnlyList<StreamState>> ReadStreamStatesAsync(
+        DbDataReader reader, CancellationToken token)
+    {
+        var identity = _events.StreamIdentity;
+        var results = new List<StreamState>();
+        while (await reader.ReadAsync(token))
+        {
+            results.Add(PcStreamsRowReader.ReadStreamState(reader, identity, _events));
+        }
+
+        return results;
+    }
+
+    private async Task<TResult> SingleStreamStateAsync<TResult>(
+        DbDataReader reader, CancellationToken token, bool canBeNull)
+    {
+        var states = await ReadStreamStatesAsync(reader, token);
+        if (states.Count == 0)
+        {
+            if (!canBeNull) throw new InvalidOperationException("Sequence contains no elements");
+            return default!;
+        }
+
+        return (TResult)(object)states[0];
+    }
+
+    private static void ApplySingleValueMode(LinqQueryParser parser)
+    {
+        if (parser.ValueMode == null) return;
+
+        var statement = parser.Statement;
+
+        switch (parser.ValueMode)
+        {
+            case SingleValueMode.First:
+            case SingleValueMode.FirstOrDefault:
+                statement.Limit = 1;
+                break;
+
+            case SingleValueMode.Single:
+            case SingleValueMode.SingleOrDefault:
+                statement.Limit = 2;
+                break;
+
+            case SingleValueMode.Last:
+            case SingleValueMode.LastOrDefault:
+                for (var i = 0; i < statement.OrderBys.Count; i++)
+                {
+                    var (locator, desc) = statement.OrderBys[i];
+                    statement.OrderBys[i] = (locator, !desc);
+                }
+
+                statement.Limit = 1;
+                break;
+
+            case SingleValueMode.Count:
+                statement.SelectColumns = "COUNT(*)";
+                break;
+
+            case SingleValueMode.LongCount:
+                statement.SelectColumns = "CAST(COUNT(*) AS bigint)";
+                break;
+
+            case SingleValueMode.Any:
+                statement.SelectColumns = "1";
+                statement.Limit = 1;
+                statement.IsExistsWrapper = true;
+                break;
+
+            default:
+                throw new NotSupportedException(
+                    $"Unsupported operation over a stream state query: {parser.ValueMode}");
+        }
+    }
+
+    // The shared JasperFx.Events.Documents terminators dispatch through these four primitives —
+    // same disposition as PolecatLinqQueryProvider: each delegates to Polecat's own terminator so
+    // the shared surface and PolecatQueryableExtensions are one execution path.
+
+    Task<IReadOnlyList<T>> JasperFx.Events.Documents.IDocumentQueryExecutor.ExecuteToListAsync<T>(
+        IQueryable<T> queryable, CancellationToken token)
+        => queryable.ToListAsync(token);
+
+    Task<T?> JasperFx.Events.Documents.IDocumentQueryExecutor.ExecuteFirstOrDefaultAsync<T>(
+        IQueryable<T> queryable, CancellationToken token) where T : default
+        => queryable.FirstOrDefaultAsync(token);
+
+    Task<int> JasperFx.Events.Documents.IDocumentQueryExecutor.ExecuteCountAsync<T>(
+        IQueryable<T> queryable, CancellationToken token)
+        => queryable.CountAsync(token);
+
+    Task<bool> JasperFx.Events.Documents.IDocumentQueryExecutor.ExecuteAnyAsync<T>(
+        IQueryable<T> queryable, CancellationToken token)
+        => queryable.AnyAsync(token);
+}

--- a/src/Polecat/Events/Linq/StreamStateMemberFactory.cs
+++ b/src/Polecat/Events/Linq/StreamStateMemberFactory.cs
@@ -1,0 +1,83 @@
+using System.Linq.Expressions;
+using JasperFx.Events;
+using Polecat.Linq.Members;
+
+namespace Polecat.Events.Linq;
+
+/// <summary>
+///     Resolves <see cref="StreamState"/> property expressions to SQL column references on the
+///     <c>pc_streams</c> table, for <see cref="QueryEventStore.QueryStreamStates"/> (jasperfx#740).
+///     Every public get member of <see cref="StreamState"/> translates; anything else — a member of
+///     a nested object like <c>AggregateType.Name</c> included — throws a
+///     <see cref="NotSupportedException"/> naming the member, never silently matching all rows
+///     (an ignored predicate returns unfiltered streams that read as filtered, the jasperfx#737
+///     failure mode the whole surface refuses).
+/// </summary>
+internal class StreamStateMemberFactory : IMemberResolver
+{
+    private readonly EventGraph _events;
+
+    public StreamStateMemberFactory(EventGraph events)
+    {
+        _events = events;
+    }
+
+    public IQueryableMember ResolveMember(MemberExpression expression)
+    {
+        // Id and Key are the same column under the two identity styles, exactly like
+        // StreamId/StreamKey on the events queryable.
+        return expression.Member.Name switch
+        {
+            nameof(StreamState.Id) => new QueryableMember("id", "id", typeof(Guid)),
+            nameof(StreamState.Key) => new QueryableMember("id", "id", typeof(string)),
+            nameof(StreamState.Version) => new QueryableMember("version", "version", typeof(long)),
+            nameof(StreamState.AggregateType) => new AggregateTypeQueryableMember(_events),
+            nameof(StreamState.LastTimestamp) =>
+                new QueryableMember("timestamp", "timestamp", typeof(DateTimeOffset)),
+            nameof(StreamState.Created) => new QueryableMember("created", "created", typeof(DateTimeOffset)),
+            nameof(StreamState.IsArchived) => new QueryableMember("is_archived", "is_archived", typeof(bool)),
+            nameof(StreamState.CompactedVersion) =>
+                new QueryableMember("compacted_version", "compacted_version", typeof(long)),
+            _ => throw new NotSupportedException(
+                $"Polecat cannot translate the member '{expression.Member.DeclaringType?.Name}.{expression.Member.Name}' " +
+                $"in a stream state query. Translatable members are the public properties of {nameof(StreamState)}: " +
+                $"{nameof(StreamState.Id)}, {nameof(StreamState.Key)}, {nameof(StreamState.Version)}, " +
+                $"{nameof(StreamState.AggregateType)}, {nameof(StreamState.LastTimestamp)}, " +
+                $"{nameof(StreamState.Created)}, {nameof(StreamState.IsArchived)}, " +
+                $"{nameof(StreamState.CompactedVersion)}.")
+        };
+    }
+
+    /// <summary>
+    ///     The <c>x.AggregateType == typeof(X)</c> translation — the Stream Compaction Policy's
+    ///     selector. The column stores the aggregate-type alias (the simple type name, stamped by
+    ///     <see cref="EventGraph.AggregateAliasFor"/> on the stream insert), so the comparison
+    ///     value converts a CLR <see cref="Type"/> to that same alias through the same method —
+    ///     one spelling, both directions.
+    /// </summary>
+    private sealed class AggregateTypeQueryableMember : IQueryableMember
+    {
+        private readonly EventGraph _events;
+
+        public AggregateTypeQueryableMember(EventGraph events)
+        {
+            _events = events;
+        }
+
+        public Type MemberType => typeof(string);
+        public string TypedLocator => "type";
+        public string RawLocator => "type";
+        public bool IsBoolean => false;
+
+        public object? ConvertValue(object? value)
+            => value switch
+            {
+                null => null,
+                Type aggregateType => _events.AggregateAliasFor(aggregateType),
+                string alias => alias,
+                _ => throw new NotSupportedException(
+                    $"{nameof(StreamState)}.{nameof(StreamState.AggregateType)} can only be compared against a " +
+                    $"CLR Type (x.AggregateType == typeof(X)) or null, not {value.GetType().FullName}.")
+            };
+    }
+}

--- a/src/Polecat/Events/Protected/SetCompactedVersionOperation.cs
+++ b/src/Polecat/Events/Protected/SetCompactedVersionOperation.cs
@@ -1,0 +1,50 @@
+using System.Data.Common;
+using JasperFx.Events;
+using Weasel.Core;
+using Weasel.SqlServer;
+
+namespace Polecat.Events.Protected;
+
+/// <summary>
+///     jasperfx#740 (#534): records the compaction watermark on <c>pc_streams</c> after a
+///     <see cref="JasperFx.Events.Protected.StreamCompactingRequest{T}"/> executes. The value is the
+///     version of the last event folded into the <see cref="Compacted{T}"/> snapshot — the cutoff
+///     version for a partial compaction, the stream's version for a full one — which is exactly
+///     what <see cref="StreamState.CompactedVersion"/> reads back, so
+///     <c>(Version - CompactedVersion)</c> measures un-compacted growth. A never-compacted stream
+///     keeps the column's NOT NULL DEFAULT 0.
+/// </summary>
+internal class SetCompactedVersionOperation : Polecat.Internal.IStorageOperation
+{
+    private readonly EventGraph _events;
+    private readonly object _streamId;
+    private readonly long _compactedVersion;
+    private readonly string _tenantId;
+
+    public SetCompactedVersionOperation(EventGraph events, object streamId, long compactedVersion, string tenantId)
+    {
+        _events = events;
+        _streamId = streamId;
+        _compactedVersion = compactedVersion;
+        _tenantId = tenantId;
+    }
+
+    public Type DocumentType => typeof(IEvent);
+    public OperationRole Role() => OperationRole.Events;
+
+    public void ConfigureCommand(ICommandBuilder builder)
+    {
+        // Tenant-qualified like every other pc_streams write: under conjoined tenancy the same
+        // stream id can exist for two tenants, and only (tenant_id, id) names one row.
+        builder.Append($"UPDATE {_events.StreamsTableName} SET compacted_version = ");
+        builder.AppendParameter(_compactedVersion);
+        builder.Append(" WHERE id = ");
+        builder.AppendParameter(_streamId);
+        builder.Append(" AND tenant_id = ");
+        builder.AppendParameter(_tenantId, System.Data.SqlDbType.VarChar);
+        builder.Append(";");
+    }
+
+    public Task PostprocessAsync(DbDataReader reader, IList<Exception> exceptions, CancellationToken token)
+        => Task.CompletedTask;
+}

--- a/src/Polecat/Events/Protected/StreamCompacting.cs
+++ b/src/Polecat/Events/Protected/StreamCompacting.cs
@@ -107,6 +107,17 @@ internal static class StreamCompactingExecution
         {
             session.WorkTracker.Add(new DeleteEventsOperation(session.Options.EventGraph, sequences));
         }
+
+        // 7. jasperfx#740: record the compaction watermark on pc_streams. request.Version was set
+        //    in step 2 to the version of the last event being folded into the snapshot — the
+        //    cutoff for a partial compaction, the stream's version for a full one — which is what
+        //    StreamState.CompactedVersion reads back so (Version - CompactedVersion) measures
+        //    un-compacted growth.
+        session.WorkTracker.Add(new SetCompactedVersionOperation(
+            graph,
+            (object?)request.StreamId ?? request.StreamKey!,
+            request.Version,
+            session.TenantId));
     }
 
     private static IAggregator<T, IQuerySession> FindAggregator<T>(DocumentSessionBase session) where T : class

--- a/src/Polecat/Events/QueryEventStore.cs
+++ b/src/Polecat/Events/QueryEventStore.cs
@@ -51,6 +51,34 @@ internal class QueryEventStore : IQueryEventStore, IReadOnlyEventStore
     }
 
     /// <summary>
+    ///     jasperfx#740 (#534): the streams table as a real <see cref="IQueryable{T}"/> of
+    ///     <see cref="StreamState"/> — the read surface behind the Stream Compaction Policies
+    ///     (<c>AggregateType == typeof(X) &amp;&amp; Version - CompactedVersion &gt; N &amp;&amp;
+    ///     !IsArchived</c>). Every public get member of <see cref="StreamState"/> translates in
+    ///     <c>Where()</c>/<c>OrderBy()</c>; an untranslatable member throws naming it. Executed
+    ///     through the shared JasperFx.Events.Documents terminators (the provider implements
+    ///     <see cref="JasperFx.Events.Documents.IDocumentQueryExecutor"/>) or Polecat's own.
+    /// </summary>
+    /// <param name="tenantId">
+    ///     Optional tenant scope. Refused with <see cref="NotSupportedException"/> on a store
+    ///     without conjoined tenancy — a tenant filter this store cannot honor must never
+    ///     silently return the unscoped global set (the jasperfx#737 rule).
+    /// </param>
+    public IQueryable<StreamState> QueryStreamStates(string? tenantId = null)
+    {
+        if (tenantId != null && _events.TenancyStyle != TenancyStyle.Conjoined)
+        {
+            throw new NotSupportedException(
+                $"A tenantId was supplied to {nameof(QueryStreamStates)}, but this event store has no tenant " +
+                "dimension (Events.TenancyStyle is not Conjoined). A tenant filter must be honored or refused, " +
+                "never silently ignored — unscoped results would read as tenant-scoped. See jasperfx#740.");
+        }
+
+        var provider = new StreamStateLinqQueryProvider(_session, _events, tenantId);
+        return new PolecatLinqQueryable<StreamState>(provider);
+    }
+
+    /// <summary>
     ///     #256 / #532 (jasperfx#737): query events across all streams with metadata filters,
     ///     inclusive timestamp/sequence windows, multi-type union, DCB tag conditions, and
     ///     pagination — the full JasperFx <see cref="EventQuery" /> surface. All supplied filters

--- a/src/Polecat/Events/Schema/StreamsTable.cs
+++ b/src/Polecat/Events/Schema/StreamsTable.cs
@@ -55,5 +55,13 @@ internal class StreamsTable : Table
         }
 
         AddColumn("is_archived", "bit").NotNull().DefaultValue(0);
+
+        // jasperfx#740 (#534): the compaction watermark — the stream version through which events
+        // have been folded into a Compacted<T> snapshot. 0 = never compacted. Written by
+        // CompactStreamAsync (SetCompactedVersionOperation), read back onto
+        // StreamState.CompactedVersion by PcStreamsRowReader, and queryable through
+        // QueryStreamStates. NOT NULL DEFAULT 0 so the Weasel delta migration backfills existing
+        // rows as "never compacted" and inserts need not name the column.
+        AddColumn("compacted_version", "bigint").NotNull().DefaultValue(0);
     }
 }

--- a/src/Polecat/Linq/Parsing/WhereClauseParser.cs
+++ b/src/Polecat/Linq/Parsing/WhereClauseParser.cs
@@ -95,6 +95,18 @@ internal class WhereClauseParser
             return moduloFragment!;
         }
 
+        // jasperfx#740: member arithmetic compared to a value — x.Version - x.CompactedVersion > N,
+        // the Stream Compaction Policy's growth predicate. Both orientations.
+        if (TryParseMemberArithmetic(binary.Left, binary.Right, op, out var arithmeticFragment))
+        {
+            return arithmeticFragment!;
+        }
+
+        if (TryParseMemberArithmetic(binary.Right, binary.Left, ReverseOperator(op), out arithmeticFragment))
+        {
+            return arithmeticFragment!;
+        }
+
         // Handle string transform methods: x.Name.ToLower() == "value"
         if (TryParseMethodTransform(binary.Left, binary.Right, op, out var transformFragment))
         {
@@ -178,6 +190,41 @@ internal class WhereClauseParser
         var member = _memberFactory.ResolveMember(innerMember);
         var value = ExtractValue(valueSide);
         fragment = new FunctionComparisonFilter("LEN", member.RawLocator, op, value!);
+        return true;
+    }
+
+    /// <summary>
+    ///     jasperfx#740: (member + member) / (member - member) compared against a value —
+    ///     e.g. <c>x.Version - x.CompactedVersion &gt; N</c>, the compaction policy's un-compacted
+    ///     growth predicate. Restricted to two document members so the emitted SQL is pure column
+    ///     arithmetic; the comparison value rides a parameter like any other comparison.
+    /// </summary>
+    private bool TryParseMemberArithmetic(Expression arithmeticSide, Expression valueSide, string op,
+        out ISqlFragment? fragment)
+    {
+        fragment = null;
+
+        if (StripConvert(arithmeticSide) is not BinaryExpression arithmetic) return false;
+
+        var sqlOperator = arithmetic.NodeType switch
+        {
+            ExpressionType.Subtract or ExpressionType.SubtractChecked => "-",
+            ExpressionType.Add or ExpressionType.AddChecked => "+",
+            _ => null
+        };
+        if (sqlOperator == null) return false;
+
+        if (StripConvert(arithmetic.Left) is not MemberExpression leftMember
+            || !IsDocumentMember(leftMember)) return false;
+        if (StripConvert(arithmetic.Right) is not MemberExpression rightMember
+            || !IsDocumentMember(rightMember)) return false;
+
+        var left = _memberFactory.ResolveMember(leftMember);
+        var right = _memberFactory.ResolveMember(rightMember);
+        var value = ExtractValue(valueSide);
+        if (value == null) return false;
+
+        fragment = new ComparisonFilter($"({left.TypedLocator} {sqlOperator} {right.TypedLocator})", op, value);
         return true;
     }
 


### PR DESCRIPTION
Closes #534. Downstream of jasperfx#740 (merged via jasperfx#741), sibling of the merged EventQuery wave (#533), pinned against the published JasperFx 2.63.0 matched set.

## The queryable

`QueryEventStore.QueryStreamStates(tenantId)` returns a real `IQueryable<StreamState>` over `pc_streams` through a new `StreamStateLinqQueryProvider` — the same `LinqQueryParser` infrastructure as the events queryable, implementing the shared `JasperFx.Events.Documents.IDocumentQueryExecutor` hook by delegating to Polecat's own terminators, so the shared Documents-tier terminators and `PolecatQueryableExtensions` are one execution path. Deliberately **no** implicit `is_archived = 0` filter: archived streams are first-class rows of this surface.

**Member translation** (`StreamStateMemberFactory`):
- `Id` / `Key` → the one `id` column (Guid vs string identity, like `StreamId`/`StreamKey` on the events queryable)
- `Version`, `CompactedVersion`, `Created`, `LastTimestamp` → their columns; `IsArchived` as a real `bit` parameter
- **`AggregateType == typeof(X)`** → `type = @alias` via a `ConvertValue` seam mapping the CLR `Type` through `EventGraph.AggregateAliasFor` — the same method that stamps the column on `StartStream<T>`, so one spelling covers both directions
- **`x.Version - x.CompactedVersion > N`** → `(version - compacted_version) > @p` via a new member-arithmetic comparison form in `WhereClauseParser` (Add/Subtract of two document members compared to a value, both orientations) — the compaction policy's growth predicate
- An untranslatable member (e.g. `AggregateType.Name`) throws naming it, and a `tenantId` on a store without conjoined tenancy is refused up front — both pinned in `stream_state_query_refusals`, the two shapes the compliance suite deliberately cannot pin.

## The watermark, write-side

`pc_streams` grows `compacted_version bigint NOT NULL DEFAULT 0` (the Weasel delta backfills existing rows as never-compacted; inserts need not name the column). It is appended **last** in `PcStreamsRowReader.SelectColumns` so every positional read keeps its ordinal — the explorer's joined `first_event_at` moved 7→8 and its `GROUP BY` gained the column. `StreamCompactingExecution` records the watermark through a new `SetCompactedVersionOperation`, tenant-qualified like every other `pc_streams` write: partial compaction writes the cutoff version, full compaction the stream version, never-compacted reads 0 — surfaced identically by `FetchStreamStateAsync` and the queryable, which is what the fetch-path compliance fact pins.

## The defect the CLI e2e caught

`stream-query`'s stated ordering tiebreaks `OrderBy(Created).ThenBy(Id).ThenBy(Key)` so it is deterministic on either identity style — but `Id` and `Key` are the same column on Polecat, and SQL Server refuses a column named twice in ORDER BY ("A column has been specified more than once in the order by list"). The provider now dedupes order-by columns by locator (first occurrence wins — semantically identity). The compliance suite could not see this (it orders by `Created` then `Id` only); the `stream_query_command_end_to_end` class added per the issue's item 4 failed on it immediately.

## Test counts (published 2.63.0, SQL Server 2025, exe driven with `--filter-class` — `dotnet test --filter` is inert under MTP)

| Suite | Result |
|---|---|
| StreamStateQueryCompliance (new, wave 13) | **15/15** on net10.0 and net9.0 |
| ConjoinedEventTenancyCompliance (incl. the new `query_stream_states_scoped_to_a_tenant` fact) | 11/11 |
| stream_state_query_refusals (new) | 2/2 |
| stream_query_command_end_to_end (new CLI e2e) | **3/3** on net10.0 and net9.0 |
| event_query_command_end_to_end / event_metadata_filter_tests (wave-12 neighbors) | 3/3 / 15/15 |
| stream_compacting_tests / StreamCompactingCompliance | 6/6 / 11/11 |
| Polecat.Tests.Linq namespace (WhereClauseParser neighbor) | 188/188 |
| **Entire Polecat.Tests.Compliance namespace — all 39 enrolled suites** | **388/388 on net10.0 AND 388/388 on net9.0** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)