### PR TITLE
Adopt JasperFx 2.67.0 and honor EventQuery.TagValues (gh-575)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -408,14 +408,14 @@
              Worth recording for the next reader: Fisher was the store that ran these suites first
              and filed both #784 and #788. Polecat inherits both fixes without having had to
              diagnose either, which is the whole argument for the shared suites. -->
-        <PackageVersion Include="JasperFx" Version="2.66.1" />
-        <PackageVersion Include="JasperFx.Events" Version="2.66.1" />
+        <PackageVersion Include="JasperFx" Version="2.67.0" />
+        <PackageVersion Include="JasperFx.Events" Version="2.67.0" />
         <!--
              The shared cross-store event sourcing compliance suites. Source-only package: the
              suites compile inside Polecat.Tests so JasperFx's aggregate source generator binds
              Polecat's own session types.
         -->
-        <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.66.1" />
+        <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.67.0" />
         <!-- Pin the sibling JasperFx packages for parity with Marten 9's matrix
              even though Polecat doesn't currently reference them directly —
              keeps the lockstep matrix coherent when transitive resolution
@@ -423,7 +423,7 @@
              RuntimeCompiler 5.x line is the active continuation of the 4.x
              lineage; do not pin against the parallel stale 2.0.x series. -->
         <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.66.1" />
+        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.67.0" />
         <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
@@ -587,7 +587,7 @@
         <PackageVersion Include="Vogen" Version="7.0.0" />
 
         <!-- Source generators (matched to JasperFx.Events above) -->
-        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.66.1" />
+        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.67.0" />
 
         <!-- Build automation -->
         <PackageVersion Include="Nuke.Common" Version="9.0.4" />

