### PR TITLE
gh-592: seed the Guid concurrency guard from the document, not just the session

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -453,15 +453,33 @@
              contracts and their Microsoft.Extensions.AI adapter, which Polecat does not implement.
              Note 2.67.0 arrived in #531 without an entry here; its contents are jasperfx#800-#808
              (compaction refusal naming, the event-query tags option, ANDed tag filters, partial
-             EventModelDescriptor round-trip). -->
-        <PackageVersion Include="JasperFx" Version="2.68.0" />
-        <PackageVersion Include="JasperFx.Events" Version="2.68.0" />
+             EventModelDescriptor round-trip).
+
+             JasperFx 2.69.0 (from 2.68.0). A compliance-heavy release: four new suites and one new
+             registration helper, and every one of them is the upstream half of an open Polecat issue.
+             (a) jasperfx#818/#820 — ProjectionStatusCompliance, nine facts on GetProjectionStatusesAsync,
+             plus the ShardStatusState vocabulary (Running / Paused / Stopped / Unknown as string
+             constants, because State is a string on a record that serializes to consumers) and
+             IComplianceCoordinatorHost.EventStore. polecat#591.
+             (b) jasperfx#819/#821 — GuidOptimisticConcurrencyCompliance, the document-concurrency
+             suite that did not exist for ANY store, plus DocumentComplianceConfig.OptimisticConcurrencyTypes
+             and UseOptimisticConcurrency<T>(). polecat#592.
+             (c) jasperfx#810/#822 — DatabasePerTenantExplorerCompliance and
+             ShardedTenancyExplorerCompliance, the multi-database arms of the explorer reads whose
+             abstraction half arrived in 2.68.0, plus the SupportsMultipleDatabases /
+             DatabaseForTenantAsync / AssignTenantToDatabase fixture seam. polecat#593.
+             (d) jasperfx#825/#826 — ProjectionEventModelSource and AddProjectionEventModelSource,
+             the store-derived Event Model rung. polecat#594.
+             NumericRevisionCompliance was refactored onto a generic base in the same release;
+             existing enrollments compile unchanged. -->
+        <PackageVersion Include="JasperFx" Version="2.69.0" />
+        <PackageVersion Include="JasperFx.Events" Version="2.69.0" />
         <!--
              The shared cross-store event sourcing compliance suites. Source-only package: the
              suites compile inside Polecat.Tests so JasperFx's aggregate source generator binds
              Polecat's own session types.
         -->
-        <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.68.0" />
+        <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.69.0" />
         <!-- Pin the sibling JasperFx packages for parity with Marten 9's matrix
              even though Polecat doesn't currently reference them directly —
              keeps the lockstep matrix coherent when transitive resolution
@@ -469,7 +487,7 @@
              RuntimeCompiler 5.x line is the active continuation of the 4.x
              lineage; do not pin against the parallel stale 2.0.x series. -->
         <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.68.0" />
+        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.69.0" />
         <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
@@ -633,7 +651,7 @@
         <PackageVersion Include="Vogen" Version="7.0.0" />
 
         <!-- Source generators (matched to JasperFx.Events above) -->
-        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.68.0" />
+        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.69.0" />
 
         <!-- Build automation -->
         <PackageVersion Include="Nuke.Common" Version="9.0.4" />

--- a/src/Polecat.Tests/Compliance/PolecatDocumentComplianceFixture.cs
+++ b/src/Polecat.Tests/Compliance/PolecatDocumentComplianceFixture.cs
@@ -103,6 +103,33 @@ public class PolecatDocumentComplianceFixture : DocumentStorageComplianceFixture
             options.CommitListeners.Add(listener);
         }
 
