### PR TITLE
CI: balance supervised lanes by measured duration instead of test count

### DIFF
--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -102,6 +102,22 @@ jobs:
       # A supervised run produces no TRX on its own — each worker executes a slice and none of
       # them knows the whole run — so the runner writes one itself, into the same TestResults/
       # directory the single-process path uses. The reporter step below is shared and unchanged.
+      # Last main run's per-test durations, so lanes are balanced by measured cost rather than by
+      # counting tests. Best-effort by design: `continue-on-error` plus the runner treating a
+      # missing file as "balance by count" means a first run on a new branch, a pruned artifact or
+      # a download hiccup costs the balancing hint and nothing else.
+      - name: Fetch previous test durations
+        if: ${{ inputs.TEST_WORKERS != 1 }}
+        continue-on-error: true
+        run: |
+          gh run download --repo "$GITHUB_REPOSITORY" \
+            --name "durations-${{ inputs.STORAGE_TYPE }}" \
+            --dir previous-durations \
+            $(gh run list --repo "$GITHUB_REPOSITORY" --workflow polecat.yml --branch main \
+                --status success --limit 1 --json databaseId --jq '.[0].databaseId')
+        env:
+          GH_TOKEN: ${{ github.token }}
+
       - name: Test (supervised)
         if: ${{ inputs.TEST_WORKERS != 1 }}
         run: |
@@ -109,7 +125,21 @@ jobs:
           ASSEMBLY=$(basename "${{ env.TEST_PROJECT_PATH }}" .csproj)
           dotnet run --project build/SupervisedTests/SupervisedTests.csproj -c Release -- \
             --executable "$PROJECT_DIR/bin/Release/net9.0/$ASSEMBLY" \