--- a/src/Polecat.Tests/Events/tag_name_resolution_tests.cs
+++ b/src/Polecat.Tests/Events/tag_name_resolution_tests.cs
@@ -1,0 +1,150 @@
+using JasperFx.Events;
+using JasperFx.Events.Aggregation;
+using JasperFx.Descriptors;
+using JasperFx.Events.Tags;
+using Polecat.Tests.Harness;
+
+namespace Polecat.Tests.Events;
+
+/// <summary>
+///     #575 / jasperfx#801 — how a tag NAME resolves, on the two Polecat paths that take one as a
+///     string: the dictionary <c>QueryByTagsAsync</c> overload and <c>EventQuery.TagValues</c>.
+/// </summary>
+/// <remarks>
+///     <para>
+///         Both now go through the shared <c>TagTypeRegistrationExtensions.RequireByTagName</c>, and
+///         that sharing is the point of these tests. The name matching <em>is</em> the contract: a
+///         caller holding a store descriptor and a name/value pair cannot discover which spelling a
+///         given engine accepts, so a store matching only the CLR name while its sibling also matched
+///         the table suffix makes the same query answer differently per store — as an
+///         <see cref="ArgumentException" /> at runtime, per store.
+///     </para>
+///     <para>
+///         That is not hypothetical. Polecat's dictionary overload accepted either spelling and
+///         compared values case-insensitively; Marten's copy of the same overload matched the CLR name
+///         only and compared case-sensitively. The divergence survived because the dictionary overload
+///         has no compliance coverage at all — <c>EventQueryCompliance</c> reaches
+///         <c>EventQuery.TagValues</c>, not this. So these are the local pin for the path the shared
+///         suite cannot see, and Polecat's behaviour is what the contract was standardized to.
+///     </para>
+/// </remarks>
+public class tag_name_resolution_tests : OneOffConfigurationsContext
+{
+    private void ConfigureStoreWithTags()
+    {
+        ConfigureStore(opts =>
+        {
+            opts.Events.RegisterTagType<StudentId>("student")
+                .ForAggregate<StudentCourseEnrollment>();
+            opts.Events.RegisterTagType<CourseId>("course")
+                .ForAggregate<StudentCourseEnrollment>();
+        });
+    }
+
+    private async Task<StudentId> SeedTaggedEventAsync()
+    {
+        ConfigureStoreWithTags();
+        await theDatabase.ApplyAllConfiguredChangesToDatabaseAsync(ct: TestContext.Current.CancellationToken);
+
+        var studentId = new StudentId(Guid.NewGuid());
+
+        await using var session = theStore.LightweightSession();
+        var e = session.Events.BuildEvent(new StudentEnrolled("Alice", "Math"));
+        e.WithTag(studentId);
+        session.Events.Append(Guid.NewGuid(), e);
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        return studentId;
+    }
+
+    /// <summary>
+    ///     Both spellings of the same tag type — the CLR simple name and the registered table suffix —
+    ///     reach the same rows, on both paths, in any casing.
+    /// </summary>
+    [Theory]
+    [InlineData("StudentId")]
+    [InlineData("studentid")]
+    [InlineData("STUDENTID")]
+    [InlineData("student")]
+    [InlineData("Student")]
+    public async Task either_spelling_of_a_tag_name_resolves_in_any_casing(string tagName)
+    {
+        var studentId = await SeedTaggedEventAsync();
+        var tags = new Dictionary<string, string> { [tagName] = studentId.Value.ToString() };
+
+        var viaDictionary = new List<EventRecord>();
+        await foreach (var e in ((IEventStore)theStore).QueryByTagsAsync(
+                           tags, JasperFx.StorageConstants.DefaultTenantId, TestContext.Current.CancellationToken))
+        {
+            viaDictionary.Add(e);
+        }
+
+        var viaQuery = await ((IEventStore)theStore).OpenReadOnlyEventStore().QueryEventsAsync(
+            new EventQuery { TagValues = { [tagName] = studentId.Value.ToString() }, PageSize = 100 },
+            TestContext.Current.CancellationToken);
+
+        viaDictionary.Count.ShouldBe(1);
+        viaQuery.TotalCount.ShouldBe(1);
+        viaQuery.Events.Count.ShouldBe(1);
+    }
+
+    /// <summary>
+    ///     An unregistered name is an error on both paths, not an empty answer. "That tag type does not
+    ///     exist here" and "no event carries that tag" must not read alike to a caller filtering events
+    ///     — the second is a fact about the data, the first is a bug in the query.
+    /// </summary>
+    [Fact]
+    public async Task an_unregistered_tag_name_is_refused_by_both_paths_and_names_what_is_registered()
+    {
+        await SeedTaggedEventAsync();
+        var tags = new Dictionary<string, string> { ["Nonexistent"] = "whatever" };
+
+        var fromDictionary = await Should.ThrowAsync<ArgumentException>(async () =>
+        {
+            await foreach (var _ in ((IEventStore)theStore).QueryByTagsAsync(
+                               tags, JasperFx.StorageConstants.DefaultTenantId, TestContext.Current.CancellationToken))
+            {
+            }
+        });
+
+        var fromQuery = await Should.ThrowAsync<ArgumentException>(
+            () => ((IEventStore)theStore).OpenReadOnlyEventStore().QueryEventsAsync(
+                new EventQuery { TagValues = { ["Nonexistent"] = "whatever" }, PageSize = 100 },
+                TestContext.Current.CancellationToken));
+
+        // Both list the registered types, in both spellings, so the caller can fix the call from the
+        // message alone rather than going to read the store's configuration.
+        foreach (var message in new[] { fromDictionary.Message, fromQuery.Message })
+        {
+            message.ShouldContain("Nonexistent");
+            message.ShouldContain(nameof(StudentId));
+            message.ShouldContain("student");
+        }
+    }
+
+    /// <summary>
+    ///     The two tag members are alternative spellings of one filter, not a combination, so supplying
+    ///     both is refused rather than silently resolved in favour of whichever the store checks first.
+    ///     Free from <c>EventQuery.AssertIsWellFormed()</c>, which <c>AssertFiltersAreSupported</c>
+    ///     calls first thing — this pins that Polecat's call site actually reaches it.
+    /// </summary>
+    [Fact]
+    public async Task supplying_both_tag_spellings_is_refused()
+    {
+        var studentId = await SeedTaggedEventAsync();
+
+        var query = new EventQuery
+        {
+            TagValues = { ["StudentId"] = studentId.Value.ToString() },
+            TagConditions = EventTagQuerySpec.From(new EventTagQuery().Or<StudentEnrolled, StudentId>(studentId)),
+            PageSize = 100
+        };
+
+        var ex = await Should.ThrowAsync<ArgumentException>(
+            () => ((IEventStore)theStore).OpenReadOnlyEventStore()
+                .QueryEventsAsync(query, TestContext.Current.CancellationToken));
+
+        ex.Message.ShouldContain(nameof(EventQuery.TagConditions));
+        ex.Message.ShouldContain(nameof(EventQuery.TagValues));
+    }
+}

