### PR TITLE
Declare the document tables a store's configuration implies (gh-573)

### DIFF
--- a/src/Polecat.Tests/Storage/configured_document_tables_tests.cs
+++ b/src/Polecat.Tests/Storage/configured_document_tables_tests.cs
@@ -1,0 +1,123 @@
+using JasperFx;
+using JasperFx.Events.Projections;
+using Polecat.Projections;
+using Polecat.Tests.Harness;
+using Polecat.Tests.Projections;
+using Polecat.TestUtils;
+using Weasel.Core.Migrations;
+
+namespace Polecat.Tests.Storage;
+
+/// <summary>
+///     #573 — a store's declared schema must include the document tables its <em>configuration</em>
+///     implies, not only the ones some session happened to touch.
+/// </summary>
+/// <remarks>
+///     <para>
+///         Reported against <c>db-ef-migration add</c>: the same projection registered on Marten and
+///         on Polecat produced a migration with the document table on Marten and without it on
+///         Polecat. The cause is not the migration command — it is that Polecat materializes a
+///         document provider lazily, on the first <c>GetProvider&lt;T&gt;()</c>, and the command
+///         configures a store, asks it for its schema, and exits without ever opening a session. The
+///         registry was empty, so <c>BuildFeatureSchemas()</c> declared no document feature at all.
+///     </para>
+///     <para>
+///         These tests go at <c>BuildFeatureSchemas()</c> rather than at the command, because that is
+///         where the decision is made and every consumer of it — migrations, the stateful resource
+///         model, <c>ApplyAllConfiguredChangesToDatabaseAsync</c> — inherits the answer.
+///     </para>
+/// </remarks>
+public class configured_document_tables_tests
+{
+    private static DocumentStore ConfigureOnly(Action<StoreOptions> configure) =>
+        DocumentStore.For(opts =>
+        {
+            opts.ConnectionString = ConnectionSource.ConnectionString;
+            opts.DatabaseSchemaName = "configured_doc_tables";
+            opts.AutoCreateSchemaObjects = AutoCreate.None;
+            opts.UseNativeJsonType = ConnectionSource.SupportsNativeJson;
+            configure(opts);
+        });
+
+    private static IReadOnlyList<string> DeclaredTableNames(DocumentStore store) =>
+        store.Database.BuildFeatureSchemas()
+            .SelectMany(x => x.Objects)
+            .OfType<Weasel.SqlServer.Tables.Table>()
+            .Select(x => x.Identifier.Name)
+            .ToList();
+
+    /// <summary>
+    ///     The reported case: a projection is registered, nothing else happens, and the store must
+    ///     still declare the projection's document table.
+    /// </summary>
+    [Fact]
+    public void a_registered_projection_declares_its_document_table_without_a_session()
+    {
+        using var store = ConfigureOnly(opts =>
+            opts.Projections.Snapshot<QuestParty>(SnapshotLifecycle.Inline));
+
+        DeclaredTableNames(store).ShouldContain("pc_doc_questparty");
+    }
+
+    /// <summary>
+    ///     The other configuration route to the same place. Schema.For&lt;T&gt;() was equally lazy.
+    /// </summary>
+    [Fact]
+    public void an_explicit_schema_registration_declares_its_document_table_without_a_session()
+    {
+        using var store = ConfigureOnly(opts => opts.Schema.For<ConfiguredOnlyDoc>());
+
+        DeclaredTableNames(store).ShouldContain("pc_doc_configuredonlydoc");
+    }
+
+    /// <summary>
+    ///     A store that configures no documents of its own must not grow any, so the fix cannot be
+    ///     "materialize everything" or "declare the document feature unconditionally".
+    /// </summary>
+    /// <remarks>
+    ///     The one <c>pc_doc_*</c> table a bare store does declare is
+    ///     <c>pc_doc_deadletterevent</c> — the async daemon's dead letter store, which is event-store
+    ///     infrastructure rather than anything the application configured, and which predates this
+    ///     change. Asserted by name rather than skipped, so that if the set of infrastructure document
+    ///     tables ever changes, this test is where it is noticed.
+    /// </remarks>
+    [Fact]
+    public void a_store_with_no_document_configuration_declares_no_document_tables_of_its_own()
+    {
+        using var store = ConfigureOnly(_ => { });
+
+        DeclaredTableNames(store)
+            .Where(x => x.StartsWith("pc_doc_"))
+            .ShouldBe(["pc_doc_deadletterevent"]);
+    }
+
+    /// <summary>
+    ///     The exclusion that makes the rest of this safe. A document whose storage has been
+    ///     redirected — the EF Core projections are the shipped case — must NOT get a Polecat table,
+    ///     because Polecat does not store it. Getting this wrong would add a spurious table to the
+    ///     very EF Core migration #573 is about.
+    /// </summary>
+    [Fact]
+    public void a_document_with_custom_projection_storage_declares_no_polecat_table()
+    {
+        using var store = ConfigureOnly(opts =>
+        {
+            opts.Projections.Snapshot<QuestParty>(SnapshotLifecycle.Inline);
+
+            // Stand in for AddEfCoreProjection<TDoc, TDbContext>(): the registration that redirects
+            // storage for this document type away from Polecat's tables. The factory is never
+            // invoked here — only its presence in the keyed registry matters, which is exactly the
+            // signal the production code reads.
+            opts.CustomProjectionStorageProviders[typeof(QuestParty)] =
+                (_, _) => throw new NotSupportedException("not invoked by this test");
+        });
+
+        DeclaredTableNames(store).ShouldNotContain("pc_doc_questparty");
+    }
+}
+
+public class ConfiguredOnlyDoc
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+}

