### PR TITLE
Bump JasperFx to 2.66.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -408,14 +408,14 @@
              Worth recording for the next reader: Fisher was the store that ran these suites first
              and filed both #784 and #788. Polecat inherits both fixes without having had to
              diagnose either, which is the whole argument for the shared suites. -->
-        <PackageVersion Include="JasperFx" Version="2.66.0" />
-        <PackageVersion Include="JasperFx.Events" Version="2.66.0" />
+        <PackageVersion Include="JasperFx" Version="2.66.1" />
+        <PackageVersion Include="JasperFx.Events" Version="2.66.1" />
         <!--
              The shared cross-store event sourcing compliance suites. Source-only package: the
              suites compile inside Polecat.Tests so JasperFx's aggregate source generator binds
              Polecat's own session types.
         -->
-        <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.66.0" />
+        <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.66.1" />
         <!-- Pin the sibling JasperFx packages for parity with Marten 9's matrix
              even though Polecat doesn't currently reference them directly —
              keeps the lockstep matrix coherent when transitive resolution
@@ -423,7 +423,7 @@
              RuntimeCompiler 5.x line is the active continuation of the 4.x
              lineage; do not pin against the parallel stale 2.0.x series. -->
         <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.66.0" />
+        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.66.1" />
         <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
@@ -587,7 +587,7 @@
         <PackageVersion Include="Vogen" Version="7.0.0" />
 
         <!-- Source generators (matched to JasperFx.Events above) -->
-        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.66.0" />
+        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.66.1" />
 
         <!-- Build automation -->
         <PackageVersion Include="Nuke.Common" Version="9.0.4" />

--- a/src/Polecat.Tests/Daemon/compaction_marker_allow_list_tests.cs
+++ b/src/Polecat.Tests/Daemon/compaction_marker_allow_list_tests.cs
@@ -206,18 +206,59 @@ public class compaction_marker_allow_list_tests : OneOffConfigurationsContext
     /// <summary>
     ///     The registered form of the projection the daemon would hand the loader: a real
     ///     <see cref="IAggregateProjection" /> over <see cref="QuestParty" />, with
-    ///     <c>IncludedEventTypes</c> filled from its conventional methods exactly as registration does.
-    ///     Notably absent from that list, and the whole point: <c>Compacted&lt;QuestParty&gt;</c>.
+    ///     <c>IncludedEventTypes</c> filled from its conventional methods exactly as registration does
+    ///     — and then the compaction marker taken back out, which is what every test below is written
+    ///     against.
     /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         The marker used to be absent from that list on its own, and the absence was the whole
+    ///         premise: #557 is about the daemon loader's allow list admitting a type the projection
+    ///         never declares. JasperFx 2.66.1 (jasperfx#796) closed the same gap one level up, by
+    ///         appending <c>Compacted&lt;TDoc&gt;</c> to a single-stream projection's event types in
+    ///         <c>JasperFxSingleStreamProjectionBase.determineEventTypes()</c> for every store at once.
+    ///     </para>
+    ///     <para>
+    ///         So the premise no longer holds by default — and taking it at face value would quietly
+    ///         retire this suite, because every test here would then pass on the <em>upstream</em> fix
+    ///         while saying nothing about Polecat's. Stripping the marker back out keeps the loader's
+    ///         own allow list under test, which is the belt to jasperfx#796's braces and the thing that
+    ///         still has to work for a projection type the upstream rule does not reach.
+    ///         <see cref="the_upstream_event_type_list_now_carries_the_marker_too" /> pins the new
+    ///         upstream half.
+    ///     </para>
+    /// </remarks>
     private static SingleStreamProjection<QuestParty, Guid> SnapshotProjection()
     {
         var projection = new SingleStreamProjection<QuestParty, Guid>();
         projection.AssembleAndAssertValidity();
 
+        projection.IncludedEventTypes.Remove(typeof(Compacted<QuestParty>));
+
         projection.IncludedEventTypes.ShouldNotBeEmpty();
         projection.IncludedEventTypes.ShouldNotContain(typeof(Compacted<QuestParty>));
 
         return projection;
+    }
+
+    /// <summary>
+    ///     The other half of the same guarantee, now that JasperFx 2.66.1 supplies it: a single-stream
+    ///     projection's declared event types carry the compaction marker — and the archival marker —
+    ///     without the store doing anything. jasperfx#796.
+    /// </summary>
+    [Fact]
+    public void the_upstream_event_type_list_now_carries_the_marker_too()
+    {
+        var projection = new SingleStreamProjection<QuestParty, Guid>();
+        projection.AssembleAndAssertValidity();
+
+        projection.IncludedEventTypes.ShouldContain(typeof(Compacted<QuestParty>));
+        projection.IncludedEventTypes.ShouldContain(typeof(Archived));
+
+        // and exactly once each: the append used to be re-applied on every evaluation, past the base's
+        // own Distinct(), and reached the generated SQL as a repeated IN member
+        projection.IncludedEventTypes.Count(x => x == typeof(Compacted<QuestParty>)).ShouldBe(1);
+        projection.IncludedEventTypes.Count(x => x == typeof(Archived)).ShouldBe(1);
     }
 
     /// <summary>


