### PR TITLE
Implement event upcasting against the shared JasperFx.Events.Upcasting contract

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,6 +171,29 @@ A bare `marten#NNNN` citation means the opposite: Polecat implemented the same f
 number is provenance. Do not treat a `marten#NNNN` count as a porting backlog; it grows with every
 parity feature and never converges.
 
+### Event hydration paths — there are five, and they are copies
+
+Anything that changes how a stored `pc_events` row becomes an `IEvent` has to change **five** places.
+`PcEventsRowReader.ReadEventCore` is the canonical one, but four other loops hand-copy it:
+
+| Path | Feeds |
+|---|---|
+| `Events/Internal/PcEventsRowReader.ReadEventCore` | `FetchStreamAsync`, live aggregation, `FetchForWriting`/`FetchLatest`, compaction, masking, batched stream fetch |
+| `Events/EventOperations.QueryByTagsAsync` | DCB tag queries |
+| `Events/EventOperations.ReadEventFromReader` | batched DCB tag queries |
+| `Events/Linq/EventListHandler` | `QueryAllRawEvents()`, `QueryEventsAsync`, `AggregateTo*` |
+| `Events/Daemon/PolecatEventLoader` | **every** async projection and subscription |
+
+Two more resolve differently and are easy to miss: `DocumentStore.ProjectionReplay.ToDomainEvent`
+keys on the event type ALIAS rather than `dotnet_type`, and `QueryRawEventDataOnly<T>` bypasses
+`EventGraph` entirely (it never builds an `IEvent`).
+
+`dotnet_type` — not the `type` alias — is the sole input to CLR type resolution on all five hot
+paths. Upcasting (#561) is the one thing that must be consulted *before* it; see
+`EventGraph.TryFindUpcast`. **The daemon loader additionally pushes a `dotnet_type` allow list into
+its SQL**, so any read-time reinterpretation of a row has to widen that filter too or the row is
+gone before hydration ever runs.
+
 ### Writing tests that survive being run in parallel processes
 
 The suite is a candidate for being run across several worker processes at once (Bobcat's supervisor

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -114,6 +114,7 @@ const config: UserConfig<DefaultTheme.Config> = {
             { text: 'Quick Start', link: '/events/quickstart' },
             { text: 'Storage', link: '/events/storage' },
             { text: 'Binary Event Serialization', link: '/events/binary-serialization' },
+            { text: 'Event Upcasting', link: '/events/upcasting' },
             { text: 'Appending Events', link: '/events/appending' },
             { text: 'Querying Events', link: '/events/querying' },
             { text: 'Metadata', link: '/events/metadata' },

--- a/docs/events/upcasting.md
+++ b/docs/events/upcasting.md
@@ -1,0 +1,117 @@
+# Event Upcasting <Badge type="tip" text="5.23" />
+
+Event schemas change; the events already in `pc_events` do not. **Upcasting** transforms a stored
+event into the current CLR type **on read**, so aggregates, projections and subscriptions only ever
+see the new shape — with no migration of existing event data, and no `if (old) … else …` branches
+scattered through your handlers.
+
+## The contract
+
+The seam is [`JasperFx.Events.Upcasting`](https://github.com/JasperFx/jasperfx), shared across the
+Critter Stack, so an upcaster you write compiles once against Marten, Polecat or Fisher.
+
+Registration is on `StoreOptions.Events`, and it comes in three shapes.
+
+### Typed: the old CLR type is still in the codebase
+
+```csharp
+// The event as it was originally written, and as rows in pc_events still record it.
+public record RoomBooked(Guid RoomId, string Guest);
+
+// The event this deployment wants to see.
+public record RoomReserved(Guid RoomId, string Guest, string Source);
+
+opts.Events.Upcast<RoomBooked, RoomReserved>(
+    old => new RoomReserved(old.RoomId, old.Guest, "legacy"));
+```
+
+The stored event type name defaults to `RoomBooked`'s conventional alias, which is what makes rows
+that were written as `RoomBooked` come back as `RoomReserved`.
+
+### Raw JSON: the old CLR type is gone
+
+This is the shape that lets you **delete the old event class**. Polecat is System.Text.Json only and
+stores event bodies in a SQL Server 2025 native `json` column, so the raw form is always available:
+
+```csharp
+opts.Events.Upcast<RoomReserved>("room_booked", document =>
+{
+    var root = document.RootElement;
+    return new RoomReserved(
+        root.GetProperty("roomId").GetGuid(),
+        root.GetProperty("guest").GetString()!,
+        "legacy");
+});
+```
+
+::: warning Property casing is your serializer's, not the contract's
+`JsonElement.GetProperty` is case-sensitive. Polecat's default `PropertyNamingPolicy` is
+`JsonNamingPolicy.CamelCase`, so the stored names are `roomId` / `guest` — **not** `RoomId` /
+`Guest`. A raw-JSON upcaster reads exactly what your serializer wrote; the typed shapes get
+case-insensitivity for free from `PropertyNameCaseInsensitive`.
+:::
+
+### Class-based
+
+Derive from the shared bases when the transformation deserves a name and a test of its own:
+
+```csharp
+public class RoomBookedUpcaster : EventUpcaster<RoomBooked, RoomReserved>
+{
+    protected override RoomReserved Upcast(RoomBooked old)
+        => new(old.RoomId, old.Guest, "legacy");
+}
+
+opts.Events.Upcast<RoomBookedUpcaster>();
+```
+
+`JasperFx.Events.Upcasting.SystemTextJson` carries the raw-JSON equivalents. The namespaces
+deliberately mirror Marten's, so migrating an existing Marten upcaster is a using-directive change.
+
+## Async upcasters
+
+Every registration shape has an async-only twin, for a transformation that genuinely has to await:
+
+```csharp
+opts.Events.Upcast<RoomBooked, RoomReserved>(
+    async (old, token) => new RoomReserved(old.RoomId, await LookupGuestAsync(old.Guest, token), "legacy"));
+```
+
+::: tip Prefer the synchronous form
+An async transformation runs **once per stored event**, so it invites N+1 behaviour on a long
+stream. Polecat's read paths are all asynchronous, so an async-only registration works everywhere
+except the batched DCB tag query, which materializes synchronously and throws `UpcastingException`.
+:::
+
+## What upcasting does and does not touch
+
+| | |
+|---|---|
+| **Applies to** | `FetchStreamAsync`, live aggregation, `FetchForWriting` / `FetchLatest`, the async daemon and every subscription, `QueryAllRawEvents()`, batched stream fetches, DCB tag queries, projection replay |
+| **Does not apply to** | `QueryRawEventDataOnly<T>()` — it never builds an `IEvent`, and by naming `T` the caller has already made the decision an upcaster would make |
+| **Never touches** | the **write** path. Upcasting is a read-time transformation; nothing rewrites `pc_events`. |
+
+An upcast event keeps reporting the **stored** name in `IEvent.EventTypeName` while
+`IEvent.EventType` and `IEvent.Data` are the new type. That is deliberate: the alias is a fact about
+the database, and rewriting it on read would make an upcast indistinguishable from a native append
+of the new type — exactly the distinction an operator needs mid-migration.
+
+## Two rules worth knowing
+
+**A registered transformation wins over the stored `dotnet_type`.** Polecat records an
+assembly-qualified CLR type hint on every event row and normally resolves the type from it. A
+registered transformation is the *authoritative* reading of its source event type name, so the hint
+does not get a vote — otherwise appending the **old** CLR type into the store that carries the
+upcaster would read straight back as the old type, and the upcaster would silently do nothing for
+exactly the rows most likely to exist during a migration. (Marten pins the same rule; see
+marten#4680.)
+
+**Registration is last-wins per stored event type name.** Registering the same source name twice
+replaces the earlier transformation rather than chaining onto it.
+
+## Binary events
+
+Upcasting does not apply to rows written by an
+[`IEventBinarySerializer`](/events/binary-serialization). The shared payload contract is a JSON one —
+both accessors presuppose a JSON body — so a binary row has nothing a transformation can read and
+keeps its ordinary binary read path.

--- a/src/Polecat.Tests/Compliance/PolecatComplianceFixture.cs
+++ b/src/Polecat.Tests/Compliance/PolecatComplianceFixture.cs
@@ -232,6 +232,13 @@ public class PolecatComplianceFixture : EventStoreComplianceFixture<IDocumentSes
     /// </summary>
     public override bool SupportsNaturalKeys => true;
 
+    /// <summary>
+    ///     #561 / jasperfx#752. Polecat routes every event hydration path through the shared
+    ///     <c>EventRegistry.Upcasters</c> and implements <c>IUpcastPayload</c> over its own row
+    ///     reader and serializer.
+    /// </summary>
+    public override bool SupportsUpcasting => true;
+
     // #364. Both operators are extensions in Polecat.Events over the store's raw-event queryable,
     // which is why they cannot be reached through any shared interface. The single Where() is the
     // seam's contract, not a convenience: the HasTag facts next door depend on the predicate staying
@@ -585,6 +592,12 @@ public class PolecatComplianceFixture : EventStoreComplianceFixture<IDocumentSes
                     x.IncludeType(eventType);
                 }
             });
+
+        // #561 / jasperfx#752. One registrar member covers every registration shape -- typed sync,
+        // typed async-only, raw JsonDocument -- because UpcastTransformation is the shared carrier
+        // they all funnel into, and the suite builds them through the shared factories.
+        public void Upcast(JasperFx.Events.Upcasting.UpcastTransformation transformation)
+            => _options.Events.Upcasters.Register(transformation);
 
         // jasperfx#763. Polecat spells the outbox as a single settable property on the event store
         // options, which the projection batch asks for a batch from once per update. The suite's

--- a/src/Polecat.Tests/Compliance/polecat_event_store_compliance_wave16.cs
+++ b/src/Polecat.Tests/Compliance/polecat_event_store_compliance_wave16.cs
@@ -1,0 +1,31 @@
+using JasperFx.Events.ComplianceTests;
+
+namespace Polecat.Tests.Compliance;
+
+/*
+ * Wave 16 -- the upcasting suite (#561 / jasperfx#752), enrolled separately from wave 15 because it
+ * is the definition of done for a feature Polecat did not have at all rather than the adoption of a
+ * suite for behaviour that already existed.
+ */
+
+/// <summary>
+///     Event upcasting: an event stored under an older schema is transformed on READ into the
+///     current CLR type, so aggregations, projections and subscriptions only ever see the new type.
+/// </summary>
+/// <remarks>
+///     <para>
+///         The suite writes its "legacy" rows through a store configured WITHOUT the upcasters and
+///         then hands the same schema to a store that has them, which is the only honest way to
+///         produce a row that predates the migration. So every fact is reading real old-shaped JSON.
+///     </para>
+///     <para>
+///         The fact worth knowing about is
+///         <c>a_typed_append_of_the_old_event_type_does_not_shadow_the_upcaster</c> -- the marten#4680
+///         authority rule. Polecat stores a <c>dotnet_type</c> hint next to the event type name, and
+///         a registered transformation has to beat that hint: otherwise appending the OLD CLR type
+///         into the store that carries the upcaster reads back as the old type, and the upcaster
+///         silently does nothing for exactly the rows most likely to exist.
+///     </para>
+/// </remarks>
+public class upcasting_compliance
+    : UpcastingCompliance<PolecatComplianceFixture, IDocumentSession, IQuerySession>;

--- a/src/Polecat.Tests/Events/upcasting_tests.cs
+++ b/src/Polecat.Tests/Events/upcasting_tests.cs
@@ -1,0 +1,187 @@
+using JasperFx.Events;
+using JasperFx.Events.Upcasting;
+using Polecat.Events;
+using Polecat.Linq;
+using Polecat.Tests.Harness;
+
+namespace Polecat.Tests.Events;
+
+// The event as it was originally written, and as rows in pc_events still record it.
+public record RoomBooked(Guid RoomId, string Guest);
+
+// The event this deployment wants to see.
+public record RoomReserved(Guid RoomId, string Guest, string Source);
+
+public record RoomCleaned(Guid RoomId);
+
+/// <summary>
+///     Polecat-local upcasting coverage (#561 / jasperfx#752) for the read paths the shared
+///     <c>UpcastingCompliance</c> suite does not reach.
+/// </summary>
+/// <remarks>
+///     <para>
+///         The suite covers stream reads, live aggregation, <c>FetchForWriting</c>, the async daemon,
+///         and the marten#4680 authority rule. It cannot cover the paths below, because each one is a
+///         Polecat surface with no counterpart in the shared contract: the raw-event LINQ query, the
+///         batched stream fetch, and the DCB tag query. All three hydrate rows through their own copy
+///         of the read loop rather than through <c>PcEventsRowReader</c>, which is exactly why they
+///         are worth pinning — a seam added to one loop and forgotten in another is the
+///         characteristic failure here, and nothing upstream would catch it.
+///     </para>
+///     <para>
+///         <c>QueryRawEventDataOnly&lt;T&gt;</c> is deliberately absent: it does not build an
+///         <see cref="IEvent" /> at all and upcasting does not apply to it. See the remarks on that
+///         method.
+///     </para>
+/// </remarks>
+public class upcasting_tests : OneOffConfigurationsContext
+{
+    private static readonly string _bookedEventTypeName =
+        EventTypeExtensions.GetEventTypeName<RoomBooked>();
+
+    /// <summary>
+    ///     Write rows the way the pre-migration application really wrote them — through a store with
+    ///     no upcasters — then hand the same schema to a store that has them. Writing them any other
+    ///     way would be testing the upcaster against JSON the upcaster's own configuration produced.
+    /// </summary>
+    private async Task<Guid> ALegacyBookingAsync()
+    {
+        ConfigureStore(opts => opts.Events.AddEventType<RoomBooked>());
+        await theDatabase.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        var streamId = Guid.NewGuid();
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Events.StartStream(streamId, new RoomBooked(Guid.NewGuid(), "Hilda"), new RoomCleaned(Guid.NewGuid()));
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        return streamId;
+    }
+
+    private async Task ConfigureUpcastingStoreAsync()
+    {
+        ConfigureStore(opts =>
+            opts.Events.Upcast<RoomBooked, RoomReserved>(
+                old => new RoomReserved(old.RoomId, old.Guest, "legacy")));
+
+        await theDatabase.ApplyAllConfiguredChangesToDatabaseAsync();
+    }
+
+    [Fact]
+    public async Task the_raw_event_linq_query_upcasts()
+    {
+        var streamId = await ALegacyBookingAsync();
+        await ConfigureUpcastingStoreAsync();
+
+        await using var session = theStore.QuerySession();
+
+        var events = await session.Events.QueryAllRawEvents()
+            .Where(e => e.StreamId == streamId)
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        var reserved = events.Select(x => x.Data).OfType<RoomReserved>().ShouldHaveSingleItem();
+        reserved.Guest.ShouldBe("Hilda");
+        reserved.Source.ShouldBe("legacy");
+    }
+
+    [Fact]
+    public async Task the_batched_stream_fetch_upcasts()
+    {
+        var streamId = await ALegacyBookingAsync();
+        await ConfigureUpcastingStoreAsync();
+
+        await using var session = theStore.QuerySession();
+
+        var batch = session.CreateBatchQuery();
+        var fetch = batch.Events.FetchStream(streamId);
+        await batch.Execute(TestContext.Current.CancellationToken);
+
+        var events = await fetch;
+        events.Select(x => x.Data).OfType<RoomReserved>().ShouldHaveSingleItem()
+            .Guest.ShouldBe("Hilda");
+    }
+
+    /// <summary>
+    ///     The stored event type name keeps recording what was actually written, even though the
+    ///     payload and <see cref="IEvent.EventType" /> are now the new type.
+    /// </summary>
+    /// <remarks>
+    ///     Worth pinning because it is the half a store is tempted to "tidy up": the row's alias is a
+    ///     fact about the database, and rewriting it on read would make an upcast indistinguishable
+    ///     from a native append of the new type — which is precisely what an operator staring at a
+    ///     mid-migration store needs to be able to tell apart.
+    /// </remarks>
+    [Fact]
+    public async Task the_stored_event_type_name_still_reports_the_source_name()
+    {
+        var streamId = await ALegacyBookingAsync();
+        await ConfigureUpcastingStoreAsync();
+
+        await using var session = theStore.QuerySession();
+        var events = await session.Events.FetchStreamAsync(streamId, token: TestContext.Current.CancellationToken);
+
+        var upcast = events.Single(x => x.Data is RoomReserved);
+        upcast.EventTypeName.ShouldBe(_bookedEventTypeName);
+        upcast.EventType.ShouldBe(typeof(RoomReserved));
+    }
+
+    /// <summary>
+    ///     Re-registering a stored event type name replaces the earlier transformation rather than
+    ///     stacking on it — the last-wins rule the shared registry documents.
+    /// </summary>
+    [Fact]
+    public async Task registering_the_same_source_name_twice_is_last_wins()
+    {
+        var streamId = await ALegacyBookingAsync();
+
+        ConfigureStore(opts =>
+        {
+            opts.Events.Upcast<RoomBooked, RoomReserved>(old => new RoomReserved(old.RoomId, old.Guest, "first"));
+            opts.Events.Upcast<RoomBooked, RoomReserved>(old => new RoomReserved(old.RoomId, old.Guest, "second"));
+        });
+        await theDatabase.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        await using var session = theStore.QuerySession();
+        var events = await session.Events.FetchStreamAsync(streamId, token: TestContext.Current.CancellationToken);
+
+        events.Select(x => x.Data).OfType<RoomReserved>().ShouldHaveSingleItem()
+            .Source.ShouldBe("second");
+    }
+
+    /// <summary>
+    ///     A store with no upcasters registered reads exactly as it always did.
+    /// </summary>
+    /// <remarks>
+    ///     The negative that keeps the seam honest: every hydration path now carries an upcast branch,
+    ///     and this is what says the branch is not taken — and not paid for — by the overwhelming
+    ///     majority of stores.
+    /// </remarks>
+    [Fact]
+    public async Task a_store_with_no_upcasters_reads_the_original_type()
+    {
+        var streamId = await ALegacyBookingAsync();
+
+        await using var session = theStore.QuerySession();
+        var events = await session.Events.FetchStreamAsync(streamId, token: TestContext.Current.CancellationToken);
+
+        events.Select(x => x.Data).OfType<RoomBooked>().ShouldHaveSingleItem()
+            .Guest.ShouldBe("Hilda");
+        theStore.Options.EventGraph.Upcasters.HasAny.ShouldBeFalse();
+    }
+
+    /// <summary>
+    ///     The upcast TARGET type is registered with the store at construction, before anything has
+    ///     ever appended one.
+    /// </summary>
+    [Fact]
+    public void the_target_event_type_is_pre_registered()
+    {
+        ConfigureStore(opts =>
+            opts.Events.Upcast<RoomBooked, RoomReserved>(
+                old => new RoomReserved(old.RoomId, old.Guest, "legacy")));
+
+        theStore.Options.EventGraph.EventMappingFor(typeof(RoomReserved)).ShouldNotBeNull();
+    }
+}

--- a/src/Polecat/DocumentStore.ProjectionReplay.cs
+++ b/src/Polecat/DocumentStore.ProjectionReplay.cs
@@ -240,10 +240,27 @@ public partial class DocumentStore
     [RequiresDynamicCode("ISerializer.FromJson uses STJ which requires runtime code generation for non-source-generated types.")]
     private IEvent? ToDomainEvent(EventRecord record)
     {
-        var clrType = ResolveEventClrType(record.EventTypeName);
-        if (clrType is null) return null;
+        // #561 / jasperfx#752: upcast first, like every other read path. This one is already keyed on
+        // the stored event type name rather than the dotnet_type hint, so there is no authority
+        // question to resolve here -- but a replay that skipped upcasting would show the timeline in
+        // terms of an event schema the rest of the store has stopped producing.
+        object? raw;
+        Type clrType;
 
-        var raw = Options.Serializer.FromJson(clrType, record.Data.GetRawText());
+        if (Events.TryFindUpcast(record.EventTypeName, bdata: null, out var transformation))
+        {
+            clrType = transformation.EventType;
+            raw = Events.Upcast(transformation, record.Data.GetRawText(), Options.Serializer);
+        }
+        else
+        {
+            var resolved = ResolveEventClrType(record.EventTypeName);
+            if (resolved is null) return null;
+
+            clrType = resolved;
+            raw = Options.Serializer.FromJson(clrType, record.Data.GetRawText());
+        }
+
         if (raw is null) return null;
 
         var mapping = Events.EventMappingFor(clrType);

--- a/src/Polecat/DocumentStore.cs
+++ b/src/Polecat/DocumentStore.cs
@@ -47,6 +47,11 @@ public partial class DocumentStore : IDocumentStore
         // function/scheme and table are created and rolled forward by schema migration at activation.
         _providers.ConfigurePartitionedDocuments();
 
+        // #561 / jasperfx#752: register the TARGET event type of every upcast transformation. An
+        // upcast row can be read before this deployment has ever appended the new type, and without
+        // a mapping there is nothing to wrap the transformed payload in.
+        options.EventGraph.RegisterUpcastTargetTypes();
+
         // Back-reference so the database can open sessions for the dead-letter
         // document store/queries (it has no store/session of its own otherwise).
         Database.Store = this;

--- a/src/Polecat/Events/Daemon/PolecatEventLoader.cs
+++ b/src/Polecat/Events/Daemon/PolecatEventLoader.cs
@@ -47,6 +47,20 @@ internal class PolecatEventLoader : IEventLoader
     private readonly string _commandText;
     private readonly string[]? _pushedDownTypeNames;
 
+    /// <summary>
+    ///     #561 / jasperfx#752: the stored event type names that have a registered upcast
+    ///     transformation. Pushed into the SQL alongside the dotnet_type allow list so a legacy row
+    ///     survives the filter and reaches the upcaster.
+    /// </summary>
+    /// <remarks>
+    ///     A SECOND column in the predicate, not more values in the first: the allow list matches on
+    ///     <c>dotnet_type</c> while an upcast source is a <c>type</c> alias, and for a raw-JSON
+    ///     transformation there may be no old CLR type — and therefore no dotnet_type — to name at
+    ///     all. Null when nothing is registered, which is the overwhelming majority and leaves the
+    ///     rendered SQL byte-for-byte as it was.
+    /// </remarks>
+    private readonly string[]? _upcastSourceNames;
+
     public PolecatEventLoader(EventGraph events, StoreOptions options, string connectionString,
         EventFilterable? filtering = null, string? tenantFilter = null)
     {
@@ -74,6 +88,15 @@ internal class PolecatEventLoader : IEventLoader
                 // values bound on each load.
                 _pushedDownTypeNames = _allowedDotNetTypes.ToArray();
             }
+        }
+
+        // Only meaningful alongside a type allow list: an unfiltered shard already reads every row.
+        if (_pushedDownTypeNames is { Length: > 0 } && events.Upcasters.HasAny)
+        {
+            _upcastSourceNames = events.Upcasters.AllTransformations
+                .Select(x => x.EventTypeName)
+                .Distinct(StringComparer.Ordinal)
+                .ToArray();
         }
 
         _commandText = BuildCommandText();
@@ -119,7 +142,16 @@ internal class PolecatEventLoader : IEventLoader
         if (_pushedDownTypeNames is { Length: > 0 })
         {
             var markers = string.Join(", ", Enumerable.Range(0, _pushedDownTypeNames.Length).Select(i => $"@t{i}"));
-            typePredicate = $" AND (dotnet_type IS NULL OR dotnet_type IN ({markers}))";
+            typePredicate = $" AND (dotnet_type IS NULL OR dotnet_type IN ({markers})";
+
+            if (_upcastSourceNames is { Length: > 0 })
+            {
+                var upcastMarkers = string.Join(", ",
+                    Enumerable.Range(0, _upcastSourceNames.Length).Select(i => $"@u{i}"));
+                typePredicate += $" OR type IN ({upcastMarkers})";
+            }
+
+            typePredicate += ")";
         }
 
         return $"""
@@ -174,6 +206,15 @@ internal class PolecatEventLoader : IEventLoader
             }
         }
 
+        if (_upcastSourceNames is not null)
+        {
+            // Same varchar binding reasoning as above (#363) — pc_events.type is varchar too.
+            for (var i = 0; i < _upcastSourceNames.Length; i++)
+            {
+                cmd.Parameters.AddVarChar($"@u{i}", _upcastSourceNames[i]);
+            }
+        }
+
         var skippedEvents = 0;
 
         await using var reader = await cmd.ExecuteReaderAsync(token);
@@ -204,49 +245,88 @@ internal class PolecatEventLoader : IEventLoader
             // when the allow-list was too large to push down. Counting a discarded row as skipped is
             // what keeps the ceiling honest in that fallback: the row genuinely consumed a slot of this
             // page's range, so the batch was saturated even though the page came back short.
-            if (_allowedDotNetTypes != null && dotNetTypeName != null &&
+            // #561 / jasperfx#752: an upcast SOURCE row is admitted whatever its dotnet_type says.
+            // The allow list is built from the projection's declared event types -- which are the
+            // NEW types -- so a legacy row would otherwise be discarded here before anything got a
+            // chance to upcast it, and for a raw-JSON transformation the old CLR type may not even
+            // exist to put on the list. Mirrors the SQL push-down in BuildCommandText.
+            var upcastable = _events.TryFindUpcast(typeName, bdata, out var transformation);
+
+            if (!upcastable && _allowedDotNetTypes != null && dotNetTypeName != null &&
                 !_allowedDotNetTypes.Contains(dotNetTypeName))
             {
                 skippedEvents++;
                 continue;
             }
 
-            var resolvedType = _events.ResolveEventType(dotNetTypeName);
-            if (resolvedType == null)
-            {
-                if (request.ErrorOptions.SkipUnknownEvents)
-                {
-                    skippedEvents++;
-                    continue;
-                }
-
-                // #368 / jasperfx#565: a typed exception carrying its own ShardFailureCategory, so a shard
-                // paused by an unregistered event type reports UnknownEventType with the offending
-                // sequence rather than classifying as Other with no detail. The daemon does not sniff
-                // exception type names — the exception has to declare its own kind.
-                throw new Polecat.Exceptions.UnknownEventTypeException(dotNetTypeName, seqId);
-            }
-
             object data;
-            try
+            IEventType mapping;
+
+            if (upcastable)
             {
-                data = _events.DeserializeEventData(resolvedType, json, bdata, _options.Serializer);
-            }
-            catch (Exception ex)
-            {
-                if (request.ErrorOptions.SkipSerializationErrors)
+                // Upcast FIRST, so the dotnet_type hint cannot shadow a registered transformation
+                // (marten#4680). The async delegate, because the daemon's read is awaited.
+                try
                 {
-                    skippedEvents++;
-                    continue;
+                    data = await _events
+                        .UpcastAsync(transformation!, json, _options.Serializer, token)
+                        .ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    if (request.ErrorOptions.SkipSerializationErrors)
+                    {
+                        skippedEvents++;
+                        continue;
+                    }
+
+                    // An upcast that throws is a payload-shape problem like any other failed
+                    // deserialization, so it carries the same ShardFailureCategory and obeys the same
+                    // SkipSerializationErrors policy rather than pausing the shard as something new.
+                    throw new Polecat.Exceptions.EventDeserializationFailureException(seqId, typeName, ex);
                 }
 
-                // #368 / jasperfx#565: report the store's type alias (the `type` column) rather than the
-                // assembly-qualified dotnet_type, matching what ShardFailure.Event.EventTypeName carries
-                // everywhere else and what a client-side consumer can act on.
-                throw new Polecat.Exceptions.EventDeserializationFailureException(seqId, typeName, ex);
+                mapping = _events.EventMappingFor(transformation!.EventType);
+            }
+            else
+            {
+                var resolvedType = _events.ResolveEventType(dotNetTypeName);
+                if (resolvedType == null)
+                {
+                    if (request.ErrorOptions.SkipUnknownEvents)
+                    {
+                        skippedEvents++;
+                        continue;
+                    }
+
+                    // #368 / jasperfx#565: a typed exception carrying its own ShardFailureCategory, so a shard
+                    // paused by an unregistered event type reports UnknownEventType with the offending
+                    // sequence rather than classifying as Other with no detail. The daemon does not sniff
+                    // exception type names — the exception has to declare its own kind.
+                    throw new Polecat.Exceptions.UnknownEventTypeException(dotNetTypeName, seqId);
+                }
+
+                try
+                {
+                    data = _events.DeserializeEventData(resolvedType, json, bdata, _options.Serializer);
+                }
+                catch (Exception ex)
+                {
+                    if (request.ErrorOptions.SkipSerializationErrors)
+                    {
+                        skippedEvents++;
+                        continue;
+                    }
+
+                    // #368 / jasperfx#565: report the store's type alias (the `type` column) rather than the
+                    // assembly-qualified dotnet_type, matching what ShardFailure.Event.EventTypeName carries
+                    // everywhere else and what a client-side consumer can act on.
+                    throw new Polecat.Exceptions.EventDeserializationFailureException(seqId, typeName, ex);
+                }
+
+                mapping = _events.EventMappingFor(resolvedType);
             }
 
-            var mapping = _events.EventMappingFor(resolvedType);
             var @event = mapping.Wrap(data);
 
             @event.Id = eventId;

--- a/src/Polecat/Events/EventGraph.cs
+++ b/src/Polecat/Events/EventGraph.cs
@@ -7,6 +7,7 @@ using JasperFx.Events;
 using JasperFx.Events.Aggregation;
 using JasperFx.Events.Projections;
 using JasperFx.Events.Tags;
+using JasperFx.Events.Upcasting;
 using Polecat.Events.Schema;
 using Polecat.Projections;
 using Polecat.Serialization;
@@ -706,6 +707,93 @@ public class EventGraph : EventRegistry, IAggregationSourceFactory<IQuerySession
     ///     being non-null is the on-row discriminator, so JSON rows written before the feature was
     ///     switched on keep deserializing through <paramref name="serializer" /> unchanged.
     /// </summary>
+    /// <summary>
+    ///     Resolve the upcast transformation registered for a stored event type name, if any. This is
+    ///     the call every Polecat hydration path makes BEFORE default deserialization.
+    /// </summary>
+    /// <param name="eventTypeName">The stored <c>pc_events.type</c> alias.</param>
+    /// <param name="bdata">
+    ///     The row's <c>bdata</c> column. Non-null means the row was written by an
+    ///     <see cref="IEventBinarySerializer" /> (#388), and upcasting deliberately does not apply:
+    ///     the shared <c>IUpcastPayload</c> is a JSON contract — <c>As&lt;T&gt;</c> and
+    ///     <c>AsJsonDocument</c> both presuppose a JSON body — so a binary row has nothing an upcast
+    ///     transformation can read. Such a row keeps its ordinary binary read path.
+    /// </param>
+    /// <remarks>
+    ///     <para>
+    ///         <b>The marten#4680 authority rule lives here, and in Polecat it is structural rather
+    ///         than a guard.</b> A registered transformation is the authoritative interpretation of
+    ///         its SOURCE event type name: once this returns true, the caller must not consult
+    ///         <see cref="ResolveEventType" /> at all. That matters because Polecat resolves an
+    ///         event's CLR type from the stored <c>dotnet_type</c> hint, so appending the OLD CLR type
+    ///         typed into the very store that carries the upcaster writes a row whose hint points
+    ///         straight back at the old type — and a read that consulted the hint first would hand
+    ///         back the old type and leave the upcaster silently doing nothing, for exactly the rows
+    ///         most likely to exist during a migration.
+    ///     </para>
+    ///     <para>
+    ///         Marten needs an explicit <c>!mapping.IsUpcastTarget</c> condition on its alt-mapping
+    ///         swap for the same reason. Polecat has no alt-mapping swap, so ordering the check first
+    ///         is the whole of it — which is why every hydration path must ask THIS method rather than
+    ///         reaching for the registry itself.
+    ///     </para>
+    ///     <para>
+    ///         <see cref="UpcastingRegistry.HasAny" /> short-circuits first so a store with no
+    ///         upcasters registered — the overwhelming majority — pays one boolean field read per row
+    ///         and keeps its unmodified hydration path.
+    ///     </para>
+    /// </remarks>
+    internal bool TryFindUpcast(string? eventTypeName, byte[]? bdata,
+        [NotNullWhen(true)] out UpcastTransformation? transformation)
+    {
+        if (bdata is not null || !Upcasters.HasAny || eventTypeName is null)
+        {
+            transformation = null;
+            return false;
+        }
+
+        return Upcasters.TryFindTransformation(eventTypeName, out transformation);
+    }
+
+    /// <summary>
+    ///     Run a transformation over a stored JSON payload on a synchronous read path. An async-only
+    ///     registration throws <see cref="UpcastingException" /> from here, by contract.
+    /// </summary>
+    internal object Upcast(UpcastTransformation transformation, string json, ISerializer serializer)
+        => transformation.Upcast(new Upcasting.PolecatUpcastPayload(json, serializer));
+
+    /// <summary>
+    ///     Run a transformation over a stored JSON payload on an asynchronous read path.
+    /// </summary>
+    /// <remarks>
+    ///     Every Polecat read that a consumer awaits must come through here rather than
+    ///     <see cref="Upcast" />: a store that routed its async reads through the synchronous delegate
+    ///     would make an async-only registration unreachable, which the contract turns into an
+    ///     <see cref="UpcastingException" /> rather than a silent fallback precisely so the mistake is
+    ///     loud.
+    /// </remarks>
+    internal ValueTask<object> UpcastAsync(UpcastTransformation transformation, string json,
+        ISerializer serializer, CancellationToken token)
+        => transformation.UpcastAsync(new Upcasting.PolecatUpcastPayload(json, serializer), token);
+
+    /// <summary>
+    ///     Pre-register the TARGET event type of every registered transformation.
+    /// </summary>
+    /// <remarks>
+    ///     Called once at <see cref="DocumentStore" /> construction. Without it the new event type is
+    ///     unknown to the store until something appends one, so an upcast row read before any append
+    ///     of the new type would have no mapping to wrap its payload in. The SOURCE name deliberately
+    ///     is not registered as an event type: it is a name in the database, not a type this
+    ///     deployment appends, and after a raw-JSON upcast the old CLR type may not exist at all.
+    /// </remarks>
+    internal void RegisterUpcastTargetTypes()
+    {
+        foreach (var transformation in Upcasters.AllTransformations)
+        {
+            AddEventType(transformation.EventType);
+        }
+    }
+
     internal object DeserializeEventData(Type resolvedType, string json, byte[]? bdata, ISerializer serializer)
     {
         if (bdata is null) return serializer.FromJson(resolvedType, json);

--- a/src/Polecat/Events/EventOperations.cs
+++ b/src/Polecat/Events/EventOperations.cs
@@ -1174,11 +1174,27 @@ internal class EventOperations : QueryEventStore, IEventOperations
             var isArchived = reader.GetBoolean(9);
             var bdata = reader.IsDBNull(10) ? null : reader.GetFieldValue<byte[]>(10); // #388
 
-            var resolvedType = _events.ResolveEventType(dotNetTypeName);
-            if (resolvedType == null) continue;
+            object data;
+            IEventType mapping;
 
-            var data = _events.DeserializeEventData(resolvedType, json, bdata, _sessionBase.Serializer);
-            var mapping = _events.EventMappingFor(resolvedType);
+            // #561 / jasperfx#752: upcast FIRST, so the dotnet_type hint below cannot shadow a
+            // registered transformation (marten#4680). See EventGraph.TryFindUpcast.
+            if (_events.TryFindUpcast(typeName, bdata, out var transformation))
+            {
+                data = await _events
+                    .UpcastAsync(transformation, json, _sessionBase.Serializer, cancellation)
+                    .ConfigureAwait(false);
+                mapping = _events.EventMappingFor(transformation.EventType);
+            }
+            else
+            {
+                var resolvedType = _events.ResolveEventType(dotNetTypeName);
+                if (resolvedType == null) continue;
+
+                data = _events.DeserializeEventData(resolvedType, json, bdata, _sessionBase.Serializer);
+                mapping = _events.EventMappingFor(resolvedType);
+            }
+
             var @event = mapping.Wrap(data);
 
             @event.Id = eventId;
@@ -1391,11 +1407,27 @@ internal class EventOperations : QueryEventStore, IEventOperations
         var isArchived = reader.GetBoolean(9);
         var bdata = reader.IsDBNull(10) ? null : reader.GetFieldValue<byte[]>(10); // #388
 
-        var resolvedType = eventGraph.ResolveEventType(dotNetTypeName);
-        if (resolvedType == null) return null;
+        object data;
+        IEventType mapping;
 
-        var data = eventGraph.DeserializeEventData(resolvedType, json, bdata, serializer);
-        var mapping = eventGraph.EventMappingFor(resolvedType);
+        // #561 / jasperfx#752: upcast FIRST -- see EventGraph.TryFindUpcast. This one is the
+        // BATCHED DCB read, whose result is materialized synchronously inside the batch's own
+        // reader walk, so an async-only registration correctly throws here rather than being
+        // silently downgraded.
+        if (eventGraph.TryFindUpcast(typeName, bdata, out var transformation))
+        {
+            data = eventGraph.Upcast(transformation, json, serializer);
+            mapping = eventGraph.EventMappingFor(transformation.EventType);
+        }
+        else
+        {
+            var resolvedType = eventGraph.ResolveEventType(dotNetTypeName);
+            if (resolvedType == null) return null;
+
+            data = eventGraph.DeserializeEventData(resolvedType, json, bdata, serializer);
+            mapping = eventGraph.EventMappingFor(resolvedType);
+        }
+
         var @event = mapping.Wrap(data);
 
         @event.Id = eventId;

--- a/src/Polecat/Events/Internal/PcEventsRowReader.cs
+++ b/src/Polecat/Events/Internal/PcEventsRowReader.cs
@@ -4,6 +4,7 @@ using System.Text;
 using System.Text.Json;
 using JasperFx.Descriptors;
 using JasperFx.Events;
+using JasperFx.Events.Upcasting;
 using Polecat.Metadata;
 
 namespace Polecat.Events.Internal;
@@ -147,6 +148,126 @@ internal static class PcEventsRowReader
     }
 
     /// <summary>
+    ///     Asynchronous twin of <see cref="ReadEventAsGuid" />, for read paths a consumer awaits.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         #561 / jasperfx#752. The ONLY thing this changes is which half of an upcast
+    ///         transformation runs: an async-only registration is unreachable from
+    ///         <see cref="UpcastTransformation.Upcast" /> and throws <c>UpcastingException</c> by
+    ///         contract, so every Polecat read a consumer awaits has to come through here or that
+    ///         registration shape is simply unusable. Nothing else about the row read is async —
+    ///         the JSON is already a materialized string by this point.
+    ///     </para>
+    ///     <para>
+    ///         Deliberately NOT an <c>async</c> method: it takes <paramref name="cache" /> by
+    ///         reference, which an async method cannot, and the fast path must stay allocation-free.
+    ///         The upcast branch — rare, and absent entirely in a store with no upcasters — hands off
+    ///         to a real async method; everything else returns the synchronous result already
+    ///         completed.
+    ///     </para>
+    /// </remarks>
+    internal static ValueTask<IEvent?> ReadEventAsGuidAsync(
+        DbDataReader reader,
+        EventHydrationContext ctx,
+        MetadataSlots slots,
+        ref EventTypeCache cache,
+        CancellationToken token)
+    {
+        if (TryBeginAsyncUpcast(reader, ctx, out var transformation))
+        {
+            return UpcastEventAsync(reader, ctx, slots, transformation, streamKey: null, token);
+        }
+
+        return new ValueTask<IEvent?>(ReadEventAsGuid(reader, ctx, slots, ref cache));
+    }
+
+    /// <summary>
+    ///     Asynchronous twin of <see cref="ReadEventAsString" />. See
+    ///     <see cref="ReadEventAsGuidAsync" />.
+    /// </summary>
+    internal static ValueTask<IEvent?> ReadEventAsStringAsync(
+        DbDataReader reader,
+        EventHydrationContext ctx,
+        MetadataSlots slots,
+        ref EventTypeCache cache,
+        CancellationToken token)
+    {
+        if (TryBeginAsyncUpcast(reader, ctx, out var transformation))
+        {
+            return UpcastEventAsync(reader, ctx, slots, transformation, ctx.StreamId.ToString(), token);
+        }
+
+        return new ValueTask<IEvent?>(ReadEventAsString(reader, ctx, slots, ref cache));
+    }
+
+    /// <summary>
+    ///     Peek at the row's stored event type name and the <c>bdata</c> discriminator to decide
+    ///     whether this row needs the async upcast branch. Both columns are cheap, fixed-ordinal
+    ///     reads and are read again by whichever path runs.
+    /// </summary>
+    private static bool TryBeginAsyncUpcast(DbDataReader reader, EventHydrationContext ctx,
+        [NotNullWhen(true)] out UpcastTransformation? transformation)
+    {
+        // Short-circuits on HasAny inside TryFindUpcast, so a store with no upcasters does not even
+        // read the columns in the common case.
+        if (!ctx.EventGraph.Upcasters.HasAny)
+        {
+            transformation = null;
+            return false;
+        }
+
+        var typeName = reader.GetString(5);
+        var bdata = reader.IsDBNull(10) ? null : reader.GetFieldValue<byte[]>(10);
+
+        return ctx.EventGraph.TryFindUpcast(typeName, bdata, out transformation);
+    }
+
+    /// <summary>
+    ///     Hydrate one row through an upcast transformation's ASYNC delegate.
+    /// </summary>
+    private static async ValueTask<IEvent?> UpcastEventAsync(
+        DbDataReader reader,
+        EventHydrationContext ctx,
+        MetadataSlots slots,
+        UpcastTransformation transformation,
+        string? streamKey,
+        CancellationToken token)
+    {
+        var seqId = reader.GetInt64(0);
+        var eventId = reader.GetGuid(1);
+        var eventVersion = reader.GetInt64(3);
+        var json = reader.GetString(4);
+        var typeName = reader.GetString(5);
+        var eventTimestamp = reader.GetFieldValue<DateTimeOffset>(6);
+        var tenantId = reader.IsDBNull(7) ? ctx.DefaultTenantId : reader.GetString(7);
+        var dotNetTypeName = reader.IsDBNull(8) ? null : reader.GetString(8);
+        var isArchived = reader.GetBoolean(9);
+
+        var data = await ctx.EventGraph
+            .UpcastAsync(transformation, json, ctx.Serializer, token).ConfigureAwait(false);
+
+        var mapping = ctx.EventGraph.EventMappingFor(transformation.EventType);
+        var @event = mapping.Wrap(data);
+
+        ApplyRowMetadata(@event, reader, ctx, slots,
+            eventId, seqId, eventVersion, eventTimestamp, tenantId, typeName, dotNetTypeName, isArchived);
+
+        // The two StreamIdentity specializations differ only here, and the caller has already told
+        // us which one it is by whether it passed a key.
+        if (streamKey == null)
+        {
+            @event.StreamId = ctx.StreamId is Guid g ? g : Guid.Empty;
+        }
+        else
+        {
+            @event.StreamKey = streamKey;
+        }
+
+        return @event;
+    }
+
+    /// <summary>
     ///     Shared body of <see cref="ReadEventAsGuid"/> /
     ///     <see cref="ReadEventAsString"/>. Reads every field EXCEPT
     ///     <c>StreamId</c> / <c>StreamKey</c>; the specialized wrappers
@@ -173,17 +294,56 @@ internal static class PcEventsRowReader
         // hot loop — a store with no binary events pays one IsDBNull per row.
         var bdata = reader.IsDBNull(10) ? null : reader.GetFieldValue<byte[]>(10);
 
-        var resolvedType = ctx.EventGraph.ResolveEventType(dotNetTypeName);
-        if (resolvedType == null) return null;
+        object data;
+        IEventType mapping;
 
-        // Per-batch single-slot type→mapping cache. For streams with
-        // repeated event types (the common shape of an aggregate stream)
-        // this collapses N dictionary lookups into 1 per distinct type.
-        var mapping = cache.LookupOrAdd(ctx.EventGraph, resolvedType);
+        // #561 / jasperfx#752. The upcast check comes FIRST, and that ordering is the marten#4680
+        // authority rule: a registered transformation is the authoritative reading of the stored
+        // event type name, so the dotnet_type hint below must never get a chance to shadow it. See
+        // EventGraph.TryFindUpcast.
+        if (ctx.EventGraph.TryFindUpcast(typeName, bdata, out var transformation))
+        {
+            data = ctx.EventGraph.Upcast(transformation, json, ctx.Serializer);
+            mapping = ctx.EventGraph.EventMappingFor(transformation.EventType);
+        }
+        else
+        {
+            var resolvedType = ctx.EventGraph.ResolveEventType(dotNetTypeName);
+            if (resolvedType == null) return null;
 
-        var data = ctx.EventGraph.DeserializeEventData(resolvedType, json, bdata, ctx.Serializer);
+            // Per-batch single-slot type→mapping cache. For streams with
+            // repeated event types (the common shape of an aggregate stream)
+            // this collapses N dictionary lookups into 1 per distinct type.
+            mapping = cache.LookupOrAdd(ctx.EventGraph, resolvedType);
+
+            data = ctx.EventGraph.DeserializeEventData(resolvedType, json, bdata, ctx.Serializer);
+        }
+
         var @event = mapping.Wrap(data);
+        ApplyRowMetadata(@event, reader, ctx, slots,
+            eventId, seqId, eventVersion, eventTimestamp, tenantId, typeName, dotNetTypeName, isArchived);
 
+        return @event;
+    }
+
+    /// <summary>
+    ///     Stamp every non-payload field of a hydrated event from the row the reader is positioned
+    ///     on. Shared by the ordinary read and the async upcast read so the two cannot drift.
+    /// </summary>
+    private static void ApplyRowMetadata(
+        IEvent @event,
+        DbDataReader reader,
+        EventHydrationContext ctx,
+        MetadataSlots slots,
+        Guid eventId,
+        long seqId,
+        long eventVersion,
+        DateTimeOffset eventTimestamp,
+        string tenantId,
+        string typeName,
+        string? dotNetTypeName,
+        bool isArchived)
+    {
         @event.Id = eventId;
         @event.Sequence = seqId;
         @event.Version = eventVersion;
@@ -219,8 +379,6 @@ internal static class PcEventsRowReader
                 ? null
                 : reader.GetString(slots.UserNameIdx);
         }
-
-        return @event;
     }
 
     /// <summary>

--- a/src/Polecat/Events/Linq/EventListHandler.cs
+++ b/src/Polecat/Events/Linq/EventListHandler.cs
@@ -46,11 +46,26 @@ internal class EventListHandler
             // #388: non-null bdata means the payload is binary, not in the JSON `data` column.
             var bdata = sqlReader.IsDBNull(10) ? null : sqlReader.GetFieldValue<byte[]>(10);
 
-            var resolvedType = _events.ResolveEventType(dotNetTypeName);
-            if (resolvedType == null) continue;
+            object data;
+            IEventType mapping;
 
-            var data = _events.DeserializeEventData(resolvedType, json, bdata, _serializer);
-            var mapping = _events.EventMappingFor(resolvedType);
+            // #561 / jasperfx#752: upcast FIRST, so the dotnet_type hint below cannot shadow a
+            // registered transformation (marten#4680). See EventGraph.TryFindUpcast.
+            if (_events.TryFindUpcast(typeName, bdata, out var transformation))
+            {
+                data = await _events.UpcastAsync(transformation, json, _serializer, token)
+                    .ConfigureAwait(false);
+                mapping = _events.EventMappingFor(transformation.EventType);
+            }
+            else
+            {
+                var resolvedType = _events.ResolveEventType(dotNetTypeName);
+                if (resolvedType == null) continue;
+
+                data = _events.DeserializeEventData(resolvedType, json, bdata, _serializer);
+                mapping = _events.EventMappingFor(resolvedType);
+            }
+
             var @event = mapping.Wrap(data);
 
             @event.Id = eventId;

--- a/src/Polecat/Events/QueryEventStore.cs
+++ b/src/Polecat/Events/QueryEventStore.cs
@@ -36,6 +36,21 @@ internal class QueryEventStore : IQueryEventStore, IReadOnlyEventStore
         _options = options;
     }
 
+    /// <remarks>
+    ///     ⚠️ <b>Upcasting deliberately does not apply here</b> (#561). This overload is the one read
+    ///     path that never builds an <see cref="IEvent" /> envelope: it filters on
+    ///     <typeparamref name="T" />'s own event type name and deserializes the bare <c>data</c>
+    ///     column straight to <typeparamref name="T" />, so there is no stored-name-to-new-type
+    ///     decision for a transformation to make — by naming <typeparamref name="T" /> the caller has
+    ///     already made it.
+    ///     <para>
+    ///     What that means in practice: rows written under an OLDER schema of
+    ///     <typeparamref name="T" />'s own name are read here as raw <typeparamref name="T" /> with
+    ///     no transformation, where <c>QueryAllRawEvents()</c> would upcast them. Use
+    ///     <c>QueryAllRawEvents()</c> when a store has upcasters registered and the query has to see
+    ///     post-migration payloads.
+    ///     </para>
+    /// </remarks>
     public IPolecatQueryable<T> QueryRawEventDataOnly<T>() where T : class
     {
         _events.AddEventType(typeof(T));
@@ -351,7 +366,8 @@ internal class QueryEventStore : IQueryEventStore, IReadOnlyEventStore
         {
             while (await reader.ReadAsync(token))
             {
-                var @event = PcEventsRowReader.ReadEventAsGuid(reader, ctx, slots, ref cache);
+                var @event = await PcEventsRowReader
+                    .ReadEventAsGuidAsync(reader, ctx, slots, ref cache, token).ConfigureAwait(false);
                 if (@event != null) results.Add(@event);
             }
         }
@@ -359,7 +375,8 @@ internal class QueryEventStore : IQueryEventStore, IReadOnlyEventStore
         {
             while (await reader.ReadAsync(token))
             {
-                var @event = PcEventsRowReader.ReadEventAsString(reader, ctx, slots, ref cache);
+                var @event = await PcEventsRowReader
+                    .ReadEventAsStringAsync(reader, ctx, slots, ref cache, token).ConfigureAwait(false);
                 if (@event != null) results.Add(@event);
             }
         }

--- a/src/Polecat/Events/Upcasting/PolecatUpcastPayload.cs
+++ b/src/Polecat/Events/Upcasting/PolecatUpcastPayload.cs
@@ -1,0 +1,69 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+using JasperFx.Events.Upcasting;
+using Polecat.Serialization;
+
+namespace Polecat.Events.Upcasting;
+
+/// <summary>
+///     Polecat's adapter for the shared <see cref="IUpcastPayload" /> seam: one stored
+///     <c>pc_events.data</c> value, presented to an upcast transformation without exposing how
+///     Polecat read it.
+/// </summary>
+/// <remarks>
+///     <para>
+///         #561 / jasperfx#752. The shared contract abstracts Marten's
+///         <c>(ISerializer, DbDataReader, index)</c> triple, which is PostgreSQL- and
+///         Marten-serializer-shaped, down to "a payload that can hand you either a deserialized old
+///         CLR type or the raw JSON". Polecat's half of that is unusually small, because by the time
+///         a row reaches here the JSON has already been pulled off the reader as a string: this type
+///         is a two-field struct-shaped adapter over <c>(json, serializer)</c> and nothing else.
+///     </para>
+///     <para>
+///         <b>The async members are deliberately synchronous underneath.</b> The contract offers them
+///         so a store whose read path can stream a payload rather than buffer it has somewhere to do
+///         that; Polecat's cannot and does not need to — the string is already materialized. What the
+///         async members are actually load-bearing for is the OTHER half of the split: an async-only
+///         transformation must be reachable, and it is reached through
+///         <see cref="IUpcastPayload.AsAsync{T}" />. Wrapping a completed value in a
+///         <see cref="ValueTask{TResult}" /> allocates nothing.
+///     </para>
+///     <para>
+///         <see cref="AsJsonDocument" /> never throws the way Marten's can. The contract allows a
+///         store whose serializer cannot produce a <see cref="JsonDocument" /> to refuse; Polecat is
+///         System.Text.Json only and stores event bodies in a SQL Server 2025 native <c>json</c>
+///         column, so the raw-JSON form is always available. That is what makes
+///         <c>JasperFx.Events.Upcasting.SystemTextJson</c>'s upcasters — the ones that let the old
+///         CLR type be deleted from the codebase entirely — unconditionally usable here.
+///     </para>
+///     <para>
+///         Short-lived and single-use by design: the contract says a transformation calls exactly one
+///         accessor exactly once per event, so nothing here is cached and the parsed document is the
+///         caller's to dispose.
+///     </para>
+/// </remarks>
+[UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
+    Justification = "Class-level: As<T>() routes through ISerializer.FromJson. The old event type is named in the consumer's upcast registration, so it is rooted by that call site; AOT consumers supply a source-generator-backed ISerializer impl.")]
+[UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+    Justification = "Class-level: ISerializer.FromJson is annotated RDC.")]
+internal sealed class PolecatUpcastPayload : IUpcastPayload
+{
+    private readonly string _json;
+    private readonly ISerializer _serializer;
+
+    public PolecatUpcastPayload(string json, ISerializer serializer)
+    {
+        _json = json;
+        _serializer = serializer;
+    }
+
+    public T As<T>() where T : notnull => _serializer.FromJson<T>(_json);
+
+    public ValueTask<T> AsAsync<T>(CancellationToken token) where T : notnull
+        => new(_serializer.FromJson<T>(_json));
+
+    public JsonDocument AsJsonDocument() => JsonDocument.Parse(_json);
+
+    public ValueTask<JsonDocument> AsJsonDocumentAsync(CancellationToken token)
+        => new(JsonDocument.Parse(_json));
+}

--- a/src/Polecat/Internal/Batching/FetchStreamBatchItem.cs
+++ b/src/Polecat/Internal/Batching/FetchStreamBatchItem.cs
@@ -89,7 +89,8 @@ internal class FetchStreamBatchItem : IBatchQueryItem
         {
             while (await reader.ReadAsync(token).ConfigureAwait(false))
             {
-                var @event = PcEventsRowReader.ReadEventAsGuid(reader, ctx, slots, ref cache);
+                var @event = await PcEventsRowReader
+                    .ReadEventAsGuidAsync(reader, ctx, slots, ref cache, token).ConfigureAwait(false);
                 if (@event != null) results.Add(@event);
             }
         }
@@ -97,7 +98,8 @@ internal class FetchStreamBatchItem : IBatchQueryItem
         {
             while (await reader.ReadAsync(token).ConfigureAwait(false))
             {
-                var @event = PcEventsRowReader.ReadEventAsString(reader, ctx, slots, ref cache);
+                var @event = await PcEventsRowReader
+                    .ReadEventAsStringAsync(reader, ctx, slots, ref cache, token).ConfigureAwait(false);
                 if (@event != null) results.Add(@event);
             }
         }

--- a/src/Polecat/StoreOptions.cs
+++ b/src/Polecat/StoreOptions.cs
@@ -4,6 +4,7 @@ using JasperFx.Events;
 using JasperFx.Events.Daemon;
 using JasperFx.Events.Fetching;
 using JasperFx.Events.Tags;
+using JasperFx.Events.Upcasting;
 using Polly;
 using Polecat.Events;
 using Polecat.Internal;
@@ -605,6 +606,115 @@ public class EventStoreOptions : IEventStoreInstrumentation
     public void AddMaskingRuleForProtectedInformation<T>(Func<T, T> func) where T : notnull
     {
         EventGraph!.AddMaskingRuleForProtectedInformation(func);
+    }
+
+    /// <summary>
+    ///     #561 / jasperfx#752: the event upcasting registry — how an event stored under an older
+    ///     schema is transformed on READ into the current CLR event type, so aggregations,
+    ///     projections and subscriptions only ever see the new type.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         The registry itself is shared (<c>JasperFx.Events.Upcasting.UpcastingRegistry</c>, hung
+    ///         off the shared <c>EventRegistry</c>), so a consumer compiling one body of source against
+    ///         several stores writes ONE upcaster. The <c>Upcast</c> methods below are the Polecat
+    ///         spelling of Marten's <c>StoreOptions.Events.Upcast(...)</c> family and forward straight
+    ///         into it.
+    ///     </para>
+    ///     <para>
+    ///         Registration is <b>last-wins per stored event type name</b>, and a registered
+    ///         transformation is the <b>authoritative</b> interpretation of that name on read — the
+    ///         stored <c>dotnet_type</c> hint does not override it (marten#4680). See
+    ///         <c>PcEventsRowReader</c>.
+    ///     </para>
+    /// </remarks>
+    public UpcastingRegistry Upcasters => EventGraph!.Upcasters;
+
+    /// <summary>
+    ///     Upcast an event stored under <typeparamref name="TOldEvent" />'s conventional event type
+    ///     name into <typeparamref name="TEvent" />, deserializing the stored payload as the old CLR
+    ///     type first.
+    /// </summary>
+    public EventStoreOptions Upcast<TOldEvent, TEvent>(Func<TOldEvent, TEvent> upcast)
+        where TOldEvent : notnull where TEvent : notnull
+    {
+        Upcasters.Upcast(upcast);
+        return this;
+    }
+
+    /// <summary>
+    ///     Upcast an event stored under an explicit event type name into <typeparamref name="TEvent" />,
+    ///     deserializing the stored payload as <typeparamref name="TOldEvent" /> first.
+    /// </summary>
+    public EventStoreOptions Upcast<TOldEvent, TEvent>(string eventTypeName, Func<TOldEvent, TEvent> upcast)
+        where TOldEvent : notnull where TEvent : notnull
+    {
+        Upcasters.Upcast(eventTypeName, upcast);
+        return this;
+    }
+
+    /// <summary>
+    ///     Async-only typed upcast. Usable only on Polecat's asynchronous read paths; the synchronous
+    ///     ones throw <see cref="UpcastingException" />.
+    /// </summary>
+    /// <remarks>
+    ///     Prefer the synchronous overloads. An async transformation runs once per stored event, so it
+    ///     invites N+1 behaviour on a long stream.
+    /// </remarks>
+    public EventStoreOptions Upcast<TOldEvent, TEvent>(Func<TOldEvent, CancellationToken, Task<TEvent>> upcastAsync)
+        where TOldEvent : notnull where TEvent : notnull
+    {
+        Upcasters.Upcast(upcastAsync);
+        return this;
+    }
+
+    /// <inheritdoc cref="Upcast{TOldEvent,TEvent}(Func{TOldEvent,CancellationToken,Task{TEvent}})" />
+    public EventStoreOptions Upcast<TOldEvent, TEvent>(string eventTypeName,
+        Func<TOldEvent, CancellationToken, Task<TEvent>> upcastAsync)
+        where TOldEvent : notnull where TEvent : notnull
+    {
+        Upcasters.Upcast(eventTypeName, upcastAsync);
+        return this;
+    }
+
+    /// <summary>
+    ///     Raw System.Text.Json upcast for the stored event type name matching
+    ///     <typeparamref name="TEvent" />'s conventional name — the "same name, older JSON schema"
+    ///     case, and the one that lets the old CLR type be deleted from the codebase entirely.
+    /// </summary>
+    public EventStoreOptions Upcast<TEvent>(Func<JsonDocument, TEvent> upcast) where TEvent : notnull
+    {
+        Upcasters.Upcast(upcast);
+        return this;
+    }
+
+    /// <summary>
+    ///     Raw System.Text.Json upcast claiming an explicit stored event type name.
+    /// </summary>
+    public EventStoreOptions Upcast<TEvent>(string eventTypeName, Func<JsonDocument, TEvent> upcast)
+        where TEvent : notnull
+    {
+        Upcasters.Upcast(eventTypeName, upcast);
+        return this;
+    }
+
+    /// <summary>
+    ///     Register one or more class-based upcasters. Derive from the shared bases in
+    ///     <c>JasperFx.Events.Upcasting</c> / <c>JasperFx.Events.Upcasting.SystemTextJson</c>.
+    /// </summary>
+    public EventStoreOptions Upcast(params IEventUpcaster[] upcasters)
+    {
+        Upcasters.Upcast(upcasters);
+        return this;
+    }
+
+    /// <summary>
+    ///     Register a class-based upcaster by type.
+    /// </summary>
+    public EventStoreOptions Upcast<TUpcaster>() where TUpcaster : IEventUpcaster, new()
+    {
+        Upcasters.Upcast<TUpcaster>();
+        return this;
     }
 
     /// <summary>


### PR DESCRIPTION
Closes #561.

Polecat had **no event upcasting at all**. [jasperfx#752](https://github.com/JasperFx/jasperfx/issues/752) (shipped in JasperFx 2.64.0) defines the store-agnostic contract — the promotion of Marten's `JsonTransformation`, with the PostgreSQL- and Marten-serializer-shaped `(ISerializer, DbDataReader, index)` triple abstracted to `IUpcastPayload`. This is Polecat's half.

## The seam

**`PolecatUpcastPayload`** is the `IUpcastPayload` adapter, and it is unusually small: by the time a row reaches it the JSON is already a materialized string, so it is `(json, serializer)` and nothing else. Its async members are synchronous underneath on purpose — Polecat's read path has nothing to stream — and what they are actually load-bearing for is the *other* half of the split: an async-only transformation is only reachable through `AsAsync`. Because Polecat is System.Text.Json only over a SQL Server 2025 native `json` column, `AsJsonDocument()` never has to refuse the way Marten's can, which makes the raw-JSON upcasters — the shape that lets the old CLR type be **deleted from the codebase** — unconditionally usable here.

**`EventGraph.TryFindUpcast` / `Upcast` / `UpcastAsync`** is the single place the marten#4680 authority rule lives. In Polecat that rule is *structural* rather than a guard: `dotnet_type` is the **sole** input to CLR type resolution on every hot path, so asking the registry before it is the whole of it. Marten needs an explicit `!mapping.IsUpcastTarget` condition on its alt-mapping swap for exactly the same reason. Without the ordering, appending the **old** CLR type into the store that carries the upcaster writes a row whose hint points straight back at the old type, and the upcaster silently does nothing for precisely the rows most likely to exist mid-migration.

Binary rows (#388) are excluded: the shared payload contract is a JSON one — both accessors presuppose a JSON body — so a `bdata` row has nothing a transformation can read and keeps its ordinary path.

## Every hydration path, because there are more than one

Polecat has **one canonical row reader and four hand-copied duplicates of the same loop**. All five now consult the registry first:

| Path | What it feeds |
|---|---|
| `PcEventsRowReader.ReadEventCore` | `FetchStreamAsync`, live aggregation, `FetchForWriting`/`FetchLatest`, compaction, masking, batched stream fetch |
| `EventOperations.QueryByTagsAsync` | DCB tag queries |
| `EventOperations.ReadEventFromReader` | batched DCB tag queries |
| `Linq/EventListHandler` | `QueryAllRawEvents()`, `QueryEventsAsync`, `AggregateTo*` |
| `Daemon/PolecatEventLoader` | **every** async projection and subscription |

Plus `DocumentStore.ProjectionReplay.ToDomainEvent`, which was already alias-keyed. `CLAUDE.md` now carries that table, because "change how a row becomes an `IEvent`" is a five-file operation in this codebase and nothing said so.

### The daemon needed a second change, and it is the one that would have been missed

The loader pushes a `dotnet_type IN (…)` allow list into its SQL, built from the projection's declared event types — which are the **new** ones. A legacy row was therefore filtered out *in the database* before anything could upcast it, and `upcasting_applies_in_async_daemon_projections` would have failed with no clue as to why. The predicate now also admits rows whose `type` is a registered upcast source. That is a **second column** in the predicate rather than more values in the first, deliberately: the allow list matches `dotnet_type` while an upcast source is a `type` alias, and a raw-JSON transformation may have no old CLR type to name at all.

### Async twins

`ReadEventAsGuidAsync` / `ReadEventAsStringAsync` change exactly one thing: which half of a transformation runs. An async-only registration is unreachable from `UpcastTransformation.Upcast` by contract, so every read a consumer awaits has to come through them or that registration shape is simply unusable. They are **not** `async` methods — they take the per-batch type cache by `ref`, which an async method cannot, and the fast path must stay allocation-free; only the rare upcast branch hands off to a real async method.

## The rest

Target types are pre-registered from `AllTransformations` at `DocumentStore` construction (an upcast row can be read before this deployment has ever appended the new type). The registrar gains `Upcast`, `SupportsUpcasting` flips true, `UpcastingCompliance` is enrolled as wave 16, and `StoreOptions.Events` gains the fluent `Upcast(...)` family kept as close to Marten's spelling as portability allows — so migrating a Marten upcaster is a using-directive change.

`QueryRawEventDataOnly<T>()` deliberately stays outside the seam, and its XML doc says so: it never builds an `IEvent`, and by naming `T` the caller has already made the decision an upcaster would make.

New docs page at `docs/events/upcasting.md`, including the casing trap — Polecat's `PropertyNamingPolicy` is camelCase, so a raw-JSON upcaster reads `roomId`, not `RoomId`.

## Tests

`UpcastingCompliance` (7 facts) covers stream reads, raw-JSON transformation, async-only on the async path, live aggregation, `FetchForWriting`, async daemon projections, and the authority rule.

`Events/upcasting_tests.cs` adds 6 local facts for what the shared suite structurally cannot reach — the raw-event LINQ query, the batched stream fetch, that `EventTypeName` keeps reporting the **stored** name while `EventType`/`Data` are the new type, last-wins re-registration, target pre-registration, and the negative that a store with no upcasters reads exactly as before.

## Test results

Honest numbers, `Compliance` + `Events` + `Daemon` + `Projections` + `Querying` + `Linq`:

```
total: 1348   succeeded: 1334   failed: 8   skipped: 6   (14m 47s)
```

**All 8 failures are pre-existing and upstream-owned**, not regressions from this change — five inherited from #560 and three in `UpcastingCompliance` itself:

- `upcasting_compliance.{a_raw_json_transformation_upcasts_without_the_old_clr_type, upcasting_applies_in_live_aggregation, upcasting_applies_in_async_daemon_projections}` — one root cause: the suite's raw-JSON transformation hardcodes **PascalCase** property names (`root.GetProperty("CartId")`), which only works on a store whose serializer writes PascalCase. Polecat's default is camelCase. Already fixed on jasperfx `main` ([jasperfx#787](https://github.com/JasperFx/jasperfx/issues/787), a case-insensitive `Property()` helper) — the fix landed while this was being written.
- The five from #560 (`aggregate_to_linq_operator`, `stream_archiving` ×2, `projection_side_effect` ×2), fixed on jasperfx `main` in #780/#784.

All eight land in **JasperFx 2.65.0, which is version-bumped but not published**, so this PR cannot consume them. Built against a working copy of jasperfx `main`'s compliance sources instead — i.e. what 2.65.0 will be — **`upcasting_compliance` is 7/7 green**, and `Events/upcasting_tests` is 6/6 against the released package.

**The follow-up for this plan is the 2.65.0 bump**, which clears all eight with no Polecat change.

No NuGet package published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