--- a/src/Polecat/DocumentStore.DocumentStoreUsage.cs
+++ b/src/Polecat/DocumentStore.DocumentStoreUsage.cs
@@ -58,28 +58,11 @@ public partial class DocumentStore : IDocumentStoreUsageSource
         //      (e.g. SingleStreamProjection<TDoc, TId>) — most Polecat
         //      services rely on this path rather than Schema.For<T>().
         var migrator = new SqlServerMigrator();
-        var seenDocumentTypes = new HashSet<Type>();
-
-        foreach (var expr in Options.Schema.Expressions)
-        {
-            var exprType = expr.GetType();
-            if (!exprType.IsGenericType) continue;
-
-            var documentType = exprType.GetGenericArguments()[0];
-            if (seenDocumentTypes.Add(documentType))
-            {
-                // Triggers the GetOrAdd path — provider lands in the registry.
-                Options.Providers.GetProvider(documentType);
-            }
-        }
-
-        foreach (var aggregate in Options.Projections.All.OfType<JasperFx.Events.Aggregation.IAggregateProjection>())
-        {
-            if (seenDocumentTypes.Add(aggregate.AggregateType))
-            {
-                Options.Providers.GetProvider(aggregate.AggregateType);
-            }
-        }
+        // #573: shared with PolecatDatabase.BuildFeatureSchemas, which needs the same set for DDL.
+        // This used to be a local walk over IAggregateProjection.AggregateType, which missed every
+        // other type a projection publishes and had no exclusion for documents whose storage is not
+        // Polecat's — so the console could describe a pc_doc_ table the migration would never create.
+        Internal.ConfiguredDocumentProviders.MaterializeConfigured(Options);
 
         foreach (var provider in Options.Providers.AllProviders.OrderBy(p => p.Mapping.Alias))
         {

--- a/src/Polecat/Internal/ConfiguredDocumentProviders.cs
+++ b/src/Polecat/Internal/ConfiguredDocumentProviders.cs
@@ -1,0 +1,94 @@
+using System.Diagnostics.CodeAnalysis;
+using Polecat.Storage;
+
+namespace Polecat.Internal;
+
+/// <summary>
+///     Forces the document providers a store's <em>configuration</em> implies into existence, for the
+///     callers that must see them before any session has opened.
+/// </summary>
+/// <remarks>
+///     <para>
+///         Polecat materializes a <see cref="DocumentProvider" /> lazily, on the first
+///         <c>GetProvider&lt;T&gt;()</c> for that type. That is the right default for a running
+///         application — a document type nobody touches costs nothing — but it means
+///         <c>Options.Providers.AllProviders</c> is <b>empty</b> in a process that has only
+///         configured a store and not yet used it. Two callers see exactly that state and need the
+///         configured set anyway:
+///     </para>
+///     <list type="bullet">
+///         <item>
+///             <c>PolecatDatabase.BuildFeatureSchemas()</c>, which decides what DDL the store
+///             declares. This is polecat#573: <c>db-ef-migration add</c> configures a store, asks it
+///             for its schema and exits, so the generated migration carried the event store tables
+///             and none of the document tables — a projection's <c>pc_doc_*</c> table was simply
+///             absent, while Marten's equivalent migration had it.
+///         </item>
+///         <item>
+///             <c>DocumentStore.TryCreateUsage()</c>, the diagnostic descriptor CritterWatch reads on
+///             a freshly booted service, which had grown its own copy of this walk.
+///         </item>
+///     </list>
+///     <para>
+///         One helper for both, because the two answers must agree: a document type that appears in
+///         the monitoring console and not in the migration (or the reverse) is a bug report either
+///         way, and the copies had already drifted — the descriptor's walk covered
+///         <c>IAggregateProjection.AggregateType</c> only, so it missed every published type a
+///         projection declares beyond its own aggregate.
+///     </para>
+/// </remarks>
+internal static class ConfiguredDocumentProviders
+{
+    /// <summary>
+    ///     Materialize a provider for every document type <paramref name="options" /> configures:
+    ///     each <c>Schema.For&lt;T&gt;()</c> registration, and every type a registered projection
+    ///     publishes.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         <b>Types with custom projection storage are excluded, and that exclusion is
+    ///         load-bearing.</b> <c>EfCoreSingleStreamProjection&lt;TDoc, TDbContext&gt;</c> derives
+    ///         from <c>SingleStreamProjection&lt;TDoc, Guid&gt;</c>, so its document is published like
+    ///         any other and is indistinguishable by shape — but it lives in a
+    ///         <c>DbContext</c>, not in a <c>pc_doc_*</c> table. Materializing a provider for it would
+    ///         invent a Polecat table for a document Polecat does not store, and #573's whole subject
+    ///         is the EF Core migration those tables land in: the fix would have added a spurious
+    ///         table to the very migration it exists to correct. <c>CustomProjectionStorageProviders</c>
+    ///         is keyed by document type and is the registration that redirects storage, so it is the
+    ///         honest test for "Polecat does not own this document". Those entities reach a migration
+    ///         by their own route, as <c>ExtendedSchemaObjects</c>.
+    ///     </para>
+    ///     <para>
+    ///         Idempotent: <c>GetProvider</c> is a get-or-add, so repeated calls are cheap and callers
+    ///         need not coordinate.
+    ///     </para>
+    /// </remarks>
+    [RequiresDynamicCode("Closes document storage generics over the configured document types via Type.MakeGenericType, the same way a first GetProvider<T>() call would.")]
+    [RequiresUnreferencedCode("Materializes document providers, which reflect over the document type's members.")]
+    internal static void MaterializeConfigured(StoreOptions options)
+    {
+        var seen = new HashSet<Type>();
+
+        foreach (var expression in options.Schema.Expressions)
+        {
+            var expressionType = expression.GetType();
+            if (!expressionType.IsGenericType) continue;
+
+            var documentType = expressionType.GetGenericArguments()[0];
+            if (seen.Add(documentType))
+            {
+                options.Providers.GetProvider(documentType);
+            }
+        }
+
+        foreach (var documentType in options.Projections.All.SelectMany(x => x.PublishedTypes()))
+        {
+            if (options.CustomProjectionStorageProviders.ContainsKey(documentType)) continue;
+
+            if (seen.Add(documentType))
+            {
+                options.Providers.GetProvider(documentType);
+            }
+        }
+    }
+}

--- a/src/Polecat/Storage/PolecatDatabase.cs
+++ b/src/Polecat/Storage/PolecatDatabase.cs
@@ -103,10 +103,19 @@ public class PolecatDatabase : DatabaseBase<SqlConnection>, IEventDatabase, IPro
             new EventStoreFeatureSchema(_events, naturalKeys)
         };
 
