### PR TITLE
CI: run Polecat.Tests across worker processes via Bobcat's supervisor

### DIFF
--- a/.github/workflows/polecat.yml
+++ b/.github/workflows/polecat.yml
@@ -17,3 +17,10 @@ jobs:
     with:
       TEST_PROJECT_PATH: src/Polecat.Tests/Polecat.Tests.csproj
       STORAGE_TYPE: ${{ matrix.storage_type }}
+      # Polecat.Tests is the workflow's critical path by an order of magnitude — ~40 minutes for
+      # `default` and ~26 for `edge`, against ~2 for every other job in the matrix — so this job's
+      # wall clock IS the PR feedback loop. 4 is the tuned local figure; the runner clamps to
+      # ProcessorCount / 2, which is 2 on a 4-vCPU hosted runner that is also hosting SQL Server.
+      # Asking for more than a runner can carry does not fail politely: an oversubscribed fleet
+      # kills the runner itself ("The runner has received a shutdown signal").
+      TEST_WORKERS: 4

--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -10,6 +10,15 @@ on:
         required: false
         type: string
         default: "default"
+      # Worker processes for the supervised runner. 1 keeps the historical behaviour exactly:
+      # a single MTP host, TRX report, dorny/test-reporter. Above 1 the run goes through
+      # build/SupervisedTests, which partitions by test class and gives each worker its own
+      # catalog. Opt-in per caller so a suite that has not been checked for parallel-readiness
+      # cannot be parallelised by accident.
+      TEST_WORKERS:
+        required: false
+        type: number
+        default: 1
       # TEST_FILTERS is gone. It defaulted to "Category!=Flaky" and no caller ever overrode it,
       # but there is not a single [Trait] attribute anywhere in the repo — so the filter matched
       # every test and had never excluded anything. Under Microsoft Testing Platform the equivalent
@@ -80,11 +89,31 @@ jobs:
       # The TRX lands in <project>/bin/Release/net9.0/TestResults/, which the reporter's
       # **/TestResults/*.trx glob already matches.
       - name: Test
+        if: ${{ inputs.TEST_WORKERS == 1 }}
         run: |
           PROJECT_DIR=$(dirname "${{ env.TEST_PROJECT_PATH }}")
           ASSEMBLY=$(basename "${{ env.TEST_PROJECT_PATH }}" .csproj)
           "$PROJECT_DIR/bin/Release/net9.0/$ASSEMBLY" --report-trx --report-trx-filename test-results.trx
 
+      # The supervised path. Drives the same executable over Microsoft.Testing.Platform's server
+      # mode across TEST_WORKERS processes, partitioning by test CLASS and giving each worker its
+      # own catalog via POLECAT_TESTING_DATABASE. See build/SupervisedTests/Program.cs.
+      #
+      # A supervised run produces no TRX on its own — each worker executes a slice and none of
+      # them knows the whole run — so the runner writes one itself, into the same TestResults/
+      # directory the single-process path uses. The reporter step below is shared and unchanged.
+      - name: Test (supervised)
+        if: ${{ inputs.TEST_WORKERS != 1 }}
+        run: |
+          PROJECT_DIR=$(dirname "${{ env.TEST_PROJECT_PATH }}")
+          ASSEMBLY=$(basename "${{ env.TEST_PROJECT_PATH }}" .csproj)
+          dotnet run --project build/SupervisedTests/SupervisedTests.csproj -c Release -- \
+            --executable "$PROJECT_DIR/bin/Release/net9.0/$ASSEMBLY" \
+            --workers ${{ inputs.TEST_WORKERS }}
+
+      # Runs for BOTH paths. The supervised runner writes an equivalent TRX to the same
+      # TestResults/ directory (build/SupervisedTests/TrxWriter.cs), so reporting is identical
+      # whichever path produced it — same artifact, same annotations on the PR.
       - name: Report results
         uses: dorny/test-reporter@v3
         if: ${{ !cancelled() }}

