### PR TITLE
Restore the loader's compaction-marker patch, kept as belt and braces (gh-568)

### DIFF
--- a/src/Polecat.Tests/Daemon/compaction_marker_allow_list_tests.cs
+++ b/src/Polecat.Tests/Daemon/compaction_marker_allow_list_tests.cs
@@ -10,13 +10,10 @@ using Polecat.Tests.Projections;
 namespace Polecat.Tests.Daemon;
 
 /// <summary>
-///     #557 / #568 — a filtered async shard has to see <see cref="Compacted{T}" /> for a stream it
-///     owns. #557 fixed that store-locally, by widening the daemon loader's <c>dotnet_type</c> allow
-///     list past the event types the projection declares an <c>Apply</c>/<c>Create</c> for.
-///     jasperfx#796 (JasperFx 2.66.1) then closed the same gap one level up, appending the marker to
-///     a single-stream projection's own event types in
-///     <c>JasperFxSingleStreamProjectionBase.determineEventTypes()</c> for every store at once, and
-///     #568 removed the store-local patch as redundant.
+///     #557 — the daemon loader's <c>dotnet_type</c> allow list is built from the event types a
+///     projection declares an <c>Apply</c>/<c>Create</c> for, and <see cref="Compacted{T}" /> is not one
+///     of them. Nothing upstream in JasperFx adds it for the store, so before the fix a projection with
+///     a declared event list never saw the compaction marker for a stream it owns.
 /// </summary>
 /// <remarks>
 ///     <para>
@@ -29,18 +26,8 @@ namespace Polecat.Tests.Daemon;
 ///     <para>
 ///         <see cref="a_filtered_and_an_unfiltered_load_agree_on_a_compacted_stream" /> is the
 ///         statement of the bug: two loads over one stream, folded by the same aggregator, disagreeing
-///         about what the stream means. It holds for a different REASON after #568 than before it, and
-///         that is the point of keeping it — the ruling outlives whichever layer enforces it.
-///     </para>
-///     <para>
-///         The rest are not made redundant by the upstream fix either. What jasperfx#796 guarantees is
-///         that the marker reaches <c>IncludedEventTypes</c>;
-///         <see cref="the_upstream_event_type_list_now_carries_the_marker_too" /> is the pin for that,
-///         and everything else here depends on it. What it says nothing about is what Polecat's loader
-///         then DOES with that list — and there are two answers, because #550's push-down bows out
-///         above SQL Server's parameter ceiling and hands the filtering to a client-side check. Both
-///         are Polecat's own code, nothing else pins them, and a marker dropped by either one fails
-///         exactly as silently as it did before #557.
+///         about what the stream means. The rest pin the two filtering paths (#550's SQL push-down and
+///         the retained client-side fallback) and the end-to-end daemon consequence.
 ///     </para>
 /// </remarks>
 public class compaction_marker_allow_list_tests : OneOffConfigurationsContext
@@ -107,9 +94,9 @@ public class compaction_marker_allow_list_tests : OneOffConfigurationsContext
     ///     with very many event types still broken, and nothing else in the suite would say so.
     /// </summary>
     /// <remarks>
-    ///     The pushed-down parameter array is taken FROM the allow-list set rather than built beside
-    ///     it, which is what keeps the two paths agreeing about which types are admitted. This test is
-    ///     what stops that being refactored apart.
+    ///     The fix is applied to the allow-list SET, from which the pushed-down parameter array is
+    ///     taken, which is what makes one addition cover both paths. This test is what stops that being
+    ///     refactored apart.
     /// </remarks>
     [Fact]
     public async Task the_marker_survives_the_client_side_fallback_filter()
@@ -162,12 +149,10 @@ public class compaction_marker_allow_list_tests : OneOffConfigurationsContext
     }
 
     /// <summary>
-    ///     The sibling marker, and the reason this is about a CATEGORY rather than one type.
-    ///     <see cref="Archived" /> reaches a single-stream projection's declared event types from
-    ///     JasperFx 2.65.0 (jasperfx#784), a release ahead of <see cref="Compacted{T}" /> — which is
-    ///     why #557's local patch admitted it redundantly, and why #568 dropped both halves at once
-    ///     rather than only the one the newer release covered. It is
-    ///     pinned here because if the upstream behaviour ever goes away the failure mode is the same
+    ///     The sibling marker, and the reason the fix admits a CATEGORY rather than one type.
+    ///     <see cref="Archived" /> reaches a single-stream projection's declared event types on its own
+    ///     from JasperFx 2.65.0 (jasperfx#784), so this passed before the fix as well — it is here to
+    ///     pin that, because if the upstream behaviour ever goes away the failure mode is the same
     ///     silent one: an async shard that never folds the marker never calls
     ///     <c>PolecatProjectionStorage.ArchiveStream</c>, and the stream is never archived.
     /// </summary>