-            --workers ${{ inputs.TEST_WORKERS }}
+            --workers ${{ inputs.TEST_WORKERS }} \
+            --durations-in previous-durations \
+            --durations-out durations/durations.json
+
+      # Published from main only. A PR's durations describe a tree that is about to stop existing,
+      # and every PR overwriting the shared hint would make the balancer track whichever branch
+      # last ran rather than the trunk everything is measured against.
+      - name: Publish test durations
+        if: ${{ inputs.TEST_WORKERS != 1 && github.ref == 'refs/heads/main' && !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: durations-${{ inputs.STORAGE_TYPE }}
+          path: durations/durations.json
+          retention-days: 30
+          if-no-files-found: warn
 
       # Runs for BOTH paths. The supervised runner writes an equivalent TRX to the same
       # TestResults/ directory (build/SupervisedTests/TrxWriter.cs), so reporting is identical

--- a/build/SupervisedTests/Durations.cs
+++ b/build/SupervisedTests/Durations.cs
@@ -1,0 +1,130 @@
+using System.Text.Json;
+using Bobcat.Supervisor;
+
+namespace Polecat.Build.SupervisedTests;
+
+/// <summary>
+///     Per-test durations, carried from one run to the next so lanes are balanced by measured cost
+///     instead of by test count.
+/// </summary>
+/// <remarks>
+///     <para>
+///         Without history the supervisor balances lanes by counting tests, which assumes every test
+///         costs the same. On this suite they do not: the main run that motivated this had four lanes
+///         of 642 tests each finish a wall clock of 18m48s against 65m58s of measured test time —
+///         perfect balance would be 16m30s, so roughly <b>2m18s</b> was lanes waiting on whichever one
+///         drew the slow classes.
+///     </para>
+///     <para>
+///         That number is also the ceiling. Duration balancing cannot beat
+///         <c>sum(durations) / lanes</c>, and it cannot split a class — the partitioner works in whole
+///         classes because xUnit's isolation contract is per class — so the largest single class is a
+///         hard floor underneath that. Worth knowing before expecting more from this than it can give.
+///     </para>
+/// </remarks>
+internal static class Durations
+{
+    private static readonly JsonSerializerOptions Json = new() { WriteIndented = true };
+
+    /// <summary>
+    ///     Writes this run's per-test durations.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         <b>First-attempt</b> durations, not totals. Lane balancing wants what running a test
+    ///         once typically costs; a retry-amplified total would overweight exactly the flaky tests,
+    ///         which are the ones whose cost is least representative.
+    ///     </para>
+    ///     <para>
+    ///         A test with no reported duration is <b>omitted, never zero-filled</b>. Bobcat charges an
+    ///         absent test the median of what is known, which is the right guess; a zero would instead
+    ///         claim the test is free and pull whichever lane received it into taking more work.
+    ///     </para>
+    /// </remarks>
+    public static void Write(SupervisorResults results, string path)
+    {
+        try
+        {
+            var durations = new SortedDictionary<string, long>(StringComparer.Ordinal);
+
+            foreach (var test in results.Tests)
+            {
+                var measured = test.Attempts
+                    .OrderBy(a => a.AttemptNumber)
+                    .Select(a => a.Outcome.Duration)
+                    .FirstOrDefault(d => d is not null);
+
+                if (measured is { } duration)
+                {
+                    durations[test.Uid] = (long)duration.TotalMilliseconds;
+                }
+            }
+
+            if (durations.Count == 0) return;
+
+            Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(path))!);
+            File.WriteAllText(path, JsonSerializer.Serialize(durations, Json));
+
+            Console.WriteLine($"Durations written: {path} ({durations.Count} test(s))");
+        }
+        catch (Exception e)
+        {
+            // Reporting ABOUT the tests must never fail the tests. A run that produced a verdict has
+            // done its job; losing next run's balancing hint is not worth turning green into red.
+            Console.WriteLine($"WARNING: could not write durations to '{path}': {e.Message}");
+        }
+    }
+
+    /// <summary>
+    ///     The previous run's durations, or null when there are none.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Null is not an error and must not read as one: it is the first run, a new branch whose
+    ///         artifact has not been produced yet, or a developer running locally. The supervisor
+    ///         degrades to count balancing, which is exactly today's behaviour.
+    ///     </para>
+    ///     <para>
+    ///         Accepts a file or a directory, and searches a directory recursively, because an
+    ///         artifact download may or may not preserve the directory it was uploaded from.
+    ///     </para>
+    /// </remarks>
+    public static IReadOnlyDictionary<string, TimeSpan>? Read(string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path)) return null;
+
+        try
+        {
+            var file = File.Exists(path)
+                ? path
+                : Directory.Exists(path)
+                    ? Directory.EnumerateFiles(path, "*.json", SearchOption.AllDirectories).FirstOrDefault()
+                    : null;
+
+            if (file is null)
+            {
+                Console.WriteLine($"No previous durations at '{path}' — balancing lanes by test count.");
+                return null;
+            }
+
+            var raw = JsonSerializer.Deserialize<Dictionary<string, long>>(File.ReadAllText(file));
+            if (raw is null || raw.Count == 0)
+            {
+                Console.WriteLine($"'{file}' held no durations — balancing lanes by test count.");
+                return null;
+            }
+
+            Console.WriteLine($"Balancing lanes with {raw.Count} duration(s) from '{file}'.");
+
+            return raw.ToDictionary(
+                pair => pair.Key,
+                pair => TimeSpan.FromMilliseconds(pair.Value),
+                StringComparer.Ordinal);
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine($"WARNING: could not read durations from '{path}' ({e.Message}) — balancing by count.");
+            return null;
+        }
+    }
+}

--- a/build/SupervisedTests/Program.cs
+++ b/build/SupervisedTests/Program.cs
@@ -78,9 +78,14 @@ var factory = new MtpWorkerFactory(executable)
 // one: an emptied filter after a rename must not read as a pass.
 var filter = ArgValue("--filter");
 
