### PR TITLE
gh-591: report the real shard state when a daemon is reachable

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -453,15 +453,33 @@
              contracts and their Microsoft.Extensions.AI adapter, which Polecat does not implement.
              Note 2.67.0 arrived in #531 without an entry here; its contents are jasperfx#800-#808
              (compaction refusal naming, the event-query tags option, ANDed tag filters, partial
-             EventModelDescriptor round-trip). -->
-        <PackageVersion Include="JasperFx" Version="2.68.0" />
-        <PackageVersion Include="JasperFx.Events" Version="2.68.0" />
+             EventModelDescriptor round-trip).
+
+             JasperFx 2.69.0 (from 2.68.0). A compliance-heavy release: four new suites and one new
+             registration helper, and every one of them is the upstream half of an open Polecat issue.
+             (a) jasperfx#818/#820 — ProjectionStatusCompliance, nine facts on GetProjectionStatusesAsync,
+             plus the ShardStatusState vocabulary (Running / Paused / Stopped / Unknown as string
+             constants, because State is a string on a record that serializes to consumers) and
+             IComplianceCoordinatorHost.EventStore. polecat#591.
+             (b) jasperfx#819/#821 — GuidOptimisticConcurrencyCompliance, the document-concurrency
+             suite that did not exist for ANY store, plus DocumentComplianceConfig.OptimisticConcurrencyTypes
+             and UseOptimisticConcurrency<T>(). polecat#592.
+             (c) jasperfx#810/#822 — DatabasePerTenantExplorerCompliance and
+             ShardedTenancyExplorerCompliance, the multi-database arms of the explorer reads whose
+             abstraction half arrived in 2.68.0, plus the SupportsMultipleDatabases /
+             DatabaseForTenantAsync / AssignTenantToDatabase fixture seam. polecat#593.
+             (d) jasperfx#825/#826 — ProjectionEventModelSource and AddProjectionEventModelSource,
+             the store-derived Event Model rung. polecat#594.
+             NumericRevisionCompliance was refactored onto a generic base in the same release;
+             existing enrollments compile unchanged. -->
+        <PackageVersion Include="JasperFx" Version="2.69.0" />
+        <PackageVersion Include="JasperFx.Events" Version="2.69.0" />
         <!--
              The shared cross-store event sourcing compliance suites. Source-only package: the
              suites compile inside Polecat.Tests so JasperFx's aggregate source generator binds
              Polecat's own session types.
         -->
-        <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.68.0" />
+        <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.69.0" />
         <!-- Pin the sibling JasperFx packages for parity with Marten 9's matrix
              even though Polecat doesn't currently reference them directly —
              keeps the lockstep matrix coherent when transitive resolution
@@ -469,7 +487,7 @@
              RuntimeCompiler 5.x line is the active continuation of the 4.x
              lineage; do not pin against the parallel stale 2.0.x series. -->
         <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.68.0" />
+        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.69.0" />
         <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
@@ -633,7 +651,7 @@
         <PackageVersion Include="Vogen" Version="7.0.0" />
 
         <!-- Source generators (matched to JasperFx.Events above) -->
-        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.68.0" />
+        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.69.0" />
 
         <!-- Build automation -->
         <PackageVersion Include="Nuke.Common" Version="9.0.4" />

--- a/src/Polecat.Tests/Compliance/PolecatComplianceFixture.cs
+++ b/src/Polecat.Tests/Compliance/PolecatComplianceFixture.cs
@@ -482,6 +482,19 @@ public class PolecatComplianceFixture : EventStoreComplianceFixture<IDocumentSes
         public IDocumentSession OpenSession()
             => _host.Services.GetRequiredService<IDocumentStore>().LightweightSession();
 
