### PR TITLE
Scope destructive event rewrites to the calling tenant; assert stream identity on CompactStreamAsync

### DIFF
--- a/src/Polecat.Tests/Events/cross_tenant_event_rewrite_tests.cs
+++ b/src/Polecat.Tests/Events/cross_tenant_event_rewrite_tests.cs
@@ -1,0 +1,249 @@
+using JasperFx;
+using JasperFx.Events;
+using JasperFx.Events.Protected;
+using Microsoft.Data.SqlClient;
+using Polecat.Tests.Harness;
+using Polecat.Tests.Projections;
+using Polecat.TestUtils;
+
+namespace Polecat.Tests.Events;
+
+// A mutable probe event so an Action masking rule can rewrite it in place.
+public class MaskProbeEvent
+{
+    public string Secret { get; set; } = string.Empty;
+}
+
+/// <summary>
+///     marten#5234's Polecat twin (fixed there in commit 5a44c7452): under
+///     <c>Events.UseTenantPartitionedEvents</c> every tenant draws from its own
+///     <c>pc_events_sequence_{ordinal}</c>, so <c>seq_id = 1</c> exists in EVERY tenant's
+///     partition. Three operations that rewrite <c>pc_events</c> keyed their WHERE on
+///     <c>seq_id</c> alone, so the write escaped the tenant the read had correctly scoped to:
+///
+///     <list type="bullet">
+///         <item>masking (<c>OverwriteEventOperation</c>) destroyed another tenant's payload and
+///         replaced it with the calling tenant's masked JSON — a cross-tenant write AND
+///         disclosure, in the feature that exists to prevent exactly that;</item>
+///         <item>compaction's delete (<c>DeleteEventsOperation</c>) permanently removed another
+///         tenant's events;</item>
+///         <item>compaction's snapshot write (<c>ReplaceEventOperation</c>) left the calling
+///         tenant's whole aggregate state sitting in the other tenant's stream.</item>
+///     </list>
+///
+///     Nothing threw in any of the three.
+/// </summary>
+[Collection("tenant-partitioning")]
+public class cross_tenant_event_rewrite_tests : IAsyncLifetime
+{
+    private const string Schema = "xtenant_rewrite";
+
+    public async ValueTask InitializeAsync()
+    {
+        await DropSchemaTablesAsync(Schema);
+        await PartitionTestCleanup.DropEventsPartitionObjectsAsync();
+        await DropSequencesAsync(Schema);
+    }
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+    private static DocumentStore CreateStore()
+    {
+        return DocumentStore.For(opts =>
+        {
+            opts.ConnectionString = ConnectionSource.ConnectionString;
+            opts.DatabaseSchemaName = Schema;
+            opts.AutoCreateSchemaObjects = AutoCreate.All;
+            opts.UseNativeJsonType = ConnectionSource.SupportsNativeJson;
+            opts.Events.TenancyStyle = TenancyStyle.Conjoined;
+            opts.EventGraph.UseTenantPartitionedEvents = true;
+
+            opts.Events.AddEventType(typeof(MaskProbeEvent));
+            opts.Events.AddMaskingRuleForProtectedInformation<MaskProbeEvent>(x => x.Secret = "***");
+        });
+    }
+
+    [Fact]
+    public async Task masking_one_tenant_must_not_rewrite_another_tenants_events()
+    {
+        using var store = CreateStore();
+        await store.Database.ApplyAllConfiguredChangesToDatabaseAsync(ct: TestContext.Current.CancellationToken);
+
+        var alphaStream = Guid.NewGuid();
+        var betaStream = Guid.NewGuid();
+
+        await using (var session = store.LightweightSession(new SessionOptions { TenantId = "alpha" }))
+        {
+            session.Events.StartStream(alphaStream, new MaskProbeEvent { Secret = "alpha-secret" });
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using (var session = store.LightweightSession(new SessionOptions { TenantId = "beta" }))
+        {
+            session.Events.StartStream(betaStream, new MaskProbeEvent { Secret = "beta-secret" });
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        // The collision this bug depends on: each tenant has its own sequence, so both events are
+        // seq_id 1. If this ever stops being true the assertion below stops proving anything.
+        (await sequenceOf(store, alphaStream, "alpha")).ShouldBe(await sequenceOf(store, betaStream, "beta"));
+
+        await store.Advanced.ApplyEventDataMasking(x =>
+        {
+            x.ForTenant("alpha");
+            x.IncludeStream(alphaStream);
+        }, TestContext.Current.CancellationToken);
+
+        await using var query = store.QuerySession(new SessionOptions { TenantId = "beta" });
+        var betaEvent = (await query.Events.FetchStreamAsync(betaStream, token: TestContext.Current.CancellationToken)).Single();
+
+        betaEvent.Data.ShouldBeOfType<MaskProbeEvent>().Secret.ShouldBe("beta-secret",
+            "masking tenant alpha must not touch tenant beta's same-numbered event");
+    }
+
+    [Fact]
+    public async Task masking_still_masks_the_tenant_it_was_asked_to()
+    {
+        // The guard must not be so tight that the feature stops working.
+        using var store = CreateStore();
+        await store.Database.ApplyAllConfiguredChangesToDatabaseAsync(ct: TestContext.Current.CancellationToken);
+
+        var alphaStream = Guid.NewGuid();
+
+        await using (var session = store.LightweightSession(new SessionOptions { TenantId = "alpha" }))
+        {
+            session.Events.StartStream(alphaStream, new MaskProbeEvent { Secret = "alpha-secret" });
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await store.Advanced.ApplyEventDataMasking(x =>
+        {
+            x.ForTenant("alpha");
+            x.IncludeStream(alphaStream);
+        }, TestContext.Current.CancellationToken);
+
+        await using var query = store.QuerySession(new SessionOptions { TenantId = "alpha" });
+        var alphaEvent = (await query.Events.FetchStreamAsync(alphaStream, token: TestContext.Current.CancellationToken)).Single();
+
+        alphaEvent.Data.ShouldBeOfType<MaskProbeEvent>().Secret.ShouldBe("***");
+    }
+
+    [Fact]
+    public async Task compacting_one_tenants_stream_must_not_delete_another_tenants_events()
+    {
+        using var store = CreateStore();
+        await store.Database.ApplyAllConfiguredChangesToDatabaseAsync(ct: TestContext.Current.CancellationToken);
+
+        var alphaStream = Guid.NewGuid();
+        var betaStream = Guid.NewGuid();
+
+        await using (var session = store.LightweightSession(new SessionOptions { TenantId = "alpha" }))
+        {
+            session.Events.StartStream(alphaStream,
+                new QuestStarted("Alpha Quest"),
+                new MembersJoined(1, "Town", ["AlphaHero"]),
+                new MonsterSlain("Goblin", 5));
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using (var session = store.LightweightSession(new SessionOptions { TenantId = "beta" }))
+        {
+            session.Events.StartStream(betaStream,
+                new QuestStarted("Beta Quest"),
+                new MembersJoined(1, "Forest", ["BetaHero"]),
+                new MonsterSlain("Dragon", 50));
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using (var session = store.LightweightSession(new SessionOptions { TenantId = "alpha" }))
+        {
+            await session.Events.CompactStreamAsync<QuestParty>(alphaStream);
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using var query = store.QuerySession(new SessionOptions { TenantId = "beta" });
+        var betaEvents = await query.Events.FetchStreamAsync(betaStream, token: TestContext.Current.CancellationToken);
+
+        // Pre-fix this was 1 — beta's first two events deleted, and the survivor at seq_id 3 was
+        // alpha's Compacted<QuestParty> snapshot sitting in beta's stream.
+        betaEvents.Count.ShouldBe(3, "compacting alpha's stream must leave beta's events alone");
+        betaEvents.ShouldAllBe(x => !(x.Data is Compacted<QuestParty>));
+    }
+
+    [Fact]
+    public async Task compaction_still_compacts_the_stream_it_was_asked_to()
+    {
+        using var store = CreateStore();
+        await store.Database.ApplyAllConfiguredChangesToDatabaseAsync(ct: TestContext.Current.CancellationToken);
+
+        var alphaStream = Guid.NewGuid();
+
+        await using (var session = store.LightweightSession(new SessionOptions { TenantId = "alpha" }))
+        {
+            session.Events.StartStream(alphaStream,
+                new QuestStarted("Alpha Quest"),
+                new MembersJoined(1, "Town", ["AlphaHero"]),
+                new MonsterSlain("Goblin", 5));
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using (var session = store.LightweightSession(new SessionOptions { TenantId = "alpha" }))
+        {
+            await session.Events.CompactStreamAsync<QuestParty>(alphaStream);
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using var query = store.QuerySession(new SessionOptions { TenantId = "alpha" });
+        var alphaEvents = await query.Events.FetchStreamAsync(alphaStream, token: TestContext.Current.CancellationToken);
+
+        var compacted = alphaEvents.Single().Data.ShouldBeOfType<Compacted<QuestParty>>();
+        compacted.Snapshot.Name.ShouldBe("Alpha Quest");
+    }
+
+    private static async Task<long> sequenceOf(DocumentStore store, Guid streamId, string tenantId)
+    {
+        await using var query = store.QuerySession(new SessionOptions { TenantId = tenantId });
+        var events = await query.Events.FetchStreamAsync(streamId, token: TestContext.Current.CancellationToken);
+        return events[0].Sequence;
+    }
+
+    private static async Task DropSchemaTablesAsync(string schema)
+    {
+        await using var conn = new SqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = """
+            DECLARE @sql nvarchar(max) = N'';
+            SELECT @sql = @sql + 'ALTER TABLE [' + s.name + '].[' + t.name + '] DROP CONSTRAINT [' + fk.name + '];'
+            FROM sys.foreign_keys fk
+            JOIN sys.tables t ON fk.parent_object_id = t.object_id
+            JOIN sys.schemas s ON t.schema_id = s.schema_id
+            WHERE s.name = @schema;
+
+            SELECT @sql = @sql + 'DROP TABLE [' + s.name + '].[' + t.name + '];'
+            FROM sys.tables t
+            JOIN sys.schemas s ON t.schema_id = s.schema_id
+            WHERE s.name = @schema;
+            EXEC sp_executesql @sql;
+            """;
+        cmd.Parameters.AddWithValue("@schema", schema);
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    private static async Task DropSequencesAsync(string schema)
+    {
+        await using var conn = new SqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = """
+            DECLARE @sql nvarchar(max) = N'';
+            SELECT @sql = @sql + 'DROP SEQUENCE [' + s.name + '].[' + sq.name + '];'
+            FROM sys.sequences sq
+            JOIN sys.schemas s ON sq.schema_id = s.schema_id
+            WHERE s.name = @schema;
+            EXEC sp_executesql @sql;
+            """;
+        cmd.Parameters.AddWithValue("@schema", schema);
+        await cmd.ExecuteNonQueryAsync();
+    }
+}

--- a/src/Polecat.Tests/Events/stream_compacting_identity_mismatch_tests.cs
+++ b/src/Polecat.Tests/Events/stream_compacting_identity_mismatch_tests.cs
@@ -1,0 +1,58 @@
+using JasperFx;
+using JasperFx.Events;
+using Polecat.Tests.Harness;
+using Polecat.Tests.Projections;
+using Polecat.TestUtils;
+
+namespace Polecat.Tests.Events;
+
+/// <summary>
+///     marten#5244's Polecat twin: <c>CompactStreamAsync&lt;T&gt;</c> branches on the store's
+///     configured <see cref="StreamIdentity" /> rather than on which overload the caller used, and
+///     never asserted the two agreed. Calling the Guid overload against a string-identified store
+///     took the AsString branch, read a null StreamKey, matched no stream, and returned
+///     successfully having compacted NOTHING — no exception, and no way to tell a no-op from a
+///     completed compaction. The mirror case failed with "Nullable object must have a value",
+///     which names nothing the caller can act on.
+/// </summary>
+[Collection("integration")]
+public class stream_compacting_identity_mismatch_tests
+{
+    private static DocumentStore CreateStore(StreamIdentity identity, string schema)
+    {
+        return DocumentStore.For(opts =>
+        {
+            opts.ConnectionString = ConnectionSource.ConnectionString;
+            opts.DatabaseSchemaName = schema;
+            opts.AutoCreateSchemaObjects = AutoCreate.All;
+            opts.UseNativeJsonType = ConnectionSource.SupportsNativeJson;
+            opts.Events.StreamIdentity = identity;
+        });
+    }
+
+    [Fact]
+    public async Task guid_overload_on_a_string_identified_store_throws_instead_of_silently_compacting_nothing()
+    {
+        using var store = CreateStore(StreamIdentity.AsString, "compact_idmix_str");
+
+        await using var session = store.LightweightSession();
+
+        var ex = await Should.ThrowAsync<InvalidOperationException>(
+            () => session.Events.CompactStreamAsync<QuestParty>(Guid.NewGuid()));
+
+        ex.Message.ShouldContain("identify streams with strings");
+    }
+
+    [Fact]
+    public async Task string_overload_on_a_guid_identified_store_throws_an_actionable_message()
+    {
+        using var store = CreateStore(StreamIdentity.AsGuid, "compact_idmix_guid");
+
+        await using var session = store.LightweightSession();
+
+        var ex = await Should.ThrowAsync<InvalidOperationException>(
+            () => session.Events.CompactStreamAsync<QuestParty>("some-stream-key"));
+
+        ex.Message.ShouldContain("identify streams with Guids");
+    }
+}

--- a/src/Polecat/Events/EventGraph.cs
+++ b/src/Polecat/Events/EventGraph.cs
@@ -320,6 +320,35 @@ public class EventGraph : EventRegistry, IAggregationSourceFactory<IQuerySession
             : StringEventStorage.UpdateProgress(shardIdentity, sequence, upsert);
 
     /// <summary>
+    ///     Guard for identity-sensitive entry points that take a Guid stream id (marten#5244's
+    ///     Polecat twin — same messages as Marten's EnsureAsGuidStorage/EnsureAsStringStorage).
+    ///     Downstream code branches on the store's configured <see cref="StreamIdentity" /> rather
+    ///     than on which overload the caller used, so a mismatched overload otherwise either
+    ///     silently matches nothing or fails with an error naming nothing actionable.
+    /// </summary>
+    internal void EnsureAsGuidStorage()
+    {
+        if (StreamIdentity == StreamIdentity.AsString)
+        {
+            throw new InvalidOperationException(
+                "This Polecat event store is configured to identify streams with strings");
+        }
+    }
+
+    /// <summary>
+    ///     Guard for identity-sensitive entry points that take a string stream key. See
+    ///     <see cref="EnsureAsGuidStorage" />.
+    /// </summary>
+    internal void EnsureAsStringStorage()
+    {
+        if (StreamIdentity == StreamIdentity.AsGuid)
+        {
+            throw new InvalidOperationException(
+                "This Polecat event store is configured to identify streams with Guids");
+        }
+    }
+
+    /// <summary>
     ///     Wrap raw event data into an IEvent instance with type metadata.
     /// </summary>
     public override IEvent BuildEvent(object eventData)

--- a/src/Polecat/Events/EventOperations.cs
+++ b/src/Polecat/Events/EventOperations.cs
@@ -524,7 +524,7 @@ internal class EventOperations : QueryEventStore, IEventOperations
             ? _sessionBase.Serializer.ToJson(@event.Headers)
             : null;
         _workTracker.Add(new Protected.OverwriteEventOperation(
-            _events, @event, serializedData, serializedBdata, serializedHeaders));
+            _events, @event, serializedData, serializedBdata, serializedHeaders, _tenantId));
     }
 
     public Guid CompletelyReplaceEvent<T>(long sequence, T eventBody) where T : class
@@ -542,7 +542,8 @@ internal class EventOperations : QueryEventStore, IEventOperations
             ? _sessionBase.Serializer.ToJson(eventBody)
             : EventGraph.JsonPlaceholderForBinaryEvent;
         var op = new Protected.ReplaceEventOperation(
-            _events, sequence, serializedData, serializedBdata, mapping.EventTypeName, mapping.DotNetTypeName);
+            _events, sequence, serializedData, serializedBdata, mapping.EventTypeName, mapping.DotNetTypeName,
+            _tenantId);
 
         _workTracker.Add(op);
         return op.Id;
@@ -931,6 +932,14 @@ internal class EventOperations : QueryEventStore, IEventOperations
     public async Task CompactStreamAsync<T>(Guid streamId, Action<StreamCompactingRequest<T>>? configure = null)
         where T : class
     {
+        // marten#5244's Polecat twin: StreamCompactingExecution branches on the store's configured
+        // StreamIdentity, not on which overload was called. Without this guard, the Guid overload
+        // against a string-identified store takes the AsString branch, reads a null StreamKey,
+        // matches no stream, and returns at the empty-events guard — compaction silently did
+        // NOTHING while looking like it succeeded, with no way to tell a no-op from a completed
+        // compaction of a destructive operation.
+        _events.EnsureAsGuidStorage();
+
         var request = new StreamCompactingRequest<T>(streamId);
         configure?.Invoke(request);
         await request.ExecuteAsync(_sessionBase).ConfigureAwait(false);
@@ -939,6 +948,11 @@ internal class EventOperations : QueryEventStore, IEventOperations
     public async Task CompactStreamAsync<T>(string streamKey, Action<StreamCompactingRequest<T>>? configure = null)
         where T : class
     {
+        // The mirror case of the Guid overload above: on a Guid-identified store the request
+        // carries a null StreamId into ExecuteAsync, and the caller got "Nullable object must have
+        // a value" — an error that names nothing the caller can act on.
+        _events.EnsureAsStringStorage();
+
         var request = new StreamCompactingRequest<T>(streamKey);
         configure?.Invoke(request);
         await request.ExecuteAsync(_sessionBase).ConfigureAwait(false);

--- a/src/Polecat/Events/Protected/ConjoinedEventFilter.cs
+++ b/src/Polecat/Events/Protected/ConjoinedEventFilter.cs
@@ -1,0 +1,45 @@
+using JasperFx.Events;
+using Weasel.SqlServer;
+
+namespace Polecat.Events.Protected;
+
+/// <summary>
+///     The tenant predicate every operation that keys a <c>pc_events</c> rewrite on
+///     <c>seq_id</c> has to carry (marten#5234 has the identical defect and fix).
+///
+///     <para>
+///         Under <see cref="EventGraph.UseTenantPartitionedEvents" /> each tenant draws from its
+///         own <c>pc_events_sequence_{ordinal}</c>, so <c>seq_id</c> is NOT unique across tenants —
+///         <c>seq_id = 1</c> exists in every tenant's partition. A <c>WHERE seq_id = @p</c> with no
+///         tenant predicate therefore rewrites, or deletes, the same-numbered event in every other
+///         tenant too. The read side of masking and compaction is correctly tenant-scoped, so the
+///         sequences collected belong to the calling tenant; only the write escaped.
+///     </para>
+///
+///     <para>
+///         Gated on <see cref="TenancyStyle.Conjoined" /> rather than on
+///         <c>UseTenantPartitionedEvents</c>, mirroring Marten's ConjoinedEventFilter.
+///         Conjoined-without-partitioning keeps a single global IDENTITY, so there the predicate
+///         filters nothing — but one shape across every call site covers any future mode that makes
+///         <c>seq_id</c> ambiguous by construction.
+///     </para>
+/// </summary>
+internal static class ConjoinedEventFilter
+{
+    /// <summary>
+    ///     Appends <c> AND tenant_id = @p</c> when the event store is conjoined. Call immediately
+    ///     after writing the <c>seq_id</c> predicate, before the statement terminator.
+    /// </summary>
+    public static void AppendConjoinedTenantFilter(this ICommandBuilder builder, EventGraph events, string tenantId)
+    {
+        if (events.TenancyStyle != TenancyStyle.Conjoined)
+        {
+            return;
+        }
+
+        // VarChar-typed like SetCompactedVersionOperation: tenant_id is varchar(250), and an
+        // nvarchar-typed parameter would force an implicit conversion over the column.
+        builder.Append(" AND tenant_id = ");
+        builder.AppendParameter(tenantId, System.Data.SqlDbType.VarChar);
+    }
+}

--- a/src/Polecat/Events/Protected/DeleteEventsOperation.cs
+++ b/src/Polecat/Events/Protected/DeleteEventsOperation.cs
@@ -10,11 +10,13 @@ internal class DeleteEventsOperation : Polecat.Internal.IStorageOperation
 {
     private readonly EventGraph _events;
     private readonly long[] _sequences;
+    private readonly string _tenantId;
 
-    public DeleteEventsOperation(EventGraph events, long[] sequences)
+    public DeleteEventsOperation(EventGraph events, long[] sequences, string tenantId)
     {
         _events = events;
         _sequences = sequences;
+        _tenantId = tenantId;
     }
 
     public Type DocumentType => typeof(IEvent);
@@ -28,7 +30,13 @@ internal class DeleteEventsOperation : Polecat.Internal.IStorageOperation
             if (i > 0) builder.Append(", ");
             builder.AppendParameter(_sequences[i]);
         }
-        builder.Append(");");
+        builder.Append(")");
+
+        // marten#5234's Polecat twin: under UseTenantPartitionedEvents seq_id is per-tenant, so
+        // without this predicate compacting one tenant's stream permanently deletes the
+        // same-numbered events out of every other tenant's partition.
+        builder.AppendConjoinedTenantFilter(_events, _tenantId);
+        builder.Append(";");
     }
 
     public Task PostprocessAsync(DbDataReader reader, IList<Exception> exceptions, CancellationToken token)

--- a/src/Polecat/Events/Protected/OverwriteEventOperation.cs
+++ b/src/Polecat/Events/Protected/OverwriteEventOperation.cs
@@ -13,15 +13,17 @@ internal class OverwriteEventOperation : Polecat.Internal.IStorageOperation
     private readonly string _serializedData;
     private readonly byte[]? _serializedBdata;
     private readonly string? _serializedHeaders;
+    private readonly string _tenantId;
 
     public OverwriteEventOperation(EventGraph events, IEvent @event, string serializedData,
-        byte[]? serializedBdata, string? serializedHeaders)
+        byte[]? serializedBdata, string? serializedHeaders, string tenantId)
     {
         _events = events;
         _event = @event;
         _serializedData = serializedData;
         _serializedBdata = serializedBdata;
         _serializedHeaders = serializedHeaders;
+        _tenantId = tenantId;
     }
 
     public Type DocumentType => typeof(IEvent);
@@ -54,6 +56,11 @@ internal class OverwriteEventOperation : Polecat.Internal.IStorageOperation
 
         builder.Append(" WHERE seq_id = ");
         builder.AppendParameter(_event.Sequence);
+
+        // marten#5234's Polecat twin: under UseTenantPartitionedEvents seq_id is per-tenant, so
+        // without this predicate masking tenant A's stream rewrites (and discloses A's masked JSON
+        // into) tenant B's same-numbered event.
+        builder.AppendConjoinedTenantFilter(_events, _tenantId);
         builder.Append(";");
     }
 

--- a/src/Polecat/Events/Protected/ReplaceEventOperation.cs
+++ b/src/Polecat/Events/Protected/ReplaceEventOperation.cs
@@ -15,9 +15,10 @@ internal class ReplaceEventOperation : Polecat.Internal.IStorageOperation
     private readonly string _eventTypeName;
     private readonly string _dotNetTypeName;
     private readonly Guid _newId;
+    private readonly string _tenantId;
 
     public ReplaceEventOperation(EventGraph events, long sequence, string serializedData,
-        byte[]? serializedBdata, string eventTypeName, string dotNetTypeName)
+        byte[]? serializedBdata, string eventTypeName, string dotNetTypeName, string tenantId)
     {
         _events = events;
         _sequence = sequence;
@@ -26,6 +27,7 @@ internal class ReplaceEventOperation : Polecat.Internal.IStorageOperation
         _eventTypeName = eventTypeName;
         _dotNetTypeName = dotNetTypeName;
         _newId = Guid.NewGuid();
+        _tenantId = tenantId;
     }
 
     public Guid Id => _newId;
@@ -66,6 +68,11 @@ internal class ReplaceEventOperation : Polecat.Internal.IStorageOperation
 
         builder.Append(" WHERE seq_id = ");
         builder.AppendParameter(_sequence);
+
+        // marten#5234's Polecat twin: without this the Compacted<T> snapshot — the calling
+        // tenant's whole aggregate state — is written into another tenant's same-numbered event
+        // under UseTenantPartitionedEvents.
+        builder.AppendConjoinedTenantFilter(_events, _tenantId);
         builder.Append(";");
     }
 

--- a/src/Polecat/Events/Protected/StreamCompacting.cs
+++ b/src/Polecat/Events/Protected/StreamCompacting.cs
@@ -98,14 +98,15 @@ internal static class StreamCompactingExecution
 
         var replaceOp = new ReplaceEventOperation(
             graph, request.Sequence, serializedData, serializedBdata,
-            mapping.EventTypeName, mapping.DotNetTypeName);
+            mapping.EventTypeName, mapping.DotNetTypeName, session.TenantId);
 
         session.WorkTracker.Add(replaceOp);
 
         // 6. Delete the old events
         if (sequences.Length > 0)
         {
-            session.WorkTracker.Add(new DeleteEventsOperation(session.Options.EventGraph, sequences));
+            session.WorkTracker.Add(new DeleteEventsOperation(session.Options.EventGraph, sequences,
+                session.TenantId));
         }
 
         // 7. jasperfx#740: record the compaction watermark on pc_streams. request.Version was set


### PR DESCRIPTION
Closes #546.

Ports marten#5234 and marten#5244's fixes to their Polecat twins, found by the `critter-hardening-audit` protected-data audit (Stoat node `polecat-protected-audit`). The two stores duplicated this code rather than sharing it, so Marten's fixes were a literal checklist — and both defects were confirmed live here by tests written first against unfixed `origin/main`.

## Cross-tenant event rewrites (marten#5234's twin)

Under `Events.UseTenantPartitionedEvents` each tenant draws from its own `pc_events_sequence_{ordinal}`, so `seq_id` is NOT unique across tenants — `seq_id = 1` exists in every tenant's partition. Three operations that rewrite `pc_events` keyed their WHERE on `seq_id` alone, so the write escaped the tenant the read had correctly scoped to:

- **`OverwriteEventOperation`** (masking) destroyed another tenant's payload and replaced it with the calling tenant's masked JSON — a cross-tenant write and a cross-tenant disclosure, in the right-to-erasure feature that exists to prevent exactly that;
- **`DeleteEventsOperation`** (compaction) permanently deleted another tenant's events;
- **`ReplaceEventOperation`** (compaction) left the calling tenant's whole aggregate state, as `Compacted<T>`, sitting in the other tenant's stream.

None of the three raised an error.

All three now append the tenant predicate through a shared `ConjoinedEventFilter` helper, gated on `TenancyStyle.Conjoined` to mirror Marten's fix (and Polecat's own `SetCompactedVersionOperation`, the one operation of this shape that already guarded itself — including its `SqlDbType.VarChar` parameter typing, since `tenant_id` is `varchar(250)`). Conjoined-without-partitioning keeps a single global IDENTITY, so there the predicate filters nothing, but one shape across every call site covers any future mode that makes `seq_id` ambiguous. Polecat operations are fully bound at construction (no session reaches `ConfigureCommand`), so the tenant id is a constructor parameter rather than Marten's session-sourced predicate.

