### PR TITLE
gh-558: refuse soft-delete LINQ operators against a type that is not soft-deleted

### DIFF
--- a/docs/documents/deletes.md
+++ b/docs/documents/deletes.md
@@ -93,6 +93,15 @@ var oldDeleted = await session.Query<Order>()
     .ToListAsync();
 ```
 
+::: warning Only against a soft-deleted type
+All four operators are refused with a `BadLinqExpressionException` when the document type is not
+configured for soft deletes, because there is no `is_deleted` column for them to filter on. They
+used to be silently ignored instead, so `IsDeleted()` on a hard-delete type returned *every* row
+rather than none. If you remove a type from soft-delete configuration, its existing
+`IsDeleted()` / `MaybeDeleted()` queries will now throw — which is the point, but it is a behavior
+change. Marten and Fisher refuse the same calls.
+:::
+
 ### Undoing Soft Deletes
 
 Restore soft-deleted documents:
@@ -101,6 +110,9 @@ Restore soft-deleted documents:
 session.UndoDeleteWhere<Order>(x => x.Description == "Restore me");
 await session.SaveChangesAsync();
 ```
+
+`UndoDeleteWhere` also throws an `InvalidOperationException` for a type that is not soft-deleted — a
+delete removed the row outright, so there is nothing to undo.
 
 ## Hard Delete (Force)
 

