### PR TITLE
gh-593: the tenant dimension of the explorer reads survives more than one database

### DIFF
--- a/src/Polecat.Tests/Compliance/PolecatComplianceFixture.cs
+++ b/src/Polecat.Tests/Compliance/PolecatComplianceFixture.cs
@@ -27,6 +27,10 @@ public class PolecatComplianceFixture : EventStoreComplianceFixture<IDocumentSes
 
     protected override async Task BuildStoreAsync(ComplianceStoreConfig config)
     {
+        // #593 / jasperfx#810: the multi-database arms want REAL databases, and they have to exist
+        // before the store's tenancy is pointed at them.
+        await CreateTenantDatabasesAsync(config).ConfigureAwait(false);
+
         var options = OptionsFor(config);
 
         _store = new DocumentStore(options);
@@ -34,8 +38,54 @@ public class PolecatComplianceFixture : EventStoreComplianceFixture<IDocumentSes
 
         // Polecat applies schema changes explicitly rather than lazily -- one of the eight
         // divergences the compliance seam exists to absorb.
-        await _store.Database.ApplyAllConfiguredChangesToDatabaseAsync().ConfigureAwait(false);
+        //
+        // #593: and once per DATABASE, not once. A tenant database left unprovisioned fails on its
+        // first write with a missing-table error, which reads as a suite bug rather than as the
+        // fixture never having migrated it. Mirrors PolecatActivator's own loop.
+        foreach (var database in await DatabasesAsync().ConfigureAwait(false))
+        {
+            await database.ApplyAllConfiguredChangesToDatabaseAsync().ConfigureAwait(false);
+        }
     }
+
+    /// <summary>
+    ///     #593 — the physical databases behind <see cref="ComplianceStoreConfig.TenantDatabases" />.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         The config carries LOGICAL names and this fixture owns the physical ones, which is what
+    ///         lets the same suite run on every store. Distinct logical names map to distinct
+    ///         databases and equal names to the same one — the only thing a suite assumes.
+    ///     </para>
+    ///     <para>
+    ///         Scoped per CLAUDE.md. A database a test creates is a SIBLING of the worker's own
+    ///         catalog rather than a child of it, so giving each parallel worker its own catalog does
+    ///         not isolate these — a hardcoded "compliance_shard_one" would be one database every
+    ///         worker on the box raced to create and drop.
+    ///     </para>
+    /// </remarks>
+    private static string PhysicalDatabaseFor(string logicalName) => ConnectionSource.Scoped(logicalName);
+
+    private static async Task CreateTenantDatabasesAsync(ComplianceStoreConfig config)
+    {
+        if (config.TenantDatabases.Count == 0) return;
+
+        await using var conn = new SqlConnection(ConnectionSource.MasterConnectionString);
+        await conn.OpenAsync().ConfigureAwait(false);
+
+        foreach (var logical in config.TenantDatabases.Values.Distinct())
+        {
+            var database = PhysicalDatabaseFor(logical);
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = $"IF DB_ID('{database}') IS NULL CREATE DATABASE [{database}];";
+            await cmd.ExecuteNonQueryAsync().ConfigureAwait(false);
+        }
+    }
+
+    private async Task<IReadOnlyList<Polecat.Storage.PolecatDatabase>> DatabasesAsync()
+        => _store.Options.Tenancy is { } tenancy
+            ? await tenancy.BuildDatabasesAsync(CancellationToken.None).ConfigureAwait(false)
+            : [_store.Database];
 
     /// <summary>
     ///     Translate the store-neutral configuration into Polecat's own <see cref="StoreOptions" />.
@@ -92,6 +142,21 @@ public class PolecatComplianceFixture : EventStoreComplianceFixture<IDocumentSes
         if (config.ConjoinedEventTenancy)
         {
             options.Events.TenancyStyle = TenancyStyle.Conjoined;
+        }
+
+        // #593 / jasperfx#810: the tenant-to-database map, which is what makes the store
+        // multi-database at all. Two distinct logical names is database-per-tenant; two tenants
+        // sharing one, alongside ConjoinedEventTenancy above, is sharded tenancy -- and those are the
+        // two arms, on genuinely independent axes.
+        if (config.TenantDatabases.Count > 0)
+        {
+            options.MultiTenantedDatabases(tenancy =>
+            {
+                foreach (var (tenantId, logical) in config.TenantDatabases)
+                {
+                    tenancy.AddTenant(tenantId, ConnectionSource.ConnectionStringFor(PhysicalDatabaseFor(logical)));
+                }
+            });
         }
 
         config.ApplyTo(new PolecatComplianceRegistrar(options));
