### PR TITLE
gh-584: give Polecat's explorer reads a database dimension

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -408,14 +408,14 @@
              Worth recording for the next reader: Fisher was the store that ran these suites first
              and filed both #784 and #788. Polecat inherits both fixes without having had to
              diagnose either, which is the whole argument for the shared suites. -->
-        <PackageVersion Include="JasperFx" Version="2.67.0" />
-        <PackageVersion Include="JasperFx.Events" Version="2.67.0" />
+        <PackageVersion Include="JasperFx" Version="2.68.0" />
+        <PackageVersion Include="JasperFx.Events" Version="2.68.0" />
         <!--
              The shared cross-store event sourcing compliance suites. Source-only package: the
              suites compile inside Polecat.Tests so JasperFx's aggregate source generator binds
              Polecat's own session types.
         -->
-        <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.67.0" />
+        <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.68.0" />
         <!-- Pin the sibling JasperFx packages for parity with Marten 9's matrix
              even though Polecat doesn't currently reference them directly —
              keeps the lockstep matrix coherent when transitive resolution
@@ -423,7 +423,7 @@
              RuntimeCompiler 5.x line is the active continuation of the 4.x
              lineage; do not pin against the parallel stale 2.0.x series. -->
         <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.67.0" />
+        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.68.0" />
         <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
@@ -587,7 +587,7 @@
         <PackageVersion Include="Vogen" Version="7.0.0" />
 
         <!-- Source generators (matched to JasperFx.Events above) -->
-        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.67.0" />
+        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.68.0" />
 
         <!-- Build automation -->
         <PackageVersion Include="Nuke.Common" Version="9.0.4" />

