### PR TITLE
Cache Event<T> wrapping and Type.GetType resolution per event (gh-537)

### DIFF
--- a/src/Polecat.Tests/Events/event_type_wrapping_and_resolution_caching_tests.cs
+++ b/src/Polecat.Tests/Events/event_type_wrapping_and_resolution_caching_tests.cs
@@ -1,0 +1,146 @@
+using System.Collections.Concurrent;
+using System.Reflection;
+using JasperFx.Events;
+using Polecat.Events;
+using Shouldly;
+
+namespace Polecat.Tests.Events;
+
+/// <summary>
+///     gh-537: two per-event reflection hotspots replaced with per-type caches.
+///     <para>
+///     1. <c>PolecatEventType.Wrap</c> used <c>MakeGenericType</c> + <c>Activator.CreateInstance</c>
+///     per event; registration now closes <c>PolecatEventType&lt;T&gt;</c> once per event type and its
+///     override is a plain <c>new Event&lt;T&gt;((T)data)</c>.
+///     </para>
+///     <para>
+///     2. <c>EventGraph.ResolveEventType</c> called <c>Type.GetType(string)</c> per event row; it is
+///     now memoized, including misses, so unknown/foreign event type names don't re-probe assemblies
+///     on every row.
+///     </para>
+///     Pure unit tests — no database.
+/// </summary>
+public class event_type_wrapping_and_resolution_caching_tests
+{
+    public record WtcSomethingHappened(string Name);
+
+    public record WtcOtherThingHappened(int Number);
+
+    private static EventGraph CreateEventGraph() => new StoreOptions().EventGraph;
+
+    [Fact]
+    public void event_mapping_is_the_reflection_free_generic_subclass()
+    {
+        var graph = CreateEventGraph();
+
+        var mapping = graph.EventMappingFor(typeof(WtcSomethingHappened));
+
+        mapping.ShouldBeOfType<PolecatEventType<WtcSomethingHappened>>();
+        mapping.EventType.ShouldBe(typeof(WtcSomethingHappened));
+
+        // and the mapping itself is cached per type
+        graph.EventMappingFor(typeof(WtcSomethingHappened)).ShouldBeSameAs(mapping);
+    }
+
+    [Fact]
+    public void wrap_returns_typed_event_with_metadata_set()
+    {
+        var graph = CreateEventGraph();
+        var mapping = graph.EventMappingFor(typeof(WtcSomethingHappened));
+
+        var data = new WtcSomethingHappened("one");
+        var wrapped = mapping.Wrap(data);
+
+        var typed = wrapped.ShouldBeOfType<Event<WtcSomethingHappened>>();
+        typed.Data.ShouldBeSameAs(data);
+        wrapped.EventTypeName.ShouldBe(mapping.EventTypeName);
+        wrapped.DotNetTypeName.ShouldBe(mapping.DotNetTypeName);
+    }
+
+    [Fact]
+    public void wrap_builds_a_fresh_envelope_per_event()
+    {
+        var mapping = CreateEventGraph().EventMappingFor(typeof(WtcOtherThingHappened));
+
+        var first = mapping.Wrap(new WtcOtherThingHappened(1));
+        var second = mapping.Wrap(new WtcOtherThingHappened(2));
+
+        first.ShouldNotBeSameAs(second);
+        first.ShouldBeOfType<Event<WtcOtherThingHappened>>().Data.Number.ShouldBe(1);
+        second.ShouldBeOfType<Event<WtcOtherThingHappened>>().Data.Number.ShouldBe(2);
+    }
+
+    [Fact]
+    public void build_event_goes_through_the_typed_wrap()
+    {
+        var graph = CreateEventGraph();
+
+        var @event = graph.BuildEvent(new WtcSomethingHappened("two"));
+
+        @event.ShouldBeOfType<Event<WtcSomethingHappened>>();
+        @event.EventTypeName.ShouldBe(graph.EventMappingFor(typeof(WtcSomethingHappened)).EventTypeName);
+        @event.DotNetTypeName.ShouldBe(graph.EventMappingFor(typeof(WtcSomethingHappened)).DotNetTypeName);
+    }
+
+    /// <summary>
+    ///     The base (non-generic) reflection path is kept as a fallback for directly constructed
+    ///     instances — behavior parity with the pre-gh-537 implementation.
+    /// </summary>
+    [Fact]
+    public void base_reflection_fallback_still_wraps_correctly()
+    {
+        var mapping = new PolecatEventType(typeof(WtcSomethingHappened));
+
+        var data = new WtcSomethingHappened("three");
+        var wrapped = mapping.Wrap(data);
+
+        var typed = wrapped.ShouldBeOfType<Event<WtcSomethingHappened>>();
+        typed.Data.ShouldBeSameAs(data);
+        wrapped.EventTypeName.ShouldBe(mapping.EventTypeName);
+        wrapped.DotNetTypeName.ShouldBe(mapping.DotNetTypeName);
+    }
+
+    [Fact]
+    public void resolve_event_type_resolves_a_known_dotnet_type_name()
+    {
+        var graph = CreateEventGraph();
+        var mapping = graph.EventMappingFor(typeof(WtcSomethingHappened));
+
+        graph.ResolveEventType(mapping.DotNetTypeName).ShouldBe(typeof(WtcSomethingHappened));
+
+        // second call is a cache hit and resolves identically
+        graph.ResolveEventType(mapping.DotNetTypeName).ShouldBe(typeof(WtcSomethingHappened));
+    }
+
+    [Fact]
+    public void resolve_event_type_tolerates_null_and_empty()
+    {
+        var graph = CreateEventGraph();
+
+        graph.ResolveEventType(null).ShouldBeNull();
+        graph.ResolveEventType(string.Empty).ShouldBeNull();
+    }
+
+    /// <summary>
+    ///     Unknown/foreign event type names (written by some other application) resolve to null —
+    ///     and the miss itself is cached so hydrating many rows of an unknown type doesn't call
+    ///     <c>Type.GetType</c> (an assembly probe) once per row.
+    /// </summary>
+    [Fact]
+    public void resolve_event_type_returns_null_for_unknown_types_and_caches_the_miss()
+    {
+        var graph = CreateEventGraph();
+        const string unknown = "Some.Foreign.EventType, Some.Foreign.Assembly";
+
+        graph.ResolveEventType(unknown).ShouldBeNull();
+        graph.ResolveEventType(unknown).ShouldBeNull();
+
+        var cache = typeof(EventGraph)
+            .GetField("_eventTypeByDotNetName", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(graph)
+            .ShouldBeOfType<ConcurrentDictionary<string, Type?>>();
+
+        cache.TryGetValue(unknown, out var cachedMiss).ShouldBeTrue();
+        cachedMiss.ShouldBeNull();
+    }
+}

--- a/src/Polecat/Events/EventGraph.cs
+++ b/src/Polecat/Events/EventGraph.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Text;
+using JasperFx.Core.Reflection;
 using JasperFx.Events;
 using JasperFx.Events.Aggregation;
 using JasperFx.Events.Projections;
@@ -32,6 +33,9 @@ public class EventGraph : EventRegistry, IAggregationSourceFactory<IQuerySession
     private readonly StoreOptions _options;
     private readonly ConcurrentDictionary<Type, PolecatEventType> _eventTypes = new();
     private readonly ConcurrentDictionary<string, Type> _aggregateTypes = new();
+
+    // Memoizes ResolveEventType, including misses (null values) — see the remarks on that method.
+    private readonly ConcurrentDictionary<string, Type?> _eventTypeByDotNetName = new();
     private readonly List<ITagTypeRegistration> _tagTypes = new();
     private readonly List<IMasker> _maskers = new();
 
@@ -341,9 +345,17 @@ public class EventGraph : EventRegistry, IAggregationSourceFactory<IQuerySession
     /// <summary>
     ///     Get or create event type metadata for the given .NET type.
     /// </summary>
+    // Roots PolecatEventType<>'s constructor for trimming / Native AOT — without this root the
+    // constructor metadata is trimmed and CloseAndBuildAs throws MissingMethodException at runtime.
+    // Same pattern as Marten's EventGraph rooting EventMapping<>.
+    [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors, typeof(PolecatEventType<>))]
     public override PolecatEventType EventMappingFor(Type eventType)
     {
-        return _eventTypes.GetOrAdd(eventType, static type => new PolecatEventType(type));
+        // The generic PolecatEventType<T> is closed ONCE per event type here at registration,
+        // so the per-event Wrap call is a plain `new Event<T>((T)data)` with no reflection
+        // (mirrors JasperFx.Events.EventTypeData<T>.Wrap). See gh-537.
+        return _eventTypes.GetOrAdd(eventType,
+            static type => typeof(PolecatEventType<>).CloseAndBuildAs<PolecatEventType>(type));
     }
 
     public override void AddEventType(Type eventType)
