### PR TITLE
gh-550: push the daemon loader's event-type filter into SQL

### DIFF
--- a/src/Polecat.Tests/Daemon/event_loader_tests.cs
+++ b/src/Polecat.Tests/Daemon/event_loader_tests.cs
@@ -149,12 +149,138 @@ public class event_loader_tests : IntegrationContext
         failure.Event.EventTypeName.ShouldBe(alias);
     }
 
-    private async Task CorruptDotNetTypeAsync(long seqId, string dotNetType)
+    // ---- #550: the event-type allow-list is applied in SQL, not after hydration ----
+
+    /// <summary>
+    ///     The discriminating fact for pushing the filter into SQL. The run of non-matching events is
+    ///     longer than the batch size, so <c>TOP(@batchSize)</c> used to fill the page entirely with rows
+    ///     the client-side filter then discarded: the page came back empty, failed
+    ///     <c>CalculateCeiling</c>'s "did not fill the batch" test, and claimed the high-water mark as its
+    ///     ceiling after looking at only the first three rows of the range. The <c>QuestStarted</c> above
+    ///     them was stepped over and never delivered — a silently skipped event, not merely a slow one.
+    ///     With the filter in SQL the query scans the whole range for matches, finds it, and the ceiling
+    ///     it claims is honest.
+    /// </summary>
+    [Fact]
+    public async Task a_matching_event_beyond_a_run_of_filtered_events_is_still_delivered()
+    {
+        await AppendAsync(Enumerable.Range(0, 10)
+            .Select(object (i) => new MembersJoined(i + 1, $"Town {i}", [$"Member {i}"]))
+            .ToArray());
+        await AppendAsync(new QuestStarted("Beyond the run"));
+
+        var highWater = await GetHighestSeqIdAsync();
+
+        var page = await CreateFilteredLoader()
+            .LoadAsync(CreateRequest(0, highWater, batchSize: 3), TestContext.Current.CancellationToken);
+
+        page.Count.ShouldBe(1);
+        page.Single().Data.ShouldBeOfType<QuestStarted>();
+
+        // Everything up to the high-water mark was scanned for matches, so the whole non-matching run is
+        // behind the floor after a single page and the shard cannot stall on it.
+        page.Ceiling.ShouldBe(highWater);
+    }
+
+    /// <summary>
+    ///     The other half of the ceiling contract under a SQL-side filter: a page that fills its batch
+    ///     with matching events claims only as far as its last row, and the following request picks up
+    ///     from there and finishes the range.
+    /// </summary>
+    [Fact]
+    public async Task a_full_page_of_matching_events_reports_the_last_matched_sequence()
+    {
+        await AppendAsync(
+            new QuestStarted("one"), new MembersJoined(1, "A", ["a"]),
+            new QuestStarted("two"), new MembersJoined(2, "B", ["b"]),
+            new QuestStarted("three"), new MembersJoined(3, "C", ["c"]));
+
+        var seqIds = await GetAllSeqIdsAsync();
+        var highWater = seqIds.Last();
+
+        var page = await CreateFilteredLoader()
+            .LoadAsync(CreateRequest(0, highWater, batchSize: 2), TestContext.Current.CancellationToken);
+
+        page.Select(x => x.Sequence).ShouldBe([seqIds[0], seqIds[2]]);
+        page.Ceiling.ShouldBe(seqIds[2]);
+
+        var next = await CreateFilteredLoader()
+            .LoadAsync(CreateRequest(page.Ceiling, highWater, batchSize: 2),
+                TestContext.Current.CancellationToken);
+
+        next.Select(x => x.Sequence).ShouldBe([seqIds[4]]);
+        next.Ceiling.ShouldBe(highWater);
+    }
+
+    /// <summary>
+    ///     A regression guard on the shape of the pushed-down predicate. A row whose <c>dotnet_type</c>
+    ///     does not resolve fails a shard that wants it (the unfiltered control below), and must stay
+    ///     excluded for a shard that does not — the SQL filter has to reject an unrecognised
+    ///     <c>dotnet_type</c>, not wave it through. This already held before the push-down, because the
+    ///     client-side check also ran ahead of type resolution, so it does <em>not</em> discriminate the
+    ///     change; it pins behaviour the new <c>IN</c> clause could quietly break.
+    /// </summary>
+    [Fact]
+    public async Task a_filtered_load_still_excludes_an_unresolvable_event_of_another_type()
+    {
+        await AppendAsync(new QuestStarted("Keep me"), new MembersJoined(1, "Town", ["Discard me"]));
+
+        var seqIds = await GetAllSeqIdsAsync();
+        var highWater = seqIds.Last();
+        await CorruptDotNetTypeAsync(highWater, "Nope.NotARealEventType, Nope");
+
+        await Should.ThrowAsync<UnknownEventTypeException>(async () => await CreateLoader()
+            .LoadAsync(CreateRequest(0, highWater, batchSize: 100), TestContext.Current.CancellationToken));
+
+        var page = await CreateFilteredLoader()
+            .LoadAsync(CreateRequest(0, highWater, batchSize: 100), TestContext.Current.CancellationToken);
+
+        page.Count.ShouldBe(1);
+        page.Single().Data.ShouldBeOfType<QuestStarted>();
+        page.Ceiling.ShouldBe(highWater);
+    }
+
+    /// <summary>
+    ///     The <c>dotnet_type is null</c> disjunct in the pushed-down filter, which exists to preserve
+    ///     behaviour exactly. The client-side check only ever excluded a row that <em>had</em> a
+    ///     dotnet_type, so a null one reached hydration and failed there. Drop the disjunct and a
+    ///     filtered shard would instead step over such a row in silence — a different, worse answer than
+    ///     the loud one this store has always given.
+    /// </summary>
+    [Fact]
+    public async Task a_null_dotnet_type_still_reaches_hydration_under_a_filtered_load()
+    {
+        await AppendAsync(new QuestStarted("Keep me"), new MembersJoined(1, "Town", ["No type at all"]));
+
+        var seqIds = await GetAllSeqIdsAsync();
+        var highWater = seqIds.Last();
+        await CorruptDotNetTypeAsync(highWater, null);
+
+        await Should.ThrowAsync<UnknownEventTypeException>(async () => await CreateFilteredLoader()
+            .LoadAsync(CreateRequest(0, highWater, batchSize: 100), TestContext.Current.CancellationToken));
+    }
+
+    private PolecatEventLoader CreateFilteredLoader()
+    {
+        var filtering = new EventFilterable();
+        filtering.IncludeType<QuestStarted>();
+
+        return new PolecatEventLoader(theStore.Database.Events, theStore.Options,
+            theStore.Options.ConnectionString, filtering);
+    }
+
+    private async Task AppendAsync(params object[] events)
+    {
+        theSession.Events.StartStream(Guid.NewGuid(), events);
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+
+    private async Task CorruptDotNetTypeAsync(long seqId, string? dotNetType)
     {
         await using var conn = await OpenConnectionAsync();
         await using var cmd = conn.CreateCommand();
         cmd.CommandText = "UPDATE [dbo].[pc_events] SET dotnet_type = @type WHERE seq_id = @seq;";
-        cmd.Parameters.AddWithValue("@type", dotNetType);
+        cmd.Parameters.AddWithValue("@type", (object?)dotNetType ?? DBNull.Value);
         cmd.Parameters.AddWithValue("@seq", seqId);
         await cmd.ExecuteNonQueryAsync();
     }

--- a/src/Polecat.Tests/Subscriptions/subscription_tests.cs
+++ b/src/Polecat.Tests/Subscriptions/subscription_tests.cs
@@ -116,6 +116,58 @@ public class subscription_tests : IntegrationContext
 
         RawSubscription.ProcessedCount.ShouldBeGreaterThan(0);
     }