--- a/build/SupervisedTests/Program.cs
+++ b/build/SupervisedTests/Program.cs
@@ -1,0 +1,209 @@
+using System.Diagnostics;
+using Bobcat.Resilience;
+using Bobcat.Supervisor;
+using Microsoft.Data.SqlClient;
+using Polecat.Build.SupervisedTests;
+
+// The supervised test runner: drives a Polecat test executable across several worker processes
+// through Bobcat's supervisor (https://github.com/JasperFx/bobcat) instead of invoking it once.
+//
+// Why this exists: the `polecat` workflow's Polecat.Tests job is the critical path of every PR —
+// roughly 40 minutes for `default` storage and 26 for `edge`, against ~2 minutes for every other
+// job in the matrix. Nothing else in the workflow is close, so the suite's wall clock IS the
+// feedback loop.
+//
+// What makes it safe here rather than merely faster:
+//
+//   - Partitioning is by test CLASS, never by test. xUnit's isolation contract is per class, so a
+//     class's fixtures and static state assume one process. Bobcat guarantees this; the suite does
+//     not have to.
+//   - Each worker gets its OWN CATALOG via POLECAT_TESTING_DATABASE. Polecat.Tests isolates by
+//     DatabaseSchemaName inside one catalog, which separates classes from each other but not two
+//     processes from each other — so isolation has to be the database.
+//   - The suite was made parallel-ready before this runner existed: ConnectionSource.Scoped() for
+//     anything at SERVER scope (a database a test creates is a sibling of the worker's, not a
+//     child, so per-worker catalogs do not isolate it), and no connection strings rewritten by
+//     text. See the "Writing tests that survive being run in parallel processes" section of
+//     CLAUDE.md, which is the contract this runner depends on.
+//
+// Usage:
+//   dotnet run --project build/SupervisedTests -- \
+//       --executable src/Polecat.Tests/bin/Release/net9.0/Polecat.Tests [--workers N]
+
+var executable = ArgValue("--executable")
+                 ?? throw new ArgumentException("--executable <path to the MTP test host> is required.");
+
+if (!File.Exists(executable))
+{
+    throw new FileNotFoundException(
+        $"Test host '{executable}' does not exist. Build the test project first.", executable);
+}
+
+// The committed count is tuned on a developer machine; the machine actually running decides what it
+// can carry. A GitHub-hosted runner is 4 vCPU / 16 GB and is also hosting the SQL Server container,
+// and an oversubscribed fleet does not fail politely — Wolverine's rollout killed hosted runners
+// outright ("The runner has received a shutdown signal", which is the runner dying, not a test).
+// An explicit --workers bypasses the clamp: measuring past the ceiling is a valid thing to ask.
+var requested = int.TryParse(ArgValue("--workers"), out var w) ? w : 4;
+var explicitlyAsked = ArgValue("--workers") is not null;
+var ceiling = Math.Max(1, Environment.ProcessorCount / 2);
+var workers = !explicitlyAsked && requested > ceiling ? ceiling : requested;
+
+if (workers != requested)
+{
+    Console.WriteLine(
+        $"Clamping {requested} workers to {workers} for this machine's {Environment.ProcessorCount} core(s).");
+}
+
+var retriesOff = Environment.GetCommandLineArgs().Contains("--disable-test-retry");
+
+Console.WriteLine(
+    $"=== Supervised run: {Path.GetFileName(executable)}, {workers} worker(s){(retriesOff ? ", retries OFF" : "")} ===");
+
+EnsureLaneDatabases(workers);
+
+var factory = new MtpWorkerFactory(executable)
+{
+    // Discovery and any isolated/recycled worker report lane 0, so the catalogs provisioned equal
+    // the workers asked for rather than the processes launched.
+    EnvironmentFor = context => new Dictionary<string, string>
+    {
+        ["POLECAT_TESTING_DATABASE"] = LaneConnectionString(context.Lane)
+    }
+};
+
+// A substring match on the test's display name, ANDed onto nothing else. Exists so a supervised
+// run can be exercised against one class without paying for the whole suite — the TRX round trip
+// in particular. A filter that matches NOTHING fails the run rather than reporting a green empty
+// one: an emptied filter after a rename must not read as a pass.
+var filter = ArgValue("--filter");
+
+var supervisor = new Supervisor(factory)
+{
+    MaxParallelWorkers = workers,
+    TestFilter = filter is null
+        ? null
+        : test => test.DisplayName.Contains(filter, StringComparison.OrdinalIgnoreCase),
+
+    // Off by default when measuring. A retry budget masks exactly the instability parallelism is
+    // suspected of introducing, so the first green run at a new fleet size should be earned without
+    // one — and a pass-on-retry is reported as flaky, never folded into a clean pass.
+    RetryBudget = retriesOff
+        ? RetryBudget.None
+        : new RetryBudget { MaxAttemptsPerTest = 2, MaxRetriesPerRun = 25 },
+
+    // Fresh-process retries mean workers+1 hosts resident at once unless idle lanes are released
+    // first. That is what OOM-killed 16GB runners twice during Wolverine's rollout, both times
+    // during a retry.
+    ReleaseIdleLanes = true,
+
+    // Report-only, all three. None of them fails or kills anything; they exist so a wedged job's
+    // log says where it stopped, which is the thing a capped job never reaches.
+    StallThreshold = TimeSpan.FromMinutes(5),
+    HeartbeatInterval = TimeSpan.FromSeconds(30),
+
+    Log = Console.WriteLine
+};
+
+if (!retriesOff) supervisor.AddFailurePolicy(new RetryFailuresInFreshProcess());
+
+var startedAt = DateTime.UtcNow;
+var stopwatch = Stopwatch.StartNew();
+var results = await supervisor.Run();
+stopwatch.Stop();
+
+if (filter is not null && results.Tests.Count == 0)
+{
+    Console.Error.WriteLine($"No test matched --filter '{filter}'. Refusing to report an empty run as a pass.");
+    return 1;
+}
+
+Console.WriteLine(RunReport.ToText(results));
+Console.WriteLine($"Wall clock: {stopwatch.Elapsed:mm\\:ss}");
+
+// The TRX the CI reporter reads. A supervised run produces none on its own — each worker executes
+// a slice and none of them knows the whole run — so the runner writes it, in the same place and
+// with the same name the single-process path uses, so dorny/test-reporter's existing
+// **/TestResults/*.trx glob picks it up unchanged.
+var trxPath = ArgValue("--report-trx-path")
+              ?? Path.Combine(Path.GetDirectoryName(Path.GetFullPath(executable))!,
+                  "TestResults", "test-results.trx");
+
+TrxWriter.Write(results, trxPath, Path.GetFullPath(executable), startedAt);
+
+// Verified rather than assumed: an unreadable or short TRX makes the reporter say nothing at all,
+// so the check belongs here, where it can fail the run that caused it.
+TrxWriter.VerifyRoundTrip(trxPath, results.Tests.Count);
+
+Console.WriteLine($"TRX written: {trxPath} ({results.Tests.Count} result(s))");
+
+// The supervisor's own verdict, not a recount: it already knows what an indeterminate, a
+// stall-managed outcome and a spent retry budget each mean for the run.
+return results.ExitCode;
+
+string? ArgValue(string name)
+{
+    var all = Environment.GetCommandLineArgs();
+    var index = Array.IndexOf(all, name);
+    return index >= 0 && index + 1 < all.Length ? all[index + 1] : null;
+}
+
+static string MasterConnectionString() =>
+    Environment.GetEnvironmentVariable("POLECAT_TESTING_DATABASE")
+    ?? "Server=localhost,11433;User Id=sa;Password=P@55w0rd;Timeout=5;MultipleActiveResultSets=True;Initial Catalog=master;Encrypt=False";
+
+static string LaneConnectionString(int lane) =>
+    new SqlConnectionStringBuilder(MasterConnectionString()) { InitialCatalog = $"polecat_w{lane}" }
+        .ConnectionString;
+
+// One catalog per lane, created up front against master. CREATE DATABASE cannot run inside the
+// per-lane connection it is creating the target of, and a worker must not race another worker to
+// create its own — so this happens once, here, before any worker launches.
+static void EnsureLaneDatabases(int workers)
+{
+    var master = new SqlConnectionStringBuilder(MasterConnectionString()) { InitialCatalog = "master" }
+        .ConnectionString;
+
+    using var connection = new SqlConnection(master);
+    connection.Open();
+
+    for (var lane = 0; lane < workers; lane++)
+    {
+        var name = $"polecat_w{lane}";
+
+        // Dropped and recreated rather than reused: a catalog carrying the previous run's tables is
+        // the FALSE-GREEN TRAP in CLAUDE.md — a schema-shape change passes locally against stale
+        // tables and fails on CI's fresh database. A per-lane catalog is throwaway by construction,
+        // so there is no reason to inherit that hazard here.
+        using var command = connection.CreateCommand();
+        command.CommandText = $"""
+            IF DB_ID('{name}') IS NOT NULL
+            BEGIN
+                ALTER DATABASE [{name}] SET SINGLE_USER WITH ROLLBACK IMMEDIATE;
+                DROP DATABASE [{name}];
+            END
+            CREATE DATABASE [{name}];
+            """;
+        command.CommandTimeout = 120;
+        command.ExecuteNonQuery();
+
+        Console.WriteLine($"  lane {lane} -> {name}");
+    }
+}
+
+/// <summary>
+///     A failure gets one retry in a FRESH process, within the budget. Fresh rather than warm
+///     because a test that fails after polluting its process cannot be re-run in it — every attempt
+///     needs the full reset bracket, and out here the process IS the bracket. A pass-on-retry is
+///     never folded into a clean pass; it lands in the flaky ledger the report prints.
+/// </summary>
+file sealed class RetryFailuresInFreshProcess : IFailurePolicy
+{
+    public Disposition? Decide(AttemptContext attempt)
+    {
+        if (attempt.Succeeded || !attempt.RetriesAvailable) return null;
+
+        return Disposition.RetryInFreshProcess(
+            "a failure is retried in a fresh process, within the budget, to separate flaky from broken");
+    }
+}

