### PR TITLE
gh-583: report polecat://store as the database SubjectUri

### DIFF
--- a/src/Polecat.Tests/Diagnostics/database_descriptor_tests.cs
+++ b/src/Polecat.Tests/Diagnostics/database_descriptor_tests.cs
@@ -1,0 +1,71 @@
+using JasperFx.Descriptors;
+using Polecat.Storage;
+using Polecat.Tests.Harness;
+using Weasel.SqlServer;
+
+namespace Polecat.Tests.Diagnostics;
+
+/// <summary>
+///     #583 — what <c>PolecatDatabase.Describe()</c> reports, which is what JasperFx's <c>db-list</c>
+///     command renders and what monitoring tools key on.
+/// </summary>
+/// <remarks>
+///     <para>
+///         There was no coverage of this method at all, which is how two properties stayed at their
+///         <see cref="DatabaseDescriptor" /> defaults through several releases: <c>SubjectUri</c> was
+///         reported as the literal <c>database://unknown</c>, and <c>SchemaOrNamespace</c> was empty,
+///         which silently dropped the schema segment from <c>DatabaseUri()</c>.
+///     </para>
+///     <para>
+///         Both are assertions about the CONFIGURED values rather than about any constant, so a
+///         descriptor that hardcoded an answer would not satisfy them.
+///     </para>
+/// </remarks>
+public class database_descriptor_tests
+{
+    private static PolecatDatabase DatabaseFor(string schemaName) =>
+        new(new StoreOptions
+        {
+            ConnectionString = ConnectionSource.ConnectionString,
+            DatabaseSchemaName = schemaName
+        });
+
+    [Fact]
+    public void reports_the_polecat_store_as_its_subject()
+    {
+        var descriptor = DatabaseFor("dbo").Describe();
+
+        // Was "database://unknown" — a Polecat store that db-list attributed to nothing, where the
+        // equivalent Marten app reports "marten://store".
+        descriptor.SubjectUri.ShouldBe(PolecatSystemPart.PolecatStoreUri);
+        descriptor.SubjectUri.ToString().ShouldStartWith("polecat://");
+    }
+
+    [Fact]
+    public void reports_the_configured_schema_as_its_namespace()
+    {
+        // Not "dbo": the default would pass against an implementation that hardcoded one.
+        DatabaseFor("descriptor_schema").Describe()
+            .SchemaOrNamespace.ShouldBe("descriptor_schema");
+    }
+
+    [Fact]
+    public void the_database_uri_carries_the_schema_segment()
+    {
+        var uri = DatabaseFor("descriptor_schema").Describe().DatabaseUri().ToString();
+
+        // DatabaseUri() drops empty segments, so an unset SchemaOrNamespace rendered
+        // "sqlserver://localhost/" while the Wolverine database beside it in the same db-list table
+        // rendered "sqlserver://localhost/dbo".
+        uri.ShouldEndWith("/descriptor_schema");
+    }
+
+    [Fact]
+    public void still_reports_the_engine_and_server_it_always_did()
+    {
+        var descriptor = DatabaseFor("dbo").Describe();
+
+        descriptor.Engine.ShouldBe(SqlServerProvider.EngineName);
+        descriptor.ServerName.ShouldNotBeEmpty();
+    }
+}

--- a/src/Polecat/Storage/PolecatDatabase.cs
+++ b/src/Polecat/Storage/PolecatDatabase.cs
@@ -126,6 +126,11 @@ public class PolecatDatabase : DatabaseBase<SqlConnection>, IEventDatabase, IPro
         return schemas.ToArray();
     }
 
