### PR TITLE
Fix SQL injection in LINQ/patching provider (marten#4911/#4954 analogues)

### DIFF
--- a/src/Polecat.Tests/Linq/group_by_having_sql_injection.cs
+++ b/src/Polecat.Tests/Linq/group_by_having_sql_injection.cs
@@ -1,0 +1,75 @@
+using Polecat.Linq.Parsing;
+using Shouldly;
+using Weasel.SqlServer;
+
+namespace Polecat.Tests.Linq;
+
+// Security regression for the LINQ/patching SQL-injection audit
+// (Stoat plan critter-hardening-audit, node polecat-sqli-audit).
+//
+// A HAVING clause built from Where(...) after GroupBy(...) compares an aggregate against a runtime
+// constant, e.g. .Where(g => g.Max(x => x.Color) == someValue). Before the fix the constant operand
+// was rendered into the SQL as constant.Value.ToString() with no escaping or parameterization, so a
+// string-typed operand could break out of the HAVING grammar and inject SQL — the same class as
+// JasperFx/marten#4954 (non-string projection constants rendered unparameterized). The constant is
+// now bound as a command parameter.
+public class group_by_having_sql_injection
+{
+    private static SqlCommandRender Render(HavingComparisonFragment fragment)
+    {
+        var builder = new BatchBuilder();
+        fragment.Apply(builder);
+        var cmd = builder.Compile().BatchCommands[0];
+        return new SqlCommandRender(cmd.CommandText,
+            cmd.Parameters.Cast<Microsoft.Data.SqlClient.SqlParameter>().Select(p => p.Value).ToArray());
+    }
+
+    private sealed record SqlCommandRender(string CommandText, object?[] ParameterValues);
+
+    [Fact]
+    public void string_having_constant_is_bound_as_a_parameter_not_injected()
+    {
+        const string attack = "x' OR '1'='1"; // classic breakout attempt
+
+        var fragment = new HavingComparisonFragment(
+            HavingOperand.Aggregate("MAX(JSON_VALUE(data, '$.color'))"),
+            "=",
+            HavingOperand.Constant(attack));
+
+        var render = Render(fragment);
+
+        // The attacker text must be absent from the SQL grammar and present in a parameter.
+        render.CommandText.ShouldNotContain(attack);
+        render.CommandText.ShouldNotContain("'1'='1");
+        render.ParameterValues.ShouldContain(attack);
+    }
+
+    [Fact]
+    public void numeric_having_constant_is_bound_as_a_parameter()
+    {
+        var fragment = new HavingComparisonFragment(
+            HavingOperand.Aggregate("COUNT(*)"),
+            ">",
+            HavingOperand.Constant(5));
+
+        var render = Render(fragment);
+
+        render.CommandText.ShouldContain("COUNT(*) > @");
+        render.ParameterValues.ShouldContain(o => Equals(o, 5));
+    }
+
+    [Fact]
+    public void aggregate_operands_are_still_rendered_inline()
+    {
+        var fragment = new HavingComparisonFragment(
+            HavingOperand.Aggregate("MIN(JSON_VALUE(data, '$.age'))"),
+            "<",
+            HavingOperand.Aggregate("MAX(JSON_VALUE(data, '$.age'))"));
+
+        var render = Render(fragment);
+
+        render.CommandText.ShouldBe(
+            "MIN(JSON_VALUE(data, '$.age')) < MAX(JSON_VALUE(data, '$.age'))");
+        render.ParameterValues.ShouldBeEmpty();
+    }
+}

--- a/src/Polecat.Tests/Patching/patching_dictionary_key_sql_injection.cs
+++ b/src/Polecat.Tests/Patching/patching_dictionary_key_sql_injection.cs
@@ -1,0 +1,83 @@
+using Polecat.Patching;
+using Polecat.Tests.Harness;
+using Shouldly;
+using Weasel.SqlServer;
+
+namespace Polecat.Tests.Patching;
+
+// End-to-end security regression for the LINQ/patching SQL-injection audit
+// (Stoat plan critter-hardening-audit, node polecat-sqli-audit).
+//
+// The exact analogue of JasperFx/marten#4911: a Dictionary<,> indexer key in a patch target
+// (x.NumberByKey[key]) is a runtime value, evaluated at patch-build time, that is inlined into the
+// JSON_MODIFY '$.numberByKey.{key}' path literal. A key containing a single quote could break out of
+// the literal and inject arbitrary SQL into the generated UPDATE. This test drives the full
+// PatchExpression -> JsonPathHelper -> PatchOperation flow against a live database with a hostile key
+// and proves the statement executes harmlessly (the table survives, the malicious key is stored as
+// data) rather than injecting.
+[Collection("integration")]
+public class patching_dictionary_key_sql_injection : IntegrationContext
+{
+    public patching_dictionary_key_sql_injection(DefaultStoreFixture fixture) : base(fixture)
+    {
+    }
+
+    public override async ValueTask InitializeAsync()
+    {
+        await StoreOptions(opts => { opts.DatabaseSchemaName = "patch_sqli"; });
+    }
+
+    [Fact]
+    public async Task malicious_dictionary_key_does_not_inject_sql()
+    {
+        var target = Target.Random();
+        theSession.Store(target);
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        // If the key were interpolated raw, these single quotes would terminate the JSON path
+        // literal and the appended tokens would run as their own statement, dropping the document
+        // table. Escaped, the whole string is a single (malformed) JSON path that SQL Server's
+        // JSON_MODIFY rejects at runtime as data — it never leaves the '$....' literal.
+        var maliciousKey = "k')); DROP TABLE pc_doc_target; SELECT ('";
+
+        Exception? thrown = null;
+        try
+        {
+            theSession.Patch<Target>(target.Id).Set(x => x.NumberByKey[maliciousKey], 42);
+            await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+        catch (Exception ex)
+        {
+            // SQL Server rejects the escaped-but-malformed JSON path ("JSON path is not properly
+            // formatted"). That the server evaluates it as a path argument — rather than parsing the
+            // quotes as SQL — is itself the proof the value stayed inside the literal.
+            thrown = ex;
+        }
+
+        // The decisive assertion: the injected DROP TABLE did not run, so the document table still
+        // exists and the original document is still loadable in a fresh session.
+        await using var query = theStore.QuerySession();
+        var reloaded = await query.LoadAsync<Target>(target.Id, TestContext.Current.CancellationToken);
+        reloaded.ShouldNotBeNull();
+
+        // If it threw at all, it was a data/JSON-path error, never evidence the statement executed.
+        if (thrown != null)
+        {
+            thrown.ToString().ShouldNotContain("Invalid object name");
+        }
+    }
+
+    // A command-rendering assertion (no execution needed) that the generated SQL never carries the
+    // odd-quoted breakout sequence — the single quote in the key is doubled inside the path literal.
+    [Fact]
+    public void generated_patch_sql_escapes_the_dictionary_key()
+    {
+        var builder = new BatchBuilder();
+        // Path as JsonPathHelper would assemble it for x.NumberByKey["a' OR '1'='1"].
+        PatchOperation.SetScalar("numberByKey.a' OR '1'='1", 42)(builder);
+        var sql = builder.Compile().BatchCommands[0].CommandText;
+
+        sql.ShouldContain("'$.numberByKey.a'' OR ''1''=''1'");
+        sql.ShouldNotContain("'$.numberByKey.a' OR '1'='1'");
+    }
+}

--- a/src/Polecat.Tests/Patching/patching_sql_injection.cs
+++ b/src/Polecat.Tests/Patching/patching_sql_injection.cs
@@ -1,0 +1,118 @@
+using Polecat.Patching;
+using Shouldly;
+using Weasel.SqlServer;
+
+namespace Polecat.Tests.Patching;
+
+// Security regression for the LINQ/patching SQL-injection audit
+// (Stoat plan critter-hardening-audit, node polecat-sqli-audit).
+//
+// A JSON path segment in a patch is assembled from runtime-supplied strings — a dictionary indexer
+// key (JsonPathHelper), or a property/key name passed straight to the patch API such as
+// Patch.Set("name", ...), Append(expr, key, ...), Remove(expr, key). Each segment is inlined into a
+// single-quoted '$.{path}' literal inside a JSON_MODIFY call. Before the fix a value containing a
+// single quote terminated that literal and injected arbitrary SQL into the generated UPDATE — the
+// same class of hole as JasperFx/marten#4911 (DictionaryItemMember JSON-path locator).
+//
+// These are pure command-rendering assertions (no database): they render each PatchOperation sink
+// against a real SQL Server CommandBuilder and assert embedded single quotes are doubled, so the
+// attacker text stays inside the literal as data.
+public class patching_sql_injection
+{
+    // A key that, unescaped, breaks out of the '$....' literal and appends its own SQL.
+    private const string MaliciousKey = "evil' OR '1'='1'; DROP TABLE pc_doc_target; --";
+    private const string EscapedKey = "evil'' OR ''1''=''1''; DROP TABLE pc_doc_target; --";
+
+    private static string Render(Action<ICommandBuilder> action)
+    {
+        var builder = new BatchBuilder();
+        action(builder);
+        return builder.Compile().BatchCommands[0].CommandText;
+    }
+
+    [Fact]
+    public void set_scalar_escapes_single_quotes_in_the_path()
+    {
+        var sql = Render(PatchOperation.SetScalar(MaliciousKey, "value"));
+
+        sql.ShouldContain($"'$.{EscapedKey}'");
+        sql.ShouldNotContain($"'$.{MaliciousKey}'");
+    }
+
+    [Fact]
+    public void delete_property_escapes_single_quotes_in_the_path()
+    {
+        var sql = Render(PatchOperation.DeleteProperty(MaliciousKey));
+
+        sql.ShouldContain(EscapedKey);
+        sql.ShouldNotContain($"$.{MaliciousKey}',");
+    }
+
+    [Fact]
+    public void set_dict_key_escapes_both_the_dictionary_path_and_the_runtime_key()
+    {
+        // Append(expr, key, element) / AppendIfNotExists route through SetDictKey with the caller's
+        // raw dictionary key. The dictionary path AND the key must both be escaped.
+        var sql = Render(PatchOperation.SetDictKey("attributes", MaliciousKey, "\"v\""));
+
+        sql.ShouldContain($"'$.attributes.{EscapedKey}'");
+        sql.ShouldNotContain($"'$.attributes.{MaliciousKey}'");
+    }
+
+    [Fact]
+    public void remove_dict_key_escapes_the_runtime_key()
+    {
+        var sql = Render(PatchOperation.RemoveDictKey("attributes", MaliciousKey));
+
+        sql.ShouldContain($"'$.attributes.{EscapedKey}'");
+        sql.ShouldNotContain($"'$.attributes.{MaliciousKey}'");
+    }
+
+    [Fact]
+    public void increment_escapes_single_quotes_in_the_path()
+    {
+        var sql = Render(PatchOperation.IncrementInt(MaliciousKey, 1, "int"));
+
+        sql.ShouldContain(EscapedKey);
+        // The bare, odd-quoted breakout sequence must not survive anywhere in the command.
+        sql.ShouldNotContain($"$.{MaliciousKey}'");
+    }
+
+    [Fact]
+    public void append_scalar_escapes_single_quotes_in_the_path()
+    {
+        var sql = Render(PatchOperation.AppendScalar(MaliciousKey, "value"));
+
+        sql.ShouldContain($"append $.{EscapedKey}");
+        sql.ShouldNotContain($"append $.{MaliciousKey}'");
+    }
+
+    [Fact]
+    public void rename_property_escapes_both_paths()
+    {
+        var sql = Render(PatchOperation.RenameProperty(MaliciousKey, "newName", isScalarType: true));
+
+        sql.ShouldContain(EscapedKey);
+        sql.ShouldNotContain($"$.{MaliciousKey}'");
+    }
+
+    [Fact]
+    public void duplicate_property_escapes_source_and_destination_paths()
+    {
+        var sql = Render(PatchOperation.DuplicateProperty(
+            MaliciousKey, new[] { MaliciousKey }, isScalarType: true));
+
+        sql.ShouldContain(EscapedKey);
+        sql.ShouldNotContain($"$.{MaliciousKey}'");
+    }
+
+    // A legitimate key that happens to contain an apostrophe now round-trips as data rather than
+    // erroring or injecting — the escaping is correct, not merely defensive.
+    [Fact]
+    public void a_legitimate_key_with_an_apostrophe_is_preserved_as_data()
+    {
+        var sql = Render(PatchOperation.SetScalar("O'Brien", "value"));
+
+        sql.ShouldContain("'$.O''Brien'");
+    }
+}

--- a/src/Polecat/Linq/Parsing/GroupBySelectBuilder.cs
+++ b/src/Polecat/Linq/Parsing/GroupBySelectBuilder.cs
@@ -297,30 +297,38 @@ internal class GroupBySelectBuilder
                 $"Unsupported comparison in HAVING: {binary.NodeType}")
         };
 