+        // #592 / jasperfx#819: the Guid optimistic-concurrency declaration, replayed as a CHECK
+        // rather than as a setting.
+        //
+        // The suite declares it twice -- ComplianceShipment implements IVersioned AND the config
+        // calls UseOptimisticConcurrency<T>() -- because the stores disagree about whether the
+        // marker is itself the opt-in or merely supplies the member to guard on. On Polecat the
+        // marker IS the opt-in: DocumentMapping.UseOptimisticConcurrency is get-only and set from
+        // IVersioned during construction, and there is no fluent DSL to turn it on separately. So
+        // there is nothing here to replay onto the store.
+        //
+        // Asserting instead of no-oping, deliberately. A silent no-op reads identically whether the
+        // marker still drives the guard or someone made it opt-in and every fact in the suite went
+        // red for a reason a fixture could have named. This fails at build time with the type in the
+        // message.
+        foreach (var type in config.OptimisticConcurrencyTypes)
+        {
+            if (!new Polecat.Storage.DocumentMapping(type, options).UseOptimisticConcurrency)
+            {
+                throw new InvalidOperationException(
+                    $"The compliance configuration declared Guid optimistic concurrency for {type.FullName}, "
+                    + "and Polecat's mapping did not turn it on. Polecat derives the guard from the IVersioned "
+                    + "marker alone (DocumentMapping.UseOptimisticConcurrency is get-only), so either the type "
+                    + "no longer implements IVersioned or that derivation has changed and this fixture needs a "
+                    + "real opt-in to replay.");
+            }
+        }
+
         _store = new DocumentStore(options);
 
         // Polecat applies schema changes explicitly rather than lazily, and the suite's very first
@@ -127,6 +154,13 @@ public class PolecatDocumentComplianceFixture : DocumentStorageComplianceFixture
     ///     #559 the strictly-greater guard the suite pins.
     /// </summary>
     public override bool SupportsNumericRevisions => true;
+
+    /// <summary>
+    ///     #592 / jasperfx#819: Polecat implements Guid optimistic concurrency — a document
+    ///     implementing <see cref="IVersioned" /> gets <c>ConcurrencyMode.Optimistic</c> on its
+    ///     mapping, a <c>guid_version</c> column, and a guarded MERGE.
+    /// </summary>
+    public override bool SupportsOptimisticConcurrency => true;
 
     public override IDocumentSessionFactory Sessions =>
         _store ?? throw new InvalidOperationException("The store has not been configured yet.");

--- a/src/Polecat.Tests/Compliance/polecat_event_store_compliance.cs
+++ b/src/Polecat.Tests/Compliance/polecat_event_store_compliance.cs
@@ -70,3 +70,19 @@ public class polecat_document_query_compliance
 
 public class polecat_numeric_revision_compliance
     : NumericRevisionCompliance<PolecatDocumentComplianceFixture>;
+
+/*
+ * #592 / jasperfx#819 -- Guid optimistic concurrency, the document-concurrency suite that did not
+ * exist for ANY store before 2.69.0. The whole shared coverage of document concurrency was
+ * NumericRevisionCompliance above; grepping the 2.68.0 suites for IVersioned returned nothing.
+ *
+ * Two stores shipped the same field broken in two different ways and neither was caught by anything
+ * shared -- fisher#245 (the guard fed from the session's own version tracker, so a document loaded
+ * in one session and stored through another failed its guard EVERY time) and marten#5372 (a mapped
+ * version member invisible to the session, so the upsert bound DBNull into its guard). Fisher passed
+ * all fifty enrolled suites throughout. Polecat's behaviour here was simply unverified, which is the
+ * point of enrolling.
+ */
+
+public class polecat_guid_optimistic_concurrency_compliance
+    : GuidOptimisticConcurrencyCompliance<PolecatDocumentComplianceFixture>;

--- a/src/Polecat/Internal/DocumentSessionBase.cs
+++ b/src/Polecat/Internal/DocumentSessionBase.cs
@@ -304,7 +304,8 @@ internal abstract class DocumentSessionBase : QuerySession, IDocumentSession
         Weasel.Storage.IStorageSession session = tenantScope ?? (Weasel.Storage.IStorageSession)this;
         var storage = (Weasel.Storage.IDocumentStorage<T>)session.StorageFor<T>();
 
