### PR TITLE
gh-548: compute the inline-projected provider set once per store

### DIFF
--- a/src/Polecat.Tests/Projections/inline_projection_tests.cs
+++ b/src/Polecat.Tests/Projections/inline_projection_tests.cs
@@ -277,4 +277,33 @@ public class inline_projection_tests : IntegrationContext
         loaded.ShouldNotBeNull();
         loaded.FirstName.ShouldBe("Test");
     }
+
+    /// <summary>
+    ///     #548 — the inline-projected provider set SaveChangesAsync pre-creates tables from is derived
+    ///     entirely from configuration, so it is computed once per store instead of being rebuilt from
+    ///     <c>Projections.All</c> on every save. Two facts: it still resolves the projections registered
+    ///     before the store was built (the reason it has to be lazy rather than eager), and repeated
+    ///     saves keep handing back the very same cached array.
+    /// </summary>
+    [Fact]
+    public async Task the_inline_projected_provider_set_is_computed_once_per_store()
+    {
+        var store = await CreateStoreWithProjections();
+
+        var providers = store.Options.Projections.InlineProjectedProviders;
+
+        // The projection was registered while the store options were still open, and it is in the set.
+        providers.Select(x => x.Mapping.DocumentType).ShouldContain(typeof(QuestParty));
+
+        await using var session = store.LightweightSession();
+        session.Events.StartStream(Guid.NewGuid(), new QuestStarted("First"));
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        await using var second = store.LightweightSession();
+        second.Events.StartStream(Guid.NewGuid(), new QuestStarted("Second"));
+        await second.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        // Same array instance, so neither save rebuilt it.
+        store.Options.Projections.InlineProjectedProviders.ShouldBeSameAs(providers);
+    }
 }

--- a/src/Polecat/Internal/DocumentSessionBase.cs
+++ b/src/Polecat/Internal/DocumentSessionBase.cs
@@ -674,13 +674,10 @@ internal abstract class DocumentSessionBase : QuerySession, IDocumentSession
             // Apply inline projections — projected document ops are queued into _workTracker
             if (_inlineProjections.Length > 0 && _workTracker.Streams.Count > 0)
             {
-                // Pre-create document tables for projected types that projections may query
-                var projectedDocTypes = Options.Projections.All
-                    .Where(x => x.Lifecycle == ProjectionLifecycle.Inline)
-                    .SelectMany(x => x.PublishedTypes())
-                    .Distinct()
-                    .Select(t => _providers.GetProvider(t));
-                await _tableEnsurer.EnsureTablesAsync(projectedDocTypes, token);
+                // Pre-create document tables for projected types that projections may query. #548: this
+                // set comes entirely from configuration, so it is computed once per store and cached
+                // rather than re-derived from Projections.All on every save.
+                await _tableEnsurer.EnsureTablesAsync(Options.Projections.InlineProjectedProviders, token);
 
                 var streams = _workTracker.Streams.ToList();
                 foreach (var projection in _inlineProjections)

--- a/src/Polecat/Projections/PolecatProjectionOptions.cs
+++ b/src/Polecat/Projections/PolecatProjectionOptions.cs
@@ -7,6 +7,7 @@ using JasperFx.Events.Projections.Composite;
 using JasperFx.Events.Subscriptions;
 using Polecat.Events;
 using Polecat.Events.Projections;
+using Polecat.Internal;
 using Polecat.Projections.Flattened;
 using Polecat.Storage;
 using Polecat.Subscriptions;
@@ -23,10 +24,21 @@ public class PolecatProjectionOptions
     private readonly EventGraph _events;
     private StoreOptions? _storeOptions;
     private IInlineProjection<IDocumentSession>[]? _inlineProjections;
+    private readonly Lazy<DocumentProvider[]> _inlineProjectedProviders;
 
     internal PolecatProjectionOptions(EventGraph events) : base(events, "polecat")
     {
         _events = events;
+
+        // #548: see InlineProjectedProviders. Lazy, not eager, because registration is still open when
+        // this runs — StoreOptions constructs the graph before any Projections.Add call, and wires
+        // StoreOptions.Providers later still, when the DocumentStore is built.
+        _inlineProjectedProviders = new Lazy<DocumentProvider[]>(() => All
+            .Where(x => x.Lifecycle == ProjectionLifecycle.Inline)
+            .SelectMany(x => x.PublishedTypes())
+            .Distinct()
+            .Select(t => _storeOptions!.Providers.GetProvider(t))
+            .ToArray());
     }
 
     internal void SetStoreOptions(StoreOptions options) => _storeOptions = options;
@@ -206,5 +218,26 @@ public class PolecatProjectionOptions
 
         return _inlineProjections;
     }