--- a/src/Polecat.Tests/Diagnostics/database_scoped_explorer_reads_tests.cs
+++ b/src/Polecat.Tests/Diagnostics/database_scoped_explorer_reads_tests.cs
@@ -1,0 +1,293 @@
+using JasperFx;
+using JasperFx.Descriptors;
+using JasperFx.Events;
+using Microsoft.Data.SqlClient;
+using Weasel.Core;
+using Polecat.Storage;
+using Polecat.Tests.Harness;
+using Polecat.Tests.Projections;
+
+namespace Polecat.Tests.ExplorerApi;
+
+/// <summary>
+///     #584 / jasperfx#810 — the database dimension of the explorer reads, on a store that actually
+///     has more than one database.
+/// </summary>
+/// <remarks>
+///     <para>
+///         <c>EventStoreExplorerCompliance</c> covers the single-database half: there, the database
+///         overload and the store-global read are the same read, so all it can pin is that they agree.
+///         The failure this issue exists to stop only appears once there are two databases — a
+///         store-global read answering from whichever one the default session resolved, with nothing
+///         in the result saying so. That needs a database-per-tenant fixture, which is what this is.
+///     </para>
+///     <para>
+///         Each tenant database gets a stream that exists ONLY there, so a read that silently answered
+///         from one database would come back missing the other's stream rather than throwing — the
+///         assertions below are written to catch that shape, not just an exception type.
+///     </para>
+/// </remarks>
+public class database_scoped_explorer_reads_tests : IAsyncLifetime
+{
+    private const string TenantA = "explorer_tenant_a";
+    private const string TenantB = "explorer_tenant_b";
+
+    // Scoped per CLAUDE.md: a database a test creates is a SIBLING of the worker's own catalog, not a
+    // child of it, so a hardcoded name would be one database every parallel worker fights over.
+    private static readonly string DbA = ConnectionSource.Scoped("explorer_a");
+    private static readonly string DbB = ConnectionSource.Scoped("explorer_b");
+
+    private static string TenantConnectionString(string dbName) =>
+        ConnectionSource.ConnectionStringFor(dbName);
+
+    public async ValueTask InitializeAsync()
+    {
+        await using var conn = new SqlConnection(ConnectionSource.MasterConnectionString);
+        await conn.OpenAsync();
+
+        foreach (var db in new[] { DbA, DbB })
+        {
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = $"IF DB_ID('{db}') IS NULL CREATE DATABASE [{db}];";
+            await cmd.ExecuteNonQueryAsync();
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await using var conn = new SqlConnection(ConnectionSource.MasterConnectionString);
+        await conn.OpenAsync();
+
+        foreach (var db in new[] { DbA, DbB })
+        {
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = $"""
+                IF DB_ID('{db}') IS NOT NULL
+                BEGIN
+                    ALTER DATABASE [{db}] SET SINGLE_USER WITH ROLLBACK IMMEDIATE;
+                    DROP DATABASE [{db}];
+                END
+                """;
+            await cmd.ExecuteNonQueryAsync();
+        }
+    }
+
+    private static DocumentStore CreateStore()
+    {
+        return DocumentStore.For(opts =>
+        {
+            opts.ConnectionString = TenantConnectionString(DbA);
+            opts.AutoCreateSchemaObjects = AutoCreate.All;
+            opts.UseNativeJsonType = ConnectionSource.SupportsNativeJson;
+            opts.DatabaseSchemaName = "explorer_by_db";
+
+            opts.MultiTenantedDatabases(tenancy =>
+            {
+                tenancy.AddTenant(TenantA, TenantConnectionString(DbA));
+                tenancy.AddTenant(TenantB, TenantConnectionString(DbB));
+            });
+        });
+    }
+
+    /// <summary>
+    ///     Appends one stream per tenant database and returns (streamInA, streamInB). Each stream id
+    ///     exists in exactly one of the two databases.
+    /// </summary>
+    private static async Task<(Guid inA, Guid inB)> SeedAsync(DocumentStore store, CancellationToken ct)
+    {
+        var inA = Guid.NewGuid();
+        var inB = Guid.NewGuid();
+
+        await using (var session = store.LightweightSession(new SessionOptions { TenantId = TenantA }))
+        {
+            session.Events.StartStream<QuestParty>(inA, new QuestStarted("a"), new MembersJoined(1, "Rivendell", ["Frodo"]));
+            await session.SaveChangesAsync(ct);
+        }
+
+        await using (var session = store.LightweightSession(new SessionOptions { TenantId = TenantB }))
+        {
+            session.Events.StartStream<QuestParty>(inB, new QuestStarted("b"));
+            await session.SaveChangesAsync(ct);
+        }
+
+        return (inA, inB);
+    }
+
+    [Fact]
+    public async Task recent_streams_scoped_to_a_database_returns_that_database_only()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var store = CreateStore();
+        var (inA, inB) = await SeedAsync(store, ct);
+
+        var eventStore = (IEventStore)store;
+        var databases = await eventStore.AllDatabases();
+        databases.Count.ShouldBe(2);
+
+        // Attribute each answer to the database it came from — the whole point of the overload.
+        var perDatabase = new Dictionary<string, List<string>>();
+        foreach (var database in databases)
+        {
+            var streams = await eventStore.GetRecentStreamsAsync(database, 10, null, ct);
+            perDatabase[database.Identifier] = streams.Select(x => x.StreamId).ToList();
+        }
+
+        // Exactly one database holds each stream, and it is not the same one.
+        perDatabase.Values.Count(x => x.Contains(inA.ToString())).ShouldBe(1);
+        perDatabase.Values.Count(x => x.Contains(inB.ToString())).ShouldBe(1);
+        perDatabase.Single(x => x.Value.Contains(inA.ToString())).Key
+            .ShouldNotBe(perDatabase.Single(x => x.Value.Contains(inB.ToString())).Key);
+    }
+
+    [Fact]
+    public async Task store_global_recent_streams_fans_out_rather_than_answering_from_one_database()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var store = CreateStore();
+        var (inA, inB) = await SeedAsync(store, ct);
+
+        var streams = await ((IEventStore)store).GetRecentStreamsAsync(10, ct);
+        var ids = streams.Select(x => x.StreamId).ToList();
+
+        // The pre-#584 behaviour returned whichever database the default session resolved, so this
+        // would have carried inA and silently dropped inB.
+        ids.ShouldContain(inA.ToString());
+        ids.ShouldContain(inB.ToString());
+    }
+
+    [Fact]
+    public async Task the_fan_out_respects_the_overall_count_cap()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var store = CreateStore();
+        await SeedAsync(store, ct);
+
+        // A cap of 1 over two databases must yield one stream, not one PER database.
+        var streams = await ((IEventStore)store).GetRecentStreamsAsync(1, ct);
+
+        streams.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task stream_metadata_scoped_to_a_database_is_null_in_the_other_one()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var store = CreateStore();
+        var (inA, _) = await SeedAsync(store, ct);
+
+        var eventStore = (IEventStore)store;
+        var databases = await eventStore.AllDatabases();
+
+        var answers = new List<StreamMetadata?>();
+        foreach (var database in databases)
+        {
+            answers.Add(await eventStore.GetStreamMetadataAsync(database, inA.ToString(), null, ct));
+        }
+
+        // "No such stream in THIS database" rather than "no such stream" — the distinction a
+        // store-global read cannot make once there is more than one database.
+        answers.Count(x => x != null).ShouldBe(1);
+        answers.Single(x => x != null)!.Version.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task stream_events_scoped_to_a_database_read_only_that_database()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var store = CreateStore();
+        var (inA, _) = await SeedAsync(store, ct);
+
+        var eventStore = (IEventStore)store;
+        var databases = await eventStore.AllDatabases();
+
+        var counts = new List<int>();
+        foreach (var database in databases)
+        {
+            var versions = new List<long>();
+            await foreach (var e in eventStore.ReadStreamAsync(database, inA.ToString(), null, ct))
+            {
+                versions.Add(e.StreamVersion);
+            }
+
+            counts.Add(versions.Count);
+        }
+
+        counts.OrderDescending().ShouldBe(new[] { 2, 0 });
+    }
+
+    [Fact]
+    public async Task projection_statuses_scoped_to_a_database_read_that_databases_progression()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var store = CreateStore();
+        await SeedAsync(store, ct);
+
+        var eventStore = (IEventStore)store;
+        var databases = await eventStore.AllDatabases();
+
+        // Progression rows live in the database whose events they track, so this has to answer per
+        // database rather than throw the way its store-global sibling now does.
+        foreach (var database in databases)
+        {
+            var statuses = await eventStore.GetProjectionStatusesAsync(database, null, ct);
+            statuses.ShouldNotBeNull();
+        }
+    }
+
+    // ---- the store-global reads that refuse rather than answering from one database ----
+    //
+    // Each of these returns ONE database's worth of answer by nature, so there is no merge that is
+    // not a fabrication: a stream's events out of two databases would interleave two independent
+    // version sequences, a stream's metadata is a single row, and progression rows named
+    // "MyProjection:All" exist once per database. Refusing and naming the database overload is the
+    // honest answer; answering from one database is the option #584 rules out.
+
+    [Fact]
+    public async Task store_global_stream_metadata_refuses_on_a_multi_database_store()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var store = CreateStore();
+        var (inA, _) = await SeedAsync(store, ct);
+
+        var ex = await Should.ThrowAsync<NotSupportedException>(
+            () => ((IEventStore)store).GetStreamMetadataAsync(inA.ToString(), ct));
+
+        ex.Message.ShouldContain("AllDatabases");
+    }
+
+    [Fact]
+    public async Task store_global_stream_read_refuses_on_a_multi_database_store()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var store = CreateStore();
+        var (inA, _) = await SeedAsync(store, ct);
+
+        await Should.ThrowAsync<NotSupportedException>(async () =>
+        {
+            await foreach (var _ in ((IEventStore)store).ReadStreamAsync(inA.ToString(), ct))
+            {
+            }
+        });
+    }
+
+    [Fact]
+    public async Task store_global_projection_statuses_refuse_on_a_multi_database_store()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var store = CreateStore();
+        await SeedAsync(store, ct);
+
+        await Should.ThrowAsync<NotSupportedException>(
+            () => ((IEventStore)store).GetProjectionStatusesAsync(ct));
+    }
+
+    [Fact]
+    public async Task a_null_database_is_rejected_rather_than_quietly_meaning_store_global()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var store = CreateStore();
+
+        await Should.ThrowAsync<ArgumentNullException>(
+            () => ((IEventStore)store).GetRecentStreamsAsync(null!, 10, null, ct));
+    }
+}