-        // Document tables + HiLo (if any providers are registered)
-        if (_options.Providers != null && _options.Providers.AllProviders.Any())
+        // #573: force the providers the CONFIGURATION implies before asking whether there are any.
+        // Providers are materialized lazily on first GetProvider<T>(), so a process that configured a
+        // store and never used it — which is exactly what `db-ef-migration add` is — saw an empty
+        // registry and declared no document tables at all. The generated migration carried the event
+        // store and nothing else, while Marten's equivalent carried the projection's document table.
+        if (_options.Providers != null)
         {
-            schemas.Add(new DocumentFeatureSchema(_options));
+            Internal.ConfiguredDocumentProviders.MaterializeConfigured(_options);
+
+            if (_options.Providers.AllProviders.Any())
+            {
+                schemas.Add(new DocumentFeatureSchema(_options));
+            }
         }
 
         if (_options.ExtendedSchemaObjects.Count > 0)


### PR DESCRIPTION
Closes #573.

## What was reported

The same projection registered on Marten and on Polecat, run through `dotnet run -- db-ef-migration add`, produced a migration containing the projection's document table on Marten and containing only the event store tables on Polecat.

## What is actually wrong

Not the migration command. Polecat materializes a `DocumentProvider` **lazily**, on the first `GetProvider<T>()` for that type. That is the right default for a running application — an untouched document type costs nothing — but `db-ef-migration add` configures a store, asks it for its schema, and exits without ever opening a session. So `Options.Providers.AllProviders` was empty, and `PolecatDatabase.BuildFeatureSchemas()` declared no document feature at all.