+
+    /// <summary>
+    ///     The document providers for every type published by an <see cref="ProjectionLifecycle.Inline" />
+    ///     projection, so <c>SaveChangesAsync</c> can pre-create those tables before the projections run.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         #548: this set is derived entirely from configuration — it cannot change between saves —
+    ///         but it used to be rebuilt from <see cref="ProjectionGraph{T,TOperations,TQuerySession}.All" />
+    ///         on <em>every</em> save that touched a stream in a store with any inline projection. Computed
+    ///         once here instead.
+    ///     </para>
+    ///     <para>
+    ///         Deferred to first use rather than computed when the store is constructed, because
+    ///         projections can be registered right up until the store is built and
+    ///         <see cref="StoreOptions.Providers" /> is not wired until then either. Same discipline as
+    ///         <see cref="BuildInlineProjections" /> above, which the store wraps in a <c>Lazy</c> for the
+    ///         same reason.
+    ///     </para>
+    /// </remarks>
+    internal DocumentProvider[] InlineProjectedProviders => _inlineProjectedProviders.Value;
 }
 


### PR DESCRIPTION
Closes #548. Stoat plan `critter-performance-2026-09`, node `polecat-savechanges-precompute`.

## What

`DocumentSessionBase.SaveChangesInternalAsync` rebuilt this on **every** save that touched a stream, in any store with an inline projection:

```csharp
var projectedDocTypes = Options.Projections.All
    .Where(x => x.Lifecycle == ProjectionLifecycle.Inline)
    .SelectMany(x => x.PublishedTypes())
    .Distinct()
    .Select(t => _providers.GetProvider(t));
```

Every input to it is configuration. It cannot change between saves, so re-walking `Projections.All`, re-materializing each source's `PublishedTypes()`, re-running `Distinct()` and re-resolving every provider was per-save allocation and work on the commit path in exchange for the same array each time.

It is now computed once and cached as `PolecatProjectionOptions.InlineProjectedProviders`.

## Why lazily rather than at construction

Projections can be registered right up until the store is built — `StoreOptions` constructs the projection graph before any `Projections.Add` call — and `StoreOptions.Providers` is not wired until the `DocumentStore` constructor runs. So the set is computed on first use behind a `Lazy<>` and cached. That is exactly the discipline `PolecatProjectionOptions.BuildInlineProjections()` already follows for the inline projection instances themselves, which `DocumentStore` wraps in a `Lazy<>` for the same reason.

## Scope

The two `_workTracker.Operations.Select(op => op.DocumentType)...` chains in the same method are left alone deliberately: those are genuinely per-call, since they depend on what the session queued.

No behaviour change — same providers, same `EnsureTablesAsync` call.

## Tests

New: `inline_projection_tests.the_inline_projected_provider_set_is_computed_once_per_store` pins both halves — the set still resolves projections registered before the store was built (the reason it has to be lazy), and two consecutive saves hand back the very same array instance, so neither rebuilt it.

`Polecat.Tests.Events` + `Polecat.Tests.Projections` against the SQL Server 2025 container: **500/500 passed, 0 failed** (16m 22s, net10.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)