### PR TITLE
gh-557: admit the compaction marker through the daemon loader's type allow list

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,6 +194,17 @@ paths. Upcasting (#561) is the one thing that must be consulted *before* it; see
 its SQL**, so any read-time reinterpretation of a row has to widen that filter too or the row is
 gone before hydration ever runs.
 
+That allow list is built from the event types a projection *declares*, so **an event type the
+FRAMEWORK writes is invisible to it** — no projection has an `Apply` for `Compacted<T>` or
+`Archived`, so neither reaches `IncludedEventTypes` from user code. `PolecatEventLoader`
+.`FrameworkMarkerTypes` is the one place that adds them back (#557), and it widens the allow-list
+*set* rather than either predicate on purpose: the pushed-down parameter array is taken from that
+set, so one addition covers both the SQL `IN` clause and the client-side fallback that carries an
+allow list too large to push down. A fix applied to only one of those paths produces a bug that
+appears solely on stores with more than 2000 event types. Note the asymmetry in what going missing
+costs: a dropped `Archived` loses an archival, but a dropped `Compacted<T>` loses the stream's whole
+pre-compaction history, because compaction *deletes* the events the marker replaces.
+
 ### Writing tests that survive being run in parallel processes
 
 The suite is a candidate for being run across several worker processes at once (Bobcat's supervisor

--- a/src/Polecat.Tests/Daemon/compaction_marker_allow_list_tests.cs
+++ b/src/Polecat.Tests/Daemon/compaction_marker_allow_list_tests.cs
@@ -1,0 +1,336 @@
+using JasperFx.Events;
+using JasperFx.Events.Aggregation;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Projections;
+using Polecat.Events.Daemon;
+using Polecat.Projections;
+using Polecat.Tests.Harness;
+using Polecat.Tests.Projections;
+
+namespace Polecat.Tests.Daemon;
+
+/// <summary>
+///     #557 — the daemon loader's <c>dotnet_type</c> allow list is built from the event types a
+///     projection declares an <c>Apply</c>/<c>Create</c> for, and <see cref="Compacted{T}" /> is not one
+///     of them. Nothing upstream in JasperFx adds it for the store, so before the fix a projection with
+///     a declared event list never saw the compaction marker for a stream it owns.
+/// </summary>
+/// <remarks>
+///     <para>
+///         What makes this worse than an ordinary dropped event: <c>CompactStreamAsync</c> DELETES the
+///         events it folds. The marker is not an extra event beside the history — it is the only thing
+///         left of it. A shard that filters the marker out is not seeing a partial stream, it is seeing
+///         a stream that appears to begin after the compaction point, and it says so with no error and
+///         no log line.
+///     </para>
+///     <para>
+///         <see cref="a_filtered_and_an_unfiltered_load_agree_on_a_compacted_stream" /> is the
+///         statement of the bug: two loads over one stream, folded by the same aggregator, disagreeing
+///         about what the stream means. The rest pin the two filtering paths (#550's SQL push-down and
+///         the retained client-side fallback) and the end-to-end daemon consequence.
+///     </para>
+/// </remarks>
+public class compaction_marker_allow_list_tests : OneOffConfigurationsContext
+{
+    private const string Owner = "Destroy the Ring";
+
+    public override async ValueTask InitializeAsync()
+    {
+        // Drops this class's schema, then stands the default store back up on it. A test that needs a
+        // different configuration (the daemon one) calls ConfigureStore again and re-applies.
+        await base.InitializeAsync();
+        ConfigureStore(_ => { });
+        await theDatabase.ApplyAllConfiguredChangesToDatabaseAsync();
+    }
+
+    /// <summary>
+    ///     THE test. A filtered shard and an unfiltered shard read the same compacted stream and must
+    ///     reach the same aggregate. Before the fix the filtered load dropped the marker, so its fold
+    ///     started from nothing and lost every member who joined before compaction — while the
+    ///     unfiltered load over the identical rows had them all.
+    /// </summary>
+    [Fact]
+    public async Task a_filtered_and_an_unfiltered_load_agree_on_a_compacted_stream()
+    {
+        await SeedCompactedStreamAsync();
+        var highWater = await HighWaterAsync();
+
+        var unfiltered = await FoldAsync(CreateLoader(filtering: null), highWater);
+        var filtered = await FoldAsync(CreateLoader(SnapshotProjection()), highWater);
+
+        // The control: this is what the stream actually means, and no shard has any business
+        // disagreeing with it.
+        unfiltered.ShouldNotBeNull();
+        unfiltered.Name.ShouldBe(Owner);
+        unfiltered.Members.ShouldBe(["Aragorn", "Legolas", "Gimli"]);
+
+        filtered.ShouldNotBeNull();
+        filtered.Name.ShouldBe(unfiltered.Name);
+        filtered.Members.ShouldBe(unfiltered.Members);
+        filtered.Location.ShouldBe(unfiltered.Location);
+    }
+
+    /// <summary>
+    ///     #550 pushed the allow list into the SQL as <c>dotnet_type in (...)</c>, so a type absent from
+    ///     it is never read off the wire at all. This is that path: a modest allow list, well under the
+    ///     parameter cap, and the marker has to survive the <c>IN</c> clause.
+    /// </summary>
+    [Fact]
+    public async Task the_marker_survives_the_pushed_down_sql_filter()
+    {
+        var streamId = await SeedCompactedStreamAsync();
+
+        var page = await LoadAsync(CreateLoader(SnapshotProjection()));
+
+        page.Select(x => x.Data.GetType())
+            .ShouldBe([typeof(Compacted<QuestParty>), typeof(MembersJoined)]);
+        page.ShouldAllBe(x => x.StreamId == streamId);
+    }
+
+    /// <summary>
+    ///     The other path, and the one that would otherwise rot unnoticed. Above SQL Server's
+    ///     2100-parameter ceiling the loader stops pushing the filter down and the client-side check
+    ///     carries it alone — so a fix applied only to the rendered <c>IN</c> clause would leave a store
+    ///     with very many event types still broken, and nothing else in the suite would say so.
+    /// </summary>
+    /// <remarks>
+    ///     The fix is applied to the allow-list SET, from which the pushed-down parameter array is
+    ///     taken, which is what makes one addition cover both paths. This test is what stops that being
+    ///     refactored apart.
+    /// </remarks>
+    [Fact]
+    public async Task the_marker_survives_the_client_side_fallback_filter()
+    {
+        await SeedCompactedStreamAsync();
+
+        var projection = SnapshotProjection();
+        foreach (var padding in PaddingEventTypes(2_100))
+        {
+            projection.IncludeType(padding);
+        }
+
+        // Well past the push-down cap, so the rendered SQL carries no type predicate at all and the
+        // hydration-side check is the only filter running.
+        projection.IncludedEventTypes.Count.ShouldBeGreaterThan(2_000);
+
+        var page = await LoadAsync(CreateLoader(projection));
+
+        page.Select(x => x.Data.GetType())
+            .ShouldBe([typeof(Compacted<QuestParty>), typeof(MembersJoined)]);
+    }
+
+    /// <summary>
+    ///     The daemon consequence, end to end: an async single-stream projection catching up over a
+    ///     stream that was compacted before the shard ever reached it. Live aggregation is the
+    ///     unfiltered control — it reads the same rows through <c>PcEventsRowReader</c>, which has no
+    ///     allow list — so the two have to land on the same document.
+    /// </summary>
+    [Fact]
+    public async Task an_async_shard_folds_a_compacted_stream_the_way_live_aggregation_does()
+    {
+        ConfigureStore(opts => opts.Projections.Snapshot<QuestParty>(SnapshotLifecycle.Async));
+        await theDatabase.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        var streamId = await SeedCompactedStreamAsync();
+
+        await theStore.WaitForProjectionAsync();
+
+        await using var query = theStore.QuerySession();
+        var live = await query.Events.AggregateStreamAsync<QuestParty>(streamId,
+            token: TestContext.Current.CancellationToken);
+        var projected = await query.LoadAsync<QuestParty>(streamId, TestContext.Current.CancellationToken);
+
+        live.ShouldNotBeNull();
+        live.Members.ShouldBe(["Aragorn", "Legolas", "Gimli"]);
+
+        projected.ShouldNotBeNull();
+        projected.Name.ShouldBe(live.Name);
+        projected.Members.ShouldBe(live.Members);
+    }
+
+    /// <summary>
+    ///     The sibling marker, and the reason the fix admits a CATEGORY rather than one type.
+    ///     <see cref="Archived" /> reaches a single-stream projection's declared event types on its own
+    ///     from JasperFx 2.65.0 (jasperfx#784), so this passed before the fix as well — it is here to
+    ///     pin that, because if the upstream behaviour ever goes away the failure mode is the same
+    ///     silent one: an async shard that never folds the marker never calls
+    ///     <c>PolecatProjectionStorage.ArchiveStream</c>, and the stream is never archived.
+    /// </summary>
+    [Fact]
+    public async Task the_archived_marker_is_admitted_by_a_filtered_load()
+    {
+        var streamId = Guid.NewGuid();
+        theSession.Events.StartStream(streamId,
+            new QuestStarted(Owner),
+            new Archived("finished"));
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var page = await LoadAsync(CreateLoader(SnapshotProjection()));
+
+        page.Select(x => x.Data.GetType())
+            .ShouldBe([typeof(QuestStarted), typeof(Archived)]);
+    }
+
+    // ---- seeding and plumbing ----
+
+    /// <summary>
+    ///     A stream whose history is compacted away and then appended to: the marker at the sequence of
+    ///     the last folded event (<c>ReplaceEventOperation</c> writes in place), and one ordinary event
+    ///     above it. Aragorn and Legolas exist ONLY inside the marker's snapshot — their events are
+    ///     deleted rows.
+    /// </summary>
+    private async Task<Guid> SeedCompactedStreamAsync()
+    {
+        var streamId = Guid.NewGuid();
+
+        theSession.Events.StartStream(streamId,
+            new QuestStarted(Owner),
+            new MembersJoined(1, "Rivendell", ["Aragorn", "Legolas"]));
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        await using (var compacting = theStore.LightweightSession())
+        {
+            await compacting.Events.CompactStreamAsync<QuestParty>(streamId);
+            await compacting.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using (var appending = theStore.LightweightSession())
+        {
+            appending.Events.Append(streamId, new MembersJoined(2, "Moria", ["Gimli"]));
+            await appending.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        return streamId;
+    }
+
+    /// <summary>
+    ///     The registered form of the projection the daemon would hand the loader: a real
+    ///     <see cref="IAggregateProjection" /> over <see cref="QuestParty" />, with
+    ///     <c>IncludedEventTypes</c> filled from its conventional methods exactly as registration does.
+    ///     Notably absent from that list, and the whole point: <c>Compacted&lt;QuestParty&gt;</c>.
+    /// </summary>
+    private static SingleStreamProjection<QuestParty, Guid> SnapshotProjection()
+    {
+        var projection = new SingleStreamProjection<QuestParty, Guid>();
+        projection.AssembleAndAssertValidity();
+
+        projection.IncludedEventTypes.ShouldNotBeEmpty();
+        projection.IncludedEventTypes.ShouldNotContain(typeof(Compacted<QuestParty>));
+
+        return projection;
+    }
+
+    /// <summary>
+    ///     Filler for the allow list, purely to push it past the push-down cap. These never match a
+    ///     stored row; only the SIZE of the list matters, because that is what decides which of the two
+    ///     filtering paths runs.
+    /// </summary>
+    private static IReadOnlyList<Type> PaddingEventTypes(int count)
+    {
+        // Self-feeding, so it cannot come up short: every type admitted is re-enqueued wrapped in a
+        // List<>, which is always a legal type argument in turn. Seeding from the several hundred
+        // public corelib types rather than a handful keeps the nesting one or two deep — seeding
+        // from ten would need a 200-deep nest, whose type NAME grows exponentially.
+        var padding = new List<Type>(count);
+        var frontier = new Queue<Type>(PaddingSeeds());
+
+        while (padding.Count < count)
+        {
+            var next = frontier.Dequeue();
+            padding.Add(next);
+            frontier.Enqueue(typeof(List<>).MakeGenericType(next));
+        }
+
+        return padding;
+    }
+
+    /// <summary>
+    ///     <c>EventGraph.EventMappingFor</c> closes <c>PolecatEventType&lt;T&gt;</c> over whatever it is
+    ///     handed and constructs it, so a seed has to survive both <c>MakeGenericType</c> AND
+    ///     <c>Activator.CreateInstance</c>.
+    /// </summary>
+    /// <remarks>
+    ///     Reflection over corelib turns up types that pass every obvious property check and still
+    ///     fail one of those two: <c>System.Void</c> is public and concrete but is rejected as a type
+    ///     argument outright, and <c>System.__Canon</c> — the shared generic instantiation — closes
+    ///     fine and then cannot be instantiated. Restricting to top-level public types screens out
+    ///     <c>__Canon</c> and its kin; the rest are asked directly rather than predicted.
+    /// </remarks>
+    private static IEnumerable<Type> PaddingSeeds()
+    {
+        return typeof(object).Assembly.GetTypes()
+            .Where(t => t.IsPublic
+                        && !t.IsAbstract
+                        && !t.IsGenericTypeDefinition
+                        && !t.ContainsGenericParameters
+                        && !t.IsByRefLike
+                        && t != typeof(void))
+            .Where(t =>
+            {
+                try
+                {
+                    return Activator.CreateInstance(typeof(List<>).MakeGenericType(t)) != null;
+                }
+                catch (Exception)
+                {
+                    return false;
+                }
+            });
+    }
+
+    private PolecatEventLoader CreateLoader(EventFilterable? filtering) =>
+        new(theStore.Database.Events, theStore.Options, theStore.Options.ConnectionString, filtering);
+
+    private async Task<EventPage> LoadAsync(PolecatEventLoader loader)
+    {
+        var highWater = await HighWaterAsync();
+        return await loader.LoadAsync(CreateRequest(0, highWater), TestContext.Current.CancellationToken);
+    }
+
+    /// <summary>
+    ///     Fold a whole load through the aggregator the store itself would use, which is where
+    ///     <c>Compacted&lt;T&gt;.MaybeFastForward</c> runs. Starting from a null snapshot is the
+    ///     rebuild/fresh-shard case — the one where the marker is the only source of the pre-compaction
+    ///     history.
+    /// </summary>
+    private async Task<QuestParty?> FoldAsync(PolecatEventLoader loader, long highWater)
+    {
+        var page = await loader.LoadAsync(CreateRequest(0, highWater), TestContext.Current.CancellationToken);
+
+        var aggregator = theStore.Options.Projections.AggregatorFor<QuestParty>();
+        await using var query = theStore.QuerySession();
+
+        return await aggregator.BuildAsync(page, query, null, TestContext.Current.CancellationToken);
+    }
+
+    private Task<long> HighWaterAsync() =>
+        theStore.Database.FetchHighestEventSequenceNumber(TestContext.Current.CancellationToken);
+
+    private static EventRequest CreateRequest(long floor, long highWater) =>
+        new()
+        {
+            Floor = floor,
+            HighWater = highWater,
+            BatchSize = 100,
+            Name = new ShardName("TestLoader"),
+            ErrorOptions = new ErrorHandlingOptions(),
+            Runtime = null!,
+            Metrics = null!
+        };
+
+    private IDocumentSession? _session;
+
+    private IDocumentSession theSession
+    {
+        get
+        {
+            if (_session == null)
+            {
+                _session = theStore.LightweightSession();
+                AsyncDisposables.Add(_session);
+            }
+
+            return _session;
+        }
+    }
+}

--- a/src/Polecat/Events/Daemon/PolecatEventLoader.cs
+++ b/src/Polecat/Events/Daemon/PolecatEventLoader.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using JasperFx.Events;
+using JasperFx.Events.Aggregation;
 using JasperFx.Events.Daemon;
 using JasperFx.Events.Projections;
 using Microsoft.Data.SqlClient;
@@ -81,6 +82,16 @@ internal class PolecatEventLoader : IEventLoader
                 _allowedDotNetTypes.Add(mapping.DotNetTypeName);
             }
 
+            // #557: and the framework's own markers, which a projection never declares a handler for
+            // and which are therefore absent from IncludedEventTypes. Widening the SET here rather
+            // than either predicate is deliberate: _pushedDownTypeNames is taken from it just below,
+            // so one addition covers BOTH the SQL push-down and the client-side fallback that carries
+            // an allow list too large to push down.
+            foreach (var markerType in FrameworkMarkerTypes(filtering))
+            {
+                _allowedDotNetTypes.Add(events.EventMappingFor(markerType).DotNetTypeName);
+            }
+
             if (_allowedDotNetTypes.Count <= MaximumPushedDownTypeNames)
             {
                 // Materialized into a stable array because a HashSet's enumeration order is
@@ -100,6 +111,65 @@ internal class PolecatEventLoader : IEventLoader
         }
 
         _commandText = BuildCommandText();
+    }
+
+    /// <summary>
+    ///     #557: the event types the FRAMEWORK writes into a stream, which no projection declares an
+    ///     <c>Apply</c>/<c>Create</c> method for and which therefore never reach
+    ///     <see cref="EventFilterable.IncludedEventTypes" /> on their own. A declared allow list is a
+    ///     statement about the projection's <em>domain</em> events; silently reading it as a statement
+    ///     about the whole stream is what makes a filtered shard diverge from an unfiltered one.
+    ///     Mirrors Marten's <c>DocumentStore.EventStore.buildEventLoaderFilters</c>, which patches
+    ///     around the same gap store-locally. jasperfx#796 proposes moving it up into
+    ///     <c>determineEventTypes()</c> beside <c>Archived</c>, where every store — Fisher's loader has
+    ///     the identical omission today — would get it for free; delete this when that lands.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         <see cref="Compacted{T}" /> is the one that bites. <c>CompactStreamAsync</c> folds a
+    ///         stream's history into a snapshot, DELETES the folded events and leaves the marker in
+    ///         their place — so the marker is not an extra event beside the history, it <em>is</em> the
+    ///         history. <c>Compacted&lt;T&gt;.MaybeFastForward</c> is what restarts a fold from that
+    ///         snapshot. Filter the marker out and the events it replaced are not filtered too, they are
+    ///         gone from the store entirely: the shard folds only what was appended after compaction
+    ///         and reports an aggregate missing everything before it, with no error anywhere.
+    ///     </para>
+    ///     <para>
+    ///         <see cref="Archived" /> is belt and braces. jasperfx#784 appends it to a single-stream
+    ///         projection's <c>determineEventTypes()</c>, so on JasperFx 2.65.0+ it already arrives in
+    ///         <c>IncludedEventTypes</c> and this add is a no-op against the same <c>HashSet</c>. It is
+    ///         here because Marten adds it unconditionally too, and because the consequence of it going
+    ///         missing is the same silent class of bug: an async single-stream shard that folds an
+    ///         <c>Archived</c> event is what calls
+    ///         <c>PolecatProjectionStorage.ArchiveStream</c>, so a shard that never sees the marker
+    ///         never archives the stream.
+    ///     </para>
+    ///     <para>
+    ///         Deliberately NOT here: <c>Tombstone</c> (a sequence-gap filler no projection folds),
+    ///         and <c>Deleted</c>/<c>Updated</c>, which are synthetic composite-projection events that
+    ///         are never persisted to <c>pc_events</c> and so can never be filtered out of a load.
+    ///     </para>
+    /// </remarks>
+    [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+        Justification = "Compacted<T> is closed over the projection's aggregate type, which is already rooted by the projection registration itself.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2055:MakeGenericType",
+        Justification = "Compacted<T> has no constraints and its type argument is the registered aggregate type.")]
+    private static IEnumerable<Type> FrameworkMarkerTypes(EventFilterable filtering)
+    {
+        // Scoped to a SINGLE-STREAM aggregate projection, and only there. Both markers are facts
+        // about one stream's own history: Compacted<T> replaces that stream's events, and
+        // maybeArchiveStream returns immediately for any other scope. A subscription or an
+        // EventProjection has no aggregate type to close Compacted<T> over and no fold for either
+        // marker to act on, and widening a MULTI-stream shard's filter would hand it events it has
+        // nothing to do with — the same line jasperfx#784 drew when it put Archived into
+        // determineEventTypes.
+        if (filtering is not IAggregateProjection { Scope: AggregationScope.SingleStream } aggregateProjection)
+        {
+            yield break;
+        }
+
+        yield return typeof(Archived);
+        yield return typeof(Compacted<>).MakeGenericType(aggregateProjection.AggregateType);
     }
 
     /// <summary>


### PR DESCRIPTION
`PolecatEventLoader` builds its `dotnet_type` allow list from the event types a projection declares an `Apply`/`Create` for. `Compacted<T>` is written by the **framework**, not by user code, so it never reaches `IncludedEventTypes` — and a shard with a filtered allow list never saw the compaction marker for a stream it owns.

## Why this is worse than an ordinary dropped event

`CompactStreamAsync` **deletes** the events it folds and writes the marker in place of the last one. The marker is not an extra event beside the history — it is the only thing left of it, and `Compacted<T>.MaybeFastForward` is what restarts a fold from it.

Filter it out and the events it replaced are not filtered too; they are gone from the store entirely. An async shard folding from a null snapshot (a rebuild, or a projection added after compaction) reports an aggregate missing everything before the compaction point, with **no exception and no log line**.

## The observable symptom

`a_filtered_and_an_unfiltered_load_agree_on_a_compacted_stream` is the statement of the bug — two loads over one stream, folded by the same aggregator, disagreeing about what the stream means. Without the fix:

```
Shouldly.ShouldAssertException : filtered.Name
    should be "Destroy the Ring"
    but was  ""
```

and the SQL-path test shows exactly what went missing:

```
    should be [Compacted`1[QuestParty], MembersJoined]
    but was  [MembersJoined]
```

The end-to-end daemon test pins the consequence at the level a user would actually meet it: the shard **persists** a `QuestParty` with `Name=""` and only the post-compaction member, while live aggregation over the identical rows has the full membership. Nothing errors.

## The fix

Widen the allow-list **set**, not either predicate. `_pushedDownTypeNames` is taken from that set on the next line, so one addition covers **both** #550's SQL `dotnet_type in (...)` push-down **and** the client-side fallback that carries an allow list too large to push down. Fixing only the rendered `IN` clause would have left a bug visible solely on stores with more than 2000 event types — which nothing in the suite would have caught. Both paths are pinned by separate tests.

## Covering a category, not one type

`Archived` is admitted alongside `Compacted<T>`. jasperfx#784 already delivers it via `determineEventTypes()`, so that add is a no-op against the same `HashSet` today — but the failure mode if it regressed is identical, since an async shard that never folds `Archived` never calls `PolecatProjectionStorage.ArchiveStream`, and the stream is never archived. Its test passes both before and after, and says so.

Both markers are scoped to `AggregationScope.SingleStream`, matching the line jasperfx#784 drew: widening a *multi*-stream shard's filter would hand it events it has nothing to do with. `Tombstone`, `Deleted` and `Updated` are deliberately excluded — a sequence-gap filler no projection folds, and synthetic composite-projection events that are never persisted and so can never be filtered out of a load. The reasoning is recorded on the method.

## Upstream

Marten patches around the same gap store-locally in `buildEventLoaderFilters`, and **Fisher's loader has the identical omission today** — `FisherEventLoader` builds `_allowedEventTypeNames` straight from `IncludedEventTypes` with nothing added, and nothing in its suite pins it. Two of three stores got this wrong independently, so JasperFx/jasperfx#796 proposes lifting it into `determineEventTypes()` beside `Archived`, where every store would get it for free. The code comment says to delete this when that lands.

## Tests

5 new facts. **Four of the five fail without the fix**; the fifth is the `Archived` guard documenting that upstream already covers it.

Local run (September policy), `Polecat.Tests.Daemon` + `Events` + `Compliance` + `Projections`:

```
total: 1151   failed: 0   succeeded: 1145   skipped: 6   duration: 12m 49s
```

The 6 skips are pre-existing.

Fixes #557

🤖 Generated with [Claude Code](https://claude.com/claude-code)