@@ -221,22 +206,33 @@ public class compaction_marker_allow_list_tests : OneOffConfigurationsContext
     /// <summary>
     ///     The registered form of the projection the daemon would hand the loader: a real
     ///     <see cref="IAggregateProjection" /> over <see cref="QuestParty" />, with
-    ///     <c>IncludedEventTypes</c> filled from its conventional methods exactly as registration does.
+    ///     <c>IncludedEventTypes</c> filled from its conventional methods exactly as registration does
+    ///     — and then the compaction marker taken back out, which is what every test below is written
+    ///     against.
     /// </summary>
     /// <remarks>
     ///     <para>
-    ///         The list carries <see cref="Compacted{T}" /> because JasperFx 2.66.1 puts it there —
-    ///         jasperfx#796, in <c>JasperFxSingleStreamProjectionBase.determineEventTypes()</c>. That
-    ///         used not to be true, and #557's fix was Polecat adding the marker to the loader's allow
-    ///         list itself; #568 deleted that patch once the upstream rule covered exactly the same
-    ///         scope. The assertion below is the seam: if the marker ever stops arriving, every test in
-    ///         this class fails HERE, naming the cause, rather than further down where the symptom is a
-    ///         wrongly-folded aggregate.
+    ///         The marker used to be absent from that list on its own, and the absence was the whole
+    ///         premise: #557 is about the daemon loader's allow list admitting a type the projection
+    ///         never declares. JasperFx 2.66.1 (jasperfx#796) closed the same gap one level up, by
+    ///         appending <c>Compacted&lt;TDoc&gt;</c> to a single-stream projection's event types in
+    ///         <c>JasperFxSingleStreamProjectionBase.determineEventTypes()</c> for every store at once.
     ///     </para>
     ///     <para>
-    ///         What the tests below still say, with the marker supplied rather than patched in, is that
-    ///         Polecat's own filtering does not drop it again — separately on each of the two paths
-    ///         #550 can take. That is store-local code and the upstream fix does not reach it.
+    ///         So the premise no longer holds by default — and taking it at face value would quietly
+    ///         retire this suite, because every test here would then pass on the <em>upstream</em> fix
+    ///         while saying nothing about Polecat's. Stripping the marker back out keeps the loader's
+    ///         own allow list under test, which is the belt to jasperfx#796's braces and the thing that
+    ///         still has to work for a projection type the upstream rule does not reach.
+    ///         <see cref="the_upstream_event_type_list_now_carries_the_marker_too" /> pins the new
+    ///         upstream half.
+    ///     </para>
+    ///     <para>
+    ///         #568 asked for the opposite — drop the local patch now that the upstream one covers
+    ///         it — and was resolved the other way: the patch is kept as belt and braces, so this
+    ///         helper is kept with it. The two decisions are the same decision. If the loader's
+    ///         patch is ever retired after all, this strip goes with it and the guard below
+    ///         inverts to <c>ShouldContain</c>.
     ///     </para>
     /// </remarks>
     private static SingleStreamProjection<QuestParty, Guid> SnapshotProjection()
@@ -244,7 +240,10 @@ public class compaction_marker_allow_list_tests : OneOffConfigurationsContext
         var projection = new SingleStreamProjection<QuestParty, Guid>();
         projection.AssembleAndAssertValidity();
 
-        projection.IncludedEventTypes.ShouldContain(typeof(Compacted<QuestParty>));
+        projection.IncludedEventTypes.Remove(typeof(Compacted<QuestParty>));
+
+        projection.IncludedEventTypes.ShouldNotBeEmpty();
+        projection.IncludedEventTypes.ShouldNotContain(typeof(Compacted<QuestParty>));
 
         return projection;
     }

--- a/src/Polecat/Events/Daemon/PolecatEventLoader.cs
+++ b/src/Polecat/Events/Daemon/PolecatEventLoader.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using JasperFx.Events;
+using JasperFx.Events.Aggregation;
 using JasperFx.Events.Daemon;
 using JasperFx.Events.Projections;
 using Microsoft.Data.SqlClient;
@@ -71,23 +72,7 @@ internal class PolecatEventLoader : IEventLoader
         // reads only that tenant's bounded sequence range, not the whole store. Null = store-global.
         _tenantFilter = tenantFilter;
 