--- a/src/Polecat/DocumentStore.EventStoreExplorer.cs
+++ b/src/Polecat/DocumentStore.EventStoreExplorer.cs
@@ -32,14 +32,34 @@ public partial class DocumentStore
     Task<IReadOnlyList<StreamSummary>> IEventStore.GetRecentStreamsAsync(int count, CancellationToken ct)
         => ((IEventStore)this).GetRecentStreamsAsync(count, null, ct);
 
+    // #584 / jasperfx#810 — the database dimension. Reads the listing from ONE database rather than
+    // from whichever database the store's default session resolves. A tool enumerates AllDatabases()
+    // and calls this per database, so every row it renders is attributable to the database it came
+    // from. On a single-database store this is the same read as the store-global overload; the
+    // argument is simply the store's one database.
+    Task<IReadOnlyList<StreamSummary>> IEventStore.GetRecentStreamsAsync(
+        IEventDatabase database, int count, string? tenantId, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(database);
+        return recentStreamsAsync(RequirePolecatDatabase(database), count, tenantId, ct);
+    }
+
     // #782 / jasperfx#503 — tenant-scoped recent-streams listing. On a conjoined multi-tenant
     // Polecat store the pc_streams rows carry a tenant_id column, so a non-null tenantId bounds
     // the listing with a tenant_id predicate. Null preserves the store-global listing across