-        storage.Store(session, document); // id assignment + identity-map/version bookkeeping
+        // id assignment + identity-map/version bookkeeping
+        StoreForConcurrency(storage, session, document);
 
         var op = kind switch
         {
@@ -328,11 +329,60 @@ internal abstract class DocumentSessionBase : QuerySession, IDocumentSession
         Weasel.Storage.IStorageSession session = tenantScope ?? (Weasel.Storage.IStorageSession)this;
         var storage = (Polecat.Storage.ClosedShape.IPolecatObjectWriteStorage)session.StorageFor(document.GetType());
 
-        storage.StoreObject(session, document);
+        // #592: the same version seeding Store<T> does, through the object bridge.
+        if (document is IVersioned objectVersioned && objectVersioned.Version != Guid.Empty)
+        {
+            storage.StoreObject(session, document, objectVersioned.Version);
+        }
+        else
+        {
+            storage.StoreObject(session, document);
+        }
+
         var op = storage.UpsertObject(document, session, session.TenantId);
         CaptureExpectedRevision(op, document);
 
         return new Operations.ClosedShapeOperationAdapter(op, session, document, provider.Mapping.GetId(document));
+    }
+
+    /// <summary>
+    ///     #592 — seed the concurrency guard from the DOCUMENT's own version, not only from what this
+    ///     session happens to have read.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Polecat's Guid optimistic concurrency used to work only inside one session. The guarded
+    ///         MERGE binds its expected version out of <c>IStorageSession.Versions</c>, and that
+    ///         tracker is written by the SELECT — so a document loaded in one session and stored
+    ///         through another had no entry, the guard bound <c>DBNull</c>, the matched branch never
+    ///         fired, and the write came back as a <c>ConcurrencyException</c>. Every time, on an
+    ///         unmodified row. That refused stale writes correctly and refused legitimate ones too,
+    ///         which is exactly the request-per-session workflow the feature exists for.
+    ///     </para>
+    ///     <para>
+    ///         A non-empty <see cref="IVersioned.Version" /> on the instance is the caller's
+    ///         expectation, so it seeds the tracker. <see cref="Guid.Empty" /> means "never stored",
+    ///         which must stay unseeded: the INSERT branch has no version to guard on. Mirrors
+    ///         Marten's <c>DocumentSessionBase.storeEntity</c>, and the same shape as fisher#245 and
+    ///         marten#5372 — the same field, found three times independently, which is why
+    ///         jasperfx#819 built a shared suite for it.
+    ///     </para>
+    ///     <para>
+    ///         Numeric revisions are NOT handled here. They travel on the operation itself through
+    ///         <see cref="CaptureExpectedRevision" />, which already reads the document rather than
+    ///         the session.
+    ///     </para>
+    /// </remarks>
+    private static void StoreForConcurrency<T>(Weasel.Storage.IDocumentStorage<T> storage,
+        Weasel.Storage.IStorageSession session, T document) where T : notnull
+    {
+        if (document is IVersioned versioned && versioned.Version != Guid.Empty)
+        {
+            storage.Store(session, document, versioned.Version);
+            return;
+        }
+
+        storage.Store(session, document);
     }
 
     // Numeric revisions: the doc-carried version is the equality expectation (0 = new/auto),

--- a/src/Polecat/Storage/ClosedShape/PolecatDocumentStorage.cs
+++ b/src/Polecat/Storage/ClosedShape/PolecatDocumentStorage.cs
@@ -33,6 +33,14 @@ internal interface IPolecatObjectWriteStorage
     /// <summary>Id assignment + session bookkeeping (identity-map add for that flavor).</summary>
     void StoreObject(IStorageSession session, object document);
 
+    /// <summary>
+    ///     #592 — the same, seeding the Guid concurrency guard with the caller's expected version.
+    ///     The object-typed twin of <c>IDocumentStorage&lt;T&gt;.Store(session, document, version)</c>,
+    ///     so a versioned document written through <c>StoreObjects</c> is guarded the same way one
+    ///     written through <c>Store&lt;T&gt;</c> is.
+    /// </summary>
+    void StoreObject(IStorageSession session, object document, Guid? version);
+
     Weasel.Storage.IStorageOperation UpsertObject(object document, IStorageSession session, string tenantId);
 
     /// <summary>Session-free upsert for the projection paths (no version-tracker reads).</summary>