--- a/src/Polecat/DocumentStore.EventStoreExplorer.cs
+++ b/src/Polecat/DocumentStore.EventStoreExplorer.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Text.Json;
 using JasperFx.Descriptors;
 using JasperFx.Events;
+using JasperFx.Events.Tags;
 using JasperFx.Events.Daemon;
 using JasperFx.Events.Projections;
 using Microsoft.Data.SqlClient;
@@ -227,15 +228,13 @@ public partial class DocumentStore
         var idx = 0;
         foreach (var (tagName, tagValue) in tags)
         {
-            var registration = registered.FirstOrDefault(r =>
-                string.Equals(r.TagType.Name, tagName, StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(r.TableSuffix, tagName, StringComparison.OrdinalIgnoreCase));
-            if (registration == null)
-            {
-                throw new ArgumentException(
-                    $"Tag type '{tagName}' is not registered on this event store. Registered tag types: {string.Join(", ", registered.Select(t => t.TagType.Name))}",
-                    nameof(tags));
-            }
+            // #575: resolved through the shared matcher rather than an inline copy of it. Polecat's
+            // behaviour here — CLR simple name OR registered table suffix, case-insensitively — is
+            // what jasperfx#801 standardized on, but Marten's copy of this same overload matched the
+            // CLR name only and compared values case-sensitively, and the divergence survived because
+            // the dictionary overload has no compliance coverage. Sharing the matcher is what stops
+            // the two drifting apart again, here and in ApplyTagValues.
+            var registration = registered.RequireByTagName(tagName, nameof(tags));
 
             if (idx > 0) sb.Append(" AND ");
 

--- a/src/Polecat/Events/Linq/EventLinqQueryProvider.cs
+++ b/src/Polecat/Events/Linq/EventLinqQueryProvider.cs
@@ -103,7 +103,7 @@ internal class EventLinqQueryProvider : IPolecatAsyncQueryProvider
             // event query is refused rather than ignored, exactly as it is over a hard-delete
             // document type.
             SoftDeleteTarget.NeverSoftDeleted("The event store"),
-            _isAllEvents ? [new HasTagParser(_events)] : null);
+            _isAllEvents ? [new HasTagParser(_events), new HasTagValueParser(_events)] : null);
         parser.Parse(expression);
 
         ApplySingleValueMode(parser);

--- a/src/Polecat/Events/Linq/HasTagParser.cs
+++ b/src/Polecat/Events/Linq/HasTagParser.cs
@@ -56,6 +56,62 @@ internal class HasTagParser : IMethodCallParser
 }
 
 /// <summary>