-        // Build an allow list of dotnet_type names from the included event types.
-        //
-        // #568: this list is taken AS GIVEN — the framework's own markers are no longer added on top
-        // of it here. #557 patched Compacted<T> and Archived in locally because a projection declares
-        // no Apply/Create for either and they were therefore absent from IncludedEventTypes;
-        // jasperfx#784 and jasperfx#796 (JasperFx 2.65.0 / 2.66.1) append both in
-        // JasperFxSingleStreamProjectionBase.determineEventTypes() instead, for every store at once.
-        // Polecat's SingleStreamProjection<TDoc, TId> derives from that base and every registration
-        // path here closes over it, so the upstream rule covers the whole scope the patch did, and
-        // re-adding the markers below would be dead weight against the same HashSet.
-        //
-        // Why the markers have to reach the list at all, in case this is ever tempting to "simplify":
-        // CompactStreamAsync DELETES the events it folds and leaves Compacted<T> in their place, so
-        // the marker is not an extra event beside the history — it IS the history. A shard that
-        // filters it out folds only what was appended after compaction and persists an aggregate
-        // missing everything before it, with no error and no log line.
-        // compaction_marker_allow_list_tests pins both halves.
+        // Build an allow list of dotnet_type names from the included event types
         if (filtering?.IncludedEventTypes is { Count: > 0 } includedTypes)
         {
             _allowedDotNetTypes = new HashSet<string>(StringComparer.Ordinal);
@@ -95,6 +80,16 @@ internal class PolecatEventLoader : IEventLoader
             {
                 var mapping = events.EventMappingFor(type);
                 _allowedDotNetTypes.Add(mapping.DotNetTypeName);
+            }
+
+            // #557: and the framework's own markers, which a projection never declares a handler for
+            // and which are therefore absent from IncludedEventTypes. Widening the SET here rather
+            // than either predicate is deliberate: _pushedDownTypeNames is taken from it just below,
+            // so one addition covers BOTH the SQL push-down and the client-side fallback that carries
+            // an allow list too large to push down.
+            foreach (var markerType in FrameworkMarkerTypes(filtering))
+            {
+                _allowedDotNetTypes.Add(events.EventMappingFor(markerType).DotNetTypeName);
             }
 
             if (_allowedDotNetTypes.Count <= MaximumPushedDownTypeNames)
@@ -116,6 +111,83 @@ internal class PolecatEventLoader : IEventLoader
         }
 
         _commandText = BuildCommandText();