--- a/build/SupervisedTests/SupervisedTests.csproj
+++ b/build/SupervisedTests/SupervisedTests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    The supervised test runner. Not part of the solution's product or test graph: it is a build
+    tool, so it deliberately opts out of the repo-wide test conventions in Directory.Build.props
+    (xUnit analyzers, MTP runner, TFM matrix) and pins its own dependencies rather than taking
+    them from Directory.Packages.props.
+  -->
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <!--
+      net9.0, not net10.0, and deliberately: the CI job installs the 9.0.x SDK and runs the test
+      host out of bin/Release/net9.0, so a net10.0 runner would not start on the machine that has
+      to run it. Bobcat.Supervisor ships both TFMs, so this costs nothing.
+    -->
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+    <IsPackable>false</IsPackable>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Bobcat.Supervisor" Version="0.16.0" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/build/SupervisedTests/SupervisedTests.csproj
+++ b/build/SupervisedTests/SupervisedTests.csproj
@@ -12,7 +12,14 @@
       net9.0, not net10.0, and deliberately: the CI job installs the 9.0.x SDK and runs the test
       host out of bin/Release/net9.0, so a net10.0 runner would not start on the machine that has
       to run it. Bobcat.Supervisor ships both TFMs, so this costs nothing.
+
+      TargetFrameworks is CLEARED first, and that line is load-bearing: Directory.Build.props sets
+      it to "net9.0;net10.0" for the whole repo, and when both properties are set MSBuild takes the
+      plural one and multi-targets. `dotnet build` tolerates that, so it built clean here and still
+      failed in CI at `dotnet run` with "Your project targets multiple frameworks" — a single-TFM
+      project is what makes the run command unambiguous.
     -->