+
+    /// <summary>
+    ///     #550 at the daemon level. The loader pushes a subscription's event-type allow-list into SQL,
+    ///     so rows of other types never leave SQL Server. Two facts this pins that the loader tests
+    ///     cannot: events of non-allowed types do not reach the subscription at all, and the shard's
+    ///     recorded progress still advances to the head across a run of filtered-out events longer than
+    ///     its batch size. Get the ceiling accounting wrong under a server-side filter and this either
+    ///     stalls short of the head or — as the client-side filter did — steps over the one event the
+    ///     subscription actually wanted.
+    /// </summary>
+    [Fact]
+    public async Task a_filtered_subscription_sees_only_its_types_and_still_reaches_the_head()
+    {
+        await StoreOptions(opts =>
+        {
+            // Its own schema, so the store is guaranteed empty: this test asserts absolute counts and
+            // an absolute progression, and the default `dbo` is shared with — and seeded by — every
+            // other class in the "integration" collection.
+            opts.DatabaseSchemaName = "filtered_subscription";
+
+            // A batch smaller than the run of filtered-out events below, so a page can be filled
+            // entirely with rows the subscription does not want.
+            opts.Projections.Subscribe<FilteredRecordingSubscription>(x => x.Options.BatchSize = 3);
+        });
+
+        FilteredRecordingSubscription.Reset();
+
+        await using (var session = theStore.LightweightSession())
+        {
+            // The run the subscription filters out, appended BEFORE the one event it wants — so the
+            // first page is nothing but discards and the loader has to scan past them to find it.
+            for (var i = 0; i < 10; i++)
+            {
+                session.Events.StartStream(Guid.NewGuid(), new MembersJoined(i + 1, $"Town {i}", [$"Member {i}"]));
+            }
+
+            session.Events.StartStream(Guid.NewGuid(), new QuestStarted("Beyond the run"));
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await theStore.WaitForProjectionAsync();
+
+        var seen = FilteredRecordingSubscription.ProcessedEvents;
+        seen.Count.ShouldBe(1);
+        seen.Single().ShouldBeOfType<QuestStarted>();
+
+        var shard = theStore.Options.Projections.AllShards()
+            .Single(x => x.Name.Identity.Contains(nameof(FilteredRecordingSubscription)));
+
+        var progress = await theStore.Database.ProjectionProgressFor(shard.Name, CancellationToken.None);
+        progress.ShouldBe(await theStore.Database.FetchHighestEventSequenceNumber(CancellationToken.None));
+    }
 }
 
 /// <summary>