@@ -450,6 +515,28 @@ public class PolecatComplianceFixture : EventStoreComplianceFixture<IDocumentSes
     ///     <c>AddProjectionCoordinator&lt;T&gt;</c> gives each one its own marker-typed coordinator.
     /// </summary>
     public override bool SupportsAncillaryCoordinators => true;
+
+    /// <summary>
+    ///     #593 / jasperfx#810 — this fixture creates and drops real SQL Server databases, so the
+    ///     multi-database explorer arms can run against a store whose cardinality is genuinely not
+    ///     <c>Single</c>.
+    /// </summary>
+    /// <remarks>
+    ///     Saying true is a commitment to both halves, and the second one is the load-bearing part:
+    ///     the <see cref="ComplianceStoreConfig.TenantDatabases" /> replay in <c>OptionsFor</c>. A
+    ///     fixture that said true and replayed nothing would not skip — the isolation facts pass
+    ///     <em>vacuously</em> against a single-database store, which is what the arms' precondition
+    ///     fact exists to catch.
+    /// </remarks>
+    public override bool SupportsMultipleDatabases => true;
+
+    /// <remarks>
+    ///     Straight through Polecat's own tenancy rather than by matching
+    ///     <see cref="IEventDatabase.Identifier" /> against the config's logical name — the logical
+    ///     name is this fixture's private business and the identifier is the store's.
+    /// </remarks>
+    public override ValueTask<IEventDatabase> DatabaseForTenantAsync(string tenantId)
+        => ValueTask.FromResult<IEventDatabase>(_store.Options.Tenancy!.GetDatabase(tenantId));
 
     /// <remarks>
     ///     The marker-typed registration lands on Polecat's OWN

--- a/src/Polecat.Tests/Compliance/polecat_event_store_compliance_wave18.cs
+++ b/src/Polecat.Tests/Compliance/polecat_event_store_compliance_wave18.cs
@@ -1,0 +1,52 @@
+using JasperFx.Events.ComplianceTests;
+
+namespace Polecat.Tests.Compliance;
+
+/*
+ * Wave 18 -- the two multi-database explorer arms (#593 / jasperfx#810). Split upstream because the
+ * gaps live on independent axes and one configuration cannot express both: database-per-tenant has
+ * no co-located tenants, so it cannot see a dropped tenant_id predicate; sharded tenancy has them,
+ * so it cannot tell "the wrong database answered" from "the right database answered about the wrong
+ * tenant".
+ *
+ * Both are the first suites in the set to make this fixture build REAL extra databases -- see
+ * SupportsMultipleDatabases and the TenantDatabases replay on PolecatComplianceFixture. Both also
+ * open with a precondition fact, because a fixture that claims the capability and builds one
+ * database satisfies every "and not the other one's data" assertion by having no other one.
+ */
+
+/// <summary>
+///     Database-per-tenant: each tenant has a database of its own, and a store-global read has to
+///     say so rather than answering from one of them.
+/// </summary>
+/// <remarks>
+///     Polecat's store-global reads were already brought into line by #584 — the recent-streams
+///     listing fans out and merges, and the rest refuse and name the database overload. The suite
+///     accepts either remedy, so this arm is the shared confirmation of a decision Polecat had
+///     already made rather than a change.
+/// </remarks>
+public class polecat_database_per_tenant_explorer_compliance
+    : DatabasePerTenantExplorerCompliance<PolecatComplianceFixture, IDocumentSession, IQuerySession>;
+
+/// <summary>
+///     Sharded tenancy — a pool of databases with many tenants co-located in each, conjoined. The arm
+///     that pins the <c>tenant_id</c> predicate.
+/// </summary>
+/// <remarks>
+///     <para>
+///         Three tenants over two databases: two co-located so a leak has somewhere to come from, and
+///         a third alone in the second shard so the store's cardinality is genuinely not
+///         <c>Single</c> — which is the whole precondition, since it is the cardinality test that
+///         turns the predicate off on the store that gets this wrong.
+///     </para>
+///     <para>
+///         Polecat filters by tenant wherever events are conjoined and decides that from tenancy
+///         style rather than from cardinality, so this arm is the rule to PRESERVE while adding the
+///         database dimension rather than one to fix. What it did change here is the routing: a
+///         tenant-scoped read used to refuse on a multi-database store, and a tenant names the
+///         database it lives in, so it now resolves to that one database and keeps the predicate on
+///         top of it.
+///     </para>
+/// </remarks>
+public class polecat_sharded_tenancy_explorer_compliance
+    : ShardedTenancyExplorerCompliance<PolecatComplianceFixture, IDocumentSession, IQuerySession>;