--- a/src/Polecat.Tests/SoftDeletes/soft_delete_operators_against_hard_deleted_types.cs
+++ b/src/Polecat.Tests/SoftDeletes/soft_delete_operators_against_hard_deleted_types.cs
@@ -1,0 +1,235 @@
+using Polecat.Linq;
+using Polecat.Linq.CursorPaging;
+using Polecat.Linq.SoftDeletes;
+using Polecat.Tests.Harness;
+
+namespace Polecat.Tests.SoftDeletes;
+
+/// <summary>
+///     gh-558: the four operators on <see cref="SoftDeletedExtensions" /> are refused against a
+///     document type that is not soft-deleted, rather than degrading to "no filter".
+/// </summary>
+/// <remarks>
+///     <para>
+///         The bug these pin was silent, not loud. Polecat appended <c>is_deleted = 0/1</c> only
+///         behind a <c>DeleteStyle == SoftDelete</c> guard, and nothing rejected the call when that
+///         guard was false — so <c>Query&lt;User&gt;().IsDeleted()</c> ran as
+///         <c>Query&lt;User&gt;()</c> and returned every row. <c>IsDeleted()</c> reads as a lifecycle
+///         or authorization filter at the call site, so the failure surfaced as "shows rows that
+///         should have been excluded".
+///     </para>
+///     <para>
+///         Marten (<c>AssertDocumentTypeIsSoftDeleted</c>, from each of its four parsers) and Fisher
+///         (one filter pass, keyed on <c>UsedSoftDeleteOperator</c>) both refuse. Polecat asserts in
+///         <c>LinqQueryParser</c>, which every query shape and every provider passes through.
+///     </para>
+/// </remarks>
+[Collection("integration")]
+public class soft_delete_operators_against_hard_deleted_types : IntegrationContext
+{
+    public soft_delete_operators_against_hard_deleted_types(DefaultStoreFixture fixture) : base(fixture)
+    {
+    }
+
+    public override async ValueTask InitializeAsync()
+    {
+        await StoreOptions(opts => { opts.DatabaseSchemaName = "soft_delete_refusal"; });
+    }
+
+    private static IQueryable<User> Apply(IQueryable<User> queryable, string operatorName) =>
+        operatorName switch
+        {
+            nameof(SoftDeletedExtensions.IsDeleted) => queryable.IsDeleted(),
+            nameof(SoftDeletedExtensions.MaybeDeleted) => queryable.MaybeDeleted(),
+            nameof(SoftDeletedExtensions.DeletedSince) => queryable.DeletedSince(DateTimeOffset.UtcNow.AddDays(-1)),
+            nameof(SoftDeletedExtensions.DeletedBefore) => queryable.DeletedBefore(DateTimeOffset.UtcNow),
+            _ => throw new ArgumentOutOfRangeException(nameof(operatorName), operatorName, null)
+        };
+
+    /// <summary>
+    ///     All four operators are refused, <c>MaybeDeleted()</c> included.
+    /// </summary>
+    /// <remarks>
+    ///     <c>MaybeDeleted()</c> has the one arguably-defensible reading of the four — "include the
+    ///     deleted ones too" is trivially satisfied by a table that has none, so every row really is
+    ///     the honest answer. It is refused anyway, because writing it says the author believes the
+    ///     type is soft-deleted and that belief is the bug; the next edit is usually
+    ///     <c>IsDeleted()</c>, which is not defensible at all. Marten and Fisher refuse all four too.
+    /// </remarks>
+    [Theory]
+    [InlineData(nameof(SoftDeletedExtensions.IsDeleted))]
+    [InlineData(nameof(SoftDeletedExtensions.MaybeDeleted))]
+    [InlineData(nameof(SoftDeletedExtensions.DeletedSince))]
+    [InlineData(nameof(SoftDeletedExtensions.DeletedBefore))]
+    public async Task each_operator_is_refused_on_a_hard_deleted_type(string operatorName)
+    {
+        await using var query = theStore.QuerySession();
+
+        var ex = await Should.ThrowAsync<BadLinqExpressionException>(async () =>
+            await Apply(query.Query<User>(), operatorName).ToListAsync(TestContext.Current.CancellationToken));
+
+        ex.Message.ShouldContain(typeof(User).FullName!);
+        ex.Message.ShouldContain(operatorName + "()");
+        ex.Message.ShouldContain("not configured for soft deletes");
+    }
+
+    /// <summary>
+    ///     The message says how to fix it, in Polecat's own configuration vocabulary.
+    /// </summary>
+    [Fact]
+    public async Task the_refusal_names_the_remedy()
+    {
+        await using var query = theStore.QuerySession();
+
+        var ex = await Should.ThrowAsync<BadLinqExpressionException>(async () =>
+            await query.Query<User>().IsDeleted().ToListAsync(TestContext.Current.CancellationToken));
+
+        ex.Message.ShouldContain("[SoftDeleted]");
+        ex.Message.ShouldContain("ISoftDeleted");
+        ex.Message.ShouldContain("SoftDeleted()");
+    }
+
+    /// <summary>
+    ///     The refusal is not attached to one execution path. Every public entry that builds a
+    ///     statement goes through <c>LinqQueryParser.Parse</c>, so all six of the provider's paths
+    ///     refuse — which is the whole reason the assertion lives in the parser rather than beside
+    ///     each of the six places that append the <c>is_deleted</c> predicate.
+    /// </summary>
+    [Fact]
+    public async Task every_execution_path_refuses()
+    {
+        await using var query = theStore.QuerySession();
+
+        // ExecuteAsync — the list, single-value and aggregate path
+        await Should.ThrowAsync<BadLinqExpressionException>(async () =>
+            await query.Query<User>().IsDeleted().ToListAsync(TestContext.Current.CancellationToken));
+        await Should.ThrowAsync<BadLinqExpressionException>(async () =>
+            await query.Query<User>().IsDeleted().CountAsync(TestContext.Current.CancellationToken));
+
+        // BuildStatement — ToSql, which never reaches the database at all
+        Should.Throw<BadLinqExpressionException>(() => query.ToSql(query.Query<User>().IsDeleted()));
+
+        // ExecuteJsonArrayAsync
+        await Should.ThrowAsync<BadLinqExpressionException>(async () =>
+            await query.Query<User>().IsDeleted().ToJsonArrayAsync(TestContext.Current.CancellationToken));
+
+        // ExecuteJsonFirstWithVersionAsync
+        await Should.ThrowAsync<BadLinqExpressionException>(async () =>
+            await query.Query<User>().IsDeleted()
+                .ToJsonFirstWithVersionAsync(TestContext.Current.CancellationToken));
+
+        // StreamPagedJsonArrayAsync
+        await Should.ThrowAsync<BadLinqExpressionException>(async () =>
+        {
+            using var stream = new MemoryStream();
+            await query.Query<User>().IsDeleted()
+                .StreamPagedJsonArray(1, 10, stream, TestContext.Current.CancellationToken);
+        });
+
+        // ExecuteCursorPageJsonAsync
+        await Should.ThrowAsync<BadLinqExpressionException>(async () =>
+            await query.Query<User>().IsDeleted().OrderBy(x => x.Id)
+                .ToJsonPageByCursorAsync(null, 10, TestContext.Current.CancellationToken));
+    }
+
+    /// <summary>
+    ///     The refusal survives being buried in a longer chain — it is keyed on the operator having
+    ///     been seen anywhere in the expression tree, not on its being the outermost call.
+    /// </summary>
+    [Fact]
+    public async Task refused_when_the_operator_is_not_the_outermost_call()
+    {
+        await using var query = theStore.QuerySession();
+
+        await Should.ThrowAsync<BadLinqExpressionException>(async () =>
+            await query.Query<User>()
+                .IsDeleted()
+                .Where(x => x.Age > 10)
+                .OrderBy(x => x.LastName)
+                .Take(5)
+                .ToListAsync(TestContext.Current.CancellationToken));
+    }
+
+    /// <summary>
+    ///     The events table has no deletion state either, and cannot be given one.
+    /// </summary>
+    [Fact]
+    public async Task refused_over_an_event_query()
+    {
+        await using var query = theStore.QuerySession();
+
+        var ex = await Should.ThrowAsync<BadLinqExpressionException>(async () =>
+            await query.Events.QueryAllRawEvents().IsDeleted()
+                .ToListAsync(TestContext.Current.CancellationToken));
+
+        ex.Message.ShouldContain("The event store");
+    }
+
+    /// <summary>
+    ///     A soft-deleted type is untouched — the assertion only fires where there is no column.
+    /// </summary>
+    [Fact]
+    public async Task a_soft_deleted_type_still_works()
+    {
+        var alive = new SoftDeletedDoc { Id = Guid.NewGuid(), Name = "alive-558" };
+        var dead = new SoftDeletedDoc { Id = Guid.NewGuid(), Name = "dead-558" };
+
+        theSession.Store(alive, dead);
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        await using var deleting = theStore.LightweightSession();
+        deleting.Delete(dead);
+        await deleting.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        await using var query = theStore.QuerySession();
+
+        var deletedOnly = await query.Query<SoftDeletedDoc>().IsDeleted()
+            .ToListAsync(TestContext.Current.CancellationToken);
+        deletedOnly.Count.ShouldBe(1);
+        deletedOnly[0].Id.ShouldBe(dead.Id);
+
+        var everything = await query.Query<SoftDeletedDoc>().MaybeDeleted()
+            .ToListAsync(TestContext.Current.CancellationToken);
+        everything.Count.ShouldBe(2);
+    }
+
+    /// <summary>
+    ///     gh-558, the non-LINQ half: <c>UndoDeleteWhere</c> issues an UPDATE against
+    ///     <c>is_deleted</c> / <c>deleted_at</c>, columns <c>DocumentTable</c> only adds for a
+    ///     soft-deleted type. Unguarded it reached SQL Server as "Invalid column name 'is_deleted'"
+    ///     at <c>SaveChangesAsync</c> — loud, but from the wrong layer and naming a column the caller
+    ///     never mentioned.
+    /// </summary>
+    [Fact]
+    public async Task undo_delete_where_is_refused_on_a_hard_deleted_type()
+    {
+        await using var session = theStore.LightweightSession();
+
+        var ex = Should.Throw<InvalidOperationException>(() =>
+            session.UndoDeleteWhere<User>(x => x.Age > 0));
+
+        ex.Message.ShouldContain(typeof(User).FullName!);
+        ex.Message.ShouldContain("nothing to undo");
+    }
+
+    [Fact]
+    public async Task undo_delete_where_still_works_on_a_soft_deleted_type()
+    {
+        var doc = new SoftDeletedDoc { Id = Guid.NewGuid(), Name = "undo-558" };
+
+        theSession.Store(doc);
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        await using var deleting = theStore.LightweightSession();
+        deleting.Delete(doc);
+        await deleting.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        await using var undoing = theStore.LightweightSession();
+        undoing.UndoDeleteWhere<SoftDeletedDoc>(x => x.Id == doc.Id);
+        await undoing.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        await using var query = theStore.QuerySession();
+        var loaded = await query.LoadAsync<SoftDeletedDoc>(doc.Id, TestContext.Current.CancellationToken);
+        loaded.ShouldNotBeNull();
+    }
+}