@@ -125,6 +177,51 @@ public class RecordingSubscription : SubscriptionBase
 {
     private static readonly List<object> _events = new();
     private static readonly object _lock = new();
+
+    public static IReadOnlyList<object> ProcessedEvents
+    {
+        get
+        {
+            lock (_lock) return _events.ToList();
+        }
+    }
+
+    public static void Reset()
+    {
+        lock (_lock) _events.Clear();
+    }
+
+    public override Task<IChangeListener> ProcessEventsAsync(
+        EventRange page,
+        ISubscriptionController controller,
+        IDocumentOperations operations,
+        CancellationToken cancellationToken)
+    {
+        lock (_lock)
+        {
+            foreach (var @event in page.Events)
+            {
+                _events.Add(@event.Data);
+            }
+        }
+
+        return Task.FromResult<IChangeListener>(NullChangeListener.Instance);
+    }
+}
+
+/// <summary>
+///     #550: a subscription that names the one event type it wants, so the daemon's loader has an
+///     allow-list to push into SQL.
+/// </summary>
+public class FilteredRecordingSubscription : SubscriptionBase
+{
+    private static readonly List<object> _events = new();
+    private static readonly object _lock = new();
+
+    public FilteredRecordingSubscription()
+    {
+        IncludeType<QuestStarted>();
+    }
 
     public static IReadOnlyList<object> ProcessedEvents
     {

--- a/src/Polecat/Events/Daemon/PolecatEventLoader.cs
+++ b/src/Polecat/Events/Daemon/PolecatEventLoader.cs
@@ -16,17 +16,36 @@ namespace Polecat.Events.Daemon;
 ///     this loader at <c>BuildEventLoader</c> time — this class is the bare
 ///     inner loader.
 /// </summary>
+/// <remarks>
+///     #550: a subscription or projection that names its event types gets that allow-list pushed into
+///     the SQL as <c>dotnet_type in (...)</c>, so non-matching rows are never read off the wire,
+///     hydrated or deserialized — the same strategy as Marten's <c>EventTypeFilter</c> fragment and
+///     fisher#153. The whole command text is composed once at construction too, because every part of
+///     it (table name, tenant predicate, type filter) is fixed for the loader's lifetime. See the
+///     constructor for why the page's ceiling accounting is <em>more</em> correct with the filter
+///     server-side, not less.
+/// </remarks>
 [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
     Justification = "Class-level: hydrates IEvent batches via EventGraph.Wrap (routed through ISerializer.FromJson). Event types are preserved by EventGraph registration on the caller side per the AOT publishing guide.")]
 [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
     Justification = "Class-level: ISerializer.FromJson and Event<T>.MakeGenericType are annotated RDC. AOT consumers register concrete event types ahead of time.")]
 internal class PolecatEventLoader : IEventLoader
 {
+    /// <summary>
+    ///     SQL Server rejects a command with more than 2100 parameters outright. An allow-list anywhere
+    ///     near this size is not a real subscription, but a shard that dies on a SqlException would be a
+    ///     far worse outcome than one that filters client-side, so the push-down bows out above this and
+    ///     the client-side check below carries the filtering on its own.
+    /// </summary>
+    private const int MaximumPushedDownTypeNames = 2000;
+
     private readonly EventGraph _events;
     private readonly StoreOptions _options;
     private readonly string _connectionString;
     private readonly HashSet<string>? _allowedDotNetTypes;
     private readonly string? _tenantFilter;
+    private readonly string _commandText;
+    private readonly string[]? _pushedDownTypeNames;
 
     public PolecatEventLoader(EventGraph events, StoreOptions options, string connectionString,
         EventFilterable? filtering = null, string? tenantFilter = null)
@@ -47,7 +66,69 @@ internal class PolecatEventLoader : IEventLoader
                 var mapping = events.EventMappingFor(type);
                 _allowedDotNetTypes.Add(mapping.DotNetTypeName);
             }