+///     Compiles <see cref="LinqExtensions.HasTagValue{TTag}" /> — the lossy name/value tag match behind
+///     <c>EventQuery.TagValues</c> (jasperfx#801 / polecat#575) — into the same correlated
+///     <c>seq_id IN (SELECT …)</c> shape <see cref="HasTagParser" /> emits, differing only in the
+///     comparison: the stored value is rendered to <c>nvarchar</c> and compared case-insensitively,
+///     because the caller supplied a string and there is no typed value to compare.
+/// </summary>
+/// <remarks>
+///     A sub-select rather than a join, for the same reason the DCB path uses one: an event carrying
+///     the tag twice must read back once, or <c>PagedEvents.TotalCount</c> counts condition hits
+///     instead of distinct events and paging walks a longer list than it reports.
+/// </remarks>
+internal class HasTagValueParser : IMethodCallParser
+{
+    private readonly EventGraph _events;
+
+    public HasTagValueParser(EventGraph events)
+    {
+        _events = events;
+    }
+
+    public bool Matches(MethodCallExpression expression)
+    {
+        return expression.Method.Name == nameof(LinqExtensions.HasTagValue)
+               && expression.Method.DeclaringType == typeof(LinqExtensions);
+    }
+
+    public ISqlFragment Parse(IMemberResolver memberFactory, MethodCallExpression expression)
+    {
+        var tagType = expression.Method.GetGenericArguments()[0];
+        var value = WhereClauseParser.ExtractValue(expression.Arguments[^1]) as string
+                    ?? throw new ArgumentException("HasTagValue() requires a non-null tag value.",
+                        nameof(expression));
+
+        var registration = _events.FindTagType(tagType)
+                           ?? throw new InvalidOperationException(
+                               $"Tag type '{tagType.Name}' is not registered. Call RegisterTagType<{tagType.Name}>() first.");
+
+        var tagTable = _events.TagTableName(registration);
+
+        // Same tenancy correlation as HasTagParser: under conjoined tenancy a tag value is unique only
+        // per tenant, so without this a value shared across tenants leaks rows into a tenant-scoped read.
+        var correlation = _events.TenancyStyle == JasperFx.MultiTenancy.TenancyStyle.Conjoined
+            ? " AND pt.tenant_id = [pc_events].[tenant_id]"
+            : string.Empty;
+
+        // CONVERT before LOWER so a non-string value column (uniqueidentifier, int, datetimeoffset)
+        // is compared on the same rendering the caller typed. LOWER on both sides rather than relying
+        // on the database collation, which a deployment can set case-sensitive.
+        return new HasTagFilter(
+            $"seq_id IN (SELECT pt.seq_id FROM {tagTable} pt WHERE LOWER(CONVERT(nvarchar(4000), pt.value)) = LOWER(",
+            value,
+            $"){correlation})");
+    }
+}
+
+/// <summary>
 ///     WHERE fragment with a single bound parameter spliced between two literal SQL segments.
 /// </summary>
 internal class HasTagFilter : ISqlFragment

--- a/src/Polecat/Events/QueryEventStore.cs
+++ b/src/Polecat/Events/QueryEventStore.cs
@@ -197,6 +197,11 @@ internal class QueryEventStore : IQueryEventStore, IReadOnlyEventStore
             queryable = ApplyTagConditions(queryable, query.TagConditions);
         }
 
+        if (query.TagValues.Count > 0)
+        {
+            queryable = ApplyTagValues(queryable, query.TagValues);
+        }
+
         var pageNumber = query.PageNumber <= 0 ? 1 : query.PageNumber;
         var pageSize = query.PageSize <= 0 ? 25 : query.PageSize;
         var offset = (pageNumber - 1) * pageSize;
@@ -232,7 +237,8 @@ internal class QueryEventStore : IQueryEventStore, IReadOnlyEventStore
                         | EventQueryFilters.TenantId
                         | EventQueryFilters.TimestampWindow
                         | EventQueryFilters.SequenceWindow
-                        | EventQueryFilters.TagConditions;
+                        | EventQueryFilters.TagConditions
+                        | EventQueryFilters.TagValues;
 
         var options = _events.EventOptions;
         if (options.EnableCorrelationId) supported |= EventQueryFilters.CorrelationId;
@@ -292,6 +298,53 @@ internal class QueryEventStore : IQueryEventStore, IReadOnlyEventStore
         }
 
         return queryable.Where(Expression.Lambda<Func<IEvent, bool>>(body!, e));
