### PR TITLE
Enroll CompositeProjectionCompliance + SingleTenantedEventSlicingCompliance (wave 14)

### DIFF
--- a/src/Polecat.Tests/Compliance/PolecatComplianceFixture.cs
+++ b/src/Polecat.Tests/Compliance/PolecatComplianceFixture.cs
@@ -284,6 +284,28 @@ public class PolecatComplianceFixture : EventStoreComplianceFixture<IDocumentSes
         // or full type name and daemon progression is keyed on it.
         public void Subscribe(ComplianceSubscription subscription)
             => _options.Projections.Subscribe(subscription, x => x.Name = ComplianceSubscription.SubscriptionName);
+
+        // Wave 13 / jasperfx#725: composites. The seam member carries a throwing default because a
+        // composite cannot be constructed by a suite -- PolecatCompositeProjection's constructor is
+        // internal and needs StoreOptions -- so the forward goes through Polecat's own
+        // Projections.CompositeProjectionFor and the builder adapts the one call the suite makes,
+        // Snapshot<T>(stageNumber), which Polecat spells identically (void-returning).
+        public void AddCompositeProjection(string name, Action<IComplianceCompositeBuilder> configure)
+            => _options.Projections.CompositeProjectionFor(name,
+                composite => configure(new ComplianceCompositeBuilder(composite)));
+    }
+
+    internal class ComplianceCompositeBuilder : IComplianceCompositeBuilder
+    {
+        private readonly Polecat.Projections.PolecatCompositeProjection _composite;
+
+        public ComplianceCompositeBuilder(Polecat.Projections.PolecatCompositeProjection composite)
+        {
+            _composite = composite;
+        }
+
+        public void Snapshot<TDoc>(int stageNumber) where TDoc : notnull
+            => _composite.Snapshot<TDoc>(stageNumber);
     }
 
     internal class PolecatComplianceBatch : IComplianceBatch

--- a/src/Polecat.Tests/Compliance/polecat_event_store_compliance_wave14.cs
+++ b/src/Polecat.Tests/Compliance/polecat_event_store_compliance_wave14.cs
@@ -1,0 +1,32 @@
+using JasperFx.Events.ComplianceTests;
+
+namespace Polecat.Tests.Compliance;
+
+/*
+ * Wave 14 -- the last two shipped suites nobody had enrolled in, and Polecat enrolls in both.
+ *
+ * CompositeProjectionCompliance is jasperfx#725: several members sharing one shard, one progression
+ * row and one event batch, executed in stage order and torn down together on rebuild. Opt-in through
+ * the AddCompositeProjection seam member (throwing default), which PolecatComplianceFixture now
+ * implements by forwarding to Projections.CompositeProjectionFor. Polecat already guards the
+ * teardown-on-rebuild half locally (Bug_439_composite_member_teardown), which is exactly the "same
+ * regression test in two products" smell the shared suite exists to absorb.
+ *
+ * SingleTenantedEventSlicingCompliance is jasperfx#724 (wolverine#2053 / marten#4085): on a
+ * single-tenanted store, events whose tenant_id values disagree must still fold into ONE async
+ * aggregate rather than being sliced per tenant into partial documents. Polecat's fix was #526.
+ * Its one fact currently SELF-SKIPS on Polecat, by the suite's own design: Polecat is
+ * QuickAppend-only, and the quick-append metadata path (the shared
+ * StreamAction.applyQuickMetadata stamps session.TenantId unconditionally, plus
+ * EventOperations.Append's action.TenantId assignment, whose setter restamps every event)
+ * normalizes disagreeing per-event tenant ids to the session tenant before they reach storage --
+ * so the mixed-tenancy precondition cannot be constructed through the shared surface. The suite
+ * detects that and skips rather than passing vacuously. Enrollment still arms the assertion
+ * should the append path ever start preserving per-event tenant ids.
+ */
+
+public class composite_projection_compliance
+    : CompositeProjectionCompliance<PolecatComplianceFixture, IDocumentSession, IQuerySession>;
+
+public class single_tenanted_event_slicing_compliance
+    : SingleTenantedEventSlicingCompliance<PolecatComplianceFixture, IDocumentSession, IQuerySession>;


### PR DESCRIPTION
Closes #536. Tracked by Stoat plan `event-compliance-wave-13`, node `polecat-enroll-composite`.

Enrolls Polecat in the last two shipped-but-unenrolled suites from `JasperFx.Events.ComplianceTests` (2.63.0), bringing Polecat to 39 of 39.

## What changed

- `PolecatComplianceFixture.PolecatComplianceRegistrar` now implements the `AddCompositeProjection` seam member (which carries a throwing default on `IComplianceStoreRegistrar`) by forwarding to Polecat's own `Projections.CompositeProjectionFor`, with a tiny `IComplianceCompositeBuilder` adapter over `PolecatCompositeProjection.Snapshot<T>(stageNumber)` — the calls are spelled identically, so the adapter is one line per member.
- New `Compliance/polecat_event_store_compliance_wave14.cs` enrolls both suites as empty subclasses closing Polecat's `IDocumentSession`/`IQuerySession` pair. (Wave 13 was already taken by `StreamStateQueryCompliance`, #535.)

## Results (local, SQL Server 2025 via docker-compose)

- **CompositeProjectionCompliance: 3/3 pass** — every stage materializes from one async pass, rebuild tears members down rather than replaying over them, and the composite presents itself as exactly one shard.
- **SingleTenantedEventSlicingCompliance: its one fact self-skips on Polecat, by the suite's own design.** Polecat is QuickAppend-only, and the quick-append metadata path normalizes disagreeing per-event tenant ids to the session tenant before they reach storage: the shared `StreamAction.applyQuickMetadata` stamps `session.TenantId` unconditionally (the rich path only fills empties), and `EventOperations.Append`'s `action.TenantId = _tenantId` restamps every event via the `StreamAction.TenantId` setter. So the mixed-tenancy precondition (jasperfx#724's wolverine#2053 / marten#4085 scenario) cannot be constructed through the shared surface, and the suite skips with an explanatory message rather than passing vacuously. The enrollment still arms the assertion should the append path ever start preserving per-event tenant ids — if that divergence from Marten's rich-append behavior is worth closing, it belongs in a follow-up (likely partly upstream in `StreamAction.applyQuickMetadata`).
- Regression spot-checks: `polecat_stream_state_query_compliance` (15 facts) and `async_daemon_compliance` still pass.

## Retirement candidates (deliberately NOT deleted here — separate wave-13 node)

- `src/Polecat.Tests/Projections/Bug_439_composite_member_teardown.cs` — `rebuilding_deletes_every_members_documents_first` overlaps the suite's rebuild-teardown fact. The other two facts (per-member teardown-rule reporting, the composite's own teardown rules) look Polecat-specific and should stay.
- `src/Polecat.Tests/Projections/composite_projection_tests.cs` — `composite_with_two_stages` overlaps the suite's staged-materialization fact; `composite_with_single_stage_snapshot`, `composite_with_multiple_snapshots_in_same_stage`, and `composite_processes_appended_events` cover shapes the suite deliberately does not.
- No Polecat-local single-tenanted slicing test exists to retire (the gh-526 fix landed via the shared jasperfx#723 base).

🤖 Generated with [Claude Code](https://claude.com/claude-code)