### PR TITLE
gh-589: answer the tenant dimension, and stop reporting a state and a head this read does not know

### DIFF
--- a/src/Polecat.Tests/Diagnostics/projection_status_tests.cs
+++ b/src/Polecat.Tests/Diagnostics/projection_status_tests.cs
@@ -1,0 +1,171 @@
+using JasperFx.Descriptors;
+using JasperFx.Events;
+using JasperFx.Events.Projections;
+using Microsoft.Data.SqlClient;
+using Polecat.Projections;
+using Polecat.Tests.Harness;
+using Polecat.Tests.Projections;
+
+namespace Polecat.Tests.ExplorerApi;
+
+/// <summary>
+///     #589 — what <c>GetProjectionStatusesAsync</c> reports, beyond the projection names and
+///     lifecycles <c>event_store_explorer_tests</c> already covers.
+/// </summary>
+/// <remarks>
+///     Every fact here pins a field this method used to answer with something it did not know: a
+///     hardcoded shard state, a lifecycle wedged into the state slot, a high-water row standing in for
+///     the head of the store, and a tenant dimension that refused outright.
+/// </remarks>
+[Collection("integration")]
+public class projection_status_tests : IntegrationContext
+{
+    public projection_status_tests(DefaultStoreFixture fixture) : base(fixture)
+    {
+    }
+
+    private async Task<DocumentStore> StoreWithProjectionsAsync(string schema)
+    {
+        await StoreOptions(opts =>
+        {
+            opts.DatabaseSchemaName = schema;
+            opts.Projections.Add<SingleStreamProjection<QuestParty, Guid>>(ProjectionLifecycle.Inline);
+            opts.Projections.Add<QuestLogProjection>(ProjectionLifecycle.Async);
+        });
+
+        return theStore;
+    }
+
+    [Fact]
+    public async Task shard_state_is_unknown_rather_than_a_confident_stopped()
+    {
+        var store = await StoreWithProjectionsAsync("status_state");
+        var statuses = await ((IEventStore)store).GetProjectionStatusesAsync(TestContext.Current.CancellationToken);
+
+        var shards = statuses.SelectMany(x => x.Shards).ToList();
+        shards.ShouldNotBeEmpty();
+
+        // "Stopped" was hardcoded here for every shard. It is a fact about the running daemon, which
+        // the progression table does not know, so it was indistinguishable from a daemon that really
+        // had stopped — and that is the reading an operator acts on.
+        shards.ShouldAllBe(x => x.State == "Unknown");
+    }
+
+    [Fact]
+    public async Task an_inline_projections_shard_reports_a_state_not_its_lifecycle()
+    {
+        var store = await StoreWithProjectionsAsync("status_inline");
+        var statuses = await ((IEventStore)store).GetProjectionStatusesAsync(TestContext.Current.CancellationToken);
+
+        var inline = statuses.Where(x => x.ProjectionName == nameof(QuestParty)).ShouldHaveSingleItem();
+
+        // The lifecycle belongs on the ProjectionStatus, and only there.
+        inline.Lifecycle.ShouldBe(ProjectionLifecycle.Inline.ToString());
+        inline.Shards.ShouldAllBe(x => x.State != ProjectionLifecycle.Inline.ToString());
+    }
+
+    [Fact]
+    public async Task no_shard_state_anywhere_is_a_lifecycle_name()
+    {
+        var store = await StoreWithProjectionsAsync("status_no_lifecycle");
+        var statuses = await ((IEventStore)store).GetProjectionStatusesAsync(TestContext.Current.CancellationToken);
+
+        var lifecycles = Enum.GetNames<ProjectionLifecycle>();
+
+        // The sharp version of the fact above: whatever State holds, it is never drawn from the
+        // lifecycle vocabulary, so a consumer reading it cannot be handed the wrong kind of value.
+        statuses.SelectMany(x => x.Shards)
+            .ShouldAllBe(shard => !lifecycles.Contains(shard.State));
+    }
+
+    [Fact]
+    public async Task event_store_sequence_is_the_head_of_the_store_not_the_daemon_high_water_row()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var store = await StoreWithProjectionsAsync("status_head");
+
+        await using (var session = store.LightweightSession())
+        {
+            session.Events.StartStream<QuestParty>(Guid.NewGuid(), new QuestStarted("head"), new QuestStarted("more"));
+            await session.SaveChangesAsync(ct);
+        }
+
+        var statuses = await ((IEventStore)store).GetProjectionStatusesAsync(ct);
+        var shards = statuses.SelectMany(x => x.Shards).ToList();
+        shards.ShouldNotBeEmpty();
+
+        // No daemon has run, so the high-water progression row is absent or 0. Sourcing
+        // EventStoreSequence from it reported every shard as 0-of-0 — caught up — over a store that
+        // genuinely has events waiting. The head comes from MAX(seq_id) instead.
+        shards.ShouldAllBe(x => x.EventStoreSequence >= 2);
+    }
+
+    [Fact]
+    public async Task the_tenant_dimension_answers_instead_of_throwing()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var store = await StoreWithProjectionsAsync("status_tenant");
+
+        // Used to be a NotSupportedException from the jasperfx#407 default.
+        var statuses = await ((IEventStore)store).GetProjectionStatusesAsync("blue", ct);
+
+        statuses.ShouldNotBeEmpty();
+    }
+
+    [Fact]
+    public async Task tenant_scoped_shard_identities_carry_the_tenant()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var store = await StoreWithProjectionsAsync("status_tenant_names");
+
+        var untenanted = await ((IEventStore)store).GetProjectionStatusesAsync(ct);
+        var tenanted = await ((IEventStore)store).GetProjectionStatusesAsync("blue", ct);
+
+        var plain = untenanted.SelectMany(x => x.Shards).Select(x => x.ShardName).ToList();
+        var scoped = tenanted.SelectMany(x => x.Shards).Select(x => x.ShardName).ToList();
+
+        plain.ShouldNotBeEmpty();
+        scoped.Count.ShouldBe(plain.Count);
+
+        // On a single-database store the tenant lives inside it and its shards carry the trailing
+        // :tenant suffix. Reporting the untenanted identity would describe a different shard.
+        scoped.ShouldAllBe(name => name.EndsWith(":blue"));
+        plain.ShouldAllBe(name => !name.EndsWith(":blue"));
+    }
+
+    [Fact]
+    public async Task a_tenant_scoped_read_finds_the_tenant_bearing_progression_row()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var store = await StoreWithProjectionsAsync("status_tenant_progress");
+
+        // The identity the daemon writes under per-tenant partitioning. Seeded directly so the fact
+        // does not depend on running a daemon.
+        var tenanted = (await ((IEventStore)store).GetProjectionStatusesAsync("blue", ct))
+            .SelectMany(x => x.Shards)
+            .Select(x => x.ShardName)
+            .First();
+
+        await using (var conn = new SqlConnection(store.Options.ConnectionString))
+        {
+            await conn.OpenAsync(ct);
+            await using var cmd = conn.CreateCommand();
+            // Delete-then-insert rather than a bare INSERT: the test database keeps its schema between
+            // runs, so a bare insert passes once and then trips the primary key forever after.
+            cmd.CommandText = $"""
+                DELETE FROM {store.Options.EventGraph.ProgressionTableName} WHERE name = @name;
+                INSERT INTO {store.Options.EventGraph.ProgressionTableName} (name, last_seq_id) VALUES (@name, 42);
+                """;
+            cmd.Parameters.AddWithValue("@name", tenanted);
+            await cmd.ExecuteNonQueryAsync(ct);
+        }
+
+        var statuses = await ((IEventStore)store).GetProjectionStatusesAsync("blue", ct);
+        var shard = statuses.SelectMany(x => x.Shards).Single(x => x.ShardName == tenanted);
+
+        // This is the whole defect: the registrations are untenanted, the rows are suffixed, and
+        // matching them by filtering rather than by COMPOSING the identity found nothing — every
+        // shard reported 0 and looked healthy.
+        shard.ProcessedSequence.ShouldBe(42);
+    }
+}