+    }
+
+    private static readonly MethodInfo _hasTagValueMethod =
+        typeof(LinqExtensions).GetMethod(nameof(LinqExtensions.HasTagValue))!;
+
+    /// <summary>
+    ///     #575 / jasperfx#801: the lossy name/value tag filter, ANDed with itself and with every other
+    ///     filter on the query — the opposite combinator from <see cref="ApplyTagConditions" />, whose
+    ///     conditions OR. An event matches when it carries <em>every</em> named tag at the given value.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Deliberately not implemented by delegating to <see cref="ApplyTagConditions" />. Beyond the
+    ///         combinator, the two differ in what they compare: a condition carries a typed value, an
+    ///         entry here carries the string form. Routing one through the other would have to invent a
+    ///         typed value by parsing, which changes the answer for any tag type whose parse is not a
+    ///         round trip.
+    ///     </para>
+    ///     <para>
+    ///         Names resolve through the shared <c>RequireByTagName</c> so every store accepts the same
+    ///         spellings — the CLR simple name or the registered table suffix, case-insensitively — and
+    ///         refuses an unknown one loudly. "That tag type does not exist here" and "no event carries
+    ///         that tag" must not read alike to a caller filtering events, so an unknown name is an
+    ///         <see cref="ArgumentException" /> naming what is registered rather than an empty page.
+    ///     </para>
+    /// </remarks>
+    private IQueryable<IEvent> ApplyTagValues(IQueryable<IEvent> queryable,
+        IReadOnlyDictionary<string, string> tagValues)
+    {
+        var registered = _events.TagTypes;
+
+        foreach (var (tagName, tagValue) in tagValues)
+        {
+            var registration = registered.RequireByTagName(tagName, nameof(EventQuery.TagValues));
+
+            var e = Expression.Parameter(typeof(IEvent), "e");
+            var call = Expression.Call(
+                _hasTagValueMethod.MakeGenericMethod(registration.TagType),
+                e,
+                Expression.Constant(tagValue, typeof(string)));
+
+            // A separate Where() per entry rather than one AndAlso chain: each becomes its own
+            // correlated sub-select, which is what keeps a doubly-tagged event counted once.
+            queryable = queryable.Where(Expression.Lambda<Func<IEvent, bool>>(call, e));
+        }
+
+        return queryable;
     }
 
     public async Task<IReadOnlyList<IEvent>> FetchStreamAsync(Guid streamId, long version = 0,

--- a/src/Polecat/LinqExtensions.cs
+++ b/src/Polecat/LinqExtensions.cs
@@ -57,6 +57,27 @@ public static class LinqExtensions
             "IEvent.HasTag<TTag>() is a marker method for LINQ event queries and cannot be invoked directly. Use it inside session.Events.QueryAllRawEvents().Where(...).");
     }
 
+    /// <summary>
+    ///     The lossy sibling of <see cref="HasTag{TTag}" />: matches events carrying the given tag whose
+    ///     value, <em>rendered as a string</em>, equals <paramref name="value" /> case-insensitively.
+    ///     Backs <c>EventQuery.TagValues</c> (jasperfx#801 / polecat#575), whose name/value dictionary
+    ///     form cannot carry a typed value.
+    ///     This is a marker method recognized by the LINQ provider and cannot be invoked directly.
+    /// </summary>
+    /// <remarks>
+    ///     Deliberately NOT expressed as <c>HasTag&lt;TTag&gt;</c> with the string parsed into
+    ///     <typeparamref name="TTag" />. The two comparisons genuinely differ: typed equality on a Guid
+    ///     tag distinguishes nothing between <c>"A1B2…"</c> and <c>"a1b2…"</c> only because Guid parsing
+    ///     normalizes, while an <c>int</c> tag would reject <c>"007"</c> that string comparison accepts,
+    ///     and a string tag is case-sensitive under typed equality and case-insensitive here. The lossy
+    ///     form's contract is the string form, so it compares the string form.
+    /// </remarks>
+    public static bool HasTagValue<TTag>(this IEvent e, string value) where TTag : notnull
+    {
+        throw new NotSupportedException(
+            "IEvent.HasTagValue<TTag>() is a marker method for LINQ event queries and cannot be invoked directly. Use it inside session.Events.QueryAllRawEvents().Where(...).");
+    }
+
     private static readonly MethodInfo AnyTenantMethodInfo =
         typeof(LinqExtensions).GetMethod(nameof(AnyTenant))!;
 