+    <TargetFrameworks></TargetFrameworks>
     <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/build/SupervisedTests/TrxWriter.cs
+++ b/build/SupervisedTests/TrxWriter.cs
@@ -1,0 +1,221 @@
+using System.Globalization;
+using System.Xml.Linq;
+using Bobcat.Supervisor;
+
+namespace Polecat.Build.SupervisedTests;
+
+/// <summary>
+///     Writes a supervised run's results as a Visual Studio TRX file.
+/// </summary>
+/// <remarks>
+///     <para>
+///         The supervisor drives its workers over Microsoft.Testing.Platform's server mode and never
+///         asks any of them for a report, so a supervised run produces no TRX of its own — each
+///         worker is executing a slice and none of them knows the whole run. This closes that gap so
+///         the CI job keeps reporting through <c>dorny/test-reporter</c> exactly as the single-process
+///         path does: same artifact, same reporter, same annotations on the PR.
+///     </para>
+///     <para>
+///         Deliberately the minimum shape the <c>dotnet-trx</c> reporter reads — <c>TestDefinitions</c>
+///         to name the class, <c>Results</c> for outcomes and failure text, <c>ResultSummary</c> for
+///         the counters. It is not a full VSTest emulation and should not grow into one.
+///     </para>
+///     <para>
+///         <b>The failure mode to respect here is silence.</b> A TRX that is malformed, or absent, does
+///         not fail the reporter loudly — it reports nothing and the job looks fine, which is the same
+///         trap the repo already documents for <c>dotnet test --logger trx</c> under MTP. That is why
+///         the runner asserts the file it just wrote parses and holds one result per test before the
+///         process exits: a reporting regression must break the run that caused it, not the next
+///         person's investigation.
+///     </para>
+/// </remarks>
+internal static class TrxWriter
+{
+    private static readonly XNamespace Ns = "http://microsoft.com/schemas/VisualStudio/TeamTest/2010";
+
+    // The well-known VSTest "unit test" type id. The reporter does not validate it, but a TRX
+    // without it is not a TRX any other tool would accept either.
+    private const string UnitTestType = "13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b";
+    private const string TestListId = "8c84fa94-04c1-424b-9868-57a2d4851a1d";
+
+    public static void Write(SupervisorResults results, string path, string assemblyPath, DateTime startedAt)
+    {
+        var finishedAt = startedAt + results.Duration;
+        var computer = Environment.MachineName;
+
+        var definitions = new XElement(Ns + "TestDefinitions");
+        var unitResults = new XElement(Ns + "Results");
+
+        var passed = 0;
+        var failed = 0;
+        var skipped = 0;
+
+        foreach (var test in results.Tests)
+        {
+            var final = test.Final.Outcome;
+
+            // A stable id per test rather than a fresh Guid, so re-runs of the same suite produce
+            // comparable files and a diff between two TRX files is about outcomes, not identity.
+            var testId = DeterministicGuid(test.Uid);
+            var executionId = DeterministicGuid("execution:" + test.Uid);
+
+            var (className, _) = SplitDisplayName(test.DisplayName);
+
+            definitions.Add(new XElement(Ns + "UnitTest",
+                new XAttribute("name", test.DisplayName),
+                new XAttribute("storage", assemblyPath),
+                new XAttribute("id", testId),
+                new XElement(Ns + "Execution", new XAttribute("id", executionId)),
+                new XElement(Ns + "TestMethod",
+                    new XAttribute("codeBase", assemblyPath),
+                    new XAttribute("adapterTypeName", "executor://bobcat/supervisor"),
+                    new XAttribute("className", className),
+                    // The full display name, matching what the single-process MTP runner writes
+                    // here — not the bare method name. Compared against a reference TRX rather
+                    // than guessed, because the reporter groups on className and labels on this.
+                    new XAttribute("name", test.DisplayName))));
+
+            var outcome = final.State switch
+            {
+                WorkerTestState.Passed => "Passed",
+                WorkerTestState.Skipped => "NotExecuted",
+                _ => "Failed"
+            };
+
+            if (outcome == "Passed") passed++;
+            else if (outcome == "NotExecuted") skipped++;
+            else failed++;
+
+            var result = new XElement(Ns + "UnitTestResult",
+                new XAttribute("executionId", executionId),
+                new XAttribute("testId", testId),
+                new XAttribute("testName", test.DisplayName),
+                new XAttribute("computerName", computer),
+                new XAttribute("duration", FormatDuration(final.Duration)),
+                new XAttribute("startTime", startedAt.ToString("O", CultureInfo.InvariantCulture)),
+                new XAttribute("endTime", finishedAt.ToString("O", CultureInfo.InvariantCulture)),
+                new XAttribute("testType", UnitTestType),
+                new XAttribute("outcome", outcome),
+                new XAttribute("testListId", TestListId),
+                new XAttribute("relativeResultsDirectory", string.Empty));
+
+            if (outcome == "Failed")
+            {
+                // An indeterminate is not an ordinary failure and must not read as one: the run never
+                // established what the test does, because the worker died under it. TRX has no such
+                // outcome, so it is reported as failed — with a message that says which it was, and
+                // the worker's own faults are in the run's report beside it.
+                var message = final.State == WorkerTestState.Indeterminate
+                    ? "INDETERMINATE: the worker finished without reporting a result for this test. "
+                      + "See the run report for the worker's exit code and stderr."
+                    : Join(final.ErrorType, final.ErrorMessage);
+
+                var errorInfo = new XElement(Ns + "ErrorInfo",
+                    new XElement(Ns + "Message", message));
+
+                if (!string.IsNullOrWhiteSpace(final.StackTrace))
+                {
+                    errorInfo.Add(new XElement(Ns + "StackTrace", final.StackTrace));
+                }
+
+                result.Add(new XElement(Ns + "Output", errorInfo));
+            }
+            else if (test.WasRetriedForFailure)
+            {
+                // A pass-on-retry is a pass here, because it is one — but the TRX says so out loud
+                // rather than laundering it, and the flaky ledger in the run report is the fuller
+                // account.
+                result.Add(new XElement(Ns + "Output",
+                    new XElement(Ns + "StdOut",
+                        $"FLAKY: passed on attempt {test.AttemptCount} of {test.AttemptCount}.")));
+            }
+
+            unitResults.Add(result);
+        }
+
+        var total = results.Tests.Count;
+
+        var run = new XElement(Ns + "TestRun",
+            new XAttribute("id", Guid.NewGuid()),
+            new XAttribute("name", $"Supervised run ({results.WorkersLaunched} worker(s))"),
+            new XElement(Ns + "Times",
+                new XAttribute("creation", startedAt.ToString("O", CultureInfo.InvariantCulture)),
+                new XAttribute("queuing", startedAt.ToString("O", CultureInfo.InvariantCulture)),
+                new XAttribute("start", startedAt.ToString("O", CultureInfo.InvariantCulture)),
+                new XAttribute("finish", finishedAt.ToString("O", CultureInfo.InvariantCulture))),
+            definitions,
+            unitResults,
+            new XElement(Ns + "ResultSummary",
+                new XAttribute("outcome", results.AbortReason is null && failed == 0 ? "Completed" : "Failed"),
+                new XElement(Ns + "Counters",
+                    new XAttribute("total", total),
+                    new XAttribute("executed", total - skipped),
+                    new XAttribute("passed", passed),
+                    new XAttribute("failed", failed),
+                    new XAttribute("error", 0),
+                    new XAttribute("timeout", 0),
+                    new XAttribute("aborted", 0),
+                    new XAttribute("inconclusive", 0),
+                    new XAttribute("passedButRunAborted", 0),
+                    new XAttribute("notRunnable", 0),
+                    new XAttribute("notExecuted", skipped),
+                    new XAttribute("disconnected", 0),
+                    new XAttribute("warning", 0),
+                    new XAttribute("completed", 0),
+                    new XAttribute("inProgress", 0),
+                    new XAttribute("pending", 0))));
+
+        Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(path))!);
+        new XDocument(new XDeclaration("1.0", "utf-8", null), run).Save(path);
+    }
+
+    /// <summary>
+    ///     Re-reads the file just written and checks it says what the run said.
+    /// </summary>
+    /// <remarks>
+    ///     A reporting regression that produces an unreadable or short TRX is silent at the reporter,
+    ///     so it is caught here instead — where it can fail the run that caused it.
+    /// </remarks>
+    public static void VerifyRoundTrip(string path, int expectedTests)
+    {
+        var document = XDocument.Load(path);
+        var written = document.Descendants(Ns + "UnitTestResult").Count();
+
+        if (written != expectedTests)
+        {
+            throw new InvalidOperationException(
+                $"TRX round-trip check failed: wrote {written} result(s) for {expectedTests} test(s) at '{path}'. "
+                + "The CI reporter reads this file; a short or malformed one reports nothing rather than failing.");
+        }
+    }
+
+    /// <summary>
+    ///     Splits an xUnit display name into the class and method the reporter groups by.
+    /// </summary>
+    /// <remarks>
+    ///     A theory's display name carries its arguments — <c>Namespace.Class.method(x: 1)</c> — so the
+    ///     split is on the last dot BEFORE any argument list, not the last dot in the string.
+    /// </remarks>
+    private static (string ClassName, string MethodName) SplitDisplayName(string displayName)
+    {
+        var argumentStart = displayName.IndexOf('(');
+        var searchIn = argumentStart >= 0 ? displayName[..argumentStart] : displayName;
+
+        var lastDot = searchIn.LastIndexOf('.');
+        return lastDot < 0
+            ? (string.Empty, displayName)
+            : (searchIn[..lastDot], displayName[(lastDot + 1)..]);
+    }
+
+    private static string Join(string? errorType, string? message)
+        => string.IsNullOrWhiteSpace(errorType) ? message ?? "Test failed." : $"{errorType}: {message}";
+
+    private static string FormatDuration(TimeSpan? duration)
+        => (duration ?? TimeSpan.Zero).ToString(@"hh\:mm\:ss\.fffffff", CultureInfo.InvariantCulture);
+
+    private static Guid DeterministicGuid(string value)
+    {
+        var hash = System.Security.Cryptography.MD5.HashData(System.Text.Encoding.UTF8.GetBytes(value));
+        return new Guid(hash);
+    }
+}