--- a/src/Polecat/DocumentStore.EventStoreExplorer.cs
+++ b/src/Polecat/DocumentStore.EventStoreExplorer.cs
@@ -424,6 +424,46 @@ public partial class DocumentStore
         return projectionStatusesAsync(SingleDatabase, tenantId: null, ct);
     }
 
+    /// <summary>
+    ///     #589 — the tenant dimension, which used to refuse.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         The argument means one of two things depending on how the store is tenanted, exactly as
+    ///         it does for <c>BuildProjectionDaemonAsync</c>, and the difference is not cosmetic.
+    ///     </para>
+    ///     <list type="bullet">
+    ///     <item>
+    ///         <b>One database</b> (conjoined tenancy with per-tenant event partitioning): the tenant
+    ///         lives inside that database and its shards carry the trailing
+    ///         <c>{Proj}:{ShardKey}:{tenant}</c> suffix, so the progression lookup must be made under
+    ///         the tenant-bearing identity.
+    ///     </item>
+    ///     <item>
+    ///         <b>Database-per-tenant</b>: the tenant names a physical database whose shards are NOT
+    ///         suffixed — each database runs its own daemon over the same shard identities — so the
+    ///         tenant selects where to read, and nothing else.
+    ///     </item>
+    ///     </list>
+    /// </remarks>
+    Task<IReadOnlyList<ProjectionStatus>> IEventStore.GetProjectionStatusesAsync(
+        string? tenantId, CancellationToken ct)
+    {
+        if (tenantId == null)
+        {
+            RequireSingleDatabase(nameof(IEventStore.GetProjectionStatusesAsync));
+            return projectionStatusesAsync(SingleDatabase, tenantId: null, ct);
+        }
+
+        // On a multi-database store the tenant resolves to the database it lives in; on a single
+        // database store there is only one place to read and the tenant narrows the shard identities.
+        var database = IsSingleDatabase
+            ? SingleDatabase
+            : Options.Tenancy!.GetDatabase(tenantId);
+
+        return projectionStatusesAsync(database, tenantId, ct);
+    }
+
     // #584 / jasperfx#810 — the database dimension, and the counterpart to the per-cell lag that
     // IEventDatabase.FetchProjectionLagAsync already reports one database at a time.
     Task<IReadOnlyList<ProjectionStatus>> IEventStore.GetProjectionStatusesAsync(
@@ -431,45 +471,53 @@ public partial class DocumentStore
     {
         ArgumentNullException.ThrowIfNull(database);
 
-        // The TENANT dimension of this read is a separate, still-open gap, and it is deeper than a
-        // predicate: Polecat encodes the tenant in the shard NAME under per-tenant partitioning, so a
-        // tenant-filtered progression read returns tenant-suffixed row names while the status loop
-        // below builds its shard list from the untenanted registrations — nothing would match. The
-        // HighWaterMark row carries no tenant suffix either, so it would be filtered out and the high
-        // water mark would read 0. Every shard would come back "0 of 0" and look perfectly healthy,
-        // which is the failure mode this issue exists to stop. The base interface already refuses a
-        // non-null tenant here, and keeping that refusal is the honest answer until the shard-name
-        // axis is done properly.
-        if (tenantId != null)
-        {
-            throw new NotSupportedException(
-                "Per-tenant GetProjectionStatusesAsync is not implemented on Polecat. Pass a null tenantId " +
-                "for the whole database's projection statuses.");
-        }
-
-        return projectionStatusesAsync(RequirePolecatDatabase(database), tenantId: null, ct);
+        // #589: the tenant axis used to refuse here. It now composes the tenant-bearing shard identity
+        // rather than filtering rows and hoping they line up with the untenanted registrations — see
+        // projectionStatusesAsync.
+        return projectionStatusesAsync(RequirePolecatDatabase(database), tenantId, ct);
     }
+
+    /// <summary>
+    ///     #589 — no daemon in this process was asked about these shards, so their runtime state is not
+    ///     something this read can report.
+    /// </summary>
+    /// <remarks>
+    ///     Deliberately not <c>"Stopped"</c>, which is what this method used to answer for every shard
+    ///     unconditionally. <see cref="ShardStatus.State" /> is a fact about the RUNNING DAEMON, and
+    ///     pc_event_progression does not know it — so "Stopped" was not a partial answer but a wrong
+    ///     one, indistinguishable from a daemon that really had stopped, and it is the reading an
+    ///     operator acts on. Marten answers "Unknown" here for the same reason. Reporting the real
+    ///     state, as Fisher does, needs a daemon accessor that does not CREATE a daemon as a side
+    ///     effect of being asked — Polecat's AllDaemonsAsync() builds one per database — so it is a
+    ///     follow-up rather than something to improvise inside a defect fix. See polecat#589,
+    ///     jasperfx#818.
+    /// </remarks>
+    private const string UnknownShardState = "Unknown";
 
     private async Task<IReadOnlyList<ProjectionStatus>> projectionStatusesAsync(
         PolecatDatabase database, string? tenantId, CancellationToken ct)
     {
-        // Pull progression rows so we can attach processed sequence numbers to each shard
+        // #589: the shard identities carry the tenant ONLY when the tenant lives inside this database.
+        // Under database-per-tenant each database runs its own daemon over the same unsuffixed
+        // identities, so there the tenant has already done its work by selecting the database.
+        var shardsAreTenantScoped = tenantId != null && IsSingleDatabase;
+
         var progress = new Dictionary<string, long>(StringComparer.OrdinalIgnoreCase);
-        long highWater = 0;
 
         // AllProjectionProgress runs inside Options.ResiliencePipeline the same way the session-bound
         // explorer reads do, and it is already per-database -- which is the whole point here.
-        foreach (var state in await database.AllProjectionProgress(tenantId, ct))
+        foreach (var state in await database.AllProjectionProgress(
+                     shardsAreTenantScoped ? tenantId : null, ct))
         {
-            if (string.Equals(state.ShardName, "HighWaterMark", StringComparison.OrdinalIgnoreCase))
-            {
-                highWater = state.Sequence;
-            }
-            else
+            // The high-water row is not a shard's progress, and it is no longer where
+            // EventStoreSequence comes from either — see headSequenceAsync.
+            if (!string.Equals(state.ShardName, ShardState.HighWaterMark, StringComparison.OrdinalIgnoreCase))
             {
                 progress[state.ShardName] = state.Sequence;
             }
         }
+
+        var head = await headSequenceAsync(database, ct);
 
         // #200: drive off the registered projection sources (not
         // AllProjectionNames(), which quote-wraps each name for SQL-list
@@ -481,24 +529,54 @@ public partial class DocumentStore
             var shards = source.Shards()
                 .Select(shard =>
                 {
-                    var shardName = shard.Name.Identity;
-                    progress.TryGetValue(shardName, out var processed);
-                    return new ShardStatus(shardName, "Stopped", processed, highWater, Error: null!);
+                    // #589: COMPOSE the tenant-bearing identity from the registration rather than
+                    // filtering rows and hoping the two spellings meet. The registrations are
+                    // untenanted, the rows are suffixed, and matching them by string was the defect.
+                    var effectiveName = shardsAreTenantScoped
+                        ? ShardName.Compose(shard.Name.Name, shard.Name.ShardKey, tenantId, shard.Name.Version)
+                        : shard.Name;
+
+                    progress.TryGetValue(effectiveName.Identity, out var processed);
+                    return new ShardStatus(effectiveName.Identity, UnknownShardState, processed, head, Error: null!);
                 })
                 .ToList();
 
-            if (shards.Count == 0)
-            {
-                shards = new List<ShardStatus>
-                {
-                    new(source.Name, source.Lifecycle.ToString(), 0, highWater, Error: null!)
-                };
-            }
-
+            // #589: a projection with no shards reports an EMPTY shard list. It used to be given a
+            // synthesised shard whose State slot held source.Lifecycle.ToString(), which made that
+            // field mean a daemon state on some rows and a lifecycle on others with nothing telling a
+            // consumer which it was holding. ProjectionStatus.Lifecycle already says why the list is
+            // empty, so a console can render "Inline — no shards" without inferring anything.
             statuses.Add(new ProjectionStatus(source.Name, source.Lifecycle.ToString(), shards));
         }
 
         return statuses;
+    }
+
+    /// <summary>
+    ///     #589 — the head of the event store, from <c>MAX(seq_id)</c> rather than from the persisted
+    ///     high-water progression row.
+    /// </summary>
+    /// <remarks>
+    ///     The two agree on a store whose daemon is current, and they differ exactly when it matters:
+    ///     the row is WHERE THE DAEMON GOT TO, and a daemon that is not running leaves it behind.
+    ///     Reporting it as <see cref="ShardStatus.EventStoreSequence" /> made every shard on a stopped
+    ///     daemon look caught up — the opposite of what a projections page is opened to find out.
+    ///     Marten and Fisher both read the head this way.
+    /// </remarks>
+    private static async Task<long> headSequenceAsync(PolecatDatabase database, CancellationToken ct)
+    {
+        try
+        {
+            return await database.FetchHighestEventSequenceNumber(ct);
+        }
+        catch (Exception)
+        {
+            // The likeliest reason this fails is that the event schema does not exist yet, which is
+            // precisely when a console is most likely to be pointed at the store. Failing the whole
+            // page over one number answers nothing at all — the same judgement TryCreateUsage makes
+            // about the same read.
+            return 0;
+        }
     }
 
     // ---- #584 / jasperfx#810: the database dimension of the explorer reads ----