### PR DESCRIPTION
Closes #575.

## Why the bump and the feature are one PR

jasperfx#801 added `TagValues` to `EventQueryFilters.All`, so `EventQueryCompliance`'s new `TagValues` section runs the moment the package moves. A store that has not written the filter goes red on the bump alone — so the two land together rather than leaving `main` red between them.

All five JasperFx pins move to 2.67.0. No source breaks.

## gh-575 — `EventQuery.TagValues`

The lossy name/value tag filter, beside the rich `TagConditions`. Until now a caller filtered by tags **or** by everything else: the dictionary form of a tag query lived only on the non-composable `QueryByTagsAsync`, which is also unpaged and has no `TotalCount`. Now it ANDs — with itself and with every other filter — and the answer stays on the `PagedEvents` path.

Implemented as a `HasTagValue<TTag>` LINQ marker and `HasTagValueParser`, siblings of the existing `HasTag`/`HasTagParser`, emitting the same correlated

```sql
seq_id IN (SELECT pt.seq_id FROM pc_event_tag_{suffix} WHERE ...)
```

with the same conjoined-tenancy correlation. A **sub-select rather than a join**, for the reason the DCB path uses one: an event carrying the tag twice must read back once, or `TotalCount` counts condition hits instead of distinct events and paging walks a longer list than it reports. One `Where()` per entry, so each entry is its own sub-select.

The comparison is where it departs from `HasTag`: the stored value is `CONVERT`ed to `nvarchar` and `LOWER`ed on both sides, because the caller supplied a string and there is no typed value to compare. `LOWER` on both sides rather than trusting the collation, which a deployment can set case-sensitive.

**Not implemented by delegating to `ApplyTagConditions`.** Beyond the combinator flip — `TagValues` ANDs, `TagConditions` ORs — the two compare different things. Delegating would have to invent a typed value by parsing the string, which changes the answer for any tag type whose parse is not a round trip: an `int` tag rejects `"007"` that string comparison accepts, and a `string` tag is case-sensitive under typed equality and case-insensitive here.

## The other half: folding the dictionary path onto the shared matcher

`DocumentStore.EventStoreExplorer.cs` carried an inline copy of the tag-name matcher, and Marten's copy of the **same overload** had already drifted from it — CLR name only vs. either spelling, case-sensitive vs. case-insensitive values — because that overload has no compliance coverage at all. Polecat's behaviour is what jasperfx#801 standardized *to*, so this is a pure de-duplication: both paths now resolve through `TagTypeRegistrationExtensions.RequireByTagName`, and neither can drift again.

`tag_name_resolution_tests.cs` is the local pin for the path `EventQueryCompliance` cannot see — both spellings in several casings, an unregistered name refused on **both** paths with a message listing what is registered, and supplying both tag members refused (which pins that Polecat's call site actually reaches `AssertIsWellFormed`).

## Arriving free on the same bump

`StreamCompactingCompliance` gains a fact pinning that a store **infers** the fold from the aggregate's `Create`/`Apply` rather than requiring a registered aggregation projection (jasperfx#805 — Marten requires the registration, Fisher does not, and the suite pinned neither). Polecat already infers, via `ProjectionGraph.AggregatorFor<T>` building one on demand. No change needed; the suite goes 12 → 13.

jasperfx#805 also restates the `CompactStreamAsync` refusal message, which named Polecat as an answer while Polecat refused the untyped overload — fixed here by #574.

## Verification

- `EventQueryCompliance` **41 → 53**, all green; `pc_event_tag_shipper` provisions itself from the suite's second tag type.
- `StreamCompactingCompliance` **13/13**.
- `tag_name_resolution_tests` 7/7.
- Full `Polecat.Tests` on net10.0: **2595 total / 2589 passed / 6 skipped / 0 failed**.

Note: this branches off `main` at #574, so it does not carry #576's restoration of the loader's marker patch. The two do not touch the same files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)