--- a/src/Polecat/DocumentStore.EventStoreExplorer.cs
+++ b/src/Polecat/DocumentStore.EventStoreExplorer.cs
@@ -54,9 +54,16 @@ public partial class DocumentStore
         int count, string? tenantId, CancellationToken ct)
         // #584 — on a multi-database store a store-global listing is a fan-out, not one database's
         // rows. See FanOutRecentStreamsAsync for why this one read merges where its siblings refuse.
-        => IsSingleDatabase
-            ? recentStreamsAsync(null, count, tenantId, ct)
-            : FanOutRecentStreamsAsync(count, tenantId, ct);
+        //
+        // #593 — but only when the read really IS store-global. A tenant names the database it lives
+        // in, so a tenant-scoped listing goes to that one database and keeps the tenant_id predicate
+        // on top of it. Fanning out for a named tenant would open every database in the pool to find
+        // rows that can only be in one of them.
+        => tenantId == null
+            ? IsSingleDatabase
+                ? recentStreamsAsync(null, count, tenantId, ct)
+                : FanOutRecentStreamsAsync(count, null, ct)
+            : recentStreamsAsync(DatabaseForTenant(tenantId), count, tenantId, ct);
 
     private async Task<IReadOnlyList<StreamSummary>> recentStreamsAsync(
         PolecatDatabase? database, int count, string? tenantId, CancellationToken ct)