+        /// <summary>
+        ///     #591 / jasperfx#818 — the HOSTED store as IEventStore, which is the one store in the
+        ///     suite set with a genuinely discoverable running daemon.
+        /// </summary>
+        /// <remarks>
+        ///     Deliberately not the fixture's own store instance. The fixture builds its store by hand
+        ///     and registers no coordinator, so asking it what state its shards are in can only ever
+        ///     answer "no daemon here to ask" — which is a real case worth pinning, and the reason the
+        ///     daemon-visible half of the ruling needs this store instead.
+        /// </remarks>
+        public JasperFx.Events.IEventStore EventStore
+            => (JasperFx.Events.IEventStore)_host.Services.GetRequiredService<IDocumentStore>();
+
         public async ValueTask DisposeAsync()
         {
             // StopAsync before Dispose, deliberately: IHost.Dispose does NOT stop a started host, so

--- a/src/Polecat.Tests/Compliance/polecat_event_store_compliance_wave17.cs
+++ b/src/Polecat.Tests/Compliance/polecat_event_store_compliance_wave17.cs
@@ -1,0 +1,32 @@
+using JasperFx.Events.ComplianceTests;
+
+namespace Polecat.Tests.Compliance;
+
+/*
+ * Wave 17 -- the projection-status suite (#591 / jasperfx#818), the follow-on to #589. Enrolled on
+ * its own because it is the definition of done for one field's meaning rather than the adoption of a
+ * suite for a whole capability.
+ */
+
+/// <summary>
+///     <c>GetProjectionStatusesAsync</c> — the snapshot a monitoring console's projections page
+///     renders before it subscribes to <c>ShardStatesChanged</c>, and what its five fields mean.
+/// </summary>
+/// <remarks>
+///     <para>
+///         #589 closed most of the gap: Polecat answers <c>Unknown</c> rather than <c>Stopped</c>
+///         when no daemon is visible, <c>EventStoreSequence</c> is the head of the event store rather
+///         than the high-water progression row, and the <c>State</c> slot no longer carries a
+///         lifecycle on some rows and a daemon state on others.
+///     </para>
+///     <para>
+///         The fact this wave is actually for is
+///         <c>a_reachable_running_daemon_reports_the_real_shard_state</c>, the other half of the same
+///         ruling: <c>Unknown</c> has to mean "there is no daemon here to ask" and nothing else, so a
+///         store that can reach one reports what it says. It runs against the coordinator host rather
+///         than the fixture's own store, because a hand-built daemon is precisely the case
+///         <c>Unknown</c> describes.
+///     </para>
+/// </remarks>
+public class polecat_projection_status_compliance
+    : ProjectionStatusCompliance<PolecatComplianceFixture, IDocumentSession, IQuerySession>;

--- a/src/Polecat/DocumentStore.EventStoreExplorer.cs
+++ b/src/Polecat/DocumentStore.EventStoreExplorer.cs
@@ -10,6 +10,7 @@ using JasperFx.Events.Daemon;
 using JasperFx.Events.Projections;
 using Microsoft.Data.SqlClient;
 using Polecat.Events;
+using Polecat.Events.Daemon;
 using Polecat.Events.Internal;
 using Polecat.Storage;
 
@@ -478,21 +479,82 @@ public partial class DocumentStore
     }
 
     /// <summary>
-    ///     #589 — no daemon in this process was asked about these shards, so their runtime state is not
+    ///     #589 / #591 — no daemon was reachable from this store, so these shards' runtime state is not
     ///     something this read can report.
     /// </summary>
     /// <remarks>
-    ///     Deliberately not <c>"Stopped"</c>, which is what this method used to answer for every shard
-    ///     unconditionally. <see cref="ShardStatus.State" /> is a fact about the RUNNING DAEMON, and
-    ///     pc_event_progression does not know it — so "Stopped" was not a partial answer but a wrong
-    ///     one, indistinguishable from a daemon that really had stopped, and it is the reading an
-    ///     operator acts on. Marten answers "Unknown" here for the same reason. Reporting the real
-    ///     state, as Fisher does, needs a daemon accessor that does not CREATE a daemon as a side
-    ///     effect of being asked — Polecat's AllDaemonsAsync() builds one per database — so it is a
-    ///     follow-up rather than something to improvise inside a defect fix. See polecat#589,
-    ///     jasperfx#818.
+    ///     <para>
+    ///         Deliberately not <c>Stopped</c>, which is what this method used to answer for every shard
+    ///         unconditionally. <see cref="ShardStatus.State" /> is a fact about the RUNNING DAEMON, and
+    ///         pc_event_progression does not know it — so "Stopped" was not a partial answer but a wrong
+    ///         one, indistinguishable from a daemon that really had stopped, and it is the reading an
+    ///         operator acts on.
+    ///     </para>
+    ///     <para>
+    ///         #591 narrows it to what it actually means. Where a coordinator IS reachable the state now
+    ///         comes from the daemon it is running (see <see cref="shardStatesAsync" />), so
+    ///         <c>Unknown</c> no longer covers "we never looked" — it is the answer for the cases where
+    ///         there genuinely is nothing to ask: <c>DaemonMode.ExternallyManaged</c>, a monitoring
+    ///         console in another process, a hand-built store. See jasperfx#818.
+    ///     </para>
     /// </remarks>
