### PR TITLE
Reuse the store's per-database DocumentTableEnsurer in daemon projection batches

### DIFF
--- a/src/Polecat.Tests/Daemon/projection_batch_table_ensurer_tests.cs
+++ b/src/Polecat.Tests/Daemon/projection_batch_table_ensurer_tests.cs
@@ -1,0 +1,66 @@
+using Polecat.Events.Daemon;
+using Polecat.Tests.Harness;
+
+namespace Polecat.Tests.Daemon;
+
+/// <summary>
+///     Regression coverage for [polecat#538](https://github.com/JasperFx/polecat/issues/538):
+///     <see cref="PolecatProjectionBatch.ExecuteAsync"/> constructed a fresh
+///     <see cref="Polecat.Internal.DocumentTableEnsurer"/> per projection batch. The ensurer
+///     memoizes on instance state, so every daemon batch re-ran the full schema-ensure work
+///     (SchemaMigration diff, version-column widening, index DDL) per projected document type —
+///     the same bug class as marten#4946. The daemon must reuse the store's long-lived
+///     per-database ensurer so the work runs once per database per type, not per batch.
+/// </summary>
+public class projection_batch_table_ensurer_tests : OneOffConfigurationsContext
+{
+    [Fact]
+    public void store_hands_out_the_same_ensurer_per_database()
+    {
+        var defaultCs = theStore.Database.ConnectionString;
+
+        // Stable identity per database — this is what makes the memoization effective.
+        theStore.EnsurerFor(defaultCs).ShouldBeSameAs(theStore.EnsurerFor(defaultCs));
+
+        // A different database gets its own (but equally stable) ensurer, so the scoping is
+        // per database rather than blindly global — required for database-per-tenant tenancy.
+        var otherCs = ConnectionSource.ConnectionStringFor("polecat_ensurer_identity_probe");
+        var other = theStore.EnsurerFor(otherCs);
+        other.ShouldNotBeSameAs(theStore.EnsurerFor(defaultCs));
+        other.ShouldBeSameAs(theStore.EnsurerFor(otherCs));
+    }
+
+    [Fact]
+    public async Task schema_ensure_work_runs_once_per_document_type_across_daemon_batches()
+    {
+        ConfigureStore(opts => opts.DatabaseSchemaName = "batch_ensurer_reuse");
+        await theDatabase.ApplyAllConfiguredChangesToDatabaseAsync(
+            ct: TestContext.Current.CancellationToken);
+
+        var ensurer = theStore.EnsurerFor(theStore.Database.ConnectionString);
+        ensurer.SchemaEnsureExecutions.ShouldBe(0);
+
+        // Simulate the daemon: one PolecatProjectionBatch per page of events, each writing the
+        // same projected document type.
+        for (var i = 0; i < 3; i++)
+        {
+            var batch = new PolecatProjectionBatch(theStore, theStore.Options.EventGraph,
+                theStore.Database);
+            var session = batch.SessionForTenant(theStore.Options.Tenancy!.DefaultTenantId);
+            session.Store(new BatchedDoc { Id = Guid.NewGuid() });
+
+            await batch.ExecuteAsync(TestContext.Current.CancellationToken);
+            await batch.DisposeAsync();
+        }
+
+        // The regression signature: with a per-batch ensurer the store's shared instance never
+        // ran (0) while three throwaway instances each ran the full schema check. With the fix,
+        // the shared ensurer ran the work exactly once for BatchedDoc across all three batches.
+        ensurer.SchemaEnsureExecutions.ShouldBe(1);
+    }
+
+    public class BatchedDoc
+    {
+        public Guid Id { get; set; }
+    }
+}

--- a/src/Polecat/DocumentStore.cs
+++ b/src/Polecat/DocumentStore.cs
@@ -170,15 +170,26 @@ public partial class DocumentStore : IDocumentStore
     ///     One <see cref="DocumentTableEnsurer" /> per database, cached for the life of the store.
     ///     The ensurer memoizes which tables it has already checked, so handing out a fresh one per
     ///     session would re-run the existence checks on every call — cheap once, but the async
-    ///     daemon opens a session per batch per tenant database. #514.
+    ///     daemon opens a session per batch per tenant database. #514. The default database maps to
+    ///     the store's shared ensurer so daemon batches (#538) and regular sessions warm the same
+    ///     memoization. Internal so <see cref="Events.Daemon.PolecatProjectionBatch" /> can resolve
+    ///     the ensurer for the database it is bound to instead of constructing one per batch.
     /// </summary>