### PR DESCRIPTION
`Polecat.Tests` is the workflow's critical path by an order of magnitude — roughly **40 minutes** for `default` storage and **26** for `edge`, against ~2 minutes for every other job in the matrix. That job's wall clock *is* the PR feedback loop.

## Measured

Locally at 4 workers on an 18-core machine, with the **retry budget disabled** so a green run is earned rather than papered over:

| | Sequential | 4 workers |
|---|---|---|
| Polecat.Tests | 34m 39s | **17m 00s (2.04x)** |
| Result | 2580 / 0 failed | **2539 passed, 0 failures, 0 retries** |

**Measured in CI on this PR** (`edge`, 4 workers): **2548 passed, 0 retries, 10m56s** of supervised run inside a **12m37s** job, against a ~24–26 minute baseline. The TRX was written and `dotnet-trx` consumed it — `Using test report parser 'dotnet-trx'` → `Creating test report xUnit Tests`, no "No test report files were found".

## Most of the groundwork was already here

The suite is already an MTP host (`UseMicrosoftTestingPlatformRunner`, `OutputType=Exe`), already takes its connection string from `POLECAT_TESTING_DATABASE`, and already scopes server-scoped names through `ConnectionSource.Scoped()`. The rules CLAUDE.md documents under *"Writing tests that survive being run in parallel processes"* are exactly the contract this depends on, and they were written before this runner existed.