### PR DESCRIPTION
Closes #589. Four fixes to `GetProjectionStatusesAsync` — one method, one pass.

## 1. The tenant dimension, which refused outright

This was the jasperfx#407 default, kept deliberately in #586 rather than shipped wrong. The naive implementation is *silently* wrong: Polecat encodes the tenant in the shard **name** under per-tenant partitioning, so a tenant-filtered progression read returns `{Proj}:{ShardKey}:{tenant}` rows while the status loop builds its shard list from the **untenanted** registrations. The two spellings never meet, every shard reports 0, and — because the `HighWaterMark` row carries no suffix and gets filtered out too — the whole thing reads "0 of 0", healthy.

Marten already solved this, and the piece I had missed is **`ShardName.Compose`**: compose the tenant-bearing identity *from* each registration and look the row up by it, instead of filtering rows and hoping.

```csharp
var effectiveName = shardsAreTenantScoped
    ? ShardName.Compose(shard.Name.Name, shard.Name.ShardKey, tenantId, shard.Name.Version)
    : shard.Name;
```

The argument means two different things, exactly as it does for `BuildProjectionDaemonAsync`: on **one database** it names a tenant living inside it and the shards *are* suffixed; under **database-per-tenant** it names a database whose shards are *not*, because each database runs its own daemon over the same identities. `shardsAreTenantScoped` is that distinction, and it is why the tenant is not simply passed through to the progression filter.