+    /// <summary>
+    ///     #583 — the descriptor JasperFx's <c>db-list</c> renders, and the shape monitoring tools key on.
+    ///     Mirrors <c>MartenDatabase.Describe()</c> field for field; the two properties below were the
+    ///     ones Polecat left at their defaults, and both of them show up in <c>db-list</c> output.
+    /// </summary>
     public override DatabaseDescriptor Describe()
     {
         var builder = new SqlConnectionStringBuilder(_connectionString);
@@ -134,6 +139,19 @@ public class PolecatDatabase : DatabaseBase<SqlConnection>, IEventDatabase, IPro
             Engine = SqlServerProvider.EngineName,
             ServerName = builder.DataSource ?? string.Empty,
             DatabaseName = builder.InitialCatalog ?? string.Empty,
+
+            // Without this, DatabaseDescriptor.SubjectUri keeps its "database://unknown" default and
+            // db-list reports a Polecat store as belonging to nothing, where the equivalent Marten
+            // app reports "marten://store". Static rather than per-store, matching
+            // MartenDatabase.Describe(): the SystemPart's own subject is what distinguishes ancillary
+            // stores in the resource model (see PolecatSystemPart<T>).
+            SubjectUri = PolecatSystemPart.PolecatStoreUri,
+
+            // DatabaseUri() is {engine}://{server}/{database}/{schema} with the empty parts dropped, so
+            // leaving this unset rendered "sqlserver://localhost/" — no schema, while the Wolverine
+            // database sitting next to it in the same table rendered "sqlserver://localhost/dbo".
+            SchemaOrNamespace = _options.DatabaseSchemaName,
+
             Subject = GetType().FullNameInCode(),
             Identifier = Identifier
         };


### PR DESCRIPTION
Closes #583.

## The bug

`dotnet run -- db-list` renders a Polecat store's databases with a `SubjectUri` of `database://unknown/`, where the equivalent Marten app reports `marten://store/`:

```
│ DatabaseUri               │ SubjectUri                │
│ sqlserver://localhost/    │ database://unknown/       │   <- Polecat
│ sqlserver://localhost/dbo │ wolverine://messages/main │
```

`database://unknown` is `DatabaseDescriptor.SubjectUri`'s **default value**. `MartenDatabase.Describe()` overwrites it; `PolecatDatabase.Describe()` never did, so the property kept its default and `db-list` attributed the store to nothing. The reporter's diagnosis is exactly right — `PolecatSystemPart.PolecatStoreUri` was already the intended value, it just wasn't reaching the descriptor.

## The fix

```csharp
SubjectUri = PolecatSystemPart.PolecatStoreUri,
```

Static rather than per-store, matching `MartenDatabase.Describe()`. The `SystemPart`'s own subject is what distinguishes ancillary stores in the resource model, and `PolecatSystemPart<T>` already carries `polecat://{typename}` for that.

## Second divergence in the same method

Look again at the two rows above: Polecat's `DatabaseUri` is `sqlserver://localhost/` — no schema — while the Wolverine database directly beneath it reads `sqlserver://localhost/dbo`. Marten's row in the reporter's output reads `postgresql://localhost/public`.

`DatabaseUri()` is `{engine}://{server}/{database}/{schema}` with the empty parts dropped, and `SchemaOrNamespace` is the **other** property `PolecatDatabase.Describe()` left at its default. Marten fills it from `DatabaseSchemaName`; this now does too.

⚠️ **This changes `DatabaseUri`**, which `DatabaseDescriptor` documents as load-bearing identity elsewhere ("folding a new segment into it would silently rename existing databases"). Anything keying Polecat databases by that URI — CritterWatch in particular — sees those rows renamed once, on upgrade. Called out deliberately rather than slipped in: it is the correct value, but it is not a free change.

## Tests

There was **no coverage of `Describe()` at all**, which is how both properties stayed at their defaults through several releases. `database_descriptor_tests` adds four facts, asserting the *configured* schema rather than the default `dbo`, so a descriptor that hardcoded an answer would not satisfy them.

Verified locally: the 4 new tests pass, as do `document_store_usage_tests` and `database_source_registration_tests`, the two existing suites that consume this descriptor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)