### PR TITLE
gh-594: register ProjectionEventModelSource from AddPolecat and AddPolecatStore<T>

### DIFF
--- a/src/Polecat.Tests/Events/event_model_source_registration_tests.cs
+++ b/src/Polecat.Tests/Events/event_model_source_registration_tests.cs
@@ -1,0 +1,220 @@
+using JasperFx.Events;
+using JasperFx.Events.EventModeling;
+using JasperFx.Events.Projections;
+using Microsoft.Extensions.DependencyInjection;
+using Polecat.Tests.Harness;
+
+namespace Polecat.Tests.Events;
+
+#region The registered projection under test
+
+public record LedgerOpened(string Owner);
+
+public record LedgerCredited(decimal Amount);
+
+public record LedgerClosed;
+
+/// <summary>
+///     A self-aggregating snapshot — one document, three applied event types, which is the whole role
+///     set of a State View slice.
+/// </summary>
+public partial class LedgerBalance
+{
+    public Guid Id { get; set; }
+    public string Owner { get; set; } = string.Empty;
+    public decimal Balance { get; set; }
+    public bool Closed { get; set; }
+
+    public static LedgerBalance Create(LedgerOpened e) => new() { Owner = e.Owner };
+
+    public void Apply(LedgerCredited e) => Balance += e.Amount;
+
+    public void Apply(LedgerClosed _) => Closed = true;
+}
+
+/// <summary>The ancillary store's marker — its own document type, so its slice is distinguishable.</summary>
+public interface IEventModelAncillaryStore : IDocumentStore;
+
+public record ManifestLogged(string Reference);
+
+public partial class ManifestLog
+{
+    public Guid Id { get; set; }
+    public string Reference { get; set; } = string.Empty;
+
+    public static ManifestLog Create(ManifestLogged e) => new() { Reference = e.Reference };
+}
+
+#endregion
+
+/// <summary>
+///     #594 / jasperfx#825 — <c>AddPolecat</c> and <c>AddPolecatStore&lt;T&gt;</c> each register the
+///     store-derived Event Model rung, so every registered projection becomes a
+///     <see cref="SlicePattern.View" /> slice with no Bobcat reference and nobody having written one
+///     down.
+/// </summary>
+/// <remarks>
+///     <para>
+///         Asserted through <see cref="EventModelDiscovery" />, the path a tool actually takes, rather
+///         than by resolving <see cref="ProjectionEventModelSource" /> out of the container and calling
+///         it. A source that is constructed and never registered under
+///         <see cref="IEventModelDefinitionSource" /> would satisfy the second and contribute nothing
+///         to the first, which is precisely the failure this issue exists to prevent.
+///     </para>
+///     <para>
+///         The ancillary arm is not a formality. <c>AddPolecatStore&lt;T&gt;</c> registers its store
+///         under the marker type <c>T</c> and deliberately does NOT add it to the
+///         <c>GetServices&lt;IEventStore&gt;()</c> list the parameterless source would read, so an
+///         ancillary store's projections are invisible unless its own registration names it.
+///     </para>
+/// </remarks>
+public class event_model_source_registration_tests
+{
+    private static void ConfigureMain(StoreOptions opts)
+    {
+        opts.ConnectionString = ConnectionSource.ConnectionString;
+        opts.DatabaseSchemaName = "event_model_main";
+        opts.UseNativeJsonType = ConnectionSource.SupportsNativeJson;
+        opts.Projections.Snapshot<LedgerBalance>(SnapshotLifecycle.Inline);
+    }
+
+    private static void ConfigureAncillary(StoreOptions opts)
+    {
+        opts.ConnectionString = ConnectionSource.ConnectionString;
+        opts.DatabaseSchemaName = "event_model_ancillary";
+        opts.UseNativeJsonType = ConnectionSource.SupportsNativeJson;
+        opts.Projections.Snapshot<ManifestLog>(SnapshotLifecycle.Inline);
+    }
+
+    private static async Task<IReadOnlyList<EventModelSliceDescriptor>> SlicesFrom(
+        IServiceProvider provider, CancellationToken token)
+    {
+        var models = await EventModelDiscovery.AssembleAsync(provider, token);
+        return models.SelectMany(x => x.Slices).ToList();
+    }
+
+    [Fact]
+    public async Task add_polecat_registers_the_store_derived_source()
+    {
+        var token = TestContext.Current.CancellationToken;
+
+        var services = new ServiceCollection();
+        services.AddPolecat(ConfigureMain);
+
+        await using var provider = services.BuildServiceProvider();
+
+        var slices = await SlicesFrom(provider, token);
+
+        var ledger = slices.ShouldHaveSingleItem();
+
+        // Named after the DOCUMENT, not the projection class — that is what makes a store-derived
+        // slice merge with a spec-declared one of the same name rather than sitting beside it.
+        ledger.Name.ShouldBe(nameof(LedgerBalance));
+        ledger.Pattern.ShouldBe(SlicePattern.View);
+
+        ledger.ReadModelTypes.Select(x => x.Name).ShouldContain(nameof(LedgerBalance));
+        ledger.ProjectionTypes.ShouldNotBeEmpty();
+
+        // Every event the projection's Create / Apply methods take.
+        var consumed = ledger.ConsumedEvents.Select(x => x.Name).ToList();
+        consumed.ShouldContain(nameof(LedgerOpened));
+        consumed.ShouldContain(nameof(LedgerCredited));
+        consumed.ShouldContain(nameof(LedgerClosed));
+
+        // Plus the two framework markers, which is shared JasperFx behaviour rather than anything
+        // Polecat adds: JasperFxSingleStreamProjectionBase.determineEventTypes appends Archived and
+        // Compacted<TDoc> to a single-stream projection's AllEventTypes (jasperfx#778 / #796), because
+        // an aggregate has no reason to declare an Apply for either and every store composes its
+        // async loader's allow list from that set. Asserted rather than filtered out: this is what
+        // Marten and Fisher report too, and a test that quietly trimmed them would hide a real change
+        // if the set ever stopped carrying them.
+        consumed.ShouldContain(typeof(JasperFx.Events.Archived).Name);
+        consumed.ShouldContain(typeof(JasperFx.Events.Compacted<LedgerBalance>).Name);
+    }
+
+    [Fact]
+    public async Task an_ancillary_store_contributes_its_own_slices()
+    {
+        var token = TestContext.Current.CancellationToken;
+
+        var services = new ServiceCollection();
+        services.AddPolecat(ConfigureMain);
+        services.AddPolecatStore<IEventModelAncillaryStore>(ConfigureAncillary);
+
+        await using var provider = services.BuildServiceProvider();
+
+        var names = (await SlicesFrom(provider, token)).Select(x => x.Name).ToList();
+
+        names.ShouldContain(nameof(LedgerBalance));
+        names.ShouldContain(nameof(ManifestLog),
+            "AddPolecatStore<T> registers its store under the marker type only, so an ancillary store's "
+            + "projections reach the Event Model only if its own registration names it.");
+    }
+
+    [Fact]
+    public async Task an_ancillary_store_on_its_own_still_contributes()
+    {
+        // No AddPolecat at all -- the ancillary registration has to stand by itself, because there is
+        // no primary store's GetServices<IEventStore>() list for it to ride in on.
+        var token = TestContext.Current.CancellationToken;
+
+        var services = new ServiceCollection();
+        services.AddPolecatStore<IEventModelAncillaryStore>(ConfigureAncillary);
+
+        await using var provider = services.BuildServiceProvider();
+
+        var slices = await SlicesFrom(provider, token);
+
+        slices.Select(x => x.Name).ShouldContain(nameof(ManifestLog));
+    }
+
+    [Fact]
+    public async Task the_derived_slice_merges_with_a_declared_slice_of_the_same_name()
+    {
+        var token = TestContext.Current.CancellationToken;
+
+        var services = new ServiceCollection();
+        services.AddPolecat(ConfigureMain);
+
+        // A Bobcat-style declaration of the SAME slice, naming the document the way the curated model
+        // file and Bobcat's {readmodel} capture do. One slice must come back carrying both claims,
+        // not two stickies saying the same thing.
+        services.AddEventModelSource(new DeclaredLedgerSource());
+
+        await using var provider = services.BuildServiceProvider();
+
+        var slices = await SlicesFrom(provider, token);
+
+        var ledger = slices.Single(x => x.Name == nameof(LedgerBalance));
+
+        // The declared half survives the merge...
+        ledger.CommandType.ShouldNotBeNull();
+        ledger.CommandType!.Name.ShouldBe(nameof(CreditLedger));
+
+        // ...and so does the derived half, which nobody wrote down.
+        ledger.ReadModelTypes.Select(x => x.Name).ShouldContain(nameof(LedgerBalance));
+        ledger.ConsumedEvents.Select(x => x.Name).ShouldContain(nameof(LedgerCredited));
+    }
+
+    public record CreditLedger(Guid Id, decimal Amount);
+
+    /// <summary>A stand-in for the Declared rung — the shape a Bobcat spec contributes.</summary>
+    private sealed class DeclaredLedgerSource : IEventModelDefinitionSource
+    {
+        public Uri Subject { get; } = new("event-model://declared-test");
+
+        public EventModelProvenance Provenance => EventModelProvenance.Declared;
+
+        public Task<EventModelDescriptor?> TryCreateAsync(IServiceProvider services, CancellationToken token)
+        {
+            var slice = EventModelSliceDescriptor.Named(nameof(LedgerBalance)) with
+            {
+                Pattern = SlicePattern.View,
+                CommandType = JasperFx.Descriptors.TypeDescriptor.For(typeof(CreditLedger))
+            };
+
+            return Task.FromResult<EventModelDescriptor?>(
+                new EventModelDescriptor(ProjectionEventModelSource.DefaultModelName, [slice]));
+        }
+    }
+}