--- a/src/Polecat/Events/Linq/EventLinqQueryProvider.cs
+++ b/src/Polecat/Events/Linq/EventLinqQueryProvider.cs
@@ -99,6 +99,10 @@ internal class EventLinqQueryProvider : IPolecatAsyncQueryProvider
     {
         // HasTag() is only meaningful over IEvent queries, where the FROM table is pc_events.
         var parser = new LinqQueryParser(_memberFactory, _eventsTable,
+            // gh-558: the events table has no is_deleted column, so a soft-delete operator over an
+            // event query is refused rather than ignored, exactly as it is over a hard-delete
+            // document type.
+            SoftDeleteTarget.NeverSoftDeleted("The event store"),
             _isAllEvents ? [new HasTagParser(_events)] : null);
         parser.Parse(expression);
 

--- a/src/Polecat/Events/Linq/StreamStateLinqQueryProvider.cs
+++ b/src/Polecat/Events/Linq/StreamStateLinqQueryProvider.cs
@@ -79,7 +79,10 @@ internal class StreamStateLinqQueryProvider : IPolecatAsyncQueryProvider,
 
     public async Task<TResult> ExecuteAsync<TResult>(Expression expression, CancellationToken token)
     {
-        var parser = new LinqQueryParser(_memberFactory, _events.StreamsTableName);
+        // gh-558: the streams table has no is_deleted column either. An archived stream is a
+        // different thing from a soft-deleted document and is not what these operators name.
+        var parser = new LinqQueryParser(_memberFactory, _events.StreamsTableName,
+            SoftDeleteTarget.NeverSoftDeleted("The stream state table"));
         parser.Parse(expression);
 
         ApplySingleValueMode(parser);

--- a/src/Polecat/Internal/DocumentSessionBase.cs
+++ b/src/Polecat/Internal/DocumentSessionBase.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using JasperFx;
+using JasperFx.Core.Reflection;
 using JasperFx.Events;
 using JasperFx.Events.Daemon;
 using JasperFx.Events.Fetching;
@@ -504,6 +505,19 @@ internal abstract class DocumentSessionBase : QuerySession, IDocumentSession
     {
         var fragment = ParseDeleteWhere(predicate);
         var storage = ClosedShapeDeletionStorageFor<T>();
+        // gh-558: UndeleteFragment is an UPDATE of is_deleted / deleted_at, columns DocumentTable
+        // only adds for a soft-deleted type. Refused here, naming the type, rather than left to
+        // fail at SaveChangesAsync as SQL Server's "Invalid column name 'is_deleted'". Marten and
+        // Fisher both guard the same call.
+        if (!storage.IsSoftDeleted)
+        {
+            throw new InvalidOperationException(
+                $"'{typeof(T).FullNameInCode()}' is not configured for soft deletes, so a delete removed "
+                + "the row outright and there is nothing to undo. Mark it with [SoftDeleted], implement "
+                + $"ISoftDeleted, or call StoreOptions.Schema.For<{typeof(T).NameInCode()}>().SoftDeleted() "
+                + "if it should be.");
+        }
+
         _workTracker.Add(new UndoDeleteWhereOperation(
             storage.UndeleteFragment, storage.IsConjoined, TenantId, fragment, typeof(T)));
     }

--- a/src/Polecat/Linq/Parsing/LinqQueryParser.cs
+++ b/src/Polecat/Linq/Parsing/LinqQueryParser.cs
@@ -18,6 +18,7 @@ namespace Polecat.Linq.Parsing;
 internal class LinqQueryParser : ExpressionVisitor
 {
     private readonly IMemberResolver _memberFactory;
+    private readonly SoftDeleteTarget _softDeleteTarget;
     private readonly WhereClauseParser _whereParser;
 
     public Statement Statement { get; }
@@ -91,6 +92,17 @@ internal class LinqQueryParser : ExpressionVisitor
     public DateTimeOffset? DeletedBeforeTimestamp { get; private set; }
 
     /// <summary>
+    ///     The name of the soft-delete operator the chain used, or null where it used none.
+    /// </summary>
+    /// <remarks>
+    ///     gh-558. Recorded so that <see cref="Parse" /> can refuse one against a target with no
+    ///     deletion state, rather than letting it fall through to "no filter" and an unfiltered
+    ///     query. Set from the declaring type rather than the operator name — see
+    ///     <see cref="VisitMethodCall" />.
+    /// </remarks>
+    public string? SoftDeleteOperator { get; private set; }
+
+    /// <summary>
     ///     If ModifiedSince() was called, the timestamp to filter by.
     /// </summary>
     public DateTimeOffset? ModifiedSinceTimestamp { get; private set; }
@@ -117,9 +129,11 @@ internal class LinqQueryParser : ExpressionVisitor
     public TimeSpan? NonStaleDataTimeout { get; private set; }
 
     public LinqQueryParser(IMemberResolver memberFactory, string fromTable,
+        SoftDeleteTarget softDeleteTarget,
         IReadOnlyList<Methods.IMethodCallParser>? additionalMethodParsers = null)
     {
         _memberFactory = memberFactory;
+        _softDeleteTarget = softDeleteTarget;
         _whereParser = new WhereClauseParser(memberFactory, additionalMethodParsers);
         Statement = new Statement { FromTable = fromTable };
     }
@@ -127,6 +141,37 @@ internal class LinqQueryParser : ExpressionVisitor
     public void Parse(Expression expression)
     {
         Visit(expression);
+        AssertSoftDeleteOperatorIsLegal();
+    }
+
+    /// <summary>
+    ///     gh-558: refuse a soft-delete operator applied to a target with no deletion state.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Run once per parse, after the whole chain has been walked, so it fires for every query
+    ///         shape and every provider that builds a statement — the six execution paths in
+    ///         <c>PolecatLinqQueryProvider</c> plus the two event-store providers. The alternative,
+    ///         asserting beside each of the six places that append the <c>is_deleted</c> predicate,
+    ///         leaves a seventh execution path free to forget.
+    ///     </para>
+    ///     <para>
+    ///         Refused rather than ignored because the ignored form is the worse failure: the query
+    ///         succeeds, returns plausible rows, and the caller's filter did nothing.
+    ///         <c>MaybeDeleted()</c> is refused alongside the other three even though "include the
+    ///         deleted ones too" is arguably satisfied by a table that has none — writing it at all
+    ///         says the author believes the type is soft-deleted, and that belief is the bug. Marten
+    ///         and Fisher both refuse all four.
+    ///     </para>
+    /// </remarks>
+    private void AssertSoftDeleteOperatorIsLegal()
+    {
+        if (SoftDeleteOperator is null || _softDeleteTarget.IsSoftDeleted) return;
+
+        throw new BadLinqExpressionException(
+            $"{_softDeleteTarget.Description} is not configured for soft deletes, so {SoftDeleteOperator}() "
+            + "has no is_deleted column to filter on. The call is refused rather than silently ignored, "
+            + $"which would return every row. {_softDeleteTarget.Remedy}");
     }
 
     protected override Expression VisitMethodCall(MethodCallExpression node)
@@ -143,6 +188,16 @@ internal class LinqQueryParser : ExpressionVisitor
         if (node.Arguments.Count > 0)
         {
             Visit(node.Arguments[0]);
+        }
+
+        // gh-558: every method declared on SoftDeletedExtensions is a soft-delete operator by
+        // construction, so the gate keys on the declaring type rather than on the four names in the
+        // switch below. A fifth operator added to that class is caught here without this file being
+        // touched, which is the point -- the check cannot be forgotten because nothing has to
+        // remember it.
+        if (node.Method.DeclaringType == typeof(SoftDeletedExtensions))
+        {
+            SoftDeleteOperator = node.Method.Name;
         }
 
         switch (node.Method.Name)

--- a/src/Polecat/Linq/Parsing/SoftDeleteTarget.cs
+++ b/src/Polecat/Linq/Parsing/SoftDeleteTarget.cs
@@ -1,0 +1,66 @@
+using JasperFx;
+using JasperFx.Core.Reflection;
+using Polecat.Storage;
+
+namespace Polecat.Linq.Parsing;
+
+/// <summary>
+///     Whether the table a query runs against has a deletion state for the operators on
+///     <see cref="SoftDeletes.SoftDeletedExtensions" /> to talk about, and what to tell the caller
+///     when it does not.
+/// </summary>
+/// <remarks>
+///     <para>
+///         gh-558. Every <see cref="LinqQueryParser" /> is handed one of these, with no default: a
+///         query provider cannot construct a parser without answering the question, and the parser
+///         refuses a soft-delete operator whose target answered "no". Previously the four operators
+///         were only ever <em>read</em> — by the six places in
+///         <see cref="PolecatLinqQueryProvider" /> that append <c>is_deleted = 0/1</c> behind a
+///         <c>DeleteStyle == SoftDelete</c> guard — so against a hard-delete type the guard was
+///         false, no predicate was appended, and <c>IsDeleted()</c> quietly returned every row.
+///     </para>
+///     <para>
+///         Marten asserts the same thing from each of its four soft-delete parsers, and Fisher from
+///         a single filter pass. Polecat asserts from the parser, which is the one place all query
+///         shapes and all three providers share.
+///     </para>
+/// </remarks>
+internal readonly record struct SoftDeleteTarget
+{
+    private SoftDeleteTarget(bool isSoftDeleted, string description, string remedy)
+    {
+        IsSoftDeleted = isSoftDeleted;
+        Description = description;
+        Remedy = remedy;
+    }
+
+    /// <summary>Whether the target table carries the <c>is_deleted</c> / <c>deleted_at</c> columns.</summary>
+    public bool IsSoftDeleted { get; }
+
+    /// <summary>How to name the target in a refusal message.</summary>
+    public string Description { get; }
+
+    /// <summary>What the caller can do about it.</summary>
+    public string Remedy { get; }
+
+    /// <summary>
+    ///     A document query, which supports the soft-delete operators exactly when the type opted in.
+    /// </summary>
+    public static SoftDeleteTarget For(DocumentMapping mapping)
+    {
+        var name = mapping.DocumentType.FullNameInCode();
+        return new SoftDeleteTarget(
+            mapping.DeleteStyle == DeleteStyle.SoftDelete,
+            $"Document type '{name}'",
+            $"Mark it with [SoftDeleted], implement ISoftDeleted, or call "
+            + $"StoreOptions.Schema.For<{mapping.DocumentType.NameInCode()}>().SoftDeleted() if it should be.");
+    }
+
+    /// <summary>
+    ///     A query over one of the event-store tables. Neither the events table nor the stream-state
+    ///     table has a deletion state, and neither can be configured to have one.
+    /// </summary>
+    public static SoftDeleteTarget NeverSoftDeleted(string description) =>
+        new(false, description,
+            "Events are never soft deleted. Use Query<T>() against a soft-deleted document type instead.");
+}

--- a/src/Polecat/Linq/PolecatLinqQueryProvider.cs
+++ b/src/Polecat/Linq/PolecatLinqQueryProvider.cs
@@ -111,7 +111,8 @@ internal class PolecatLinqQueryProvider : IPolecatAsyncQueryProvider,
         var provider = _providers.GetProvider(documentType);
 
         var memberFactory = new MemberFactory(_session.Options, provider.Mapping);
-        var parser = new LinqQueryParser(memberFactory, provider.Mapping.QualifiedTableName);
+        var parser = new LinqQueryParser(memberFactory, provider.Mapping.QualifiedTableName,
+            SoftDeleteTarget.For(provider.Mapping));
         parser.Parse(expression);
 
         ApplySingleValueMode(parser);
@@ -150,7 +151,8 @@ internal class PolecatLinqQueryProvider : IPolecatAsyncQueryProvider,
         await _tableEnsurer.EnsureTableAsync(provider, token);
 
         var memberFactory = new MemberFactory(_session.Options, provider.Mapping);
-        var parser = new LinqQueryParser(memberFactory, provider.Mapping.QualifiedTableName);
+        var parser = new LinqQueryParser(memberFactory, provider.Mapping.QualifiedTableName,
+            SoftDeleteTarget.For(provider.Mapping));
         parser.Parse(expression);
 
         // Choose the streamed columns. A whole-document query streams the raw `data` column. A
@@ -215,7 +217,8 @@ internal class PolecatLinqQueryProvider : IPolecatAsyncQueryProvider,
         await _tableEnsurer.EnsureTableAsync(provider, token);
 
         var memberFactory = new MemberFactory(_session.Options, provider.Mapping);
-        var parser = new LinqQueryParser(memberFactory, provider.Mapping.QualifiedTableName);
+        var parser = new LinqQueryParser(memberFactory, provider.Mapping.QualifiedTableName,
+            SoftDeleteTarget.For(provider.Mapping));
         parser.Parse(expression);
 
         // Read the persisted JSON and the version column together — one round trip, no reserialize.
@@ -284,7 +287,8 @@ internal class PolecatLinqQueryProvider : IPolecatAsyncQueryProvider,
         await _tableEnsurer.EnsureTableAsync(provider, token);
 
         var memberFactory = new MemberFactory(_session.Options, provider.Mapping);
-        var parser = new LinqQueryParser(memberFactory, provider.Mapping.QualifiedTableName);
+        var parser = new LinqQueryParser(memberFactory, provider.Mapping.QualifiedTableName,
+            SoftDeleteTarget.For(provider.Mapping));
         parser.Parse(expression);
 
         // Ride the total-rows window column alongside the raw data column so the total comes back
@@ -372,7 +376,8 @@ internal class PolecatLinqQueryProvider : IPolecatAsyncQueryProvider,
         await _tableEnsurer.EnsureTableAsync(provider, token);
 
         var memberFactory = new MemberFactory(_session.Options, provider.Mapping);
-        var parser = new LinqQueryParser(memberFactory, provider.Mapping.QualifiedTableName);
+        var parser = new LinqQueryParser(memberFactory, provider.Mapping.QualifiedTableName,
+            SoftDeleteTarget.For(provider.Mapping));
         parser.Parse(expression);
 
         var orderBy = parser.OrderByMembers;
@@ -519,7 +524,8 @@ internal class PolecatLinqQueryProvider : IPolecatAsyncQueryProvider,
         await _tableEnsurer.EnsureTableAsync(provider, token);
 
         var memberFactory = new MemberFactory(_session.Options, provider.Mapping);
-        var parser = new LinqQueryParser(memberFactory, provider.Mapping.QualifiedTableName);
+        var parser = new LinqQueryParser(memberFactory, provider.Mapping.QualifiedTableName,
+            SoftDeleteTarget.For(provider.Mapping));
         parser.Parse(expression);
 
         // Route to GroupJoin execution if detected


### PR DESCRIPTION
## The bug

`IsDeleted()` / `MaybeDeleted()` / `DeletedSince()` / `DeletedBefore()` applied to a document type
that is **not** configured for soft deletes returned **every row**.

`PolecatLinqQueryProvider` appended the `is_deleted` predicate at six sites, each behind the same
guard:

```csharp
if (provider.Mapping.DeleteStyle == DeleteStyle.SoftDelete && !parser.IsMaybeDeleted)
```

For a hard-delete type that condition is false, no predicate was appended, and **nothing rejected
the call**. The operator degraded to "no filter": the query succeeded, returned plausible data, and
the caller's filter did nothing. `IsDeleted()` reads as a lifecycle or authorization filter at the
call site, so the failure mode was "shows rows that should have been excluded", not "throws". A user
who removed `SoftDeleted()` from a type's configuration got no signal at all — their existing
`IsDeleted()` queries quietly started matching everything.

Marten refuses (`IReadOnlyStoreOptions.AssertDocumentTypeIsSoftDeleted`, called from each of its four
parsers). Fisher refuses, and its source comment predicts exactly this failure mode. Polecat was the
outlier.

## Where the assertion went, and why

**In `LinqQueryParser`, not beside the six append sites.** Two properties make a forgotten fifth
operator impossible:

**1. The gate keys on the declaring type, not on the operator name.**

```csharp
if (node.Method.DeclaringType == typeof(SoftDeletedExtensions))
{
    SoftDeleteOperator = node.Method.Name;
}
```

Every method on `SoftDeletedExtensions` is a soft-delete operator by construction. A fifth one added
to that class is covered without this file being touched — nothing has to remember the check,
because there is no per-operator registration to forget. This is stronger than either sibling:
Marten repeats the assertion in each of its four parsers (a fifth parser can omit it), and Fisher
funnels through a `MarkSoftDelete` helper (a fifth operator can forget to call it).

**2. The check runs once at the end of `Parse()`**, which every query shape and all three query
providers pass through. Asserting beside each of the six places that append `is_deleted = 0/1`
leaves a *seventh execution path* free to forget — and there are already six, which is how the hole
stayed open. The test `every_execution_path_refuses` pins all six (`ExecuteAsync`, `BuildStatement`,
`ExecuteJsonArrayAsync`, `ExecuteJsonFirstWithVersionAsync`, `StreamPagedJsonArrayAsync`,
`ExecuteCursorPageJsonAsync`).

The new `SoftDeleteTarget` constructor argument is **required, with no default**, so a provider
cannot construct a parser without answering whether its table has a deletion state. That is what
extends the fix to the event and stream-state providers for free — their tables have no `is_deleted`
column and cannot be given one, so `QueryAllRawEvents().IsDeleted()` was silently unfiltered too.

## `MaybeDeleted()` — the one with a defensible reading

It is refused with the other three, but it is worth saying why, because it is not the same case.

`MaybeDeleted()` is a filter-*removal* operator: "include the deleted ones too". Against a table
with no deleted rows, every row genuinely is the complete and correct answer — unlike `IsDeleted()`,
where returning everything is the exact opposite of the truth. So there is a reading on which
`MaybeDeleted()` on a hard-delete type is honest.

Refused anyway, for two reasons. Writing it at all says the author believes the type is soft-deleted;
that belief is the bug, and the next edit is usually `IsDeleted()`, which is not defensible at all.
And both siblings refuse all four — Fisher's comment reasons about precisely this case ("`IsDeleted()`
would come back empty and `MaybeDeleted()` would come back complete, both of which look like real
answers"). Silently accepting one of the four would make the type's soft-delete status something a
caller can only discover by trying each operator.

## Exception type

**`Polecat.Linq.BadLinqExpressionException`** — Polecat's existing type for a LINQ expression it will
not honour, already used elsewhere in the same provider, and the same type Fisher throws for the
same refusal.

The three stores have **not** converged here, which is worth recording since the issue assumed they
had:

| Store | This refusal | Has its own `BadLinqExpressionException`? |
|---|---|---|
| Marten | `InvalidOperationException` | Yes — but does not use it here |
| Fisher | `BadLinqExpressionException` | Yes |
| Polecat | `BadLinqExpressionException` (this PR) | Yes |

Nothing named `BadLinqExpression*` exists in `JasperFx` (checked `origin/master`, not just the local
branch), so there was no shared type to adopt. Following the "file an issue rather than lift one
now" instruction: **jasperfx#795** proposes lifting a canonical `BadLinqExpressionException` on the
jasperfx#751/#756 pattern. It explicitly does not propose changing Marten — marten#5346 ruled that
Marten keeps its own hierarchy (`all_exceptions_should_derive_from_MartenException` plus single
inheritance) and deferred adoption to Marten 10.

`UndoDeleteWhere` throws `InvalidOperationException` instead: it is session API misuse rather than an
untranslatable LINQ expression, and that is what both Marten and Fisher throw there.

## The non-LINQ surfaces

Checked, as asked. One had the same unguarded shape, one did not:

- **`UndoDeleteWhere<T>` — same gap, now fixed.** `PolecatDocumentStorage` builds
  `_undeleteFragment` unconditionally as `UPDATE ... SET is_deleted = 0, deleted_at = NULL`, but
  `DocumentTable` only adds those columns when `DeleteStyle == SoftDelete`. On a hard-delete type the
  call reached SQL Server as `Invalid column name 'is_deleted'` at `SaveChangesAsync` — loud rather
  than silent, but from the wrong layer, naming a column the caller never mentioned, and deferred to
  a later call. Now refused at the call site with the type named. Marten and Fisher both guard it.
- **`DeleteWhere` / `HardDeleteWhere` — no gap.** `DeleteFragment` is already soft-or-hard per the
  type, and `HardDeleteWhere` is meaningful for both, so neither operator claims something the type
  cannot honour.
- **Metadata accessors — no gap, and correctly so.** `IsSoftDeleted` reading `false` for a
  hard-delete type is an honest answer to a question about the type, not a filter that quietly
  matched everything. Fisher documents the same reading.

## Behaviour change — wants a release note

**Code that today calls `IsDeleted()` / `MaybeDeleted()` / `DeletedSince()` / `DeletedBefore()` on a
hard-delete type silently gets every row, and will now throw `BadLinqExpressionException`.**
Likewise `UndoDeleteWhere<T>` on a hard-delete type will now throw `InvalidOperationException`
instead of failing at `SaveChangesAsync`. That is the point of the fix, but it is a runtime break for
any caller relying on the old silence, and it should be called out in the release notes rather than
left to be discovered.

The exposure is bounded in a useful way: any caller hitting this was already getting wrong results,
so the break converts a silent wrong answer into a loud one rather than breaking working code.
`docs/documents/deletes.md` carries the note.

## Tests

New `src/Polecat.Tests/SoftDeletes/soft_delete_operators_against_hard_deleted_types.cs` (11 tests):

- all four operators refused on a hard-delete type (theory), message naming the type and the operator
- the message names the remedy in Polecat's own configuration vocabulary
- all six provider execution paths refuse
- refused when the operator is buried mid-chain rather than outermost
- refused over an event query
- a soft-deleted type is untouched — `IsDeleted()` and `MaybeDeleted()` still behave
- `UndoDeleteWhere` refused on a hard-delete type, still working on a soft-deleted one

Local results, one run at a time against the shared `polecat-sqlserver` container (CI is stalled
org-wide and is not a gate):

| Area | Result |
|---|---|
| `Polecat.Tests.SoftDeletes` | 42/42 passed |
| `Polecat.Tests.Linq` | 191/191 passed |
| `Polecat.Tests.Compliance` | 517 total, 0 failed, 3 skipped |
| `Events` + `Querying` + `Documents` + `Reading` | 477/477 passed |

Two attempts at the whole suite in one process were reaped by the environment partway through — at
1652 and at 844 tests — both with **zero failures** up to the cut. Two runs (one Compliance, one
Events-group) each showed a single failure that passed on immediate rerun with nothing else changed;
both were in areas untouched by this PR (`dcb_has_tag_linq_compliance`,
`rebuild_concurrency_cap_compliance`) and both slow runs coincided with other work on the box, so
they read as contention flakes rather than regressions.

Fixes #558

🤖 Generated with [Claude Code](https://claude.com/claude-code)