@@ -492,10 +504,18 @@ public class EventGraph : EventRegistry, IAggregationSourceFactory<IQuerySession
     /// <summary>
     ///     Try to resolve a .NET type from the dotnet_type name stored in the database.
     /// </summary>
+    /// <remarks>
+    ///     Memoized — <see cref="Type.GetType(string)" /> parses the assembly-qualified name and
+    ///     probes assemblies on every call, and this runs once per event row hydrated. Mirrors
+    ///     Marten's <c>EventGraph.TypeForDotNetName</c> cache, except Polecat tolerates
+    ///     unknown/foreign event types by returning null — so misses are cached too (the null
+    ///     value in the dictionary is the sentinel) and an unrecognized type name stored by some
+    ///     other application does not re-probe assemblies for every row it appears on. See gh-537.
+    /// </remarks>
     internal Type? ResolveEventType(string? dotNetTypeName)
     {
         if (string.IsNullOrEmpty(dotNetTypeName)) return null;
-        return Type.GetType(dotNetTypeName);
+        return _eventTypeByDotNetName.GetOrAdd(dotNetTypeName, static name => Type.GetType(name));
     }
 
     internal StreamsTable BuildStreamsTable()
@@ -807,12 +827,36 @@ public class PolecatEventType : IEventType
     /// <summary>
     ///     Wrap raw event data into an Event&lt;T&gt; with type metadata.
     /// </summary>