## 2. Every shard reported `"Stopped"`

Hardcoded. `State` is a fact about the **running daemon**, which `pc_event_progression` does not know — so it was not a partial answer but a wrong one, indistinguishable from a daemon that really had stopped, and it is the reading an operator acts on. Fisher's source names this defect directly (polecat#200, fisher#120). Now `"Unknown"`, matching Marten.

**Not attempted here:** reporting the *real* state the way Fisher does. That needs a daemon accessor that does not **create** a daemon as a side effect of being asked, and Polecat's `AllDaemonsAsync()` builds one per database through `StartProjectionDaemon`. Improvising that plumbing inside a defect fix is how `"Stopped"` got here in the first place.

## 3. `EventStoreSequence` came from the high-water progression row

That row is *where the daemon got to*, and a daemon that is not running leaves it behind — so every shard on a stopped daemon looked caught up. Now `MAX(seq_id)` via `FetchHighestEventSequenceNumber`, as Marten and Fisher both do, swallowing a failure to 0 because the likeliest cause is an event schema that does not exist yet, which is precisely when a console is most likely to be pointed at the store.

## 4. The synthesised shard — latent, and the issue overstated it

I filed this as a live defect. It is not, and the correction is [on the issue](https://github.com/JasperFx/polecat/issues/589#issuecomment-5648097851). `ProjectionGraph.All` holds only registered Inline/Async projections and every one declares a shard through `Shards()` regardless of lifecycle; live aggregations and subscriptions live in separate collections this loop never touches. So `shards.Count == 0` was **unreachable**, and no consumer has ever been handed a lifecycle in a `State` slot.

Removed anyway — it would do the wrong thing if reached, and both other stores report an empty list — but as dead-code removal, not a bug fix. My first test for it asserted an Inline projection reports no shards and failed for exactly this reason; the invariant is now pinned by `no_shard_state_anywhere_is_a_lifecycle_name` instead.

## Deliberately unchanged

**Subscriptions are still omitted.** The loop iterates `Projections.All`, which excludes `_subscriptions`, so a Polecat store with subscriptions reports none of them. Fisher uses `AllShards()` and includes them. Both readings are defensible — that is a contract question for jasperfx#818, not one to settle unilaterally in a defect fix.

**A tenant-scoped read still reports the store-global `MAX(seq_id)`** as `EventStoreSequence` rather than that tenant's own head, which overstates the tenant's lag. Marten does the same. Also left for jasperfx#818.

## Tests

`projection_status_tests`, seven facts covering the shard state, the head sequence over a store with events and no daemon, the tenant dimension answering at all, tenant-bearing shard identities, and the lifecycle-never-in-state invariant.

The tenant-bearing progression lookup — the actual defect — is proven by seeding the composed row directly rather than by running a daemon, so the fact is deterministic. Seeds delete-then-insert because the test database keeps its schema between runs; a bare insert passes once and then trips the primary key forever after, which it did.

Verified locally: 7/7 new, 33/33 `ExplorerApi`, 18/18 `event_store_explorer_compliance`, 4/4 `event_store_usage`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)