### PR TITLE
Adopt the strictly-greater numeric revision rule (#559)

### DIFF
--- a/docs/documents/concurrency.md
+++ b/docs/documents/concurrency.md
@@ -52,25 +52,48 @@ public class Order : IRevisioned
 }
 ```
 
-Usage:
+A supplied revision is the **target version** — the revision the document is being asked to *become* —
+and it is accepted only when it is **strictly greater** than the revision currently stored. A revision
+of `0` means "auto": increment whatever is stored, whatever that is.
 
 ```cs
 var order = await session.LoadAsync<Order>(orderId);
 // order.Version == 1 (after first save)
 
 order.Description = "Updated";
-session.Store(order);
+session.UpdateRevision(order, order.Version + 1);   // target revision 2
 await session.SaveChangesAsync();
 // order.Version == 2
 ```
 
-### UpdateRevision
+::: warning
+`Store(order)` passes the document's own `Version` as the target revision, so re-storing a document
+still carrying the revision it was loaded at raises a `ConcurrencyException` — the loaded value is
+equal to what is stored, and equal is not greater. Either name the next revision with
+`UpdateRevision(order, order.Version + 1)`, or set `order.Version = 0` to take the auto path.
+:::
 
-Explicitly set the expected revision:
+An explicit revision may also **jump**, which is what lets a caller adopt a revision decided somewhere
+else — an upstream version, a stream version, an imported record:
 
 ```cs
-session.UpdateRevision(order, expectedRevision: 3);
+session.UpdateRevision(order, 10);   // from 3 straight to 10
+await session.SaveChangesAsync();
+// order.Version == 10 — exactly the revision named, not 11
 ```
+
+### Explicit revisions on insert
+
+A brand-new document carrying a non-zero `Version` is stored at **exactly** that revision rather than
+normalised to 1, and the strictly-greater guard then applies from there:
+
+```cs
+session.Insert(new Order { Id = id, Version = 7, Description = "Imported" });
+await session.SaveChangesAsync();
+// the row lands at revision 7; the next auto store lands at 8
+```
+
+Leave `Version` at its default `0` to start a document at revision 1.
 
 ## Long Numeric Revisions (ILongVersioned)
 
@@ -91,7 +114,7 @@ Usage mirrors `IRevisioned`, with a `long` overload of `UpdateRevision` for expl
 ```cs
 var view = await session.LoadAsync<CustomerOrderHistory>(id);
 view.Description = "Updated";