+
+            if (_allowedDotNetTypes.Count <= MaximumPushedDownTypeNames)
+            {
+                // Materialized into a stable array because a HashSet's enumeration order is
+                // unspecified, and the parameter names rendered into the SQL have to line up with the
+                // values bound on each load.
+                _pushedDownTypeNames = _allowedDotNetTypes.ToArray();
+            }
         }
+
+        _commandText = BuildCommandText();
+    }
+
+    /// <summary>
+    ///     Compose the one SELECT this loader will ever issue. Every input is fixed for the loader's
+    ///     lifetime, so rebuilding the string per page — as this used to — bought nothing.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         <b>Why pushing the type filter down keeps the ceiling honest.</b>
+    ///         <c>EventPage.CalculateCeiling</c>'s contract is "a page that did not fill the batch
+    ///         exhausted everything up to the bound it was given". With the filter in SQL, a query that
+    ///         comes back with fewer than <c>BatchSize</c> <em>matching</em> rows really has scanned the
+    ///         whole <c>(floor, high-water]</c> range, so claiming the high-water mark as the ceiling
+    ///         steps the floor past every non-matching sequence in that range in a single page — which
+    ///         is exactly what stops a shard stalling behind a long run of events it will never apply. A
+    ///         page that does fill the batch claims only its last matched sequence, as before; the rows
+    ///         above it are re-scanned by the next request and still match nothing.
+    ///     </para>
+    ///     <para>
+    ///         Filtering client-side, as this loader used to, made that same claim <em>dishonestly</em>:
+    ///         <c>TOP(@batchSize)</c> applied before the filter, so a page whose rows were all discarded
+    ///         came back empty, failed the "did not fill the batch" test, and reported the high-water
+    ///         mark as its ceiling — after looking at only the first <c>BatchSize</c> rows of the range.
+    ///         Any matching event further up that range was stepped over and never delivered. Pushing
+    ///         the filter down is therefore a correctness fix as much as a performance one.
+    ///     </para>
+    ///     <para>
+    ///         The <c>dotnet_type is null</c> disjunct preserves today's behaviour precisely: the
+    ///         client-side check only ever excluded a row that <em>had</em> a dotnet_type, so a null one
+    ///         still reaches hydration (where it fails or is skipped per the shard's error options)
+    ///         rather than being silently dropped by a filtered shard. The column is nullable — see
+    ///         <c>EventsTable</c>.
+    ///     </para>
+    /// </remarks>
+    private string BuildCommandText()
+    {
+        var tenantPredicate = _tenantFilter != null ? " AND tenant_id = @tenant" : "";
+
+        var typePredicate = "";
+        if (_pushedDownTypeNames is { Length: > 0 })
+        {
+            var markers = string.Join(", ", Enumerable.Range(0, _pushedDownTypeNames.Length).Select(i => $"@t{i}"));
+            typePredicate = $" AND (dotnet_type IS NULL OR dotnet_type IN ({markers}))";
+        }
+
+        return $"""
+            SELECT TOP(@batchSize) seq_id, id, stream_id, version, data, type, timestamp,
+                tenant_id, dotnet_type, is_archived, bdata
+            FROM {_events.EventsTableName}
+            WHERE seq_id > @floor AND seq_id <= @ceiling AND is_archived = 0{tenantPredicate}{typePredicate}
+            ORDER BY seq_id;
+            """;
     }
 
     public async Task<EventPage> LoadAsync(EventRequest request, CancellationToken token)