-    public IEvent Wrap(object eventData)
+    /// <remarks>
+    ///     This base implementation is a reflection fallback for directly constructed instances.
+    ///     Everything registered through <see cref="EventGraph.EventMappingFor" /> gets the generic
+    ///     <see cref="PolecatEventType{T}" /> subclass, whose override constructs the
+    ///     <see cref="Event{T}" /> envelope with no per-event reflection (gh-537).
+    /// </remarks>
+    public virtual IEvent Wrap(object eventData)
     {
         var genericType = typeof(Event<>).MakeGenericType(_eventType);
         var @event = (IEvent)Activator.CreateInstance(genericType, eventData)!;
         @event.EventTypeName = EventTypeName;
         @event.DotNetTypeName = DotNetTypeName;
         return @event;
+    }
+}
+
+/// <summary>
+///     Reflection-free <see cref="PolecatEventType.Wrap" /> for a known event type. Closed once
+///     per event type at registration in <see cref="EventGraph.EventMappingFor" />, so the
+///     per-event cost is a constructor call and a cast — the same shape as
+///     JasperFx.Events' <c>EventTypeData&lt;T&gt;.Wrap</c> (gh-537).
+/// </summary>
+public class PolecatEventType<T> : PolecatEventType where T : notnull
+{
+    public PolecatEventType() : base(typeof(T))
+    {
+    }
+
+    public override IEvent Wrap(object eventData)
+    {
+        return new Event<T>((T)eventData) { EventTypeName = EventTypeName, DotNetTypeName = DotNetTypeName };
     }
 }


### PR DESCRIPTION
Closes #537.

Two per-event reflection hotspots in `src/Polecat/Events/EventGraph.cs`, hot on both the append and read paths, replaced with per-type caches:

## `PolecatEventType.Wrap` — reflection moved from per-event to per-type

Before: every `Wrap` call did `typeof(Event<>).MakeGenericType(_eventType)` + `Activator.CreateInstance` — once per event appended (`BuildEvent`) and once per event row hydrated (`PcEventsRowReader`, `PolecatEventLoader`, `EventListHandler`, `EventOperations`, projection replay).

Now: `EventGraph.EventMappingFor` closes a generic `PolecatEventType<T>` subclass **once per event type** at registration (`CloseAndBuildAs`, with a `[DynamicDependency]` root for trimming/AOT mirroring Marten's `EventMapping<>` root). Its `Wrap` override is `new Event<T>((T)data) { EventTypeName = ..., DotNetTypeName = ... }` — the same reflection-free shape as `JasperFx.Events.EventTypeData<T>.Wrap`. The non-generic base `Wrap` is kept as a virtual reflection fallback for directly constructed `PolecatEventType` instances, so behavior parity is preserved everywhere (binary-event dispatch is untouched — it lives on `EventGraph`'s serializer resolution, not on the wrap path).

## `ResolveEventType` — memoized, misses included

Before: `Type.GetType(dotNetTypeName)` uncached, once per event row hydrated — an assembly-qualified-name parse plus assembly probe per row.

Now: memoized through a `ConcurrentDictionary<string, Type?>`, mirroring Marten's `EventGraph.TypeForDotNetName` cache (`Ref<ImHashMap<string, Type>>`), with one deliberate difference: Polecat tolerates unknown/foreign event types by returning null instead of throwing, so **misses are cached too** (the null value is the sentinel) — an unknown type name written by another application no longer re-probes assemblies on every row it appears on.

## Tests

`src/Polecat.Tests/Events/event_type_wrapping_and_resolution_caching_tests.cs` — 8 pure unit tests (no database): typed mapping registration and per-type caching, `Wrap` returning `Event<T>` with data + metadata set, fresh envelope per event, `BuildEvent` path, base reflection fallback parity, known-type resolution, null/empty tolerance, and null-miss caching for unknown type names.

## Verification

- `Polecat` and `Polecat.Tests` build clean; no new warnings.
- New unit tests: 8/8 passing.
- Event-store integration subset (`Polecat.Tests.Events` + compliance namespaces, needs SQL Server 2025): run status reported in a PR comment — the shared SQL Server container was contended by a sibling agent's test run at the time this PR was opened, and per repo guidance two runs must not share the container.

Tracked by Stoat plan `critter-performance-2026-09`, node `polecat-event-hydration-caches`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)