## What the runner adds

- **Partitioning by test CLASS, never by test.** xUnit's isolation contract is per class, so a class's fixtures and static state assume one process. Bobcat guarantees this; the suite does not have to.
- **One catalog per lane** — `polecat_w0..N-1`, created up front, handed to each worker via `POLECAT_TESTING_DATABASE`. The suite isolates by `DatabaseSchemaName` *inside* one catalog, which separates classes from each other but not two **processes** from each other — so isolation has to be the database. Dropped and recreated per run rather than reused, since a catalog carrying the previous run's tables is the false-green trap CLAUDE.md already warns about, and a per-lane catalog is throwaway by construction.
- **A worker clamp of `ProcessorCount / 2`.** The committed count is tuned on a developer machine; the machine running decides. An oversubscribed fleet does not fail politely — it kills the runner outright (`The runner has received a shutdown signal`). **In the event, this repo's runners are wide enough that the clamp did not bite and CI ran all 4 workers** (see the measured section). It stays as insurance for a narrower runner, not as something currently limiting the run.

## TRX reporting is unchanged

A supervised run produces no TRX of its own — each worker executes a slice and none of them knows the whole run — so `TrxWriter` writes one into the same `TestResults/` directory. `dorny/test-reporter` keeps working through its existing `**/TestResults/*.trx` glob, with **no change to the reporter step**: same artifact, same PR annotations.