-session.UpdateRevision(view, expectedRevision: 4_000_000_000L);
+session.UpdateRevision(view, 4_000_000_000L);   // the TARGET revision, above whatever is stored
 await session.SaveChangesAsync();
 ```
 

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -144,6 +144,56 @@ public string CorrelationId { get; set; } = string.Empty;
 
 [#140](https://github.com/JasperFx/polecat/issues/140). The lifted `JasperFx.DocumentAlreadyExistsException` keeps Polecat's `DocumentType` (Type) and `Id` properties and the `(Type, object)` ctor, so the duplicate-key `catch` path is a near-no-op rebind. But the thrown **`Message`** now uses Marten's FullName-based format — `"Document already exists {FullName}: {id}"` (was `"A document of type '{Name}' with id '{id}' already exists."`). If you assert on or parse `.Message`, update the expectation; assertions on `.DocumentType` / `.Id` are unaffected.
 
+#### Numeric revisions are now strictly-greater, and honoured on insert
+
+[#559](https://github.com/JasperFx/polecat/issues/559), settled by the maintainer ruling on
+[jasperfx#785](https://github.com/JasperFx/jasperfx/issues/785). Polecat previously read an explicit
+numeric revision as an **equality expectation** — the supplied value had to *match* the stored
+revision, and the row then auto-incremented past it — and discarded an explicit revision entirely on
+insert. Both are now Marten's and Fisher's rule: an explicit revision is the **target version**,
+accepted only when it is **strictly greater** than what is stored, and stored verbatim. A revision of
+`0` still means "auto". This affects every document implementing `IRevisioned` or `ILongVersioned`,
+and it breaks in two different ways.
+
+**The update path breaks loudly.** The natural read-modify-write spelling now throws:
+
+```csharp
+// before (Polecat 3.x / early 4.x): the loaded revision was an equality expectation
+session.UpdateRevision(doc, doc.Version);        // now throws ConcurrencyException
+
+// after: name the revision the document is moving TO
+session.UpdateRevision(doc, doc.Version + 1);
+```
+
+`Store(doc)` passes the document's own `Version` as the target revision, so `Store` on a document
+still carrying the revision it was loaded at throws for the same reason. Set `doc.Version = 0` before
+storing to take the auto path instead. In exchange, an explicit revision may now **jump** (3 → 10)
+and lands at exactly the value named rather than one past it — which is what lets a caller adopt a
+revision decided upstream.
+
+**The insert path breaks silently, and this is the one to search your code for.** A document built
+with a non-zero `Version` and inserted was previously normalised to revision 1. It is now stored at
+that revision:
+
+```csharp
+session.Insert(new Order { Id = id, Version = 7 });
+// before: the row landed at revision 1
+// after:  the row lands at revision 7
+```
+
+Nothing throws at the call site. The failure surfaces later, when an `UpdateRevision` computed
+against an assumed revision of 1 is refused. The escape hatch is to set `Version = 0` on any document
+you are inserting and expecting the store to number for you — which is what a freshly constructed
+document does by default, so only code that populates `Version` before a first write is affected.
+
+::: warning
+**Negative revisions changed as a side effect.** Polecat's hard-coded insert value used to swallow a
+negative `Version` into 1; the new `CASE` stores it verbatim, after which the strictly-greater guard
+refuses every write below it. No store range-checks a negative revision and the shared compliance
+suite deliberately leaves the case unpinned — treat a negative `Version` as unsupported rather than
+as a behavior to rely on.
+:::
+
 ### Event-sourcing API changes
 
 #### Projections and self-aggregating documents must be `partial`

--- a/src/Polecat.Tests/Compliance/PolecatDocumentComplianceFixture.cs
+++ b/src/Polecat.Tests/Compliance/PolecatDocumentComplianceFixture.cs
@@ -121,6 +121,13 @@ public class PolecatDocumentComplianceFixture : DocumentStorageComplianceFixture
     ///     <see cref="IDocumentStore" /> implements <see cref="IDocumentSessionFactory" /> directly —
     ///     there is no adapter here, which is the point of #443.
     /// </summary>
+    /// <summary>
+    ///     #559 / jasperfx#785: Polecat implements numeric revisions — a document implementing
+    ///     <see cref="IRevisioned" /> gets <c>ConcurrencyMode.Numeric</c> on its mapping, and since
+    ///     #559 the strictly-greater guard the suite pins.
+    /// </summary>
+    public override bool SupportsNumericRevisions => true;
+
     public override IDocumentSessionFactory Sessions =>
         _store ?? throw new InvalidOperationException("The store has not been configured yet.");
 

--- a/src/Polecat.Tests/Compliance/polecat_event_store_compliance.cs
+++ b/src/Polecat.Tests/Compliance/polecat_event_store_compliance.cs
@@ -59,3 +59,14 @@ public class polecat_document_delete_compliance
 
 public class polecat_document_query_compliance
     : DocumentQueryCompliance<PolecatDocumentComplianceFixture>;
+
+/*
+ * #559 / jasperfx#785 -- numeric revision semantics. Enrolled as part of adopting the ruled
+ * strictly-greater contract: an explicit revision is the version the caller is asking the document
+ * to BECOME, accepted only when it exceeds what is stored, and honoured verbatim on insert. Polecat
+ * previously read it as an equality expectation and always auto-incremented, and hard-coded the
+ * insert to 1; the suite is what holds all three SQL sites to the same rule.
+ */
+
+public class polecat_numeric_revision_compliance
+    : NumericRevisionCompliance<PolecatDocumentComplianceFixture>;

--- a/src/Polecat.Tests/Storage/sqlserver_descriptor_builder_tests.cs
+++ b/src/Polecat.Tests/Storage/sqlserver_descriptor_builder_tests.cs
@@ -222,23 +222,60 @@ public class sqlserver_descriptor_builder_tests : OneOffConfigurationsContext
         await executeAsync(second, session);
         doc.Version.ShouldBe(2);
 
-        // POLECAT numeric semantics (#273 E2c): the explicit revision is an EQUALITY
-        // expectation against the current version (bespoke-pipeline parity), and version
-        // always auto-increments — unlike Marten's explicit-greater rule.
+        // #559 / jasperfx#785: an explicit revision is the TARGET version and must be strictly
+        // greater than what is stored. Below the stored revision is the unambiguous stale write.
         var stale = new NumericClosedShapeUpsertOperation<RevisionedDoc, Guid>(
             doc, doc.Id, session.TenantId, descriptor, OperationRole.Upsert, revisions) { Revision = 1 };
         await Should.ThrowAsync<JasperFx.ConcurrencyException>(() => executeAsync(stale, session));
 
-        // A jump past the current version is also a mismatch
+        // Equal is not greater — re-storing at the revision just loaded is a concurrency failure,
+        // which is the sharp edge the ruling deliberately keeps.
+        var equal = new NumericClosedShapeUpsertOperation<RevisionedDoc, Guid>(
+            doc, doc.Id, session.TenantId, descriptor, OperationRole.Upsert, revisions) { Revision = 2 };
+        await Should.ThrowAsync<JasperFx.ConcurrencyException>(() => executeAsync(equal, session));
+
+        // A non-contiguous jump is accepted and lands at EXACTLY the revision named — the explicit
+        // branch assigns the caller's value rather than incrementing past it.
         var jump = new NumericClosedShapeUpsertOperation<RevisionedDoc, Guid>(
             doc, doc.Id, session.TenantId, descriptor, OperationRole.Upsert, revisions) { Revision = 10 };
-        await Should.ThrowAsync<JasperFx.ConcurrencyException>(() => executeAsync(jump, session));
+        await executeAsync(jump, session);
+        doc.Version.ShouldBe(10);
+        revisions[doc.Id].ShouldBe(10);
 
-        // Matching the current version succeeds and increments
-        var match = new NumericClosedShapeUpsertOperation<RevisionedDoc, Guid>(
-            doc, doc.Id, session.TenantId, descriptor, OperationRole.Upsert, revisions) { Revision = 2 };
-        await executeAsync(match, session);
-        doc.Version.ShouldBe(3);
+        // Auto still wins and resumes counting from what is stored, not from what the caller knew.
+        var resume = new NumericClosedShapeUpsertOperation<RevisionedDoc, Guid>(
+            doc, doc.Id, session.TenantId, descriptor, OperationRole.Upsert, revisions) { Revision = 0 };
+        await executeAsync(resume, session);
+        doc.Version.ShouldBe(11);
+    }
+
+    /// <summary>
+    ///     #559 site 3: the INSERT branch honours an explicit revision rather than discarding it in
+    ///     favour of 1. The row lands at exactly the revision the caller named, and the
+    ///     strictly-greater guard then applies from there.
+    /// </summary>
+    [Fact]
+    public async Task numeric_descriptor_honours_an_explicit_revision_on_insert()
+    {
+        var descriptor = descriptorFor<RevisionedDoc>();
+
+        await using var raw = theStore.LightweightSession();
+        var session = (IStorageSession)raw;
+
+        var doc = new RevisionedDoc { Id = Guid.NewGuid(), Name = "imported" };
+        var revisions = new Dictionary<Guid, long>();
+
+        var seeded = new NumericClosedShapeUpsertOperation<RevisionedDoc, Guid>(
+            doc, doc.Id, session.TenantId, descriptor, OperationRole.Upsert, revisions) { Revision = 7 };
+        await executeAsync(seeded, session);
+        doc.Version.ShouldBe(7);
+        revisions[doc.Id].ShouldBe(7);
+
+        // It really wrote 7 — the store counts on from it rather than from 1.
+        var next = new NumericClosedShapeUpsertOperation<RevisionedDoc, Guid>(
+            doc, doc.Id, session.TenantId, descriptor, OperationRole.Upsert, revisions) { Revision = 0 };
+        await executeAsync(next, session);
+        doc.Version.ShouldBe(8);
     }
 
     [Fact]

--- a/src/Polecat.Tests/Storage/sqlserver_descriptor_builder_tests.cs
+++ b/src/Polecat.Tests/Storage/sqlserver_descriptor_builder_tests.cs
@@ -257,6 +257,10 @@ public class sqlserver_descriptor_builder_tests : OneOffConfigurationsContext
     [Fact]
     public async Task numeric_descriptor_honours_an_explicit_revision_on_insert()
     {
+        await using var bootstrap = theStore.LightweightSession();
+        bootstrap.Store(new RevisionedDoc { Name = "seed" }); // force table creation
+        await bootstrap.SaveChangesAsync(TestContext.Current.CancellationToken);
+
         var descriptor = descriptorFor<RevisionedDoc>();
 
         await using var raw = theStore.LightweightSession();

--- a/src/Polecat.Tests/Versioning/concurrent_revision_write_loss_tests.cs
+++ b/src/Polecat.Tests/Versioning/concurrent_revision_write_loss_tests.cs
@@ -16,7 +16,7 @@ namespace Polecat.Tests.Versioning;
 ///     from the UPDATE itself (<c>RETURNING</c>), so a filtered-out update returns nothing.
 ///
 ///     Polecat's equivalent is the guarded MERGE built by SqlServerDocumentStorageDescriptorBuilder:
-///     <c>WHEN MATCHED AND (? = 0 OR t.version = ?) THEN UPDATE … OUTPUT inserted.version</c>. OUTPUT
+///     <c>WHEN MATCHED AND (? = 0 OR t.version &lt; ?) THEN UPDATE … OUTPUT inserted.version</c>. OUTPUT
 ///     is MERGE's RETURNING — it only emits a row for a row the MERGE actually acted on — so the
 ///     structure carries the fix by construction. These tests exercise that claim with genuine
 ///     concurrency rather than asserting on SQL shape: the invariant under test is that N racing
@@ -36,7 +36,8 @@ public class concurrent_revision_write_loss_tests : IntegrationContext
     }
 
     /// <summary>
-    ///     Two sessions load the same revision-1 document and both call UpdateRevision(doc, 1).
+    ///     Two sessions load the same revision-1 document and both call UpdateRevision(doc, 2) —
+    ///     under the #559 strictly-greater rule the target version is named, not the loaded one.
     ///     Exactly one may win. The loser must throw — not report success over a write that never
     ///     landed. The discriminating assertion is the pairing: the winner's name must be the one in
     ///     the database. A silent write-loss shows up as "both succeeded" with only one name stored.
@@ -61,8 +62,8 @@ public class concurrent_revision_write_loss_tests : IntegrationContext
 
         d1.Name = "writer-1";
         d2.Name = "writer-2";
-        s1.UpdateRevision(d1, 1);
-        s2.UpdateRevision(d2, 1);
+        s1.UpdateRevision(d1, 2);
+        s2.UpdateRevision(d2, 2);
 
         // Genuinely concurrent: both flushes are in flight at once.
         var r1 = SaveOutcomeAsync(s1, "writer-1");
@@ -115,7 +116,7 @@ public class concurrent_revision_write_loss_tests : IntegrationContext
                 var doc = await session.LoadAsync<RevisionedDoc>(id, TestContext.Current.CancellationToken);
                 doc.ShouldNotBeNull();
                 doc.Name = name;
-                session.UpdateRevision(doc, 1);
+                session.UpdateRevision(doc, 2);
 
                 tasks.Add(Task.Run(async () =>
                 {

--- a/src/Polecat.Tests/Versioning/long_versioned_operations.cs
+++ b/src/Polecat.Tests/Versioning/long_versioned_operations.cs
@@ -48,8 +48,11 @@ public class long_versioned_operations : IntegrationContext
         loaded.ShouldNotBeNull();
         loaded.Version.ShouldBe(1L);
 
+        // #559: Store passes the document's own Version as the TARGET revision, which must be
+        // strictly greater than what is stored — so a loaded document moves forward by naming the
+        // next revision rather than by handing back the one it arrived with.
         loaded.Name = "v2";
-        session2.Store(loaded);
+        session2.UpdateRevision(loaded, loaded.Version + 1);
         await session2.SaveChangesAsync(TestContext.Current.CancellationToken);
         loaded.Version.ShouldBe(2L);
     }
@@ -91,12 +94,13 @@ public class long_versioned_operations : IntegrationContext
         loaded2.ShouldNotBeNull();
 
         loaded1.Name = "updated-by-session1";
-        session1.Store(loaded1);
+        session1.UpdateRevision(loaded1, loaded1.Version + 1);
         await session1.SaveChangesAsync(TestContext.Current.CancellationToken);
         loaded1.Version.ShouldBe(2L);
 
+        // Its target (2) no longer exceeds the stored 2 (#559).
         loaded2.Name = "updated-by-session2";
-        session2.Store(loaded2);
+        session2.UpdateRevision(loaded2, loaded2.Version + 1);
 
         await Should.ThrowAsync<ConcurrencyException>(async () =>
         {
@@ -116,7 +120,7 @@ public class long_versioned_operations : IntegrationContext
         var loaded = await session2.LoadAsync<LongVersionedDoc>(doc.Id, TestContext.Current.CancellationToken);
         loaded.ShouldNotBeNull();
         loaded.Name = "updated";
-        session2.UpdateRevision(loaded, 1L); // explicitly set expected revision via the long overload
+        session2.UpdateRevision(loaded, 2L); // #559: the TARGET revision, via the long overload
         await session2.SaveChangesAsync(TestContext.Current.CancellationToken);
         loaded.Version.ShouldBe(2L);
     }
@@ -149,9 +153,9 @@ public class long_versioned_operations : IntegrationContext
         loaded.ShouldNotBeNull();
         loaded.Version.ShouldBe(bigVersion);
 
-        // Storing with the big expected revision succeeds and increments past the Int32 range.
+        // Naming the next big revision succeeds and increments past the Int32 range.
         loaded.Name = "big-updated";
-        session2.Store(loaded);
+        session2.UpdateRevision(loaded, loaded.Version + 1);
         await session2.SaveChangesAsync(TestContext.Current.CancellationToken);
         loaded.Version.ShouldBe(bigVersion + 1);
 
@@ -164,12 +168,12 @@ public class long_versioned_operations : IntegrationContext
         l2.ShouldNotBeNull();
 
         l1.Name = "s1";
-        s1.Store(l1);
+        s1.UpdateRevision(l1, l1.Version + 1);
         await s1.SaveChangesAsync(TestContext.Current.CancellationToken);
         l1.Version.ShouldBe(bigVersion + 2);
 
         l2.Name = "s2";
-        s2.Store(l2);
+        s2.UpdateRevision(l2, l2.Version + 1);
         await Should.ThrowAsync<ConcurrencyException>(async () => await s2.SaveChangesAsync());
     }
 }

--- a/src/Polecat.Tests/Versioning/revisioned_operations.cs
+++ b/src/Polecat.Tests/Versioning/revisioned_operations.cs
@@ -42,8 +42,13 @@ public class revisioned_operations : IntegrationContext
         doc.Version.ShouldBe(1);
     }
 
+    /// <summary>
+    ///     #559: <c>Store</c> passes the document's own <c>Version</c> as the target revision, and the
+    ///     target must be strictly greater than what is stored — so re-storing a document at the
+    ///     revision it was loaded at is a concurrency failure, not an increment.
+    /// </summary>
     [Fact]
-    public async Task store_existing_document_increments_version()
+    public async Task store_existing_document_at_the_loaded_revision_is_refused()
     {
         var doc = new RevisionedDoc { Id = Guid.NewGuid(), Name = "v1" };
 
@@ -58,8 +63,93 @@ public class revisioned_operations : IntegrationContext
 
         loaded.Name = "v2";
         session2.Store(loaded);
+
+        await Should.ThrowAsync<ConcurrencyException>(async () =>
+        {
+            await session2.SaveChangesAsync();
+        });
+    }
+
+    /// <summary>
+    ///     #559: the two supported ways to move a loaded document forward — name the revision it is
+    ///     going to (<c>doc.Version + 1</c>), or hand back <c>Version = 0</c> and let the store
+    ///     increment whatever it has.
+    /// </summary>
+    [Fact]
+    public async Task store_existing_document_moves_forward_by_naming_the_next_revision()
+    {
+        var doc = new RevisionedDoc { Id = Guid.NewGuid(), Name = "v1" };
+
+        theSession.Store(doc);
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        await using var session2 = theStore.LightweightSession();
+        var loaded = await session2.LoadAsync<RevisionedDoc>(doc.Id, TestContext.Current.CancellationToken);
+        loaded.ShouldNotBeNull();
+        loaded.Name = "v2";
+        session2.UpdateRevision(loaded, loaded.Version + 1);
         await session2.SaveChangesAsync(TestContext.Current.CancellationToken);
         loaded.Version.ShouldBe(2);
+
+        await using var session3 = theStore.LightweightSession();
+        var again = await session3.LoadAsync<RevisionedDoc>(doc.Id, TestContext.Current.CancellationToken);
+        again.ShouldNotBeNull();
+        again.Name = "v3";
+        again.Version = 0; // the auto escape hatch
+        session3.Store(again);
+        await session3.SaveChangesAsync(TestContext.Current.CancellationToken);
+        again.Version.ShouldBe(3);
+    }
+
+    /// <summary>
+    ///     #559: an explicit revision may skip ahead, and the row lands at exactly the revision named
+    ///     rather than one past it.
+    /// </summary>
+    [Fact]
+    public async Task explicit_revision_may_jump_and_lands_exactly()
+    {
+        var doc = new RevisionedDoc { Id = Guid.NewGuid(), Name = "v1" };
+
+        theSession.Store(doc);
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        await using var session2 = theStore.LightweightSession();
+        var loaded = await session2.LoadAsync<RevisionedDoc>(doc.Id, TestContext.Current.CancellationToken);
+        loaded.ShouldNotBeNull();
+        loaded.Name = "imported";
+        session2.UpdateRevision(loaded, 10);
+        await session2.SaveChangesAsync(TestContext.Current.CancellationToken);
+        loaded.Version.ShouldBe(10);
+
+        await using var query = theStore.QuerySession();
+        var stored = await query.LoadAsync<RevisionedDoc>(doc.Id, TestContext.Current.CancellationToken);
+        stored.ShouldNotBeNull();
+        stored.Version.ShouldBe(10);
+    }
+
+    /// <summary>
+    ///     #559 site 3: an explicit revision on a brand-new document is honoured rather than
+    ///     normalised to 1, and the store counts on from it.
+    /// </summary>
+    [Fact]
+    public async Task insert_honours_an_explicit_revision()
+    {
+        var doc = new RevisionedDoc { Id = Guid.NewGuid(), Name = "imported", Version = 7 };
+
+        theSession.Insert(doc);
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
+        doc.Version.ShouldBe(7);
+
+        await using var session2 = theStore.LightweightSession();
+        var loaded = await session2.LoadAsync<RevisionedDoc>(doc.Id, TestContext.Current.CancellationToken);
+        loaded.ShouldNotBeNull();
+        loaded.Version.ShouldBe(7);
+
+        loaded.Name = "moved on";
+        loaded.Version = 0;
+        session2.Store(loaded);
+        await session2.SaveChangesAsync(TestContext.Current.CancellationToken);
+        loaded.Version.ShouldBe(8);
     }
 
     [Fact]
@@ -109,15 +199,16 @@ public class revisioned_operations : IntegrationContext
         var loaded2 = await session2.LoadAsync<RevisionedDoc>(doc.Id, TestContext.Current.CancellationToken);
         loaded2.ShouldNotBeNull();
 
-        // First session saves successfully
+        // First session saves successfully by naming the revision it is moving to (#559)
         loaded1.Name = "updated-by-session1";
-        session1.Store(loaded1);
+        session1.UpdateRevision(loaded1, loaded1.Version + 1);
         await session1.SaveChangesAsync(TestContext.Current.CancellationToken);
         loaded1.Version.ShouldBe(2);
 
-        // Second session tries to save with stale version (1) — should fail
+        // Second session tries to save against the revision it loaded (1) — 1 is not greater than
+        // the stored 2, so it is refused
         loaded2.Name = "updated-by-session2";
-        session2.Store(loaded2);
+        session2.UpdateRevision(loaded2, loaded2.Version + 1);
 
         await Should.ThrowAsync<ConcurrencyException>(async () =>
         {
@@ -139,6 +230,7 @@ public class revisioned_operations : IntegrationContext
         loaded.Version.ShouldBe(1);
 
         loaded.Name = "updated";
+        loaded.Version = 2; // #559: name the target revision, which must exceed the stored 1
         session2.Update(loaded);
         await session2.SaveChangesAsync(TestContext.Current.CancellationToken);
         loaded.Version.ShouldBe(2);
@@ -163,11 +255,13 @@ public class revisioned_operations : IntegrationContext
 
         // First update succeeds
         l1.Name = "s1-update";
+        l1.Version += 1;
         s1.Update(l1);
         await s1.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        // Second update fails with stale version
+        // Second update fails: its target revision (2) no longer exceeds the stored 2
         l2.Name = "s2-update";
+        l2.Version += 1;
         s2.Update(l2);
 
         await Should.ThrowAsync<ConcurrencyException>(async () =>
@@ -188,7 +282,7 @@ public class revisioned_operations : IntegrationContext
         var loaded = await session2.LoadAsync<RevisionedDoc>(doc.Id, TestContext.Current.CancellationToken);
         loaded.ShouldNotBeNull();
         loaded.Name = "updated";
-        session2.UpdateRevision(loaded, 1); // explicitly set expected revision
+        session2.UpdateRevision(loaded, 2); // #559: the TARGET revision, strictly greater than 1
         await session2.SaveChangesAsync(TestContext.Current.CancellationToken);
         loaded.Version.ShouldBe(2);
     }
@@ -206,6 +300,7 @@ public class revisioned_operations : IntegrationContext
         var loaded = await session2.LoadAsync<RevisionedDoc>(doc.Id, TestContext.Current.CancellationToken);
         loaded.ShouldNotBeNull();
         loaded.Name = "updated";
+        loaded.Version = 0; // #559: auto, rather than re-storing at the loaded revision
         session2.Store(loaded);
         await session2.SaveChangesAsync(TestContext.Current.CancellationToken);
 

--- a/src/Polecat/Storage/SqlServerDocumentStorageDescriptorBuilder.cs
+++ b/src/Polecat/Storage/SqlServerDocumentStorageDescriptorBuilder.cs
@@ -341,10 +341,15 @@ internal static class SqlServerDocumentStorageDescriptorBuilder
         {
             if (column == "rev0")
             {
-                // Bespoke parity: INSERT always starts at revision 1 regardless of the
-                // doc-carried value (the expectation only applies to existing rows).
+                // #559: an explicit revision is HONOURED on insert — the row lands at exactly the
+                // revision the caller named, and auto (0) starts at 1. Marten spells this
+                // "CASE WHEN ? = 0 THEN 1 ELSE ? END" and Fisher's NumericRevision.InsertValueSql
+                // is the same; here the two ? slots are already in flight as the rev0/rev1 source
+                // columns, so the CASE reads them off the USING row rather than claiming two more
+                // parameter slots the shared insert/upsert operations would never bind. rev1 stays
+                // skipped below for that reason: it is a second parameter slot, not a target column.
                 insertColumns.Add("version");
-                insertValues.Add("1");
+                insertValues.Add("CASE WHEN s.rev0 = 0 THEN 1 ELSE s.rev1 END");
             }
             else if (column != "rev1")
             {
@@ -389,10 +394,11 @@ internal static class SqlServerDocumentStorageDescriptorBuilder
         var updateAssignments = new List<string> { "data = s.data" };
         if (numeric)
         {
-            // POLECAT numeric semantics (deliberate divergence from Marten's explicit-greater
-            // rule): the doc-carried revision is an EQUALITY expectation and version always
-            // auto-increments. Explicit path sets ? + 1 to match the bespoke pipeline.
-            updateAssignments.Add("version = CASE WHEN ? = 0 THEN t.version + 1 ELSE ? + 1 END");
+            // #559: an explicit revision is the TARGET version, so the explicit branch assigns it
+            // verbatim — incrementing it again would overshoot the revision the caller asked for.
+            // Auto (? = 0) still increments whatever is stored. Same pair as Marten's
+            // "CASE WHEN ? = 0 THEN {version} + 1 ELSE ? END" and Fisher's NumericRevision.
+            updateAssignments.Add("version = CASE WHEN ? = 0 THEN t.version + 1 ELSE ? END");
         }
         else
         {
@@ -414,10 +420,12 @@ internal static class SqlServerDocumentStorageDescriptorBuilder
         }
         else if (numeric)
         {
-            // Equality expectation (Polecat parity): auto (? = 0) always wins; an explicit
-            // revision must MATCH the current version. The shared numeric ops always bind the
-            // four trailing slots, so the shape is constant whether guarded or not.
-            guard = " AND (? = 0 OR t.version = ?)";
+            // #559, strictly-greater: auto (? = 0) always wins; an explicit revision is accepted
+            // only when it EXCEEDS the stored one, which is what lets it jump non-contiguously
+            // (3 -> 10) and what makes re-storing at the loaded revision a concurrency failure.
+            // The shared numeric ops always bind the four trailing slots, so the shape is
+            // constant whether guarded or not.
+            guard = " AND (? = 0 OR t.version < ?)";
         }
 
         return $"MERGE {table} WITH (HOLDLOCK) AS t " +
@@ -504,8 +512,11 @@ internal static class SqlServerDocumentStorageDescriptorBuilder
         }
 
         var updateAssignments = new List<string> { "data = s.data" };
+        // #559: the same strictly-greater pair as BuildMergeSql's update branch. Fixing only the
+        // upsert would leave this statement — every Update()/UpdateRevision() that routes here —
+        // on the old equality contract, which is the divergence the ruling removed.
         updateAssignments.Add(numeric
-            ? "version = CASE WHEN s.rev0 = 0 THEN t.version + 1 ELSE s.rev1 + 1 END"
+            ? "version = CASE WHEN s.rev0 = 0 THEN t.version + 1 ELSE s.rev1 END"
             : "version = t.version + 1");
         updateAssignments.AddRange(binders
             .Where(b => !b.IsServerSide && b.ColumnName != "tenant_id" && !ReferenceEquals(b, revisionBinder))
@@ -516,7 +527,7 @@ internal static class SqlServerDocumentStorageDescriptorBuilder
         var guard = mode switch
         {
             ConcurrencyMode.Optimistic => " AND t.guid_version = ?",
-            ConcurrencyMode.Numeric => " AND (? = 0 OR t.version = ?)",
+            ConcurrencyMode.Numeric => " AND (? = 0 OR t.version < ?)",
             _ => string.Empty
         };
 


### PR DESCRIPTION
Adopts the maintainer ruling on [jasperfx#785](https://github.com/JasperFx/jasperfx/issues/785): an explicit numeric revision is the **target version**, accepted only when it is **strictly greater** than what is stored, and honoured verbatim rather than incremented past. On the insert path an explicit revision is **honoured**, not discarded. `? = 0` still means "auto". Marten and Fisher already behave this way; Polecat was the outlier on both paths.

## The three sites

All in `src/Polecat/Storage/SqlServerDocumentStorageDescriptorBuilder.cs`.

**1. The single-document MERGE (`BuildMergeSql`, update branch).** The guard `AND (? = 0 OR t.version = ?)` becomes `AND (? = 0 OR t.version < ?)`, and the assignment loses its `+ 1`:

```
version = CASE WHEN ? = 0 THEN t.version + 1 ELSE ? + 1 END   ->   ... ELSE ? END
```

Once the revision *is* the target version, incrementing again overshoots.

**2. The update-only MERGE (`BuildUpdateSql`), via the `rev0`/`rev1` source columns.** The same guard/`CASE` pair. Fixing only the first site would have left every `Update()` / `UpdateRevision()` that routes through this statement on the old equality contract — which is precisely the divergence the ruling removed.

**3. The INSERT branch.** `insertValues.Add("1")` becomes `CASE WHEN s.rev0 = 0 THEN 1 ELSE s.rev1 END`.

On that third one: Marten spells the value `CASE WHEN ? = 0 THEN 1 ELSE ? END` and Fisher's `NumericRevision.InsertValueSql` is identical, but both are plain positional INSERTs. In Polecat's MERGE the revision's two `?` slots are **already in flight** as the `rev0`/`rev1` USING-source columns, so the `CASE` reads them off the source row. Two fresh `?` would claim parameter slots that `NumericClosedShapeInsertOperation` (2 slots) and `NumericClosedShapeUpsertOperation` (4 trailing) never bind. The `rev1` skip just below stays exactly as it was, for the same reason: `rev1` is a second parameter slot, not a target column.

No parameter counts changed at any site — only operators and the source of the insert value.

## Compliance

`NumericRevisionCompliance` is enrolled (`polecat_numeric_revision_compliance`) and `PolecatDocumentComplianceFixture.SupportsNumericRevisions` is flipped to `true`. **All 9 facts pass**, including the two insert-path facts that were red before this change.

Refusal is asserted as the shared `JasperFx.ConcurrencyException`. Polecat already satisfies this with no change: Weasel's `NumericClosedShapeUpsertOperation` / `NumericClosedShapeUpdateOperation` throw exactly that type when the guarded statement returns no `OUTPUT` row.

## Release note — this breaks in two different ways

**Update path, loud.** The natural read-modify-write now throws:

```csharp
session.UpdateRevision(doc, doc.Version);       // now throws ConcurrencyException
session.UpdateRevision(doc, doc.Version + 1);   // name the revision it is moving TO
```

`Store(doc)` passes the document's own `Version` as the target revision, so re-storing a document still carrying the revision it was loaded at throws for the same reason. In exchange, an explicit revision may now jump non-contiguously (3 -> 10) and lands at exactly the value named.

**Insert path, silent — the stronger argument for a major over a minor.** A document built with a non-zero `Version` and inserted used to be normalised to revision 1; it now lands at that revision. Nothing throws at the call site. The failure surfaces later, when an `UpdateRevision` computed against an assumed 1 is refused. `Version = 0` is the escape hatch for both halves.

**Negative revisions changed as a side effect.** The hard-coded `1` used to swallow a negative `Version`; the new `CASE` stores it verbatim, after which the strictly-greater guard refuses everything below it. The shared compliance suite deliberately leaves negative revisions unpinned because all three stores handle them accidentally rather than by contract — flagging it as a deliberate decision rather than something noticed later.

Both halves and the negative-revision note are documented in `docs/migration-guide.md`; `docs/documents/concurrency.md` is rewritten around the new rule.

## Validation

Local runs are the gate (September policy). Merged `origin/main` (`bf62bec`, the #564 soft-delete LINQ work) before running; clean merge, disjoint from these changes.

- `Polecat.Tests.Compliance` + `.Versioning` + `.Storage` + `.Documents` + `.Operations` — 841 total, 837 passed, 3 skipped, 1 failed. The single failure was a missing table-creation bootstrap in a test added by this PR, not a product failure; fixed in 6e36902.
- `NumericRevisionCompliance` alone — 9/9.
- `sqlserver_descriptor_builder_tests` after the fix — 11/11.

Fixes #559

🤖 Generated with [Claude Code](https://claude.com/claude-code)