@@ -75,21 +156,23 @@ internal class PolecatEventLoader : IEventLoader
         await using var conn = new SqlConnection(_connectionString);
         await conn.OpenAsync(token);
 
-        var tenantPredicate = _tenantFilter != null ? " AND tenant_id = @tenant" : "";
-
         await using var cmd = conn.CreateCommand();
-        cmd.CommandText = $"""
-            SELECT TOP(@batchSize) seq_id, id, stream_id, version, data, type, timestamp,
-                tenant_id, dotnet_type, is_archived, bdata
-            FROM {_events.EventsTableName}
-            WHERE seq_id > @floor AND seq_id <= @ceiling AND is_archived = 0{tenantPredicate}
-            ORDER BY seq_id;
-            """;
+        cmd.CommandText = _commandText;
 
         cmd.Parameters.AddWithValue("@batchSize", request.BatchSize);
         cmd.Parameters.AddWithValue("@floor", request.Floor);
         cmd.Parameters.AddWithValue("@ceiling", request.HighWater);
         if (_tenantFilter != null) cmd.Parameters.AddVarChar("@tenant", _tenantFilter);
+
+        if (_pushedDownTypeNames is not null)
+        {
+            // AddVarChar rather than AddWithValue (#363): dotnet_type is varchar, and binding these as
+            // nvarchar would put CONVERT_IMPLICIT on the column side of the IN.
+            for (var i = 0; i < _pushedDownTypeNames.Length; i++)
+            {
+                cmd.Parameters.AddVarChar($"@t{i}", _pushedDownTypeNames[i]);
+            }
+        }
 
         var skippedEvents = 0;
 
@@ -109,10 +192,22 @@ internal class PolecatEventLoader : IEventLoader
             // #388: non-null bdata means this row's payload is binary, not JSON.
             var bdata = reader.IsDBNull(10) ? null : reader.GetFieldValue<byte[]>(10);
 
-            // Apply event type allow-list filter (skip events not in the subscription's filter)
+            // #550: how far this query actually got, whether or not the row survives into the page.
+            // EventPage.CalculateCeiling uses it to avoid claiming progress past rows nobody read when a
+            // full batch is entirely skipped (jasperfx#667) — the case the fallback path below can
+            // produce on an allow-list too large to push into SQL.
+            page.LastObservedSequence = seqId;
+
+            // Apply event type allow-list filter (skip events not in the subscription's filter).
+            // #550: normally dead code — the SQL above already excluded these rows — and kept as belt
+            // and braces in case the rendered filter and the set ever disagree. It is the only filter
+            // when the allow-list was too large to push down. Counting a discarded row as skipped is
+            // what keeps the ceiling honest in that fallback: the row genuinely consumed a slot of this
+            // page's range, so the batch was saturated even though the page came back short.
             if (_allowedDotNetTypes != null && dotNetTypeName != null &&
                 !_allowedDotNetTypes.Contains(dotNetTypeName))
             {
+                skippedEvents++;
                 continue;
             }
 


### PR DESCRIPTION
Closes #550. Stoat plan `critter-performance-2026-09`, node `polecat-loader-filter`. Sibling of fisher#153 / JasperFx/fisher#160.

## What

`PolecatEventLoader` applied a subscription's event-type allow-list only **after** the row came off the wire, so a shard scoped to a few event types in a busy store read essentially the whole event log to produce nothing. The allow-list is fully known at construction, so it is now rendered as a parameterized `dotnet_type in (@t0, @t1, ...)` on the SELECT. The whole command text is composed once at construction too, rather than interpolated per page — every input to it is fixed for the loader's lifetime, which is what Marten's `EventLoader` does with its prebuilt command.