--- a/src/Polecat/PolecatServiceCollectionExtensions.cs
+++ b/src/Polecat/PolecatServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using JasperFx.CommandLine.Descriptions;
 using JasperFx.Events;
+using JasperFx.Events.EventModeling;
 using JasperFx.MultiTenancy;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -153,6 +154,21 @@ public static class PolecatServiceCollectionExtensions
             (JasperFx.Events.IEventStore)sp.GetRequiredService<IDocumentStore>());
         services.AddSingleton<JasperFx.Documents.IDocumentStoreDiagnostics>(sp =>
             (JasperFx.Documents.IDocumentStoreDiagnostics)sp.GetRequiredService<IDocumentStore>());
+
+        // #594 / jasperfx#825 -- the store-derived Event Model rung. One SlicePattern.View slice per
+        // registered projection: the document it produces, the projection type, and every event its
+        // Apply / Create / Evolve methods take.
+        //
+        // Bobcat declares slices and Wolverine derives them from its chains, but nothing derived them
+        // from the STORE -- so a View slice appeared on an Event Model canvas only when a human had
+        // written one down, even though the store knows the whole role set exactly.
+        //
+        // The resolver overload rather than the parameterless one, deliberately: the default reads
+        // GetServices<IEventStore>(), which on a host with an ancillary store would sweep up every
+        // registered store into the primary's registration and then again into the ancillary's own.
+        // Naming this store keeps each registration describing the store it belongs to. Nothing here
+        // resolves at registration time -- the lambda runs when the model is assembled.
+        services.AddProjectionEventModelSource(sp => [(JasperFx.Events.IEventStore)sp.GetRequiredService<IDocumentStore>()]);
 
         // Default session factory: lightweight sessions
         services.TryAddSingleton<ISessionFactory>(sp =>

--- a/src/Polecat/PolecatStoreServiceCollectionExtensions.cs
+++ b/src/Polecat/PolecatStoreServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using JasperFx.Events;
+using JasperFx.Events.EventModeling;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Polecat.Internal;
@@ -91,6 +92,18 @@ public static class PolecatStoreServiceCollectionExtensions
             sp.GetRequiredService<T>());
         services.AddSingleton<JasperFx.Documents.IDocumentStoreDiagnostics>(sp =>
             (JasperFx.Documents.IDocumentStoreDiagnostics)sp.GetRequiredService<T>());