@@ -685,6 +693,9 @@ internal abstract class PolecatDocumentStorage<TDoc, TId>
     }
 
     public void StoreObject(IStorageSession session, object document) => Store(session, (TDoc)document);
+
+    public void StoreObject(IStorageSession session, object document, Guid? version)
+        => Store(session, (TDoc)document, version);
 
     public Weasel.Storage.IStorageOperation UpsertObject(object document, IStorageSession session, string tenantId)
         => Upsert((TDoc)document, session, tenantId);

--- a/src/Polecat/Storage/ClosedShape/SubClassPolecatStorage.cs
+++ b/src/Polecat/Storage/ClosedShape/SubClassPolecatStorage.cs
@@ -251,6 +251,9 @@ internal sealed class SubClassPolecatStorage<T, TRoot, TId>
 
     public void StoreObject(IStorageSession session, object document) => ParentBridge.StoreObject(session, document);
 
+    public void StoreObject(IStorageSession session, object document, Guid? version)
+        => ParentBridge.StoreObject(session, document, version);
+
     public Weasel.Storage.IStorageOperation UpsertObject(object document, IStorageSession session, string tenantId)
         => ParentBridge.UpsertObject(document, session, tenantId);
 


### PR DESCRIPTION
Closes #592.

## The suite found a real bug

`GuidOptimisticConcurrencyCompliance` is new in JasperFx 2.69.0 — there was no shared suite for `Guid` document concurrency, **for any store**. Polecat's behaviour here was unverified in either direction, which is the point of enrolling. Three of its five facts failed on first run:

```
JasperFx.ConcurrencyException : Optimistic concurrency check failed for ComplianceShipment #05a0d6d8…
  a_document_loaded_in_one_session_can_be_stored_through_another
  a_stale_instance_is_refused_and_the_winner_stands
  a_successful_write_moves_the_instances_own_version_on
```

Polecat's Guid optimistic concurrency worked only **inside one session**. The guarded MERGE binds its expected version out of `IStorageSession.Versions`, and that tracker is written by the SELECT — so a document loaded in one session and stored through another had no entry, the guard bound `DBNull`, the matched branch never fired, and the write came back as a `ConcurrencyException`. Every time, on an unmodified row. It refused stale writes correctly and refused legitimate ones too, which is exactly the request-per-session workflow the feature exists for:

```csharp
Order order;
await using (var session = store.LightweightSession())
    order = await session.LoadAsync<Order>(id);

order.Status = "shipped";
await using (var session = store.LightweightSession())
{
    session.Store(order);          // ConcurrencyException, every time
    await session.SaveChangesAsync();
}
```

This is the same field as JasperFx/fisher#245 and JasperFx/marten#5372 — three stores, three independent discoveries, which is why jasperfx#819 built a shared suite for it.

## The fix

Mirrors Marten's `DocumentSessionBase.storeEntity`: a non-empty `IVersioned.Version` on the instance is the caller's expectation, so it seeds the tracker through the `Store(session, document, Guid? version)` overload that already existed on `IDocumentStorage<T>` and was never called.

- `Guid.Empty` stays unseeded — that means "never stored", and the INSERT branch has no version to guard on. That is what keeps fact 3 (staleness still refused) passing alongside fact 2.
- Numeric revisions are untouched: they already travel on the operation through `CaptureExpectedRevision`, which reads the document rather than the session.
- The object-write bridge is covered too, so `StoreObjects` guards a versioned document the same way `Store<T>` does. `IPolecatObjectWriteStorage` gains the object-typed twin of the versioned `Store`.

## Fixture

`SupportsOptimisticConcurrency => true`, and the `OptimisticConcurrencyTypes` replay written as a **check** rather than a setting: on Polecat the `IVersioned` marker *is* the opt-in (`DocumentMapping.UseOptimisticConcurrency` is get-only) and there is no fluent DSL to replay, so there is nothing to set. A silent no-op would read identically whether that is still true or someone made it opt-in and every fact went red for a reason a fixture could have named — so it throws with the type in the message instead.

All five facts pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)