-        var leftSql = ResolveHavingOperand(binary.Left, groupingParam);
-        var rightSql = ResolveHavingOperand(binary.Right, groupingParam);
+        var leftOperand = ResolveHavingOperand(binary.Left, groupingParam);
+        var rightOperand = ResolveHavingOperand(binary.Right, groupingParam);
 
-        return new LiteralSqlFragment($"{leftSql} {op} {rightSql}");
+        return new HavingComparisonFragment(leftOperand, op, rightOperand);
     }
 
-    private string ResolveHavingOperand(Expression expr, ParameterExpression groupingParam)
+    /// <summary>
+    ///     An operand of a HAVING comparison: either a server-side aggregate expression (safe,
+    ///     built from developer-controlled member locators) or a runtime constant value. Constants
+    ///     are bound as command parameters rather than rendered into the SQL text — the constant is a
+    ///     captured local / request value and rendering its <c>ToString()</c> verbatim was a SQL
+    ///     injection vector (CWE-89), the same class as JasperFx/marten#4954 (non-string projection
+    ///     constants rendered unparameterized).
+    /// </summary>
+    private HavingOperand ResolveHavingOperand(Expression expr, ParameterExpression groupingParam)
     {
         if (expr is MethodCallExpression method)
         {
             var sql = ResolveAggregate(method, groupingParam);
-            if (sql != null) return sql;
+            if (sql != null) return HavingOperand.Aggregate(sql);
         }
 
         if (expr is ConstantExpression constant)
         {
-            return constant.Value?.ToString() ?? "NULL";
+            return HavingOperand.Constant(constant.Value);
         }
 
         // Try to evaluate as constant
         try
         {
             var value = Expression.Lambda(expr).Compile().DynamicInvoke();
-            return value?.ToString() ?? "NULL";
+            return HavingOperand.Constant(value);
         }
         catch
         {
@@ -373,6 +381,72 @@ internal class GroupBySelectBuilder
     private string FormatKey(string name)
     {
         return _namingPolicy?.ConvertName(name) ?? name;
+    }
+}
+
+/// <summary>
+///     One side of a HAVING comparison — either aggregate SQL rendered inline (developer-controlled)
+///     or a runtime constant value that must be bound as a parameter.
+/// </summary>
+internal readonly struct HavingOperand
+{
+    private HavingOperand(string? sql, object? value, bool isConstant)
+    {
+        Sql = sql;
+        Value = value;
+        IsConstant = isConstant;
+    }
+
+    public string? Sql { get; }
+    public object? Value { get; }
+    public bool IsConstant { get; }
+
+    public static HavingOperand Aggregate(string sql) => new(sql, null, isConstant: false);
+    public static HavingOperand Constant(object? value) => new(null, value, isConstant: true);
+}
+
+/// <summary>
+///     Emits <c>{left} {op} {right}</c> for a HAVING comparison. Aggregate operands are appended as
+///     SQL text; constant operands are bound as command parameters so an attacker-influenced value
+///     cannot break out of the SQL grammar.
+/// </summary>
+internal class HavingComparisonFragment : ISqlFragment
+{
+    private readonly HavingOperand _left;
+    private readonly string _op;
+    private readonly HavingOperand _right;
+
+    public HavingComparisonFragment(HavingOperand left, string op, HavingOperand right)
+    {
+        _left = left;
+        _op = op;
+        _right = right;
+    }
+
+    public void Apply(ICommandBuilder builder)
+    {
+        ApplyOperand(builder, _left);
+        builder.Append(" ");
+        builder.Append(_op);
+        builder.Append(" ");
+        ApplyOperand(builder, _right);
+    }
+
+    private static void ApplyOperand(ICommandBuilder builder, HavingOperand operand)
+    {
+        if (!operand.IsConstant)
+        {
+            builder.Append(operand.Sql!);
+            return;
+        }
+
+        if (operand.Value == null)
+        {
+            builder.Append("NULL");
+            return;
+        }
+
+        builder.AppendParameter(operand.Value);
     }
 }
 

--- a/src/Polecat/Patching/PatchOperation.cs
+++ b/src/Polecat/Patching/PatchOperation.cs
@@ -49,8 +49,22 @@ internal class PatchOperation : Polecat.Internal.IStorageOperation
 
     // --- Static helpers for building JSON_MODIFY expressions ---
 
+    /// <summary>
+    ///     Escapes a JSON path (or a single path segment) that is inlined into a single-quoted
+    ///     <c>'$.{path}'</c> literal inside a JSON_MODIFY / JSON_VALUE / JSON_QUERY call. The path is
+    ///     assembled from runtime-supplied strings — a dictionary indexer key (see
+    ///     <see cref="JsonPathHelper"/>), or a property/key name passed straight to the patch API
+    ///     (e.g. <c>Patch.Set("name", ...)</c>, <c>Append(expr, key, ...)</c>) — so a value containing
+    ///     a single quote would otherwise terminate the literal and inject arbitrary SQL into the
+    ///     generated UPDATE (SQL injection, CWE-89; the same class of hole as JasperFx/marten#4911).
+    ///     Doubling embedded single quotes keeps the value as data. The '.' path separators are not
+    ///     quote characters, so escaping only single quotes leaves legitimate nested paths intact.
+    /// </summary>
+    internal static string EscapePath(string path) => path.Replace("'", "''");
+
     internal static Action<ICommandBuilder> SetScalar(string jsonPath, object? value)
     {
+        jsonPath = EscapePath(jsonPath);
         return builder =>
         {
             builder.Append($"JSON_MODIFY(data, '$.{jsonPath}', ");
@@ -61,6 +75,7 @@ internal class PatchOperation : Polecat.Internal.IStorageOperation
 
     internal static Action<ICommandBuilder> SetComplex(string jsonPath, string jsonValue)
     {
+        jsonPath = EscapePath(jsonPath);
         return builder =>
         {
             builder.Append($"JSON_MODIFY(data, '$.{jsonPath}', JSON_QUERY(");
@@ -71,6 +86,7 @@ internal class PatchOperation : Polecat.Internal.IStorageOperation
 
     internal static Action<ICommandBuilder> IncrementInt(string jsonPath, object increment, string sqlType)
     {
+        jsonPath = EscapePath(jsonPath);
         return builder =>
         {
             builder.Append(
@@ -82,6 +98,7 @@ internal class PatchOperation : Polecat.Internal.IStorageOperation
 
     internal static Action<ICommandBuilder> IncrementFloat(string jsonPath, object increment, string sqlType)
     {
+        jsonPath = EscapePath(jsonPath);
         return builder =>
         {
             builder.Append(
@@ -93,6 +110,7 @@ internal class PatchOperation : Polecat.Internal.IStorageOperation
 
     internal static Action<ICommandBuilder> AppendScalar(string jsonPath, object element)
     {
+        jsonPath = EscapePath(jsonPath);
         return builder =>
         {
             builder.Append($"JSON_MODIFY(data, 'append $.{jsonPath}', ");
@@ -103,6 +121,7 @@ internal class PatchOperation : Polecat.Internal.IStorageOperation
 
     internal static Action<ICommandBuilder> AppendComplex(string jsonPath, string jsonElement)
     {
+        jsonPath = EscapePath(jsonPath);
         return builder =>
         {
             builder.Append($"JSON_MODIFY(data, 'append $.{jsonPath}', JSON_QUERY(");
@@ -113,6 +132,7 @@ internal class PatchOperation : Polecat.Internal.IStorageOperation
 
     internal static Action<ICommandBuilder> AppendIfNotExistsScalar(string jsonPath, object element)
     {
+        jsonPath = EscapePath(jsonPath);
         return builder =>
         {
             builder.Append($"CASE WHEN NOT EXISTS (SELECT 1 FROM OPENJSON(JSON_QUERY(data, '$.{jsonPath}')) ");
@@ -126,6 +146,7 @@ internal class PatchOperation : Polecat.Internal.IStorageOperation
 
     internal static Action<ICommandBuilder> AppendIfNotExistsComplex(string jsonPath, string jsonElement)
     {
+        jsonPath = EscapePath(jsonPath);
         return builder =>
         {
             builder.Append($"CASE WHEN NOT EXISTS (SELECT 1 FROM OPENJSON(JSON_QUERY(data, '$.{jsonPath}')) ");
@@ -139,6 +160,8 @@ internal class PatchOperation : Polecat.Internal.IStorageOperation
 
     internal static Action<ICommandBuilder> SetDictKey(string dictPath, string key, string jsonValue)
     {
+        dictPath = EscapePath(dictPath);
+        key = EscapePath(key);
         return builder =>
         {
             builder.Append($"JSON_MODIFY(data, '$.{dictPath}.{key}', JSON_QUERY(");
@@ -149,6 +172,8 @@ internal class PatchOperation : Polecat.Internal.IStorageOperation
 
     internal static Action<ICommandBuilder> SetDictKeyIfNotExists(string dictPath, string key, string jsonValue)
     {
+        dictPath = EscapePath(dictPath);
+        key = EscapePath(key);
         return builder =>
         {
             builder.Append($"CASE WHEN JSON_VALUE(data, '$.{dictPath}.{key}') IS NULL AND ");
@@ -168,6 +193,7 @@ internal class PatchOperation : Polecat.Internal.IStorageOperation
     internal static Action<ICommandBuilder> InsertAtIndex(string jsonPath, int index, object element, bool isComplex,
         string? jsonElement, ISerializer serializer)
     {
+        jsonPath = EscapePath(jsonPath);
         return builder =>
         {
             builder.Append($"JSON_MODIFY(data, '$.{jsonPath}', JSON_QUERY(");
@@ -191,6 +217,7 @@ internal class PatchOperation : Polecat.Internal.IStorageOperation
     internal static Action<ICommandBuilder> InsertIfNotExistsScalar(string jsonPath, object element, int? index,
         ISerializer serializer)
     {
+        jsonPath = EscapePath(jsonPath);
         return builder =>
         {
             builder.Append($"CASE WHEN NOT EXISTS (SELECT 1 FROM OPENJSON(JSON_QUERY(data, '$.{jsonPath}')) ");
@@ -229,6 +256,7 @@ internal class PatchOperation : Polecat.Internal.IStorageOperation
     internal static Action<ICommandBuilder> InsertIfNotExistsComplex(string jsonPath, string jsonElement, int? index,
         ISerializer serializer)
     {
+        jsonPath = EscapePath(jsonPath);
         return builder =>
         {
             builder.Append($"CASE WHEN NOT EXISTS (SELECT 1 FROM OPENJSON(JSON_QUERY(data, '$.{jsonPath}')) ");
@@ -264,6 +292,7 @@ internal class PatchOperation : Polecat.Internal.IStorageOperation
 
     internal static Action<ICommandBuilder> RemoveScalarFirst(string jsonPath, object element)
     {
+        jsonPath = EscapePath(jsonPath);
         return builder =>
         {
             builder.Append($"JSON_MODIFY(data, '$.{jsonPath}', JSON_QUERY(");
@@ -286,6 +315,7 @@ internal class PatchOperation : Polecat.Internal.IStorageOperation
 
     internal static Action<ICommandBuilder> RemoveScalarAll(string jsonPath, object element)
     {
+        jsonPath = EscapePath(jsonPath);
         return builder =>
         {
             builder.Append($"JSON_MODIFY(data, '$.{jsonPath}', JSON_QUERY(");
@@ -304,6 +334,7 @@ internal class PatchOperation : Polecat.Internal.IStorageOperation
 
     internal static Action<ICommandBuilder> RemoveComplexFirst(string jsonPath, string jsonElement)
     {
+        jsonPath = EscapePath(jsonPath);
         return builder =>
         {
             builder.Append($"JSON_MODIFY(data, '$.{jsonPath}', JSON_QUERY(");
@@ -325,6 +356,7 @@ internal class PatchOperation : Polecat.Internal.IStorageOperation
 
     internal static Action<ICommandBuilder> RemoveComplexAll(string jsonPath, string jsonElement)
     {
+        jsonPath = EscapePath(jsonPath);
         return builder =>
         {
             builder.Append($"JSON_MODIFY(data, '$.{jsonPath}', JSON_QUERY(");
@@ -342,16 +374,21 @@ internal class PatchOperation : Polecat.Internal.IStorageOperation
 
     internal static Action<ICommandBuilder> RemoveDictKey(string dictPath, string key)
     {
+        dictPath = EscapePath(dictPath);
+        key = EscapePath(key);
         return builder => { builder.Append($"JSON_MODIFY(data, '$.{dictPath}.{key}', NULL)"); };
     }
 
     internal static Action<ICommandBuilder> DeleteProperty(string jsonPath)
     {
+        jsonPath = EscapePath(jsonPath);
         return builder => { builder.Append($"JSON_MODIFY(data, '$.{jsonPath}', NULL)"); };
     }
 
     internal static Action<ICommandBuilder> RenameProperty(string oldJsonPath, string newJsonPath, bool isScalarType)
     {
+        oldJsonPath = EscapePath(oldJsonPath);
+        newJsonPath = EscapePath(newJsonPath);
         return builder =>
         {
             builder.Append($"JSON_MODIFY(JSON_MODIFY(data, '$.{newJsonPath}', ");
@@ -363,6 +400,8 @@ internal class PatchOperation : Polecat.Internal.IStorageOperation
 
     internal static Action<ICommandBuilder> DuplicateProperty(string sourcePath, string[] destPaths, bool isScalarType)
     {
+        sourcePath = EscapePath(sourcePath);
+        destPaths = Array.ConvertAll(destPaths, EscapePath);
         return builder =>
         {
             for (var i = 0; i < destPaths.Length; i++)


### PR DESCRIPTION
Fixes the two exploitable SQL-injection vectors found in the LINQ/patching audit (#542), using the Marten fixes (JasperFx/marten#4911, #4954) as the checklist.

## 1. Patching JSON paths — analogue of marten#4911

A JSON path segment in a patch is assembled from runtime-supplied strings:
- a `Dictionary<,>` indexer key evaluated at patch-build time (`Patching/JsonPathHelper.cs`), and
- a property/key name passed straight to the patch API — `Patch.Set("name", ...)`, `Append(expr, key, ...)`, `Remove(expr, key)`.

Each segment is inlined into a single-quoted `'$.{path}'` literal inside every `JSON_MODIFY` / `JSON_VALUE` / `JSON_QUERY` call in `PatchOperation`. A value containing a single quote terminated the literal and injected arbitrary SQL into the generated `UPDATE` (CWE-89).

**Fix:** escape embedded single quotes (double them) at the `PatchOperation` sink — the single place every patch path is rendered. `.` path separators are not quote characters, so nested paths are unaffected, and a legitimate key with an apostrophe now round-trips correctly instead of erroring or injecting.

## 2. GroupBy HAVING constant operand — analogue of marten#4954

A `Where(...)` after `GroupBy(...)` becomes a `HAVING` clause comparing an aggregate against a runtime constant. `GroupBySelectBuilder.ResolveHavingOperand` rendered that constant as `constant.Value.ToString()` verbatim, so a string-typed operand (`g.Max(x => x.Color) == someValue`) could break out of the `HAVING` grammar.

**Fix:** bind every constant operand as a command parameter via the new `HavingComparisonFragment`; aggregate operands (developer-controlled member locators) still render inline.

## Tests

- `patching_sql_injection` — command-rendering assertions that every patch sink escapes the path/key.
- `patching_dictionary_key_sql_injection` — end-to-end patch with a hostile dictionary key proving the document table survives, plus a rendering assertion.
- `group_by_having_sql_injection` — HAVING string constant is bound as a parameter, numeric constant is parameterized, aggregate-vs-aggregate still renders inline.

All new tests pass (14). Existing `Polecat.Tests.Patching` (67) and `group_by_operator` (10) suites still pass — the escaping is a no-op for the quote-free paths in normal use.

The query-side paths (WHERE / ORDER BY / IN / cursor pagination / Select projection) were audited and found already parameterized; see #542 for the full findings table. Does **not** merge; for maintainer review.

Closes #542.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