+// The previous run's measured costs, when a CI step (or a developer) has fetched them. Null
+// degrades to exactly today's behaviour: balance the lanes by counting tests.
+var knownDurations = Durations.Read(ArgValue("--durations-in"));
+
 var supervisor = new Supervisor(factory)
 {
     MaxParallelWorkers = workers,
+    KnownTestDurations = knownDurations,
     TestFilter = filter is null
         ? null
         : test => test.DisplayName.Contains(filter, StringComparison.OrdinalIgnoreCase),
@@ -136,6 +141,14 @@ TrxWriter.Write(results, trxPath, Path.GetFullPath(executable), startedAt);
 TrxWriter.VerifyRoundTrip(trxPath, results.Tests.Count);
 
 Console.WriteLine($"TRX written: {trxPath} ({results.Tests.Count} result(s))");
+
+// This run's costs, for the next run's balancer. Written unconditionally when asked for, even on
+// a red run: a failing test still measured something, and the balancer wants typical cost rather
+// than only the cost of runs that happened to pass.
+if (ArgValue("--durations-out") is { } durationsOut)
+{
+    Durations.Write(results, durationsOut);
+}
 
 // The supervisor's own verdict, not a recount: it already knows what an indeterminate, a
 // stall-managed outcome and a spent retry budget each mean for the run.


### PR DESCRIPTION
Follow-up to #580, which noted this as the next increment.

## The problem

Without history the supervisor balances lanes by **counting tests**, which assumes every test costs the same. They do not. The `main` run that motivated this put 642 tests in each of four lanes and finished in **18m48s** against **65m58s** of measured test time — so roughly two minutes was lanes idling while one finished the slow classes.

The runner now writes its per-test durations and reads the previous run's, feeding `Supervisor.KnownTestDurations` so `WorkPlan` packs longest-processing-time-first.

## Measured

Same machine, retries off, back to back:

| | baseline | balanced |
|---|---|---|
| lanes (tests) | 642 / 642 / 642 / 642 | 585 / **726** / 637 / 620 |
| parallel efficiency | 3.41x | **3.61x** |
| wall clock | 16m06s | **14m07s** |

**−1m59s (−12.3%)**, both runs 2568 passed / 0 retries. The lanes are deliberately **uneven by count** now, which is the visible sign the balancer is weighting cost rather than headcount.

**Caveat, recorded rather than buried:** measured test time differed between the two runs (54m56s vs 51m01s), so some of the wall-clock delta is machine noise. The efficiency ratio is the sounder number because it is independent of total load, and it moved 3.41x → 3.61x.

## The ceiling was computed, not discovered

Perfect balance is `sum(durations) / lanes` = **13.73 min**, and the partitioner cannot split a class — xUnit's isolation contract is per class — so the largest class is a hard floor underneath that. Here it is `master_table_tenancy_tests` at **94.5s**, far below 13.73, so the floor does not bind and near-perfect packing was achievable.

14m07s against a 13.73 min prediction is worker launch and discovery, which no balancing removes. Knowing the ceiling up front is what says whether to expect more from this — if the largest class had been 12 minutes, the answer would have been "split that class", not "wire up balancing".

<sub>Deriving that required joining the durations file to class names: durations are keyed by hashed uid, and a first pass at the analysis silently treated every test as its own class and reported a meaningless 25s "largest class". The TRX from #580 carries `className`, and its `testId` is a deterministic hash of the uid, so the join recovers the real structure — 2568/2568 matched.</sub>

## Two details taken from Wolverine's rollout rather than reinvented

- **First-attempt** durations, not totals. Balancing wants what running a test once typically costs; a retry-amplified total overweights exactly the flaky tests, whose cost is least representative.
- A test with no reported duration is **omitted, never zero-filled**. Bobcat charges an absent test the median of what is known, which is the right guess; a zero would claim the test is free and pull its lane into taking more work.

## Failure behaviour

Everything is best-effort. A missing, empty or unreadable durations file logs one line and falls back to count balancing — today's behaviour exactly — and writing the file can never fail a run that already produced a verdict. In CI the fetch is `continue-on-error` for the same reason: a pruned artifact or a download hiccup costs the hint and nothing else.

Durations are published from **main only**. A PR's durations describe a tree that is about to stop existing, and letting every PR overwrite the shared artifact would make the balancer track whichever branch ran last instead of the trunk.

Note this PR's own CI run has no artifact to fetch yet, so it balances by count — the gain shows up on the first PR after this merges and `main` publishes one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)