### PR TITLE
gh-544: batch the per-stream UPDLOCK stream-state reads into one query per save

### DIFF
--- a/src/Polecat.Tests/Events/batched_stream_state_read_tests.cs
+++ b/src/Polecat.Tests/Events/batched_stream_state_read_tests.cs
@@ -1,0 +1,276 @@
+using JasperFx.Events;
+using Polecat.Exceptions;
+using Polecat.Logging;
+using Polecat.Tests.Harness;
+using Shouldly;
+
+namespace Polecat.Tests.Events;
+
+/// <summary>
+///     gh-544: SaveChanges used to issue one UPDLOCK/HOLDLOCK stream-state round trip PER stream
+///     being appended to. These tests pin the batched replacement — one locking read per save —
+///     and its exact (currentVersion, exists, archived) per-stream semantics, for both Guid and
+///     string stream identity.
+/// </summary>
+[Collection("integration")]
+public class batched_stream_state_read_tests : IntegrationContext
+{
+    public batched_stream_state_read_tests(DefaultStoreFixture fixture) : base(fixture)
+    {
+    }
+
+    private static bool IsStreamStateRead(string commandText)
+        => commandText.TrimStart().StartsWith("SELECT", StringComparison.OrdinalIgnoreCase)
+           && commandText.Contains("pc_streams")
+           && commandText.Contains("WITH (UPDLOCK, HOLDLOCK)");
+
+    [Fact]
+    public async Task multi_stream_append_issues_one_stream_state_query()
+    {
+        var streamIds = Enumerable.Range(0, 20).Select(_ => Guid.NewGuid()).ToArray();
+
+        foreach (var id in streamIds)
+        {
+            theSession.Events.StartStream(id, new QuestStarted($"Quest {id}"));
+        }
+
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var logger = new CommandRecordingLogger();
+        await using var session = theStore.LightweightSession();
+        session.Logger = logger;
+
+        foreach (var id in streamIds)
+        {
+            session.Events.Append(id, new MembersJoined(2, "Town", ["Hero"]));
+        }
+
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var stateReads = logger.Commands.Where(IsStreamStateRead).ToArray();
+        stateReads.Length.ShouldBe(1);
+        stateReads[0].ShouldContain("OPENJSON(@ids)");
+
+        // And the batched read fed the exact same version bookkeeping as the per-stream reads did
+        await using var query = theStore.QuerySession();
+        foreach (var id in streamIds)
+        {
+            var state = await query.Events.FetchStreamStateAsync(id, TestContext.Current.CancellationToken);
+            state.ShouldNotBeNull();
+            state!.Version.ShouldBe(2);
+        }
+    }
+
+    [Fact]
+    public async Task single_stream_append_keeps_the_point_lookup()
+    {
+        var streamId = Guid.NewGuid();
+        theSession.Events.StartStream(streamId, new QuestStarted("Solo"));
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var logger = new CommandRecordingLogger();
+        await using var session = theStore.LightweightSession();
+        session.Logger = logger;
+        session.Events.Append(streamId, new MembersJoined(2, "Town", ["Hero"]));
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var stateReads = logger.Commands.Where(IsStreamStateRead).ToArray();
+        stateReads.Length.ShouldBe(1);
+        stateReads[0].ShouldContain("WHERE id = @id");
+        stateReads[0].ShouldNotContain("OPENJSON");
+    }
+
+    [Fact]
+    public async Task batched_read_preserves_existing_and_missing_stream_semantics()
+    {
+        // One stream that exists with 2 events, one that exists with 1, and one the save creates
+        var existingA = Guid.NewGuid();
+        var existingB = Guid.NewGuid();
+        var missing = Guid.NewGuid();
+
+        theSession.Events.StartStream(existingA, new QuestStarted("A"), new MembersJoined(1, "Town", ["X"]));
+        theSession.Events.StartStream(existingB, new QuestStarted("B"));
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        await using var session = theStore.LightweightSession();
+        session.Events.Append(existingA, new MembersJoined(2, "Castle", ["Y"]));
+        session.Events.Append(existingB, new MembersJoined(2, "Castle", ["Z"]));
+        session.Events.Append(missing, new QuestStarted("Born by append"));
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        await using var query = theStore.QuerySession();
+        (await query.Events.FetchStreamStateAsync(existingA, TestContext.Current.CancellationToken))!
+            .Version.ShouldBe(3);
+        (await query.Events.FetchStreamStateAsync(existingB, TestContext.Current.CancellationToken))!
+            .Version.ShouldBe(2);
+        (await query.Events.FetchStreamStateAsync(missing, TestContext.Current.CancellationToken))!
+            .Version.ShouldBe(1);
+
+        var born = await query.Events.FetchStreamAsync(missing, token: TestContext.Current.CancellationToken);
+        born.Count.ShouldBe(1);
+        born[0].Version.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task archived_stream_in_a_multi_stream_save_still_throws()
+    {
+        var healthy = Guid.NewGuid();
+        var archived = Guid.NewGuid();
+
+        theSession.Events.StartStream(healthy, new QuestStarted("Healthy"));
+        theSession.Events.StartStream(archived, new QuestStarted("Doomed"));
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        await using (var archiver = theStore.LightweightSession())
+        {
+            archiver.Events.ArchiveStream(archived);
+            await archiver.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using var session = theStore.LightweightSession();
+        session.Events.Append(healthy, new MembersJoined(2, "Town", ["A"]));
+        session.Events.Append(archived, new MembersJoined(2, "Town", ["B"]));
+
+        await Should.ThrowAsync<InvalidStreamException>(async () =>
+        {
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        });
+    }
+
+    [Fact]
+    public async Task expected_version_mismatch_in_a_multi_stream_save_still_throws()
+    {
+        var fine = Guid.NewGuid();
+        var contested = Guid.NewGuid();
+
+        theSession.Events.StartStream(fine, new QuestStarted("Fine"));
+        theSession.Events.StartStream(contested, new QuestStarted("Contested"));
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        await using var session = theStore.LightweightSession();
+        session.Events.Append(fine, new MembersJoined(2, "Town", ["A"]));
+        await session.Events.AppendOptimistic(contested, TestContext.Current.CancellationToken,
+            new MembersJoined(2, "Town", ["B"]));
+
+        // Bump the contested stream behind the session's back
+        await using (var interloper = theStore.LightweightSession())
+        {
+            interloper.Events.Append(contested, new MembersJoined(2, "Keep", ["C"]));
+            await interloper.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await Should.ThrowAsync<EventStreamUnexpectedMaxEventIdException>(async () =>
+        {
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        });
+    }
+
+    [Fact]
+    public async Task string_identity_multi_stream_append_batches_and_preserves_state()
+    {
+        await StoreOptions(opts =>
+        {
+            opts.DatabaseSchemaName = "batched_read_strings";
+            opts.Events.StreamIdentity = StreamIdentity.AsString;
+        });
+
+        var keys = Enumerable.Range(0, 8).Select(i => $"stream-{Guid.NewGuid():N}-{i}").ToArray();
+
+        await using (var seed = theStore.LightweightSession())
+        {
+            foreach (var key in keys)
+            {
+                seed.Events.StartStream(key, new QuestStarted(key));
+            }
+
+            await seed.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        var logger = new CommandRecordingLogger();
+        await using var session = theStore.LightweightSession();
+        session.Logger = logger;
+
+        foreach (var key in keys)
+        {
+            session.Events.Append(key, new MembersJoined(2, "Town", ["Hero"]));
+        }
+
+        var freshKey = $"fresh-{Guid.NewGuid():N}";
+        session.Events.Append(freshKey, new QuestStarted("Fresh"));
+
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var stateReads = logger.Commands.Where(IsStreamStateRead).ToArray();
+        stateReads.Length.ShouldBe(1);
+        stateReads[0].ShouldContain("OPENJSON(@ids)");
+        stateReads[0].ShouldContain("CAST(value AS varchar(250))");
+
+        await using var query = theStore.QuerySession();
+        foreach (var key in keys)
+        {
+            (await query.Events.FetchStreamStateAsync(key, TestContext.Current.CancellationToken))!
+                .Version.ShouldBe(2);
+        }
+
+        (await query.Events.FetchStreamStateAsync(freshKey, TestContext.Current.CancellationToken))!
+            .Version.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task concurrent_saves_over_overlapping_stream_sets_do_not_deadlock()
+    {
+        // Two sessions appending to the same streams enqueued in OPPOSITE orders. The batched read
+        // sorts the ids client-side into one locking statement, so the sessions serialize on the
+        // pc_streams rows instead of interleaving N per-stream lock acquisitions in opposite order.
+        var streamIds = Enumerable.Range(0, 10).Select(_ => Guid.NewGuid()).ToArray();
+
+        foreach (var id in streamIds)
+        {
+            theSession.Events.StartStream(id, new QuestStarted($"Quest {id}"));
+        }
+
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var token = TestContext.Current.CancellationToken;
+
+        async Task AppendAll(IEnumerable<Guid> ids)
+        {
+            await using var session = theStore.LightweightSession();
+            foreach (var id in ids)
+            {
+                session.Events.Append(id, new MembersJoined(2, "Town", ["Racer"]));
+            }
+
+            await session.SaveChangesAsync(token);
+        }
+
+        await Task.WhenAll(
+            Task.Run(() => AppendAll(streamIds), token),
+            Task.Run(() => AppendAll(Enumerable.Reverse(streamIds)), token));
+
+        await using var query = theStore.QuerySession();
+        foreach (var id in streamIds)
+        {
+            (await query.Events.FetchStreamStateAsync(id, token))!.Version.ShouldBe(3);
+        }
+    }
+
+    private class CommandRecordingLogger : IPolecatSessionLogger
+    {
+        public List<string> Commands { get; } = new();
+
+        public void OnBeforeExecute(string commandText) => Commands.Add(commandText);
+
+        public void LogSuccess(string commandText)
+        {
+        }
+
+        public void LogFailure(string commandText, Exception ex)
+        {
+        }
+
+        public void RecordSavedChanges(IDocumentSession session)
+        {
+        }
+    }
+}

--- a/src/Polecat/Events/Daemon/PolecatProjectionBatch.cs
+++ b/src/Polecat/Events/Daemon/PolecatProjectionBatch.cs
@@ -361,9 +361,10 @@ internal class PolecatProjectionBatch : IProjectionBatch<IDocumentSession, IQuer
                      .GroupBy(a => a.TenantId ?? JasperFx.StorageConstants.DefaultTenantId))
         {
             var session = (DocumentSessionBase)SessionForTenant(group.Key);
-            foreach (var action in group)
+            // One batched stream-state read per tenant group instead of one per action.
+            var built = await session.BuildRaisedEventAppendsAsync(group.ToList(), token).ConfigureAwait(false);
+            foreach (var op in built)
             {
-                var op = await session.BuildRaisedEventAppendAsync(action, token).ConfigureAwait(false);
                 // The batch configures commands with a null session, so the append has to arrive
                 // already bound to the one that will write it.
                 ops.Add(new SessionBoundOperationAdapter(op, (Weasel.Storage.IStorageSession)session));

--- a/src/Polecat/Internal/DocumentSessionBase.cs
+++ b/src/Polecat/Internal/DocumentSessionBase.cs
@@ -908,6 +908,10 @@ internal abstract class DocumentSessionBase : QuerySession, IDocumentSession
 
         var ops = new List<Weasel.Storage.IStorageOperation>();
 
+        // First pass: run the no-event consistency asserts and collect the appending streams that
+        // need a stream-state read, so the N per-stream locking round trips collapse into ONE
+        // batched read per save below.
+        var appendingStreams = new List<StreamAction>();
         foreach (var stream in _workTracker.Streams)
         {
             if (!stream.Events.Any())
@@ -920,6 +924,21 @@ internal abstract class DocumentSessionBase : QuerySession, IDocumentSession
                     await AssertStreamVersionAsync(stream, token);
                 }
 
+                continue;
+            }
+
+            if (stream.ActionType != StreamActionType.Start)
+            {
+                appendingStreams.Add(stream);
+            }
+        }
+
+        var states = await ReadStreamStatesForClosedShapeAsync(appendingStreams, token);
+
+        foreach (var stream in _workTracker.Streams)
+        {
+            if (!stream.Events.Any())
+            {
                 continue;
             }
 
@@ -936,9 +955,11 @@ internal abstract class DocumentSessionBase : QuerySession, IDocumentSession
             }
             else
             {
-                var (currentVersion, exists, archived) = await ReadStreamStateForClosedShapeAsync(stream, token);
-
                 var streamId = isGuid ? (object)stream.Id : stream.Key!;
+                var (currentVersion, exists, archived) = states.TryGetValue(streamId, out var state)
+                    ? state
+                    : (0L, false, false);
+
                 if (archived)
                 {
                     throw new Exceptions.InvalidStreamException(streamId, "Cannot append to an archived stream.");
@@ -968,11 +989,12 @@ internal abstract class DocumentSessionBase : QuerySession, IDocumentSession
     }
 
     /// <summary>
-    ///     #420: build the append operation for a <see cref="StreamAction" /> a projection raised,
-    ///     so the async daemon batch can write it inside its own transaction rather than dropping
-    ///     it. Same path as the inline append — resolve the tenant partition, read the stream row
-    ///     under <c>UPDLOCK, HOLDLOCK</c>, assign versions client-side from what that read
-    ///     returned, then build the closed-shape quick-append op.
+    ///     #420: build the append operations for the <see cref="StreamAction" />s a projection
+    ///     raised, so the async daemon batch can write them inside its own transaction rather than
+    ///     dropping them. Same path as the inline append — resolve the tenant partition, read the
+    ///     stream rows under <c>UPDLOCK, HOLDLOCK</c> (one batched read for the whole group),
+    ///     assign versions client-side from what that read returned, then build the closed-shape
+    ///     quick-append ops.
     ///     <para>
     ///     The one deliberate difference is the concurrency expectation. JasperFx's
     ///     <c>EventSlice.BuildOperations</c> pre-assigns versions on the single-stream-start path
@@ -982,35 +1004,49 @@ internal abstract class DocumentSessionBase : QuerySession, IDocumentSession
     ///     and as the guard on the stream-row update.
     ///     </para>
     /// </summary>
-    internal async Task<Weasel.Storage.IStorageOperation> BuildRaisedEventAppendAsync(
-        StreamAction stream, CancellationToken token)
+    internal async Task<List<Weasel.Storage.IStorageOperation>> BuildRaisedEventAppendsAsync(
+        IReadOnlyList<StreamAction> streams, CancellationToken token)
     {
+        var ops = new List<Weasel.Storage.IStorageOperation>();
+        if (streams.Count == 0) return ops;
+
         var storage = _eventGraph.ClosedShapeEventStorage;
         var isGuid = _eventGraph.StreamIdentity == JasperFx.Events.StreamIdentity.AsGuid;
 
-        var (partitionOrdinal, partitionSequenceName) = await ResolvePartitionForClosedShapeAsync(stream, token);
-        var (currentVersion, exists, archived) = await ReadStreamStateForClosedShapeAsync(stream, token);
+        // One batched locking read for the whole group instead of one round trip per action.
+        var states = await ReadStreamStatesForClosedShapeAsync(streams, token);
 
-        var streamId = isGuid ? (object)stream.Id : stream.Key!;
-        if (archived)
+        foreach (var stream in streams)
         {
-            throw new Exceptions.InvalidStreamException(streamId, "Cannot append to an archived stream.");
+            var (partitionOrdinal, partitionSequenceName) = await ResolvePartitionForClosedShapeAsync(stream, token);
+
+            var streamId = isGuid ? (object)stream.Id : stream.Key!;
+            var (currentVersion, exists, archived) = states.TryGetValue(streamId, out var state)
+                ? state
+                : (0L, false, false);
+
+            if (archived)
+            {
+                throw new Exceptions.InvalidStreamException(streamId, "Cannot append to an archived stream.");
+            }
+
+            AssignEventMetadataForClosedShape(stream, currentVersion);
+            stream.Version = currentVersion + stream.Events.Count;
+
+            // Replace (not ??=) JasperFx's client-side guess with the locked read, so the guarded
+            // stream-row update asserts something true rather than failing the shard on a stream the
+            // projection has only partially seen. A stream row that does not exist yet is inserted.
+            stream.ExpectedVersionOnServer = exists ? currentVersion : null;
+
+            var mode = exists
+                ? Polecat.Events.Storage.StreamWriteMode.Update
+                : Polecat.Events.Storage.StreamWriteMode.Insert;
+
+            ops.Add(QuickAppendEventsClosedShape(storage, isGuid, stream, mode,
+                partitionOrdinal, partitionSequenceName));
         }
 
-        AssignEventMetadataForClosedShape(stream, currentVersion);
-        stream.Version = currentVersion + stream.Events.Count;
-
-        // Replace (not ??=) JasperFx's client-side guess with the locked read, so the guarded
-        // stream-row update asserts something true rather than failing the shard on a stream the
-        // projection has only partially seen. A stream row that does not exist yet is inserted.
-        stream.ExpectedVersionOnServer = exists ? currentVersion : null;
-
-        var mode = exists
-            ? Polecat.Events.Storage.StreamWriteMode.Update
-            : Polecat.Events.Storage.StreamWriteMode.Insert;
-
-        return QuickAppendEventsClosedShape(storage, isGuid, stream, mode,
-            partitionOrdinal, partitionSequenceName);
+        return ops;
     }
 
     private async Task<(int? ordinal, string? sequenceName)> ResolvePartitionForClosedShapeAsync(
@@ -1062,26 +1098,120 @@ internal abstract class DocumentSessionBase : QuerySession, IDocumentSession
         }
     }
 
-    private async Task<(long currentVersion, bool exists, bool archived)> ReadStreamStateForClosedShapeAsync(
-        StreamAction stream, CancellationToken token)
+    /// <summary>
+    ///     Read the (version, exists, archived) state of every stream in <paramref name="streams" />
+    ///     under <c>UPDLOCK, HOLDLOCK</c> in ONE round trip, instead of one locking read per stream.
+    ///     A stream absent from the result simply has no entry in the returned dictionary — callers
+    ///     treat that as (0, not-exists, not-archived), exactly as the old per-stream read did.
+    ///     <para>
+    ///     Lock ordering: the ids travel to <c>OPENJSON</c> pre-sorted — <see cref="SqlGuid" />
+    ///     ordering for Guid identity (matching SQL Server's uniqueidentifier index order) and
+    ///     ordinal ordering for string identity — so two sessions appending to overlapping stream
+    ///     sets tend to acquire their row locks in a consistent order. A single statement per save
+    ///     also removes the interleaving window the old N sequential statements offered.
+    ///     </para>
+    ///     <para>
+    ///     Tenancy: like the per-stream read this replaces, the lookup is scoped to the session's
+    ///     own <see cref="QuerySession.TenantId" /> (the daemon path builds one session per tenant
+    ///     group before calling in).
+    ///     </para>
+    /// </summary>
+    private async Task<Dictionary<object, (long currentVersion, bool exists, bool archived)>>
+        ReadStreamStatesForClosedShapeAsync(IReadOnlyList<StreamAction> streams, CancellationToken token)
     {
-        var streamId = _eventGraph.StreamIdentity == JasperFx.Events.StreamIdentity.AsGuid
-            ? (object)stream.Id
-            : stream.Key!;
+        var states = new Dictionary<object, (long currentVersion, bool exists, bool archived)>();
+        if (streams.Count == 0) return states;
 
-        await using var cmd = new SqlCommand();
-        cmd.CommandText =
-            $"SELECT version, is_archived FROM {_eventGraph.StreamsTableName} WITH (UPDLOCK, HOLDLOCK) WHERE id = @id AND tenant_id = @tenant_id;";
-        cmd.Parameters.AddIdParameter("@id", streamId);
-        cmd.Parameters.AddVarChar("@tenant_id", TenantId);
+        var isGuid = _eventGraph.StreamIdentity == JasperFx.Events.StreamIdentity.AsGuid;
 
-        await using var reader = await ExecuteReaderAsync(cmd, token);
-        if (await reader.ReadAsync(token))
+        if (streams.Count == 1)
         {
-            return (reader.GetInt64(0), true, reader.GetBoolean(1));
+            // Single-aggregate saves are the hot path; keep the simple point-lookup SQL (and its plan).
+            var streamId = isGuid ? (object)streams[0].Id : streams[0].Key!;
+
+            await using var cmd = new SqlCommand();
+            cmd.CommandText =
+                $"SELECT version, is_archived FROM {_eventGraph.StreamsTableName} WITH (UPDLOCK, HOLDLOCK) WHERE id = @id AND tenant_id = @tenant_id;";
+            cmd.Parameters.AddIdParameter("@id", streamId);
+            cmd.Parameters.AddVarChar("@tenant_id", TenantId);
+
+            // Through the db-neutral seam so the session logger sees the stream-state read
+            await using var reader = await ExecuteReaderAsync((System.Data.Common.DbCommand)cmd, token);
+            if (await reader.ReadAsync(token))
+            {
+                states[streamId] = (reader.GetInt64(0), true, reader.GetBoolean(1));
+            }
+
+            return states;
         }
 
-        return (0, false, false);
+        // #363 OPENJSON id-list pattern (see PolecatDocumentStorage): SQL Server has no array
+        // parameters, so the ids travel as one JSON array. OPENJSON's value column is nvarchar(4000),
+        // so cast back to the id column's own type to keep the index seek.
+        object[] ids = isGuid
+            ? streams.Select(x => x.Id).Distinct()
+                .OrderBy(x => new System.Data.SqlTypes.SqlGuid(x))
+                .Cast<object>().ToArray()
+            : streams.Select(x => x.Key!).Distinct()
+                .OrderBy(x => x, StringComparer.Ordinal)
+                .Cast<object>().ToArray();
+
+        var idsSelect = isGuid
+            ? "SELECT CAST(value AS uniqueidentifier) FROM OPENJSON(@ids)"
+            : "SELECT CAST(value AS varchar(250)) FROM OPENJSON(@ids)";
+
+        await using var batchCmd = new SqlCommand();
+        batchCmd.CommandText =
+            $"SELECT id, version, is_archived FROM {_eventGraph.StreamsTableName} WITH (UPDLOCK, HOLDLOCK) WHERE tenant_id = @tenant_id AND id IN ({idsSelect});";
+        batchCmd.Parameters.Add(
+            new SqlParameter("@ids", WriteStreamIdsAsJsonArray(ids))
+            {
+                SqlDbType = System.Data.SqlDbType.NVarChar
+            });
+        batchCmd.Parameters.AddVarChar("@tenant_id", TenantId);
+
+        // Through the db-neutral seam so the session logger sees the stream-state read
+        await using var batchReader = await ExecuteReaderAsync((System.Data.Common.DbCommand)batchCmd, token);
+        while (await batchReader.ReadAsync(token))
+        {
+            var id = isGuid ? (object)batchReader.GetGuid(0) : batchReader.GetString(0);
+            states[id] = (batchReader.GetInt64(1), true, batchReader.GetBoolean(2));
+        }
+
+        return states;
+    }
+
+    /// <summary>
+    ///     Stream ids as one JSON array string for OPENJSON — the same manual, reflection-free
+    ///     writing as <c>SqlServerStorageDialect.WriteIdsAsJsonArray</c> (that one is private on a
+    ///     generic type). Only Guid and string, the two stream identity modes.
+    /// </summary>
+    private static string WriteStreamIdsAsJsonArray(object[] ids)
+    {
+        var buffer = new System.Buffers.ArrayBufferWriter<byte>();
+        using (var writer = new System.Text.Json.Utf8JsonWriter(buffer))
+        {
+            writer.WriteStartArray();
+            foreach (var id in ids)
+            {
+                switch (id)
+                {
+                    case Guid guid:
+                        writer.WriteStringValue(guid);
+                        break;
+                    case string text:
+                        writer.WriteStringValue(text);
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException(nameof(ids),
+                            $"Unsupported stream id type {id?.GetType().FullName ?? "null"}; expected Guid or string.");
+                }
+            }
+
+            writer.WriteEndArray();
+        }
+
+        return System.Text.Encoding.UTF8.GetString(buffer.WrittenSpan);
     }
 
     private async Task ExecuteClosedShapeEventOperationsAsync(


### PR DESCRIPTION
Closes #544. Part of Stoat plan `critter-performance-2026-09`, node `polecat-stream-version-batch`.

## What

`SaveChangesAsync` issued one locking round trip per stream being appended to:

```sql
SELECT version, is_archived FROM pc_streams WITH (UPDLOCK, HOLDLOCK)
WHERE id = @id AND tenant_id = @tenant_id;
```

called from the `ProcessStreamsClosedShapeAsync` loop, and again per raised-event action on the async daemon batch path (`BuildRaisedEventAppendAsync`). A session appending to 20 streams paid 20 sequential locking round trips before the append batch even started.

This PR collapses those N reads into **one** batched statement per save:

```sql
SELECT id, version, is_archived FROM pc_streams WITH (UPDLOCK, HOLDLOCK)
WHERE tenant_id = @tenant_id AND id IN (SELECT CAST(value AS ...) FROM OPENJSON(@ids));
```

reusing the #363 OPENJSON id-list pattern from `PolecatDocumentStorage` (with the same cast-back-to-column-type trick that keeps the index seek). The single-aggregate save — the hot path — keeps the existing point-lookup SQL and its plan.

## Lock-ordering decision

The ids travel to `OPENJSON` **pre-sorted client-side**: `SqlGuid` ordering for Guid identity (matching SQL Server's uniqueidentifier index/comparison order) and ordinal ordering for string identity. Two sessions appending to overlapping stream sets therefore tend to acquire their `UPDLOCK` row locks in a consistent order. Just as important, one statement per save removes the cross-statement interleaving window that N sequential per-stream statements offered — the old path acquired locks in *user append order*, so two sessions appending to the same streams in opposite orders could deadlock; a single sorted statement forecloses that. (SQL Server does not contractually guarantee row-touch order inside one statement, so the sort is a strong mitigation plus a determinism guarantee for the SQL text, not a hard ordering proof.)

## Semantics preserved

- A stream absent from the result set keeps the exact `(currentVersion: 0, exists: false, archived: false)` behavior of the old per-stream read — append to a nonexistent stream still inserts starting at version 1, archived streams still throw `InvalidStreamException`, expected-version mismatches still throw `EventStreamUnexpectedMaxEventIdException`.
- Both stream identity modes (Guid and string) are covered, with the string ids cast back to `varchar(250)` per #363.
- Tenancy scoping is unchanged: like the per-stream read it replaces, the lookup is bound to the session's own `TenantId` (the daemon path already builds one session per tenant group before calling in).
- **Async daemon raised events**: `BuildRaisedEventAppendAsync` could not reuse the inline save's batch (it runs on the daemon's own per-tenant sessions in a different transaction), so it got the same treatment — `BuildRaisedEventAppendsAsync` now does one batched read per tenant group instead of one per raised action.
- **`AppendOptimistic` / `AppendExclusive` untouched**: their up-front version reads are a separate path (`ReadVersionFromExistingStream`), and their save-time flow goes through the same batched read with identical semantics (mapped the call graph before changing anything).
- The stream-state reads now execute through the db-neutral `DbCommand` seam so the session logger observes them (previously they bypassed logging entirely).

## Tests

New `batched_stream_state_read_tests` (7 tests, all green against the shared SQL Server 2025 container):

- a 20-stream save issues exactly **one** stream-state query (asserted via a recording `IPolecatSessionLogger`), and the versions land identically
- single-stream save keeps the point lookup (no OPENJSON)
- existing + missing stream mix preserves per-stream `(version, exists)` semantics
- archived stream inside a multi-stream save still throws
- expected-version conflict inside a multi-stream save still throws
- string-identity variant (batching + `varchar(250)` cast + fresh-stream insert)
- two concurrent sessions appending to the same 10 streams in **opposite** orders complete without deadlock, versions correct

Plus the full `Polecat.Tests.Events` namespace and the event-store compliance suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