As with marten#5234: damage already written by an affected version cannot be reversed by this fix.

## CompactStreamAsync identity assertions (marten#5244's twin)

`StreamCompactingExecution.ExecuteAsync` branches on the store's configured `StreamIdentity`, not on which overload the caller used, and never asserted the two agreed. The Guid overload against a string-identified store took the AsString branch, read a null `StreamKey`, matched no stream, and **returned successfully having compacted nothing** — no way to tell a no-op from a completed compaction. The mirror case failed with "Nullable object must have a value", naming nothing actionable.

Both `EventOperations.CompactStreamAsync<T>` overloads now assert up front via new `EventGraph.EnsureAsGuidStorage`/`EnsureAsStringStorage` helpers, with the same messages Marten uses for this class of mistake. (The store-level `IEventStore.CompactStreamAsync` throws `NotSupportedException` explicitly in Polecat, so marten#5240's store-level silent no-op has no counterpart here.)

## Tests

- `cross_tenant_event_rewrite_tests` (in the serialized `tenant-partitioning` collection): masking and compaction each get a cross-tenant isolation test **verified to fail on unfixed main** (masking: beta's secret came back masked by alpha's pass; compaction: beta's stream went from 3 events to 1, the survivor being alpha's `Compacted<QuestParty>` snapshot), plus a feature-preservation test each proving the guard is not so tight the feature stops working. The seq_id collision precondition is asserted explicitly so the tests stop proving anything loudly if per-tenant sequencing ever changes.
- `stream_compacting_identity_mismatch_tests`: both wrong-overload combinations, **verified to fail on unfixed main**, now assert the actionable `InvalidOperationException`.

Audit trail, per-item verdicts, and the item-1 (marten#5199/#422 — already fixed on main) evidence are in #546.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