### PR DESCRIPTION
Moves all five JasperFx pins from 2.66.0 to 2.66.1 in `Directory.Packages.props`.

Prompted by the Wolverine 6.35 cut, which pins JasperFx 2.66.1 — a store compiled against 2.66.0
would roll forward at runtime, but the store's own floor is what a standalone Polecat consumer gets,
and there is a reason to want it here.

## Why 2.66.1 matters for Polecat specifically

jasperfx#796 appends `Compacted<TDoc>` to a single-stream projection's event types in
`JasperFxSingleStreamProjectionBase.determineEventTypes()` — the shared fix for **polecat#557**. Its
own commentary names the failure:

> a filtered async shard catching up over a compacted stream from a null snapshot folds only what was
> appended *after* compaction and persists an aggregate missing everything before it, with no
> exception and no log line, while an unfiltered shard over the identical rows disagrees.

The same release also dedupes that append, which had been reaching the generated SQL as a repeated
`IN` member and a repeated parameter slot.

No new interface members between 2.66.0 and 2.66.1, so this is a floor move rather than a port.

## The four tests this moved, and why not by flipping an assertion

`compaction_marker_allow_list_tests` exists for **#557**: the daemon loader's `dotnet_type` allow
list is built from the event types a projection declares, `Compacted<T>` is not one of them, and the
fix admits it anyway. Its helper asserted that premise outright:

```csharp
projection.IncludedEventTypes.ShouldNotContain(typeof(Compacted<QuestParty>));
```

jasperfx#796 makes that false — the marker is now in the list, upstream, for every store. So four
tests went red on the premise rather than on any behaviour.

Flipping the assertion to `ShouldContain` would have quietly **retired this suite**: every test in it
would then be passing on the *upstream* fix while saying nothing about Polecat's own. Instead the
helper strips the marker back out, restoring exactly the shape those tests were written against, so
the loader's allow list stays under test — the belt to jasperfx#796's braces, and the half that still
has to work for a projection the upstream rule does not reach.

The new upstream half gets its own test,
`the_upstream_event_type_list_now_carries_the_marker_too`, which also pins that the marker appears
**exactly once** — the duplicate `IN` member 2.66.1 deduplicated.

## Verification

`dotnet build polecat.slnx -c Release` clean.

| Suite | net9.0 | net10.0 |
|---|---|---|
| `Polecat.Tests` | 2563 passed, 6 skipped, **0 failed** | — |
| `Polecat.AspNetCore.Testing` | 80 passed | 80 passed |
| `Polecat.EntityFrameworkCore.Tests` | 39 passed | 39 passed |

`Polecat.Tests` was measured **twice, cleanly, and agreed exactly** (2563/6/2569 both times). Worth
saying why that mattered: a first sweep reported 18 failures and a total of 2577, but I had started a
second run over the same SQL Server while it was going, and these suites share one database — the
schema-drop and FK errors in it are two runs tearing down each other's tables, and the inflated total
is leftover state feeding data-driven cases. That measurement is discarded, not reconciled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