-    private const string UnknownShardState = "Unknown";
+    private const string UnknownShardState = ShardStatusState.Unknown;
+
+    /// <summary>
+    ///     #591 — the running daemon's answer for each shard in this database, keyed by
+    ///     <see cref="ShardName.Identity" />. Empty when no daemon is reachable.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Read through <see cref="JasperFx.Events.Daemon.IProjectionCoordinator.AllDaemonsAsync" />
+    ///         and never through <c>DaemonForDatabase</c>: this is a diagnostics read and must not change
+    ///         what is running. <c>DaemonForDatabase</c> is contractually allowed to go looking and START
+    ///         a daemon, and a projections page that starts one by being opened is a monitoring tool with
+    ///         a side effect on the system it monitors. jasperfx#818 pins that separately.
+    ///     </para>
+    ///     <para>
+    ///         Filtered to the daemon serving the database being read. Shard identities are NOT unique
+    ///         across databases on a sharded store — every database runs its own <c>MyProjection:All</c> —
+    ///         so folding every daemon's agents into one map would let one database answer for another.
+    ///     </para>
+    /// </remarks>
+    private static async Task<Dictionary<string, string>> shardStatesAsync(
+        JasperFx.Events.Daemon.IProjectionCoordinator? coordinator, PolecatDatabase database)
+    {
+        var states = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        if (coordinator == null) return states;
+
+        IReadOnlyList<IProjectionDaemon> daemons;
+        try
+        {
+            daemons = await coordinator.AllDaemonsAsync().ConfigureAwait(false);
+        }
+        catch (Exception)
+        {
+            // Same judgement headSequenceAsync makes: a projections page that cannot reach a daemon
+            // still has progression rows and a head to render, and Unknown is already the defined
+            // answer for "no daemon to ask".
+            return states;
+        }
+
+        foreach (var daemon in daemons)
+        {
+            // Polecat's coordinator only ever builds PolecatProjectionDaemon, which carries the
+            // database it serves.
+            if (daemon is not PolecatProjectionDaemon polecatDaemon) continue;
+            if (!string.Equals(polecatDaemon.Database.Identifier, database.Identifier, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            foreach (var agent in polecatDaemon.CurrentAgents())
+            {
+                states[agent.Name.Identity] = ShardStatusState.From(agent.Status);
+            }
+        }
+
+        return states;
+    }
 
     private async Task<IReadOnlyList<ProjectionStatus>> projectionStatusesAsync(
         PolecatDatabase database, string? tenantId, CancellationToken ct)
@@ -519,6 +581,9 @@ public partial class DocumentStore
 
         var head = await headSequenceAsync(database, ct);
 
+        // #591: the running daemon's answer, where one is reachable at all.
+        var shardStates = await shardStatesAsync(Coordinator, database);
+
         // #200: drive off the registered projection sources (not
         // AllProjectionNames(), which quote-wraps each name for SQL-list
         // display). Each source exposes its real Lifecycle and ShardNames,
@@ -537,7 +602,13 @@ public partial class DocumentStore
                         : shard.Name;
 
                     progress.TryGetValue(effectiveName.Identity, out var processed);
-                    return new ShardStatus(effectiveName.Identity, UnknownShardState, processed, head, Error: null!);
+
+                    // #591: what the daemon says, or Unknown when there is no daemon to ask. A shard
+                    // the daemon has no agent for is Unknown rather than Stopped for the same reason
+                    // -- this store never heard the daemon say anything about it.
+                    var state = shardStates.GetValueOrDefault(effectiveName.Identity, UnknownShardState);
+
+                    return new ShardStatus(effectiveName.Identity, state, processed, head, Error: null!);
                 })
                 .ToList();
 

--- a/src/Polecat/DocumentStore.cs
+++ b/src/Polecat/DocumentStore.cs
@@ -97,6 +97,34 @@ public partial class DocumentStore : IDocumentStore
 
     internal IInlineProjection<IDocumentSession>[] InlineProjections => _inlineProjections.Value;
 
+    /// <summary>
+    ///     #591 — the projection coordinator built over THIS store, if the host registered one.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Set by <c>Polecat.Events.Daemon.Coordination.ProjectionCoordinator</c>'s constructor,
+    ///         which already receives the store it coordinates. The store cannot go the other way and
+    ///         resolve a coordinator out of DI — it has no container, and an ancillary store's
+    ///         coordinator is registered under a marker-typed interface only its own registration
+    ///         knows the name of.
+    ///     </para>
+    ///     <para>
+    ///         It exists for exactly one read: <c>GetProjectionStatusesAsync</c> reports
+    ///         <see cref="JasperFx.Descriptors.ShardStatus.State" /> from the running daemon when one
+    ///         is reachable, and <c>Unknown</c> when none is. Null here is the second case, and it is
+    ///         a real operational situation rather than a gap — <c>DaemonMode.ExternallyManaged</c>, a
+    ///         monitoring console in another process, and a hand-built store all land on it.
+    ///     </para>
+    /// </remarks>
+    internal JasperFx.Events.Daemon.IProjectionCoordinator? Coordinator { get; private set; }
+
+    /// <summary>
+    ///     #591 — attach the coordinator that was built over this store. Called once, from the
+    ///     coordinator's own constructor.
+    /// </summary>
+    internal void AttachCoordinator(JasperFx.Events.Daemon.IProjectionCoordinator coordinator)
+        => Coordinator = coordinator;
+
     internal DocumentProvider GetProvider(Type documentType) => _providers.GetProvider(documentType);
 
     /// <summary>

