### PR TITLE
Bring Directory.Build.props back in step with the released line (5.25.0)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,18 @@
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>5.22.0</Version>
+        <!--
+          Kept in step with the released line by hand. This is NOT what decides a package's version:
+          publish.yml derives that from the tag name (v5.25.0 -> 5.25.0) and passes it to `dotnet
+          pack` as -p:Version, so this property is overridden on every tagged publish and cannot
+          make a release wrong. What it does set is the assembly and file version of a LOCAL build,
+          and anything reading Assembly.GetName().Version at runtime — including Polecat's own
+          EventStoreUsage descriptor, which reports the store's version to CritterWatch.
+          It had drifted two releases behind (5.22.0 while 5.24.0 shipped) precisely because nothing
+          in the publish path reads it, so a stale value is invisible until someone asks a running
+          store what version it is.
+        -->
+        <Version>5.25.0</Version>
         <LangVersion>latest</LangVersion>
         <Authors>Jeremy D. Miller</Authors>
         <PackageIcon>logo.png</PackageIcon>


### PR DESCRIPTION
`Directory.Build.props` said **5.22.0** while **5.24.0** had shipped — two releases of drift. Set to 5.25.0 ahead of that tag, so the released tree carries the version it claims.

## Why it drifted

Nothing in the publish path reads it. `publish.yml` derives the package version from the **tag name** (`v5.25.0` → `5.25.0`) and passes it to `dotnet pack` as `-p:Version`, which overrides this property on every tagged publish.

So a stale value here cannot make a release wrong — and equally, nothing ever failed to point out that it was stale.

## Why it still matters

It sets the assembly and file version of a local build, and therefore anything reading `Assembly.GetName().Version` at runtime — including Polecat's own `EventStoreUsage` descriptor in `DocumentStore.EventStore.cs`, which reports the store's version to CritterWatch:

```csharp
Version = GetType().Assembly.GetName().Version?.ToString()!,
```

A monitoring console naming a version two releases behind what is actually deployed is the shape of the problem, and it is invisible until someone asks a running store what version it is.

The property now carries a comment explaining both halves — that the publish overrides it, and that it is not therefore cosmetic — which is the thing that would otherwise let it drift again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)