+
+        // #594 / jasperfx#825: an ancillary store's projections are View slices too, and its own
+        // registration is the only place that knows the marker type they hang off.
+        //
+        // Not covered by AddPolecat's registration even in a host that calls both: this store is
+        // registered under T, and AddPolecat names IDocumentStore. Nor by the parameterless
+        // ProjectionEventModelSource, since AddPolecatStore<T> deliberately does not add T to the
+        // GetServices<IEventStore>() list -- that list is the primary store's.
+        //
+        // The slices merge with the primary's by document-type NAME, so two stores projecting the
+        // same document type contribute one slice rather than two stickies saying the same thing.
+        services.AddProjectionEventModelSource(sp => [(JasperFx.Events.IEventStore)sp.GetRequiredService<T>()]);
 
         // #501: and the db-apply / db-assert / db-dump half, so an ancillary store's databases are
         // migrated by those commands too. Marten registers IDatabaseSource for its ancillary stores


### PR DESCRIPTION
Closes #594.

## The gap

Bobcat declares slices, Wolverine derives Command and Automation slices from its chains, CritterWatch observes a running system — and nobody derived from the **store**. So a View slice (event → projection → read model) appeared on an Event Model canvas only when a human had written one down, even though the store knows the whole role set exactly.

`ProjectionEventModelSource` shipped in JasperFx 2.69.0. Polecat's job is one registration per store.