@@ -111,10 +118,19 @@ public partial class DocumentStore
     IAsyncEnumerable<EventRecord> IEventStore.ReadStreamAsync(
         string streamId, string? tenantId, CancellationToken ct)
     {
+        // #593 — a tenant names the database it lives in, so a tenant-scoped read is not the
+        // ambiguous cross-database read the refusal below exists for. It resolves to one database
+        // and keeps the tenant_id predicate: under conjoined tenancy the identity of a stream is
+        // (tenant, id), not id alone, so both axes apply.
+        if (tenantId != null)
+        {
+            return readStreamAsync(DatabaseForTenant(tenantId), streamId, tenantId, ct);
+        }
+
         // #584 — concatenating one stream id's events out of several databases would interleave two
         // independent version sequences into something that reads as a single stream and is not.
         RequireSingleDatabase(nameof(IEventStore.ReadStreamAsync));
-        return readStreamAsync(null, streamId, tenantId, ct);
+        return readStreamAsync(null, streamId, null, ct);
     }
 
     private async IAsyncEnumerable<EventRecord> readStreamAsync(
@@ -170,11 +186,30 @@ public partial class DocumentStore
 
     Task<StreamMetadata?> IEventStore.GetStreamMetadataAsync(
         string streamId, CancellationToken ct)
+        => ((IEventStore)this).GetStreamMetadataAsync(streamId, null, ct);
+
+    /// <summary>
+    ///     #593 — the tenant dimension of the metadata read, which used to refuse.
+    /// </summary>
+    /// <remarks>
+    ///     Both axes apply and they are independent. The tenant selects the database it lives in
+    ///     (a no-op on a single-database store), and the <c>tenant_id</c> predicate selects its rows
+    ///     within that database — which matters because sharded tenancy co-locates many tenants in
+    ///     each database, so "the tenant's database" is not "the tenant's data". Deciding from
+    ///     cardinality alone, as Marten does, drops the predicate exactly there (marten#5383 §2).
+    /// </remarks>
+    Task<StreamMetadata?> IEventStore.GetStreamMetadataAsync(
+        string streamId, string? tenantId, CancellationToken ct)
     {
+        if (tenantId != null)
+        {
+            return streamMetadataAsync(DatabaseForTenant(tenantId), streamId, tenantId, ct);
+        }
+
         // #584 — this read returns ONE row. On a multi-database store two databases can each hold a
         // stream with this id, and there is no answer that names both.
         RequireSingleDatabase(nameof(IEventStore.GetStreamMetadataAsync));
-        return streamMetadataAsync(null, streamId, ct);
+        return streamMetadataAsync(null, streamId, null, ct);
     }
 
     // #584 / jasperfx#810 — the database dimension. A null answer from this overload means "no such
@@ -184,18 +219,14 @@ public partial class DocumentStore
         IEventDatabase database, string streamId, string? tenantId, CancellationToken ct)
     {
         ArgumentNullException.ThrowIfNull(database);
-        if (tenantId != null)
-        {
-            throw new NotSupportedException(
-                "Tenant-scoped GetStreamMetadataAsync is not implemented on Polecat. Pass a null tenantId " +
-                "to read the stream from the database without a tenant predicate.");
-        }
 
-        return streamMetadataAsync(RequirePolecatDatabase(database), streamId, ct);
+        // #593: the tenant axis used to refuse here. Naming the database does not turn the tenant
+        // predicate off -- the database says where to look, the tenant says which rows.
+        return streamMetadataAsync(RequirePolecatDatabase(database), streamId, tenantId, ct);
     }
 
     private async Task<StreamMetadata?> streamMetadataAsync(
-        PolecatDatabase? database, string streamId, CancellationToken ct)
+        PolecatDatabase? database, string streamId, string? tenantId, CancellationToken ct)
     {
         ArgumentException.ThrowIfNullOrEmpty(streamId);
 
@@ -212,15 +243,20 @@ public partial class DocumentStore
         // first_event_at column is appended after the canonical projection
         // (index 8, following jasperfx#740's compacted_version at 7) and
         // threaded into ReadStreamMetadata explicitly.
+        // #593: under conjoined tenancy pc_streams holds one row per (tenant, id), so without this
+        // predicate a tenant-scoped read returns whichever of them the scan reached first -- a
+        // plausible, complete-looking answer about the wrong tenant.
+        var tenantFilter = tenantId == null ? "" : "\n              AND s.tenant_id = @tenant_id";
         cmd.CommandText = $"""
             SELECT {PcStreamsRowReader.SelectColumnsWithAlias("s")},
                    MIN(e.timestamp) AS first_event_at
             FROM {Events.StreamsTableName} s
             LEFT JOIN {Events.EventsTableName} e ON e.stream_id = s.id AND e.tenant_id = s.tenant_id
-            WHERE s.id = @id
+            WHERE s.id = @id{tenantFilter}
             GROUP BY s.id, s.type, s.version, s.created, s.timestamp, s.tenant_id, s.is_archived, s.compacted_version;
             """;
         cmd.Parameters.AddIdParameter("@id", resolvedStreamId);
+        if (tenantId != null) cmd.Parameters.AddVarChar("@tenant_id", tenantId);
 
         await using var reader = await session.ExecuteReaderAsync(cmd, ct);
         if (!await reader.ReadAsync(ct))
@@ -270,7 +306,9 @@ public partial class DocumentStore
 
     IAsyncEnumerable<EventRecord> IEventStore.QueryByTagsAsync(
         IReadOnlyDictionary<string, string> tags, string? tenantId, CancellationToken ct)
-        => queryByTagsAsync(null, tags, tenantId, ct);
+        // #593: a named tenant selects the database it lives in, exactly as it does for the stream
+        // reads. Null stays on the default routing and reaches the store-global refusal below.
+        => queryByTagsAsync(tenantId == null ? null : DatabaseForTenant(tenantId), tags, tenantId, ct);
 
     private async IAsyncEnumerable<EventRecord> queryByTagsAsync(
         PolecatDatabase? database,
@@ -608,6 +646,25 @@ public partial class DocumentStore
             ? databases[0]
             : throw new InvalidOperationException(
                 "This Polecat store has no database configured, so the event store explorer has nothing to read.");
+
+    /// <summary>
+    ///     #593 — the database a tenant's data lives in, or null to leave the read on the store's
+    ///     default routing.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Null on a single-database store, deliberately: there is one place to read and
+    ///         <see cref="ExplorerSession" /> already opens it. That keeps every single-database
+    ///         store on exactly the session it used before this change.
+    ///     </para>
+    ///     <para>
+    ///         The tenant is the <em>database</em> axis. It is not the row filter, and resolving it
+    ///         here never removes one: the <c>tenant_id</c> predicate is passed separately and applies
+    ///         on top, because a sharded store co-locates many tenants in each database.
+    ///     </para>
+    /// </remarks>
+    private PolecatDatabase? DatabaseForTenant(string tenantId)
+        => IsSingleDatabase ? null : Options.Tenancy!.GetDatabase(tenantId);
 
     private void RequireSingleDatabase(string member)
     {


### PR DESCRIPTION
Closes #593.

## What was left

The five database-scoped overloads landed in #584, and Polecat's store-global reads already fan out or refuse rather than answering from one database — so acceptance items 1 and 2 were done. What was still missing was the **other axis on a store that actually has several databases**.

A tenant-scoped explorer read *refused* there. The store-global refusal #584 added did not distinguish "no tenant, so this could be any database" from "a tenant, which names exactly one":

```csharp
// before — NotSupportedException on any multi-database store
await store.ReadStreamAsync(streamId, "acme", ct);
```

## The rule

**A tenant is the database axis *and* the row filter, and the two compose.** The database says where to look; the tenant says which rows. Naming one does not turn the other off.

- `ReadStreamAsync(streamId, tenantId)`, `GetRecentStreamsAsync(count, tenantId)` and `QueryByTagsAsync(tags, tenantId)` resolve the tenant's database and keep the `tenant_id` predicate on top of it. A **null** tenant still fans out or refuses, unchanged — that is the genuinely ambiguous case #584 exists for.
- `GetStreamMetadataAsync` gains the tenant dimension it never had. The tenant overload used to fall through to JasperFx's default (which throws), and the database-scoped overload refused a non-null tenant outright.
- `streamMetadataAsync` applies `s.tenant_id`. Under conjoined tenancy `pc_streams` holds one row per `(tenant, id)`, so without the predicate a tenant-scoped read returned whichever of them the scan reached first — a plausible, complete-looking answer about the wrong tenant.

This **preserves** Polecat's existing rule rather than changing it: the `tenant_id` predicate is decided by tenancy *style*, not by cardinality. Marten decides from cardinality and drops the predicate on a multi-database store — true for database-per-tenant, false for sharded tenancy, where many tenants share each database (marten#5383 §2).

`DatabaseForTenant` returns **null** on a single-database store, so every single-database store stays on exactly the session it used before this change.

## Compliance

`DatabasePerTenantExplorerCompliance` and `ShardedTenancyExplorerCompliance` enrolled as wave 18. **7 + 7 facts, all pass, no skips** — so each arm's precondition fact confirms the store really is backed by more than one database and nothing passed vacuously.

This makes `PolecatComplianceFixture` the first in the set to build **real** extra databases:

- `SupportsMultipleDatabases => true` and `DatabaseForTenantAsync`, straight through Polecat's own tenancy rather than by matching an `IEventDatabase.Identifier` against the config's private logical name.
- The `TenantDatabases` replay through `MultiTenantedDatabases(...)` — load-bearing, not belt-and-braces: a fixture that says true and replays nothing does not skip, the isolation facts pass vacuously.
- Per-database schema migration, mirroring `PolecatActivator`'s own loop — a tenant database left unprovisioned fails on its first write with a missing-table error that reads as a suite bug.
- `ConnectionSource.Scoped(...)` names, per CLAUDE.md: a database a test creates is a sibling of the worker's catalog, so a hardcoded `compliance_shard_one` would be one database every parallel worker raced over.

Regression check: `Polecat.Tests.ExplorerApi`, `MultiTenancy` and `Diagnostics` — 107 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)