Type names bind through `AddVarChar`, not `AddWithValue`: `dotnet_type` is `varchar`, and binding `nvarchar` would put `CONVERT_IMPLICIT` on the column side of the `IN` (#363).

## This is a correctness fix, not only a performance one

`TOP(@batchSize)` applied **before** the client-side filter. So a page whose rows were all discarded came back empty, failed `CalculateCeiling`'s "did not fill the batch" test, and reported the **high-water mark** as its ceiling — after the query had looked at only the first `BatchSize` rows of the range. Any matching event further up that range was stepped over and never delivered, and the shard committed progress past it.

With the filter server-side, `CalculateCeiling`'s contract holds for real:

- A page returning **fewer than `BatchSize` matching rows** genuinely has scanned the whole `(floor, high-water]` range, so the high-water ceiling is honest — the floor advances past the entire filtered-out run in one page, which is what stops a shard stalling behind events it will never apply.
- A **full page** claims only its last matched sequence, exactly as before; the non-matching rows above it are re-scanned by the next request and still match nothing.

Two smaller pieces of the same accounting:

- The `dotnet_type is null` disjunct preserves today's behaviour precisely. The client-side check only ever excluded a row that *had* a dotnet_type, so a null one still reaches hydration and fails loudly rather than being dropped in silence by a filtered shard.
- The loader now records `LastObservedSequence`, so a fully-skipped batch cannot claim progress past rows nobody read (jasperfx#667). That is reachable through the client-side fallback, which is retained for an allow-list too large to push into SQL — SQL Server caps a command at 2100 parameters, and a shard dying on a `SqlException` would be worse than one that filters client-side. In that fallback a discarded row is now counted as skipped, which is what keeps its ceiling honest.

## Tests

Four new, all verified against the old loader by stashing the production change:

| Test | Old loader |
|---|---|
| `a_matching_event_beyond_a_run_of_filtered_events_is_still_delivered` — 10 non-matching events, then one the shard wants, `BatchSize = 3` | **fails**: `page.Count` 0, the event silently skipped |
| `a_full_page_of_matching_events_reports_the_last_matched_sequence` — the full-page half of the contract, plus the follow-up request finishing the range | **fails**: wrong sequences |
| `subscriptions.a_filtered_subscription_sees_only_its_types_and_still_reaches_the_head` — daemon level: non-allowed types never reach the subscription, progress still advances to the head | **fails**: `seen.Count` 0 |
| `a_null_dotnet_type_still_reaches_hydration_under_a_filtered_load` — pins the null disjunct | passes (behaviour deliberately preserved) |

Plus `a_filtered_load_still_excludes_an_unresolvable_event_of_another_type`, a regression guard on the predicate's shape. Noted in its own docstring as **not** discriminating: unlike Fisher's equivalent, Polecat's client-side check already ran ahead of type resolution, so this held before the change too. It is there to catch a future `IN` clause that waves an unrecognised `dotnet_type` through.

The daemon-level test sets its own `DatabaseSchemaName` — it asserts absolute counts and an absolute progression, and the default `dbo` is shared with, and seeded by, every other class in the "integration" collection.

## Connection reuse: deliberately not done

The node also proposed reusing one `SqlConnection` across pages. I did not, and the reason is worth recording: **nothing disposes an `IEventLoader`.** The interface has no disposal contract, and `SubscriptionAgent` — which owns the loader — disposes its execution and its timer but never the loader. Holding an open connection on the loader would therefore leak one per shard start, and shards restart on pause/resume, rebuild, and HotCold failover. Marten does not do this either: its `EventLoader` opens a fresh `QuerySession` per `loadNormalAsync`, and what it actually prebuilds is the *command*, which is the part adopted here. `new SqlConnection` + `OpenAsync` against a warm pool is a pool rent, not a physical connect, and is negligible beside a page of JSON deserialization. Making it safe would need a disposal contract on `IEventLoader` in JasperFx, which is a separate change.

## Validation

`Polecat.Tests.Events` + `Polecat.Tests.Daemon` + `Polecat.Tests.Subscriptions` against the SQL Server 2025 container: **542 total, 539 passed, 0 failed, 3 skipped** (10m 57s, net10.0). The 3 skips are pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)