## The registrations

```csharp
// AddPolecat
services.AddProjectionEventModelSource(sp => [(IEventStore)sp.GetRequiredService<IDocumentStore>()]);

// AddPolecatStore<T>
services.AddProjectionEventModelSource(sp => [(IEventStore)sp.GetRequiredService<T>()]);
```

The **resolver** overload rather than the parameterless one, deliberately. `AddPolecat` does already register `JasperFx.Events.IEventStore`, so the default `GetServices<IEventStore>()` would have found the primary store — but on a host with an ancillary store it would sweep every registered store into the primary's registration and then again into the ancillary's own. Naming the store keeps each registration describing the store it belongs to.

The **ancillary half is not a formality**: `AddPolecatStore<T>` registers its store under the marker type `T` and deliberately does *not* add it to the `GetServices<IEventStore>()` list, so an ancillary store's projections are invisible unless its own registration names them.

## Tests — four, all green

Asserted through `EventModelDiscovery`, the path a tool actually takes, rather than by resolving `ProjectionEventModelSource` out of the container and calling it: a source that is constructed and never registered under `IEventModelDefinitionSource` would satisfy the second and contribute nothing to the first, which is precisely the failure this issue exists to prevent.

- `AddPolecat` yields one View slice named after the **document**, with the projection type, the read model, and every applied event.
- An ancillary store contributes its own slices **alongside** a primary store...
- ...and **standing alone**, with no `AddPolecat` at all.
- A `Declared` slice of the same name merges with the derived one into a single slice carrying both claims — which is the whole reason the slice is named after the document rather than the projection class.

## One thing worth knowing about `ConsumedEvents`

A single-stream projection's applied-event set also carries `Archived` and `Compacted<TDoc>`. That is shared JasperFx behaviour, not something Polecat adds — `JasperFxSingleStreamProjectionBase.determineEventTypes` appends both (jasperfx#778 / #796) because an aggregate has no reason to declare an `Apply` for either and every store composes its async loader's allow list from that set. Marten and Fisher report the same.

The test asserts them rather than filtering them out, so a change upstream shows up here instead of passing silently. Whether a *canvas* should render framework markers as consumed events is a question for jasperfx#825's own follow-up, not something to paper over in a store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)