`ConfiguredDocumentProviders.MaterializeConfigured()` forces the set the *configuration* implies: every `Schema.For<T>()` registration, plus every type a registered projection publishes.

## The exclusion is load-bearing

Types with custom projection storage are skipped, and this is the part that needed care rather than the materialization itself.

`EfCoreSingleStreamProjection<TDoc, TDbContext>` derives from `SingleStreamProjection<TDoc, Guid>`, so its document is published like any other and is **indistinguishable by shape** — but it lives in a `DbContext`, not a `pc_doc_*` table. Without the exclusion, this fix would have invented a Polecat table for a document Polecat does not store, and added it to the very EF Core migration the issue is about.

`CustomProjectionStorageProviders` is keyed by document type and is the registration that redirects storage, so it is the honest test for "Polecat does not own this document". Those entities already reach a migration by their own route, as `ExtendedSchemaObjects`.

## One helper, two callers

`DocumentStore.TryCreateUsage()` — the descriptor CritterWatch reads on a freshly booted service — had grown its own copy of this walk for exactly the same reason, and the copies had **already drifted**: it covered `IAggregateProjection.AggregateType` only, so it missed every other published type and had no custom-storage exclusion. The two answers have to agree; a document type that appears in the monitoring console but not in the migration is a bug report either way.

## Tests

Four tests aimed at `BuildFeatureSchemas()` rather than at the CLI, because that is where the decision is made and migrations, the stateful resource model, and `ApplyAllConfiguredChangesToDatabaseAsync` all inherit the answer:

- a registered projection declares its document table with no session — **verified to fail with the hook reverted**
- `Schema.For<T>()` does too — likewise
- a store configuring no documents of its own grows none, so the fix cannot be "declare the feature unconditionally"
- a document with custom projection storage gets **no** Polecat table

The one `pc_doc_*` table a bare store still declares is `pc_doc_deadletterevent`, the async daemon's dead letter store — event-store infrastructure rather than application configuration, and pre-existing (confirmed by reverting). It is asserted by name, so a change to the infrastructure set is noticed here.

`configured_document_tables_tests` 4/4 on net10.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)