--- a/src/Polecat/Events/Daemon/Coordination/ProjectionCoordinator.cs
+++ b/src/Polecat/Events/Daemon/Coordination/ProjectionCoordinator.cs
@@ -52,6 +52,12 @@ internal class ProjectionCoordinator : ProjectionCoordinatorBase, IProjectionCoo
         _store = store;
         _options = store.Options;
         _loggerFactory = loggerFactory ?? NullLoggerFactory.Instance;
+
+        // #591: hand the store a way back to its coordinator. GetProjectionStatusesAsync reports
+        // ShardStatus.State from the running daemon when one is reachable, and the store has no
+        // container to resolve a coordinator from -- but the coordinator is always constructed with
+        // the store it coordinates, so the reference travels in this direction instead.
+        store.AttachCoordinator(this);
     }
 
     protected override IProjectionDaemon ResolveDaemon(IProjectionSet set)


### PR DESCRIPTION
Closes #591. Stacked on #595 (the JasperFx 2.69.0 bump) — the bump commit drops out of this diff once that merges.

## The ruling

`ShardStatus.State` is a fact about the running daemon. A store that can reach one reports what it says; a store that cannot reports `Unknown`, which means "there is no daemon here to ask" — a genuinely different operational situation from `Stopped`.

#589 got the absence half right. It did not get the presence half: Polecat never looked at a daemon at all, so `Unknown` was the answer unconditionally and the word meant "we did not ask" rather than "there is nothing to ask".

## What changed

- **`DocumentStore.Coordinator`**, an internal back-reference attached by `ProjectionCoordinator`'s own constructor. The store has no container to resolve a coordinator from, and an ancillary store's coordinator is registered under a marker-typed interface that only its own registration knows the name of — so the reference travels from the coordinator to the store rather than the other way.
- **`projectionStatusesAsync` reads through `IProjectionCoordinator.AllDaemonsAsync()`**, never `DaemonForDatabase`. This is a diagnostics read and must not change what is running; `DaemonForDatabase` is contractually allowed to go looking and *start* a daemon. `reading_the_statuses_does_not_start_a_daemon` pins that separately.
- **Agents are matched to the database being read.** A shard identity is not unique across databases on a sharded store — every database runs its own `MyProjection:All` — so folding every daemon's agents into one map would let one database answer for another.
- A shard the reachable daemon has no agent for stays `Unknown`, not `Stopped`, for the same reason: this store never heard the daemon say anything about it.
- `UnknownShardState` is now `ShardStatusState.Unknown` rather than a local literal, per the new vocabulary.

The inline-projection shard list is untouched. jasperfx#818 proposed an empty list there and **that requirement was dropped** — Marten's `SignalBoard:All / Unknown / 0 / 0` stands, and the harmful half (a lifecycle in the `State` slot) was already fixed by #589.

## Enrollment

`ProjectionStatusCompliance` as wave 17, plus `IComplianceCoordinatorHost.EventStore` on `PolecatCoordinatorHost` — the hosted store, deliberately not the fixture's hand-built one, which is itself an instance of the case `Unknown` describes.

**9 of 9 pass** (was 8 of 9 against `main` with a local 2.69.0 pack).

## Noticed while running this — an upstream JasperFx bug, not fixed here

The coordinator host logs an agent-start failure for the suite's registered subscription:

```
System.ArgumentOutOfRangeException: Must implement JasperFx.Events.Daemon.ISubscriptionRunner<Polecat.Subscriptions.ISubscription> (Parameter 'storage')
   at JasperFx.Events.Subscriptions.JasperFxSubscriptionBase`3.ISubscriptionFactory<...>.BuildExecution(...)
```

`JasperFxSubscriptionBase`'s two `BuildExecution` overloads disagree: the `ILogger` one passes `store` as the execution's `storage`, and the explicit-interface `ILoggerFactory` one passes `database`. `JasperFxAsyncDaemon.buildAgentForShard` calls the second, so **a subscription registered in an app that uses `AddProjectionCoordinator` can never start** — on any store. The fixture-built daemon path every subscription suite drives takes the other overload, which is why nothing has caught it. It has been that way since the store/storage rename.

It does not affect any fact in this suite (the subscription is registered only so the inventory ruling is observable), so nothing here works around it. Worth a JasperFx issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)