-    private DocumentTableEnsurer EnsurerFor(string connectionString) =>
-        _tableEnsurers.GetOrAdd(connectionString, cs =>
+    internal DocumentTableEnsurer EnsurerFor(string connectionString)
+    {
+        if (string.Equals(connectionString, _connectionFactory.ConnectionString,
+                StringComparison.OrdinalIgnoreCase))
+        {
+            return _tableEnsurer;
+        }
+
+        return _tableEnsurers.GetOrAdd(connectionString, cs =>
         {
             var ensurer = new DocumentTableEnsurer(new ConnectionFactory(cs), Options);
             ensurer.SetProviderRegistry(_providers);
             return ensurer;
         });
+    }
 
     public IDocumentSession LightweightSession()
     {

--- a/src/Polecat/Events/Daemon/PolecatProjectionBatch.cs
+++ b/src/Polecat/Events/Daemon/PolecatProjectionBatch.cs
@@ -99,8 +99,14 @@ internal class PolecatProjectionBatch : IProjectionBatch<IDocumentSession, IQuer
     {
         // Collect all operations outside the lambda to keep state simple
         var allOps = new List<Weasel.Storage.IStorageOperation>();
-        var tableEnsurer = new DocumentTableEnsurer(
-            new ConnectionFactory(_connectionString), _store.Options);
+
+        // #538: resolve the store's long-lived, per-database ensurer instead of constructing one
+        // per batch. DocumentTableEnsurer memoizes on instance state, so a per-batch instance
+        // re-ran the full schema check (SchemaMigration.DetermineAsync + version-column widening +
+        // index DDL) for every projected document type on every single daemon batch — the same bug
+        // class as marten#4946. The store cache is keyed per connection string, so scoping stays
+        // correct under database-per-tenant tenancy.
+        var tableEnsurer = _store.EnsurerFor(_connectionString);
 
         // #420: built before the session sweep below so any tenant session this creates is picked
         // up by it (and disposed with the rest). The appends themselves are added after the

--- a/src/Polecat/Internal/DocumentTableEnsurer.cs
+++ b/src/Polecat/Internal/DocumentTableEnsurer.cs
@@ -34,6 +34,16 @@ internal class DocumentTableEnsurer
 
     private bool _hiloTableEnsured;
 
+    private int _schemaEnsureExecutions;
+
+    /// <summary>
+    ///     #538: how many times the actual schema-ensure work (migration diff + DDL) has run on this
+    ///     instance — i.e. slow-path executions past the per-type memo, not calls. Test seam for the
+    ///     regression where the daemon constructed a fresh (empty-memo) ensurer per projection batch
+    ///     and re-ran the full schema check per document type on every batch.
+    /// </summary>
+    internal int SchemaEnsureExecutions => Volatile.Read(ref _schemaEnsureExecutions);
+
     public async Task EnsureTableAsync(DocumentProvider provider, CancellationToken token)
     {
         var docType = provider.Mapping.DocumentType;
@@ -59,6 +69,8 @@ internal class DocumentTableEnsurer
             {
                 return;
             }
+
+            Interlocked.Increment(ref _schemaEnsureExecutions);
 
             await using var conn = _connectionFactory.Create();
             await conn.OpenAsync(token);


### PR DESCRIPTION
Fixes #538

## The bug

`PolecatProjectionBatch.ExecuteAsync` constructed a fresh `DocumentTableEnsurer` (and a fresh `ConnectionFactory`) per projection batch. Since the ensurer memoizes on instance state (`ConcurrentDictionary<Type,bool> _ensured`), every daemon batch re-ran the full schema-ensure pass — `WidenVersionColumnIfNeededAsync`, `ConvertStrongTypedIdColumnIfNeededAsync`, a full `SchemaMigration.DetermineAsync` + `SqlServerMigrator.ApplyAllAsync`, and every index DDL statement — per projected document type, on a freshly opened connection. Same bug class as marten#4946.

## The fix

- `PolecatProjectionBatch.ExecuteAsync` now resolves the ensurer via `DocumentStore.EnsurerFor(_connectionString)` — the store-lifetime, per-connection-string cache added for #514 — instead of newing one up. Scoping stays per database, so database-per-tenant tenancy is unaffected.
- `EnsurerFor` (now internal) short-circuits the default database's connection string to the store's shared `_tableEnsurer`, so daemon batches and regular sessions warm the same memoization instead of holding two ensurers for the same database.
- Adds an internal `SchemaEnsureExecutions` seam on `DocumentTableEnsurer` counting slow-path (actual DDL work) executions.

## Tests

New `projection_batch_table_ensurer_tests`:
- `store_hands_out_the_same_ensurer_per_database` — stable identity per database, distinct instances across databases.
- `schema_ensure_work_runs_once_per_document_type_across_daemon_batches` — three daemon batches writing the same document type produce exactly one schema-ensure execution (the regression signature: before the fix the shared ensurer never ran and three throwaway ones each ran the full check).

Verified locally against the dockerized SQL Server 2025:
- `Polecat.Tests.Daemon` namespace: 143 tests, 140 passed / 3 skipped, 0 failed
- `Polecat.Tests.MultiTenancy` namespace: 52 passed, 0 failed

Tracked by Stoat plan `critter-performance-2026-09`, node `polecat-batch-table-ensurer`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)