### PR TITLE
Close the SqlBatch connection leak: every batch-executed read leaked a pooled connection

### DIFF
--- a/src/Polecat.Tests/Storage/batch_reader_connection_release_tests.cs
+++ b/src/Polecat.Tests/Storage/batch_reader_connection_release_tests.cs
@@ -1,0 +1,176 @@
+using JasperFx;
+using JasperFx.Events;
+using Microsoft.Data.SqlClient;
+using Polecat.Linq;
+using Polecat.Tests.Harness;
+using Polecat.TestUtils;
+
+namespace Polecat.Tests.Storage;
+
+/// <summary>
+///     Every read on a query session that runs through a <see cref="SqlBatch" /> — document LINQ,
+///     event LINQ, batched queries, session loads — must return its pooled connection when the reader
+///     is disposed.
+/// </summary>
+/// <remarks>
+///     <para>
+///         <c>AutoClosingLifetime</c> asked for <c>CommandBehavior.CloseConnection</c> on both of its
+///         reader paths and relied on it for both. Microsoft.Data.SqlClient honours it for a
+///         <see cref="SqlCommand" /> reader and <b>silently ignores it</b> for a <see cref="SqlBatch" />
+///         one, so the batch path leaked a pooled connection per query.
+///     </para>
+///     <para>
+///         Why it went unnoticed: the default max pool size is 100, and a process reaches that only
+///         after a hundred queries on one connection string. When it did, the failure named neither the
+///         leak nor the query that caused it — just "Timeout expired" on whichever unlucky query
+///         crossed the line, in whichever class happened to be longest that day. These tests pin the
+///         connection accounting directly, against a pool small enough that a single leak is fatal, so
+///         a regression fails here and says what broke.
+///     </para>
+/// </remarks>
+public class batch_reader_connection_release_tests
+{
+    /// <summary>
+    ///     A pool of 3 against 25 queries: any per-query leak exhausts it long before the end. The
+    ///     distinct application name gives each test its own pool, so one test's leak cannot be
+    ///     mistaken for another's.
+    /// </summary>
+    private static string SmallPool(string name) =>
+        new SqlConnectionStringBuilder(ConnectionSource.ConnectionString)
+        {
+            MaxPoolSize = 3, ConnectTimeout = 5, ApplicationName = name
+        }.ConnectionString;
+
+    private static DocumentStore StoreOn(string connectionString, string schema) =>
+        DocumentStore.For(opts =>
+        {
+            opts.ConnectionString = connectionString;
+            opts.DatabaseSchemaName = schema;
+            opts.AutoCreateSchemaObjects = AutoCreate.All;
+            opts.UseNativeJsonType = ConnectionSource.SupportsNativeJson;
+        });
+
+    /// <summary>
+    ///     The ADO.NET fact the fix rests on, asserted rather than assumed.
+    /// </summary>
+    /// <remarks>
+    ///     Written to document the driver's behaviour, not to demand it stay broken: if a future
+    ///     Microsoft.Data.SqlClient starts honouring the flag for batches, this is the one test that
+    ///     fails, its message says the decorator is now redundant, and every other test in the class
+    ///     keeps passing.
+    /// </remarks>
+    [Fact]
+    public async Task sql_batch_does_not_honour_close_connection_so_polecat_must_close_it()
+    {
+        var cs = SmallPool("polecat_batch_behaviour_probe");
+
+        var leaked = false;
+        try
+        {
+            for (var i = 0; i < 25; i++)
+            {
+                var conn = new SqlConnection(cs);
+                await conn.OpenAsync(TestContext.Current.CancellationToken);
+                await using var batch = new SqlBatch { Connection = conn };
+                batch.BatchCommands.Add(new SqlBatchCommand("select 1"));
+                await using var reader = await batch.ExecuteReaderAsync(
+                    System.Data.CommandBehavior.CloseConnection, TestContext.Current.CancellationToken);
+                while (await reader.ReadAsync(TestContext.Current.CancellationToken)) { }
+            }
+        }
+        catch (InvalidOperationException e) when (e.Message.Contains("pool"))
+        {
+            leaked = true;
+        }
+
+        leaked.ShouldBeTrue(
+            "SqlBatch appears to honour CommandBehavior.CloseConnection now — ConnectionClosingDataReader " +
+            "is no longer load-bearing, though it remains correct.");
+    }
+
+    /// <summary>
+    ///     The SqlCommand control: the same loop on the path where the flag <em>is</em> honoured, so a
+    ///     failure above can be read as "batches differ" rather than "the pool is too small".
+    /// </summary>
+    [Fact]
+    public async Task sql_command_does_honour_close_connection()
+    {
+        var cs = SmallPool("polecat_command_behaviour_probe");
+
+        for (var i = 0; i < 25; i++)
+        {
+            var conn = new SqlConnection(cs);
+            await conn.OpenAsync(TestContext.Current.CancellationToken);
+            var cmd = new SqlCommand("select 1", conn);
+            await using var reader = await cmd.ExecuteReaderAsync(
+                System.Data.CommandBehavior.CloseConnection, TestContext.Current.CancellationToken);
+            while (await reader.ReadAsync(TestContext.Current.CancellationToken)) { }
+        }
+    }
+
+    [Fact]
+    public async Task repeated_document_linq_queries_do_not_exhaust_the_pool()
+    {
+        using var store = StoreOn(SmallPool("polecat_doc_linq_pool"), "pool_doc_linq");
+
+        await using (var session = store.LightweightSession())
+        {
+            session.Store(new PoolTarget { Id = Guid.NewGuid(), Name = "seed" });
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        for (var i = 0; i < 25; i++)
+        {
+            await using var query = store.QuerySession();
+            var all = await query.Query<PoolTarget>().ToListAsync(TestContext.Current.CancellationToken);
+            all.Count.ShouldBeGreaterThan(0);
+        }
+    }
+
+    [Fact]
+    public async Task repeated_event_queries_do_not_exhaust_the_pool()
+    {
+        using var store = StoreOn(SmallPool("polecat_event_query_pool"), "pool_event_query");
+
+        await using (var session = store.LightweightSession())
+        {
+            session.Events.StartStream(Guid.NewGuid(), new QuestStarted("seed"));
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        // OpenReadOnlyEventStore() per call is how both the Event Store Explorer and
+        // EventQueryCompliance use it, and it is the shape that first hit the ceiling.
+        for (var i = 0; i < 25; i++)
+        {
+            var page = await ((IEventStore)store).OpenReadOnlyEventStore()
+                .QueryEventsAsync(new EventQuery { PageSize = 10 }, TestContext.Current.CancellationToken);
+            page.TotalCount.ShouldBeGreaterThan(0);
+        }
+    }
+
+    [Fact]
+    public async Task repeated_session_loads_do_not_exhaust_the_pool()
+    {
+        using var store = StoreOn(SmallPool("polecat_session_load_pool"), "pool_session_load");
+
+        var id = Guid.NewGuid();
+        await using (var session = store.LightweightSession())
+        {
+            session.Store(new PoolTarget { Id = id, Name = "seed" });
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        for (var i = 0; i < 25; i++)
+        {
+            await using var query = store.QuerySession();
+            var loaded = await query.LoadAsync<PoolTarget>(id, TestContext.Current.CancellationToken);
+            loaded.ShouldNotBeNull();
+        }
+    }
+}
+
+public class PoolTarget
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+}

--- a/src/Polecat/Events/EventOperations.cs
+++ b/src/Polecat/Events/EventOperations.cs
@@ -19,6 +19,7 @@ using Polecat.Internal.Operations;
 using Polecat.Projections;
 using Polecat.Serialization;
 using Weasel.SqlServer;
+using Polecat.Internal.Sessions;
 
 namespace Polecat.Events;
 
@@ -1158,7 +1159,7 @@ internal class EventOperations : QueryEventStore, IEventOperations
 
         var results = new List<IEvent>();
         await using var dbReader = await _sessionBase.ExecuteReaderAsync(cmd, cancellation);
-        var reader = (SqlDataReader)dbReader;
+        var reader = dbReader.AsSqlDataReader();
 
         while (await reader.ReadAsync(cancellation))
         {
@@ -1394,7 +1395,7 @@ internal class EventOperations : QueryEventStore, IEventOperations
     internal static IEvent? ReadEventFromReader(DbDataReader reader, ISerializer serializer, EventGraph eventGraph)
     {
         var eventOptions = eventGraph.EventOptions;
-        var sqlReader = (SqlDataReader)reader;
+        var sqlReader = reader.AsSqlDataReader();
 
         var seqId = reader.GetInt64(0);
         var eventId = reader.GetGuid(1);

--- a/src/Polecat/Events/Fetching/NaturalKeyFetchPlanner.cs
+++ b/src/Polecat/Events/Fetching/NaturalKeyFetchPlanner.cs
@@ -1,6 +1,7 @@
 using JasperFx.Events;
 using Microsoft.Data.SqlClient;
 using Polecat.Internal;
+using Polecat.Internal.Sessions;
 
 namespace Polecat.Events.Fetching;
 
@@ -55,7 +56,7 @@ internal static class NaturalKeyFetchPlanner
         object? streamId = null;
         bool streamExists = false;
 
-        await using (var reader = (SqlDataReader)await session.ExecuteReaderAsync(cmd, cancellation))
+        await using (var reader = (await session.ExecuteReaderAsync(cmd, cancellation)).AsSqlDataReader())
         {
             if (await reader.ReadAsync(cancellation))
             {

--- a/src/Polecat/Events/Linq/EventListHandler.cs
+++ b/src/Polecat/Events/Linq/EventListHandler.cs
@@ -3,6 +3,7 @@ using System.Diagnostics.CodeAnalysis;
 using JasperFx.Events;
 using Microsoft.Data.SqlClient;
 using Polecat.Serialization;
+using Polecat.Internal.Sessions;
 
 namespace Polecat.Events.Linq;
 
@@ -29,7 +30,7 @@ internal class EventListHandler
     public async Task<IReadOnlyList<IEvent>> HandleAsync(DbDataReader reader, CancellationToken token)
     {
         var results = new List<IEvent>();
-        var sqlReader = (SqlDataReader)reader;
+        var sqlReader = reader.AsSqlDataReader();
 
         while (await sqlReader.ReadAsync(token))
         {

--- a/src/Polecat/Internal/Sessions/AutoClosingLifetime.cs
+++ b/src/Polecat/Internal/Sessions/AutoClosingLifetime.cs
@@ -57,6 +57,22 @@ internal class AutoClosingLifetime : IConnectionLifetime
         }
     }
 
+    /// <summary>
+    ///     The batch counterpart of <see cref="ExecuteReaderAsync(SqlCommand, CancellationToken)" />,
+    ///     and the one place the two genuinely differ: Microsoft.Data.SqlClient honours
+    ///     <see cref="CommandBehavior.CloseConnection" /> for a <see cref="SqlCommand" /> reader and
+    ///     silently ignores it for a <see cref="SqlBatch" /> one.
+    /// </summary>
+    /// <remarks>
+    ///     This method used to pass the flag and rely on it, exactly as the command overload does, so
+    ///     every batch-executed read leaked its pooled connection — the reader was disposed, the
+    ///     connection was not, and it never went back to the pool. Nearly every read on a query session
+    ///     runs through a batch (document and event LINQ, batched queries, session loads), so a process
+    ///     hit the pool ceiling in proportion to how many queries it had issued, and failed on whichever
+    ///     query crossed it with "Timeout expired. The timeout period elapsed prior to obtaining a
+    ///     connection from the pool" — an error naming neither the leak nor the query that caused it.
+    ///     <see cref="ConnectionClosingDataReader" /> supplies the missing behaviour explicitly.
+    /// </remarks>
     public async Task<DbDataReader> ExecuteReaderAsync(SqlBatch batch, CancellationToken token)
     {
         var conn = _connectionFactory.Create();
@@ -65,7 +81,8 @@ internal class AutoClosingLifetime : IConnectionLifetime
             await conn.OpenAsync(token);
             batch.Connection = conn;
             batch.Timeout = CommandTimeout;
-            return await batch.ExecuteReaderAsync(CommandBehavior.CloseConnection, token);
+            var reader = await batch.ExecuteReaderAsync(token);
+            return new ConnectionClosingDataReader(reader, conn);
         }
         catch
         {

--- a/src/Polecat/Internal/Sessions/ConnectionClosingDataReader.cs
+++ b/src/Polecat/Internal/Sessions/ConnectionClosingDataReader.cs
@@ -1,0 +1,188 @@
+using System.Collections;
+using System.Data;
+using System.Data.Common;
+using Microsoft.Data.SqlClient;
+
+namespace Polecat.Internal.Sessions;
+
+/// <summary>
+///     A <see cref="DbDataReader" /> that owns its connection and closes it when the reader is
+///     disposed — the behaviour <see cref="System.Data.CommandBehavior.CloseConnection" /> gives a
+///     <see cref="SqlCommand" /> reader, and does <b>not</b> give a <see cref="SqlBatch" /> one.
+/// </summary>
+/// <remarks>
+///     <para>
+///         Microsoft.Data.SqlClient honours <c>CloseConnection</c> for
+///         <c>SqlCommand.ExecuteReaderAsync</c> and silently ignores it for
+///         <c>SqlBatch.ExecuteReaderAsync</c>. <see cref="AutoClosingLifetime" /> passed the flag on
+///         both paths and relied on it for both, so every batch-executed read leaked its pooled
+///         connection: the reader was disposed, the connection was not, and it never returned to the
+///         pool.
+///     </para>
+///     <para>
+///         That is nearly every read on a query session — document and event LINQ, batched queries,
+///         session loads all execute through <see cref="SqlBatch" />. The symptom is the pool ceiling
+///         rather than an error at the call site, so it surfaces far from its cause and only under
+///         enough queries per process: "Timeout expired. The timeout period elapsed prior to obtaining
+///         a connection from the pool", on whichever query happens to be the one past the limit.
+///     </para>
+/// </remarks>
+internal sealed class ConnectionClosingDataReader : DbDataReader
+{
+    private readonly DbDataReader _inner;
+    private readonly SqlConnection _connection;
+    private bool _disposed;
+
+    public ConnectionClosingDataReader(DbDataReader inner, SqlConnection connection)
+    {
+        _inner = inner;
+        _connection = connection;
+    }
+
+    /// <summary>
+    ///     The reader this wraps, for the few call sites that need the concrete
+    ///     <see cref="SqlDataReader" /> rather than the <see cref="DbDataReader" /> contract.
+    ///     Reach it through <see cref="DbDataReaderExtensions.AsSqlDataReader" />, never by casting.
+    /// </summary>
+    internal DbDataReader Inner => _inner;
+
+    public override int Depth => _inner.Depth;
+    public override int FieldCount => _inner.FieldCount;
+    public override bool HasRows => _inner.HasRows;
+    public override bool IsClosed => _inner.IsClosed;
+    public override int RecordsAffected => _inner.RecordsAffected;
+    public override object this[int ordinal] => _inner[ordinal];
+    public override object this[string name] => _inner[name];
+
+    public override bool GetBoolean(int ordinal) => _inner.GetBoolean(ordinal);
+    public override byte GetByte(int ordinal) => _inner.GetByte(ordinal);
+
+    public override long GetBytes(int ordinal, long dataOffset, byte[]? buffer, int bufferOffset, int length)
+        => _inner.GetBytes(ordinal, dataOffset, buffer, bufferOffset, length);
+
+    public override char GetChar(int ordinal) => _inner.GetChar(ordinal);
+
+    public override long GetChars(int ordinal, long dataOffset, char[]? buffer, int bufferOffset, int length)
+        => _inner.GetChars(ordinal, dataOffset, buffer, bufferOffset, length);
+
+    public override string GetDataTypeName(int ordinal) => _inner.GetDataTypeName(ordinal);
+    public override DateTime GetDateTime(int ordinal) => _inner.GetDateTime(ordinal);
+    public override decimal GetDecimal(int ordinal) => _inner.GetDecimal(ordinal);
+    public override double GetDouble(int ordinal) => _inner.GetDouble(ordinal);
+    public override Type GetFieldType(int ordinal) => _inner.GetFieldType(ordinal);
+    public override float GetFloat(int ordinal) => _inner.GetFloat(ordinal);
+    public override Guid GetGuid(int ordinal) => _inner.GetGuid(ordinal);
+    public override short GetInt16(int ordinal) => _inner.GetInt16(ordinal);
+    public override int GetInt32(int ordinal) => _inner.GetInt32(ordinal);
+    public override long GetInt64(int ordinal) => _inner.GetInt64(ordinal);
+    public override string GetName(int ordinal) => _inner.GetName(ordinal);
+    public override int GetOrdinal(string name) => _inner.GetOrdinal(name);
+    public override string GetString(int ordinal) => _inner.GetString(ordinal);
+    public override object GetValue(int ordinal) => _inner.GetValue(ordinal);
+    public override int GetValues(object[] values) => _inner.GetValues(values);
+    public override bool IsDBNull(int ordinal) => _inner.IsDBNull(ordinal);
+
+    public override T GetFieldValue<T>(int ordinal) => _inner.GetFieldValue<T>(ordinal);
+
+    public override Task<T> GetFieldValueAsync<T>(int ordinal, CancellationToken cancellationToken)
+        => _inner.GetFieldValueAsync<T>(ordinal, cancellationToken);
+
+    public override Task<bool> IsDBNullAsync(int ordinal, CancellationToken cancellationToken)
+        => _inner.IsDBNullAsync(ordinal, cancellationToken);
+
+    public override Stream GetStream(int ordinal) => _inner.GetStream(ordinal);
+    public override TextReader GetTextReader(int ordinal) => _inner.GetTextReader(ordinal);
+    public override DataTable? GetSchemaTable() => _inner.GetSchemaTable();
+
+    public override Task<DataTable?> GetSchemaTableAsync(CancellationToken cancellationToken = default)
+        => _inner.GetSchemaTableAsync(cancellationToken);
+
+    public override bool Read() => _inner.Read();
+
+    public override Task<bool> ReadAsync(CancellationToken cancellationToken)
+        => _inner.ReadAsync(cancellationToken);
+
+    public override bool NextResult() => _inner.NextResult();
+
+    public override Task<bool> NextResultAsync(CancellationToken cancellationToken)
+        => _inner.NextResultAsync(cancellationToken);
+
+    public override IEnumerator GetEnumerator() => _inner.GetEnumerator();
+
+    public override void Close()
+    {
+        _inner.Close();
+        _connection.Close();
+    }
+
+    public override Task CloseAsync() => CloseAsyncCore();
+
+    private async Task CloseAsyncCore()
+    {
+        await _inner.CloseAsync().ConfigureAwait(false);
+        await _connection.CloseAsync().ConfigureAwait(false);
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (_disposed) return;
+        _disposed = true;
+
+        if (!disposing) return;
+
+        // The connection is disposed even if the reader's own disposal throws — leaking it is the
+        // failure this class exists to prevent, and it is the more expensive of the two to lose.
+        try
+        {
+            _inner.Dispose();
+        }
+        finally
+        {
+            _connection.Dispose();
+        }
+    }
+
+    public override async ValueTask DisposeAsync()
+    {
+        if (_disposed) return;
+        _disposed = true;
+
+        try
+        {
+            await _inner.DisposeAsync().ConfigureAwait(false);
+        }
+        finally
+        {
+            await _connection.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+}
+
+
+/// <summary>
+///     Unwrapping helper for the call sites that need SQL Server's concrete reader.
+/// </summary>
+internal static class DbDataReaderExtensions
+{
+    /// <summary>
+    ///     The <see cref="SqlDataReader" /> behind a reader that may have been wrapped by
+    ///     <see cref="ConnectionClosingDataReader" />.
+    /// </summary>
+    /// <remarks>
+    ///     A plain <c>(SqlDataReader)reader</c> cast is what broke when the wrapper was introduced,
+    ///     and it broke at runtime rather than at compile time because the parameter is typed as the
+    ///     <see cref="DbDataReader" /> base. Casting is therefore a mistake this codebase can make
+    ///     silently; this method is the one place that knows about the wrapper, so a future decorator
+    ///     only has to be handled here.
+    /// </remarks>
+    internal static SqlDataReader AsSqlDataReader(this DbDataReader reader)
+    {
+        return reader switch
+        {
+            SqlDataReader sql => sql,
+            ConnectionClosingDataReader wrapper => wrapper.Inner.AsSqlDataReader(),
+            _ => throw new InvalidOperationException(
+                $"Expected a {nameof(SqlDataReader)} but got {reader.GetType().FullName}.")
+        };
+    }
+}


### PR DESCRIPTION
Found while investigating CI failures on #577. **It is not #577's bug** — #577 only crossed a threshold that was always there.

## What is wrong

`AutoClosingLifetime` asks for `CommandBehavior.CloseConnection` on both of its reader paths and relies on it for both. Microsoft.Data.SqlClient honours that flag for `SqlCommand.ExecuteReaderAsync` and **silently ignores it** for `SqlBatch.ExecuteReaderAsync`. On the batch path the reader was disposed, the connection was not, and it never returned to the pool.

That is nearly every read on a query session — document LINQ, event LINQ, batched queries and session loads all execute through a `SqlBatch`. A process leaked one pooled connection per query until it hit the ceiling, then failed with:

```
Timeout expired. The timeout period elapsed prior to obtaining a connection from the pool.
```

on whichever query happened to cross it — an error naming neither the leak nor the query that caused it, arbitrarily far from the cause. **This affects applications, not just tests.**

## Why it stayed hidden

The default max pool size is 100, and no single test class had issued that many queries against one connection string. #575 adds twelve `EventQueryCompliance` facts, which pushed `polecat_event_query_compliance` past the line — surfacing as seven unrelated-looking failures in a class that had not changed.

## Established, not assumed

- `main` at 2.66.1 fails identically under a small pool → predates #575.
- An isolated ADO.NET probe **passes on `SqlCommand` and fails on `SqlBatch`** at the same pool size, on separate pools so neither can contaminate the other.
- 40 `QueryEventsAsync` calls exhaust a pool of 5.

## The fix

`ConnectionClosingDataReader` supplies the missing behaviour explicitly: it owns the connection and closes it when the reader closes, disposing the connection even if the inner reader's disposal throws — leaking it is the failure being fixed, and it is the more expensive of the two to lose.

Introducing a wrapper flushed out four `(SqlDataReader)` downcasts that broke at **runtime** rather than compile time, because the parameter is typed as the `DbDataReader` base. Those now go through `AsSqlDataReader()`, so a future decorator only has to be handled in one place.

## Tests

Five tests pin connection accounting directly, against a pool of 3 where a single leak is fatal: the two ADO.NET behaviour probes (batch and command, as a matched pair so a failure reads as "batches differ" rather than "the pool is too small"), plus document LINQ, event queries and session loads.

The batch probe documents the driver's behaviour rather than demanding it stay broken — if SqlClient ever honours the flag for batches, that test alone fails and its message says the decorator has become redundant.

## Verification

- `polecat_event_query_compliance` under a pool of 12 that previously failed outright: **41/41**.
- Full `Polecat.Tests` on net10.0: **2580 total / 2572 passed / 6 skipped**. Two failures were `Execution Timeout Expired` (error 258) in `closed_shape_event_append_tests`, caused by my compiling another branch against the same Docker SQL Server mid-run; that class re-runs **21/21** clean on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)