+    }
+
+    /// <summary>
+    ///     #557: the event types the FRAMEWORK writes into a stream, which no projection declares an
+    ///     <c>Apply</c>/<c>Create</c> method for and which therefore never reach
+    ///     <see cref="EventFilterable.IncludedEventTypes" /> on their own. A declared allow list is a
+    ///     statement about the projection's <em>domain</em> events; silently reading it as a statement
+    ///     about the whole stream is what makes a filtered shard diverge from an unfiltered one.
+    ///     Mirrors Marten's <c>DocumentStore.EventStore.buildEventLoaderFilters</c>, which patches
+    ///     around the same gap store-locally.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         <see cref="Compacted{T}" /> is the one that bites. <c>CompactStreamAsync</c> folds a
+    ///         stream's history into a snapshot, DELETES the folded events and leaves the marker in
+    ///         their place — so the marker is not an extra event beside the history, it <em>is</em> the
+    ///         history. <c>Compacted&lt;T&gt;.MaybeFastForward</c> is what restarts a fold from that
+    ///         snapshot. Filter the marker out and the events it replaced are not filtered too, they are
+    ///         gone from the store entirely: the shard folds only what was appended after compaction
+    ///         and reports an aggregate missing everything before it, with no error anywhere.
+    ///     </para>
+    ///     <para>
+    ///         <see cref="Archived" /> is belt and braces. jasperfx#784 appends it to a single-stream
+    ///         projection's <c>determineEventTypes()</c>, so on JasperFx 2.65.0+ it already arrives in
+    ///         <c>IncludedEventTypes</c> and this add is a no-op against the same <c>HashSet</c>. It is
+    ///         here because Marten adds it unconditionally too, and because the consequence of it going
+    ///         missing is the same silent class of bug: an async single-stream shard that folds an
+    ///         <c>Archived</c> event is what calls
+    ///         <c>PolecatProjectionStorage.ArchiveStream</c>, so a shard that never sees the marker
+    ///         never archives the stream.
+    ///     </para>
+    ///     <para>
+    ///         Deliberately NOT here: <c>Tombstone</c> (a sequence-gap filler no projection folds),
+    ///         and <c>Deleted</c>/<c>Updated</c>, which are synthetic composite-projection events that
+    ///         are never persisted to <c>pc_events</c> and so can never be filtered out of a load.
+    ///     </para>
+    ///     <para>
+    ///         <b>#568: this method is KEPT, not retired.</b> It used to end with "delete this when
+    ///         jasperfx#796 lands". jasperfx#796 landed — <c>determineEventTypes()</c> now appends
+    ///         <see cref="Compacted{T}" /> beside the <c>Archived</c> that jasperfx#784 already put
+    ///         there, so on JasperFx 2.66.1+ both markers arrive in <c>IncludedEventTypes</c> on their
+    ///         own and every add below is a no-op against the same <c>HashSet</c>. It stays anyway,
+    ///         deliberately, as the belt to that fix's braces: the cost is two set adds per loader
+    ///         construction, and the failure it guards is silent in the worst way an event store can
+    ///         be — a shard that reports a confidently wrong aggregate and logs nothing. That trade
+    ///         does not need re-litigating, so do not delete this on the grounds that it is redundant.
+    ///         It is redundant, and that is the point.
+    ///     </para>
+    ///     <para>
+    ///         What it still covers on its own: a single-stream <see cref="IAggregateProjection" />
+    ///         that does not derive from <c>JasperFxSingleStreamProjectionBase</c>, which the upstream
+    ///         rule cannot reach. Nothing in Polecat is shaped that way today — every registration
+    ///         path closes over <c>SingleStreamProjection&lt;TDoc, TId&gt;</c> — but the scope check
+    ///         below is written against the interface, not the base class, so a consumer's own
+    ///         implementation is covered here and would not be upstream.
+    ///     </para>
+    /// </remarks>
+    [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+        Justification = "Compacted<T> is closed over the projection's aggregate type, which is already rooted by the projection registration itself.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2055:MakeGenericType",
+        Justification = "Compacted<T> has no constraints and its type argument is the registered aggregate type.")]
+    private static IEnumerable<Type> FrameworkMarkerTypes(EventFilterable filtering)
+    {
+        // Scoped to a SINGLE-STREAM aggregate projection, and only there. Both markers are facts
+        // about one stream's own history: Compacted<T> replaces that stream's events, and
+        // maybeArchiveStream returns immediately for any other scope. A subscription or an
+        // EventProjection has no aggregate type to close Compacted<T> over and no fold for either
+        // marker to act on, and widening a MULTI-stream shard's filter would hand it events it has
+        // nothing to do with — the same line jasperfx#784 drew when it put Archived into
+        // determineEventTypes.
+        if (filtering is not IAggregateProjection { Scope: AggregationScope.SingleStream } aggregateProjection)
+        {
+            yield break;
+        }
+
+        yield return typeof(Archived);
+        yield return typeof(Compacted<>).MakeGenericType(aggregateProjection.AggregateType);
     }
 
     /// <summary>


### PR DESCRIPTION
Follow-up to #574, which merged before its second commit landed and so took only the half of #568 that **deleted** `PolecatEventLoader`'s framework-marker patch. The call is to keep it. This puts it back.

## Why keep something redundant

It *is* redundant. jasperfx#784 (2.65.0) and jasperfx#796 (2.66.1) append `Archived` and `Compacted<TDoc>` in `JasperFxSingleStreamProjectionBase.determineEventTypes()`, and every Polecat registration path closes over `SingleStreamProjection<TDoc, TId>`, which derives from that base. So on the versions we ship against, every add the patch makes is a no-op against the same `HashSet`.

The cost of keeping it is two set adds per loader construction. The failure it guards is the silent kind: a filtered async shard that never sees `Compacted<T>` folds a compacted stream from nothing and persists an aggregate missing its entire pre-compaction history — no exception, no log line, just a confidently wrong answer. `CompactStreamAsync` **deletes** the events it folds, so the marker is not an extra event beside the history, it *is* the history. That asymmetry is what makes belt and braces the right trade here.

It also still covers one case alone: the scope check is written against `IAggregateProjection`, not the base class, so a consumer's own single-stream implementation is caught here and would not be caught upstream. Nothing in Polecat is shaped that way today.

## The one thing that does not go back

The doc comment used to end with *"delete this when that lands"*. It has landed. Left as-is that sentence is a standing instruction to redo this deletion on exactly the grounds already weighed and rejected — which is how #574 happened. It now records the decision and the reasoning instead.

`compaction_marker_allow_list_tests` likewise goes back to stripping the marker out of the projection's declared types. That is the same decision expressed in the suite: it is what holds the loader's allow list under test, rather than letting every test in the class pass on the upstream fix while saying nothing about Polecat's. Its doc now notes that #568 asked the opposite and how the strip and the patch move together if the patch is ever retired after all.

## Verification

`compaction_marker_allow_list_tests` 6/6 on net10.0; solution builds clean. The diff against pre-#574 `main` is doc comments only — the code is byte-identical to what shipped before #574.

🤖 Generated with [Claude Code](https://claude.com/claude-code)