-    // every tenant (today's behaviour). Database-per-tenant scoping (StaticMultiple /
-    // DynamicMultiple) is a separate, broader gap — the tenant-less explorer reads themselves do
-    // not yet resolve per-database — so it is not attempted here.
-    async Task<IReadOnlyList<StreamSummary>> IEventStore.GetRecentStreamsAsync(
+    // every tenant within a database. The database axis is independent and is handled by the
+    // IEventDatabase overload above (#584); the tenant_id predicate here applies on top of whichever
+    // database ends up being opened.
+    Task<IReadOnlyList<StreamSummary>> IEventStore.GetRecentStreamsAsync(
         int count, string? tenantId, CancellationToken ct)
+        // #584 — on a multi-database store a store-global listing is a fan-out, not one database's
+        // rows. See FanOutRecentStreamsAsync for why this one read merges where its siblings refuse.
+        => IsSingleDatabase
+            ? recentStreamsAsync(null, count, tenantId, ct)
+            : FanOutRecentStreamsAsync(count, tenantId, ct);
+
+    private async Task<IReadOnlyList<StreamSummary>> recentStreamsAsync(
+        PolecatDatabase? database, int count, string? tenantId, CancellationToken ct)
     {
         if (count <= 0) return Array.Empty<StreamSummary>();
 
@@ -47,7 +67,7 @@ public partial class DocumentStore
 
         // #148: run through a QuerySession so the command is covered by
         // Options.ResiliencePipeline (Polly) like the rest of the read path.
-        await using var session = (Internal.QuerySession)QuerySession();
+        await using var session = ExplorerSession(database);
         await using var cmd = new SqlCommand();
         // #57: share the column projection + row read with FetchStreamStateAsync
         // and GetStreamMetadataAsync via PcStreamsRowReader so all three sites
@@ -73,13 +93,33 @@ public partial class DocumentStore
     IAsyncEnumerable<EventRecord> IEventStore.ReadStreamAsync(string streamId, CancellationToken ct)
         => ((IEventStore)this).ReadStreamAsync(streamId, null, ct);
 
+    // #584 / jasperfx#810 — the database dimension matters more here than for a listing: the same
+    // stream id can exist in several databases, each with its own version sequence, so "which
+    // database" is part of the stream's identity rather than a filter over one answer.
+    IAsyncEnumerable<EventRecord> IEventStore.ReadStreamAsync(
+        IEventDatabase database, string streamId, string? tenantId, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(database);
+        return readStreamAsync(RequirePolecatDatabase(database), streamId, tenantId, ct);
+    }
+
     // #782 / jasperfx#503 — tenant-scoped stream read. On a conjoined multi-tenant Polecat
     // store the same stream id can exist under two tenants; the tenant-less overload reads
     // across every tenant and returns their ambiguous union. A non-null tenantId filters the
-    // read to that tenant's rows via a tenant_id predicate. Null preserves the store-global
-    // read. (See the GetRecentStreamsAsync note on the database-per-tenant boundary.)
-    async IAsyncEnumerable<EventRecord> IEventStore.ReadStreamAsync(
-        string streamId, string? tenantId, [EnumeratorCancellation] CancellationToken ct)
+    // read to that tenant's rows via a tenant_id predicate. Null preserves the read across every
+    // tenant in the database. The database axis is the IEventDatabase overload above (#584).
+    IAsyncEnumerable<EventRecord> IEventStore.ReadStreamAsync(
+        string streamId, string? tenantId, CancellationToken ct)
+    {
+        // #584 — concatenating one stream id's events out of several databases would interleave two
+        // independent version sequences into something that reads as a single stream and is not.
+        RequireSingleDatabase(nameof(IEventStore.ReadStreamAsync));
+        return readStreamAsync(null, streamId, tenantId, ct);
+    }
+
+    private async IAsyncEnumerable<EventRecord> readStreamAsync(
+        PolecatDatabase? database, string streamId, string? tenantId,
+        [EnumeratorCancellation] CancellationToken ct)
     {
         ArgumentException.ThrowIfNullOrEmpty(streamId);
 
@@ -91,7 +131,7 @@ public partial class DocumentStore
         // #148: run through a QuerySession so the command is covered by
         // Options.ResiliencePipeline (Polly). The session is kept alive for the
         // duration of the enumeration via await using.
-        await using var session = (Internal.QuerySession)QuerySession();
+        await using var session = ExplorerSession(database);
         await using var cmd = new SqlCommand();
 
         // #57 pc_events half: share the column projection + row hydration
@@ -128,8 +168,34 @@ public partial class DocumentStore
         }
     }
 
-    async Task<StreamMetadata?> IEventStore.GetStreamMetadataAsync(
+    Task<StreamMetadata?> IEventStore.GetStreamMetadataAsync(
         string streamId, CancellationToken ct)
+    {
+        // #584 — this read returns ONE row. On a multi-database store two databases can each hold a
+        // stream with this id, and there is no answer that names both.
+        RequireSingleDatabase(nameof(IEventStore.GetStreamMetadataAsync));
+        return streamMetadataAsync(null, streamId, ct);
+    }
+
+    // #584 / jasperfx#810 — the database dimension. A null answer from this overload means "no such
+    // stream in THIS database" rather than "no such stream", which is exactly the distinction the
+    // store-global read cannot make once there is more than one database.
+    Task<StreamMetadata?> IEventStore.GetStreamMetadataAsync(
+        IEventDatabase database, string streamId, string? tenantId, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(database);
+        if (tenantId != null)
+        {
+            throw new NotSupportedException(
+                "Tenant-scoped GetStreamMetadataAsync is not implemented on Polecat. Pass a null tenantId " +
+                "to read the stream from the database without a tenant predicate.");
+        }
+
+        return streamMetadataAsync(RequirePolecatDatabase(database), streamId, ct);
+    }
+
+    private async Task<StreamMetadata?> streamMetadataAsync(
+        PolecatDatabase? database, string streamId, CancellationToken ct)
     {
         ArgumentException.ThrowIfNullOrEmpty(streamId);
 
@@ -139,7 +205,7 @@ public partial class DocumentStore
 
         // #148: run through a QuerySession so the command is covered by
         // Options.ResiliencePipeline (Polly).
-        await using var session = (Internal.QuerySession)QuerySession();
+        await using var session = ExplorerSession(database);
         await using var cmd = new SqlCommand();
         // #57: share the pc_streams column projection + row read with the
         // other two stream-reading sites via PcStreamsRowReader. The JOIN'd
@@ -184,15 +250,30 @@ public partial class DocumentStore
     ///     single tenant with an <c>e.tenant_id</c> predicate on pc_events, AND-combining a <c>seq_id</c>
     ///     sub-select per requested tag (matching the Marten companion's shape).
     ///     <para>
-    ///     Scope here is the conjoined single-database <c>tenant_id</c>-predicate path only. A null
-    ///     <paramref name="tenantId"/> delegates to the tenant-less overload — still a NotSupportedException,
-    ///     because store-global DCB tag queries are a separate, pre-existing Polecat gap. Database-per-tenant
-    ///     explorer scoping is likewise a pre-existing Polecat gap (the stream-read explorer methods don't
-    ///     open a per-database session either); when that lands, this method grows the same
-    ///     FindOrCreateDatabase branch its Marten counterpart already uses.
+    ///     A null <paramref name="tenantId"/> delegates to the tenant-less overload — still a
+    ///     NotSupportedException, because store-global DCB tag queries are a separate, pre-existing Polecat
+    ///     gap. The DATABASE axis is independent of this one and is now closed (#584): the IEventDatabase
+    ///     overload picks the database, and the <c>e.tenant_id</c> predicate below applies within it.
     ///     </para>
     /// </summary>
-    async IAsyncEnumerable<EventRecord> IEventStore.QueryByTagsAsync(
+    // #584 / jasperfx#810 — the database dimension. Tag values are not unique across databases, so
+    // a store-global tag query on a sharded store would answer from one database and show no sign of
+    // it. This overload names the database; the tenant predicate below is the independent second
+    // axis, and both apply.
+    IAsyncEnumerable<EventRecord> IEventStore.QueryByTagsAsync(
+        IEventDatabase database, IReadOnlyDictionary<string, string> tags, string? tenantId,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(database);
+        return queryByTagsAsync(RequirePolecatDatabase(database), tags, tenantId, ct);
+    }
+
+    IAsyncEnumerable<EventRecord> IEventStore.QueryByTagsAsync(
+        IReadOnlyDictionary<string, string> tags, string? tenantId, CancellationToken ct)
+        => queryByTagsAsync(null, tags, tenantId, ct);
+
+    private async IAsyncEnumerable<EventRecord> queryByTagsAsync(
+        PolecatDatabase? database,
         IReadOnlyDictionary<string, string> tags,
         string? tenantId,
         [EnumeratorCancellation] CancellationToken ct)
@@ -334,31 +415,59 @@ public partial class DocumentStore
         return new AggregateAtVersion(aggregateType.FullName ?? aggregateTypeName, stateJson, resolvedVersion, eventsApplied);
     }
 
-    async Task<IReadOnlyList<ProjectionStatus>> IEventStore.GetProjectionStatusesAsync(CancellationToken ct)
+    Task<IReadOnlyList<ProjectionStatus>> IEventStore.GetProjectionStatusesAsync(CancellationToken ct)
+    {
+        // #584 — progression rows live in the database whose events they track. Merging them across
+        // databases would collapse N rows named "MyProjection:All" into one, so a store-global
+        // snapshot on a sharded store describes one database and reads as the whole store's.
+        RequireSingleDatabase(nameof(IEventStore.GetProjectionStatusesAsync));
+        return projectionStatusesAsync(SingleDatabase, tenantId: null, ct);
+    }
+
+    // #584 / jasperfx#810 — the database dimension, and the counterpart to the per-cell lag that
+    // IEventDatabase.FetchProjectionLagAsync already reports one database at a time.
+    Task<IReadOnlyList<ProjectionStatus>> IEventStore.GetProjectionStatusesAsync(
+        IEventDatabase database, string? tenantId, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(database);
+
+        // The TENANT dimension of this read is a separate, still-open gap, and it is deeper than a
+        // predicate: Polecat encodes the tenant in the shard NAME under per-tenant partitioning, so a
+        // tenant-filtered progression read returns tenant-suffixed row names while the status loop
+        // below builds its shard list from the untenanted registrations — nothing would match. The
+        // HighWaterMark row carries no tenant suffix either, so it would be filtered out and the high
+        // water mark would read 0. Every shard would come back "0 of 0" and look perfectly healthy,
+        // which is the failure mode this issue exists to stop. The base interface already refuses a
+        // non-null tenant here, and keeping that refusal is the honest answer until the shard-name
+        // axis is done properly.
+        if (tenantId != null)
+        {
+            throw new NotSupportedException(
+                "Per-tenant GetProjectionStatusesAsync is not implemented on Polecat. Pass a null tenantId " +
+                "for the whole database's projection statuses.");
+        }
+
+        return projectionStatusesAsync(RequirePolecatDatabase(database), tenantId: null, ct);
+    }
+
+    private async Task<IReadOnlyList<ProjectionStatus>> projectionStatusesAsync(
+        PolecatDatabase database, string? tenantId, CancellationToken ct)
     {
         // Pull progression rows so we can attach processed sequence numbers to each shard
         var progress = new Dictionary<string, long>(StringComparer.OrdinalIgnoreCase);
         long highWater = 0;
 
-        // #148: run through a QuerySession so the command is covered by
-        // Options.ResiliencePipeline (Polly).
-        await using (var session = (Internal.QuerySession)QuerySession())
+        // AllProjectionProgress runs inside Options.ResiliencePipeline the same way the session-bound
+        // explorer reads do, and it is already per-database -- which is the whole point here.
+        foreach (var state in await database.AllProjectionProgress(tenantId, ct))
         {
-            await using var cmd = new SqlCommand();
-            cmd.CommandText = $"SELECT name, last_seq_id FROM {Events.ProgressionTableName};";
-            await using var reader = await session.ExecuteReaderAsync(cmd, ct);
-            while (await reader.ReadAsync(ct))
+            if (string.Equals(state.ShardName, "HighWaterMark", StringComparison.OrdinalIgnoreCase))
             {
-                var name = reader.GetString(0);
-                var seq = reader.GetInt64(1);
-                if (string.Equals(name, "HighWaterMark", StringComparison.OrdinalIgnoreCase))
-                {
-                    highWater = seq;
-                }
-                else
-                {
-                    progress[name] = seq;
-                }
+                highWater = state.Sequence;
+            }
+            else
+            {
+                progress[state.ShardName] = state.Sequence;
             }
         }
 
@@ -390,6 +499,96 @@ public partial class DocumentStore
         }
 
         return statuses;
+    }
+
+    // ---- #584 / jasperfx#810: the database dimension of the explorer reads ----
+    //
+    // Every explorer read below used to open the store's default session, which on a store with more
+    // than one database silently picks whichever database that session resolves. The result is
+    // indistinguishable from a complete answer — a console over 512 shard databases lists recent
+    // streams from one of them and says nothing about the other 511 (CritterWatch#1231).
+    //
+    // The fix has two halves, and they are independent axes:
+    //   * the database-scoped overloads open the database they are GIVEN, so a tool enumerates
+    //     AllDatabases() and attributes each answer to the database it came from; and
+    //   * the store-global overloads stop answering from one database. Each either fans out (the
+    //     recent-streams listing, where merging is well defined) or refuses and names the database
+    //     overload. Answering from one database is the one option ruled out.
+    //
+    // The tenant predicate is the OTHER axis and is unchanged: Polecat already applies tenant_id
+    // wherever events are conjoined, and it applies on top of whichever database is opened.
+
+    private bool IsSingleDatabase => (Options.Tenancy?.Cardinality ?? DatabaseCardinality.Single)
+        == DatabaseCardinality.Single;
+
+    /// <summary>
+    ///     The store's one database, for the store-global reads that are only reachable when there is
+    ///     exactly one. Callers must have passed <see cref="RequireSingleDatabase" /> first.
+    /// </summary>
+    private PolecatDatabase SingleDatabase =>
+        Options.Tenancy?.AllDatabases() is { Count: > 0 } databases
+            ? databases[0]
+            : throw new InvalidOperationException(
+                "This Polecat store has no database configured, so the event store explorer has nothing to read.");
+
+    private void RequireSingleDatabase(string member)
+    {
+        if (IsSingleDatabase) return;
+
+        throw new NotSupportedException(
+            $"Store-global {member} is not supported on this Polecat store, whose DatabaseCardinality is " +
+            $"{Options.Tenancy!.Cardinality}. It would answer from whichever database the default session " +
+            "resolved, and the result would be indistinguishable from a complete answer. Enumerate " +
+            $"IEventStore.AllDatabases() and call the IEventDatabase overload of {member} per database " +
+            "instead (jasperfx#810, polecat#584).");
+    }
+
+    private static PolecatDatabase RequirePolecatDatabase(IEventDatabase database) =>
+        database as PolecatDatabase
+        ?? throw new ArgumentException(
+            $"Expected a Polecat database but got '{database.GetType().FullName}'. The database-scoped event " +
+            "store explorer reads only accept databases this store produced through AllDatabases().",
+            nameof(database));
+
+    /// <summary>
+    ///     Opens the session an explorer read runs on: the database it was given, or the store's
+    ///     default routing when it was given none.
+    /// </summary>
+    private Internal.QuerySession ExplorerSession(PolecatDatabase? database) =>
+        (Internal.QuerySession)(database == null
+            ? QuerySession()
+            : QuerySession(SessionOptions.ForDatabase(database)));
+
+    /// <summary>
+    ///     The store-global recent-streams listing on a multi-database store. This is the one explorer
+    ///     read whose store-global answer stays meaningful across databases: "the N most recently
+    ///     updated streams" is well defined over a union, because <see cref="StreamSummary" /> carries
+    ///     the LastUpdatedAt the merge orders on. Its siblings refuse instead — a stream's events, a
+    ///     stream's metadata and a database's projection progression are each scoped to one database
+    ///     by nature, and merging them would fabricate a stream or a shard that does not exist.
+    ///     <para>
+    ///     Each database is capped at <paramref name="count" /> because no database can contribute more
+    ///     than that to the top <paramref name="count" /> overall, so the cap costs nothing and bounds
+    ///     the fan-out.
+    ///     </para>
+    /// </summary>
+    private async Task<IReadOnlyList<StreamSummary>> FanOutRecentStreamsAsync(
+        int count, string? tenantId, CancellationToken ct)
+    {
+        if (count <= 0) return Array.Empty<StreamSummary>();
+
+        var databases = await ((IEventStore)this).AllDatabases();
+
+        var merged = new List<StreamSummary>(capacity: count * Math.Max(databases.Count, 1));
+        foreach (var database in databases)
+        {
+            merged.AddRange(await recentStreamsAsync(RequirePolecatDatabase(database), count, tenantId, ct));
+        }
+
+        return merged
+            .OrderByDescending(x => x.LastUpdatedAt)
+            .Take(count)
+            .ToList();
     }
 
     // #373: one answer to "what type is this alias". This used to be a second, near-identical copy of the


### PR DESCRIPTION
Closes #584. Bumps JasperFx 2.67.0 → 2.68.0 and implements the database-scoped explorer reads that release added (jasperfx#810, abstraction half in JasperFx/jasperfx#817).

## The gap

The explorer reads on `IEventStore` were scoped by tenant only, and every one of them opened the store's **default** session. On a store whose `DatabaseCardinality` is not `Single`, that makes a store-global read a silent partial answer: it comes back from whichever database the default session resolved, and nothing in the result says so. A console over N shard databases lists recent streams from one of them and it reads as the whole store (CritterWatch#1231).

`DocumentStore.EventStoreExplorer` named this gap in a comment and deferred it, because the surface to close it did not exist yet. It does now.

## Two halves, two independent axes

**The five database-scoped overloads** — `GetRecentStreamsAsync`, `ReadStreamAsync`, `GetStreamMetadataAsync`, `QueryByTagsAsync`, `GetProjectionStatusesAsync` — open the database they are *given*, through `SessionOptions.ForDatabase`. That is the same seam the async daemon already uses to bind a session to a database it resolved (polecat#514), so this adds no new routing concept. A tool enumerates `AllDatabases()` and attributes each answer to the database it came from.

**The store-global overloads stop answering from one database.** Each either fans out or refuses and names the database overload. Answering from one database is the option the issue rules out.

| Read | Store-global behaviour on a multi-database store |
|---|---|
| `GetRecentStreamsAsync` | **Fans out and merges** by `LastUpdatedAt`, capped at `count` per database |
| `ReadStreamAsync` | Refuses, naming the `IEventDatabase` overload |
| `GetStreamMetadataAsync` | Refuses |
| `GetProjectionStatusesAsync` | Refuses |
| `QueryByTagsAsync` | Unchanged — already a pre-existing `NotSupportedException` store-globally |

The split is not arbitrary. Recent-streams is the one read whose store-global answer stays *meaningful* across databases: "the N most recently updated streams" is well defined over a union, because `StreamSummary` carries the timestamp the merge orders on. Each database is capped at `count` because no database can contribute more than that to the top `count` overall, so the cap costs nothing and bounds the fan-out.

Merging the others would fabricate something that does not exist. One stream id's events out of two databases would interleave two independent version sequences into what reads as a single stream. Stream metadata is one row, and two databases can each hold a stream with that id. Progression rows named `MyProjection:All` exist once per database, and `ProjectionStatus` has no field to attribute them with.

The **tenant predicate is untouched** and applies on top of whichever database is opened. Polecat already applied `tenant_id` wherever events are conjoined — that was always the correct half; the missing half was opening the right database.

## One sibling deliberately left refusing

The **tenant** dimension of `GetProjectionStatusesAsync` stays a `NotSupportedException`, and that is a considered call rather than an oversight. It is deeper than a predicate: Polecat encodes the tenant in the shard **name** under per-tenant partitioning, so a tenant-filtered progression read returns tenant-suffixed row names while the status loop builds its shard list from the *untenanted* registrations — nothing would match. The `HighWaterMark` row carries no tenant suffix either, so it would be filtered out and the high water mark would read 0.

Every shard would come back "0 of 0" and look perfectly healthy. That is precisely the failure shape this issue exists to stop, so refusing is the honest answer until the shard-name axis is done properly.

## Tests

`EventStoreExplorerCompliance` was already enrolled (wave 5) and picks up the four database-scoped arms jasperfx#817 added — but those `Assert.Skip` unless the store reports exactly one database, so all they can pin is that the database overload *agrees* with the store-global read.

The failure this issue is about needs two databases. `database_scoped_explorer_reads_tests` adds a database-per-tenant fixture where each tenant database holds a stream that exists **only** there, so the assertions catch a read that silently answered from one database (a *missing stream*) rather than only an exception type. 10 tests, covering per-database attribution, the fan-out and its cap, the three refusals, and the rejected null database.

Verified locally against SQL Server 2025: the 10 new tests pass, the 18 `event_store_explorer_compliance` facts pass, and all 26 `ExplorerApi` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)