Built against a reference TRX from the single-process runner rather than from the schema. Verified identical: result attributes, `TestMethod` attributes, and the full counter set — and `TestMethod.name` carries the full display name, because that is what MTP writes there.

The runner then **re-reads the file it just wrote** and fails if it does not hold one result per test. That check earns its place because the failure mode here is *silence*: a malformed or short TRX makes the reporter report nothing rather than erroring — the same trap this repo already records for `dotnet test --logger trx` under MTP. A reporting regression must break the run that caused it, not the next person's investigation.

An **indeterminate** — the run never established what the test does, because the worker died under it — has no TRX outcome of its own. It is written as failed, with a message saying which it was, so it is never quietly filed as an assertion failure.

## Opt-in

`TEST_WORKERS` defaults to **1** on the template, which is byte-for-byte today's behaviour: same executable, same TRX, same reporter. Only `polecat.yml` opts in. A suite that has not been checked for parallel-readiness cannot be parallelised by accident.

## Known follow-up

Lanes are balanced by **test count**, so the last ~2.5 minutes of the local run were a single lane finishing the `MultiTenancy` classes alone. Bobcat accepts `KnownTestDurations` for longest-processing-time balancing; feeding it the previous main run's durations is the next increment and should recover most of that tail.

This PR's own CI run exercises the supervised path end to end, including the TRX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
