### PR TITLE
Bump JasperFx to 2.69.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -471,15 +471,43 @@
              (d) jasperfx#825/#826 — ProjectionEventModelSource and AddProjectionEventModelSource,
              the store-derived Event Model rung. polecat#594.
              NumericRevisionCompliance was refactored onto a generic base in the same release;
-             existing enrollments compile unchanged. -->
-        <PackageVersion Include="JasperFx" Version="2.69.0" />
-        <PackageVersion Include="JasperFx.Events" Version="2.69.0" />
+             existing enrollments compile unchanged.
+
+             JasperFx 2.69.1 (from 2.69.0). A two-commit patch release, and NEITHER half is inert
+             here — both are upstream fixes for defects Polecat's own #591-#594 work surfaced the
+             same day.
+             (a) jasperfx#827/#828 — JasperFxSubscriptionBase's two BuildExecution overloads
+             disagreed about what they passed as SubscriptionExecution's `storage`: the ILogger one
+             passed the store (correct), the explicit-interface ILoggerFactory one passed the
+             DATABASE. SubscriptionExecution casts storage to ISubscriptionRunner<T>, which an
+             IEventDatabase never implements, so it threw ArgumentOutOfRangeException. Since
+             JasperFxAsyncDaemon.buildAgentForShard calls the second overload, **a subscription
+             registered in an app using AddProjectionCoordinator could never start** — on every
+             store, since the rename in jasperfx commit 87fa883. Nothing caught it because every
+             subscription compliance suite drives a daemon the fixture built by hand, which takes the
+             other overload; it surfaced as a logged agent-start failure while running
+             ProjectionStatusCompliance (#591), whose coordinator host registers a subscription.
+             Polecat's own subscription tests all go through WaitForProjectionAsync — also the
+             working overload — so the coordinator path had no coverage here either. This bump adds
+             it: see subscription_under_coordinator_tests.
+             (b) jasperfx#829/#830 — ProjectionEventModelSource.ToSlice now filters Archived and
+             Compacted<T> out of a View slice's ConsumedEvents.
+             JasperFxSingleStreamProjectionBase.determineEventTypes concatenates both onto every
+             non-empty apply set whether or not the aggregate declares an Apply, which is correct
+             about what the projection HANDLES and is not what an Event Model canvas means by the
+             events a read model consumes — they render as stickies for events no command slice
+             emits, linking to nothing. Filtered in the source rather than in the reader that fills
+             AppliedEvents, deliberately: the same reader feeds AggregateDescriptor.AppliedEvents and
+             a monitoring console wants both. #594's test asserted the pre-fix set, so it inverts
+             here. Found independently while wiring the same source into Fisher. -->
+        <PackageVersion Include="JasperFx" Version="2.69.1" />
+        <PackageVersion Include="JasperFx.Events" Version="2.69.1" />
         <!--
              The shared cross-store event sourcing compliance suites. Source-only package: the
              suites compile inside Polecat.Tests so JasperFx's aggregate source generator binds
              Polecat's own session types.
         -->
-        <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.69.0" />
+        <PackageVersion Include="JasperFx.Events.ComplianceTests" Version="2.69.1" />
         <!-- Pin the sibling JasperFx packages for parity with Marten 9's matrix
              even though Polecat doesn't currently reference them directly —
              keeps the lockstep matrix coherent when transitive resolution
@@ -487,7 +515,7 @@
              RuntimeCompiler 5.x line is the active continuation of the 4.x
              lineage; do not pin against the parallel stale 2.0.x series. -->
         <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0" />
-        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.69.0" />
+        <PackageVersion Include="JasperFx.SourceGenerator" Version="2.69.1" />
         <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
@@ -651,7 +679,7 @@
         <PackageVersion Include="Vogen" Version="7.0.0" />
 
         <!-- Source generators (matched to JasperFx.Events above) -->
-        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.69.0" />
+        <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.69.1" />
 
         <!-- Build automation -->
         <PackageVersion Include="Nuke.Common" Version="9.0.4" />

--- a/src/Polecat.Tests/Events/event_model_source_registration_tests.cs
+++ b/src/Polecat.Tests/Events/event_model_source_registration_tests.cs
@@ -121,15 +121,29 @@ public class event_model_source_registration_tests
         consumed.ShouldContain(nameof(LedgerCredited));
         consumed.ShouldContain(nameof(LedgerClosed));
 
-        // Plus the two framework markers, which is shared JasperFx behaviour rather than anything
-        // Polecat adds: JasperFxSingleStreamProjectionBase.determineEventTypes appends Archived and
-        // Compacted<TDoc> to a single-stream projection's AllEventTypes (jasperfx#778 / #796), because
-        // an aggregate has no reason to declare an Apply for either and every store composes its
-        // async loader's allow list from that set. Asserted rather than filtered out: this is what
-        // Marten and Fisher report too, and a test that quietly trimmed them would hide a real change
-        // if the set ever stopped carrying them.
-        consumed.ShouldContain(typeof(JasperFx.Events.Archived).Name);
-        consumed.ShouldContain(typeof(JasperFx.Events.Compacted<LedgerBalance>).Name);
+        // And NOT the two stream lifecycle markers -- inverted from #594, which asserted the
+        // pre-fix set against 2.69.0. jasperfx#829/#830 filters them in
+        // ProjectionEventModelSource.ToSlice.
+        //
+        // JasperFxSingleStreamProjectionBase.determineEventTypes still appends Archived and
+        // Compacted<TDoc> to every non-empty apply set (jasperfx#778 / #796), so this projection's
+        // AllEventTypes genuinely carries five types -- correct about what the projection HANDLES.
+        // A View slice is a narrower question: these render as stickies for events the application
+        // never wrote and no command slice emits, so they link to nothing on a canvas. Filtered in
+        // the source rather than in the reader that fills AppliedEvents, because the same reader
+        // feeds AggregateDescriptor.AppliedEvents and a monitoring console asking "what does this
+        // projection handle" wants both.
+        //
+        // Still asserted rather than dropped, and now in the other direction: the whole content of
+        // this pair of lines is which of the two questions the slice answers, and a test that simply
+        // stopped mentioning the markers would go quiet if the filter were ever lost.
+        consumed.ShouldNotContain(typeof(JasperFx.Events.Archived).Name);
+        consumed.ShouldNotContain(typeof(JasperFx.Events.Compacted<LedgerBalance>).Name);
+
+        // The consequence, stated plainly: exactly the events the aggregate declares an Apply or
+        // Create for.
+        consumed.OrderBy(x => x)
+            .ShouldBe([nameof(LedgerClosed), nameof(LedgerCredited), nameof(LedgerOpened)]);
     }
 
     [Fact]

--- a/src/Polecat.Tests/Subscriptions/subscription_under_coordinator_tests.cs
+++ b/src/Polecat.Tests/Subscriptions/subscription_under_coordinator_tests.cs
@@ -1,0 +1,140 @@
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Projections;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Polecat.Subscriptions;
+using Polecat.Tests.Harness;
+
+namespace Polecat.Tests.Subscriptions;
+
+/// <summary>
+///     A subscription registered in a real host reaches events through
+///     <c>AddProjectionCoordinator</c> — jasperfx#827 / JasperFx 2.69.1.
+/// </summary>
+/// <remarks>
+///     <para>
+///         <b>This could not work before 2.69.1, on any store.</b>
+///         <c>JasperFxSubscriptionBase</c>'s two <c>BuildExecution</c> overloads disagreed about what
+///         they handed <c>SubscriptionExecution</c> as its <c>storage</c> argument: the <c>ILogger</c>
+///         one passed the store, and the explicit-interface <c>ILoggerFactory</c> one passed the
+///         <em>database</em>. <c>SubscriptionExecution</c> casts that argument to
+///         <c>ISubscriptionRunner&lt;T&gt;</c>, which an <c>IEventDatabase</c> never implements, so
+///         it threw <c>ArgumentOutOfRangeException</c> — and
+///         <c>JasperFxAsyncDaemon.buildAgentForShard</c> calls the second overload.
+///     </para>
+///     <para>
+///         <b>Why the existing subscription tests could not see it.</b> Every one of them —
+///         <c>subscription_tests</c> here, and <c>SubscriptionCompliance</c> — drives the daemon
+///         through <c>WaitForProjectionAsync</c> or a fixture-built daemon, and those take the
+///         <em>working</em> overload. The gap is specific to the daemon a host builds for itself, so
+///         closing it needs a test that registers Polecat the documented way and starts the host.
+///         That is the whole point of this file: it is the shape of a real application, not of a
+///         test harness.
+///     </para>
+///     <para>
+///         It surfaced as a logged agent-start failure rather than a red test, while running
+///         <c>ProjectionStatusCompliance</c> (#591) — whose coordinator host is the only one in the
+///         suite set that registers a subscription <em>and</em> a coordinator.
+///     </para>
+/// </remarks>
+public class subscription_under_coordinator_tests
+{
+    [Fact]
+    public async Task a_subscription_receives_events_through_the_projection_coordinator()
+    {
+        var token = TestContext.Current.CancellationToken;
+
+        CoordinatorRecordingSubscription.Reset();
+
+        var builder = Host.CreateApplicationBuilder();
+        builder.Services.AddLogging();
+
+        // The documented registration, coordinator and all -- AddProjectionCoordinator rather than
+        // AddAsyncDaemon, because the coordinator is the path that was broken.
+        builder.Services.AddPolecat(opts =>
+            {
+                opts.ConnectionString = ConnectionSource.ConnectionString;
+                opts.DatabaseSchemaName = "subscription_coordinator";
+                opts.UseNativeJsonType = ConnectionSource.SupportsNativeJson;
+                opts.AutoCreateSchemaObjects = JasperFx.AutoCreate.All;
+                opts.Projections.Subscribe<CoordinatorRecordingSubscription>();
+            })
+            .AddProjectionCoordinator(DaemonMode.Solo);
+
+        using var host = builder.Build();
+
+        var store = host.Services.GetRequiredService<IDocumentStore>();
+        await store.Advanced.ResetAllData(token);
+
+        await host.StartAsync(token);
+
+        try
+        {
+            var streamId = Guid.NewGuid();
+            await using (var session = store.LightweightSession())
+            {
+                session.Events.StartStream(streamId,
+                    new QuestStarted("Coordinated Quest"),
+                    new MembersJoined(1, "Bree", ["Strider"]));
+                await session.SaveChangesAsync(token);
+            }
+
+            // The coordinator's own daemon, not one this test built -- asking the fixture for a
+            // daemon here would take the overload that always worked and prove nothing.
+            var coordinator = host.Services.GetRequiredService<IProjectionCoordinator>();
+            await coordinator.DaemonForMainDatabase().WaitForNonStaleData(TimeSpan.FromSeconds(60));
+
+            CoordinatorRecordingSubscription.ProcessedEvents.Count.ShouldBeGreaterThanOrEqualTo(2,
+                "The subscription's agent never delivered a range. Before jasperfx#828 its agent "
+                + "could not start at all under a coordinator, and the failure was logged rather "
+                + "than thrown, so a test that only asserted 'no exception' would pass over it.");
+        }
+        finally
+        {
+            // StopAsync before disposal: IHost.Dispose does not stop a started host, and an
+            // abandoned coordinator goes on holding shard locks against a shared SQL Server.
+            await host.StopAsync(token);
+        }
+    }
+}
+
+/// <summary>
+///     Deliberately its own type rather than a reuse of <c>RecordingSubscription</c>: that one is
+///     driven by <c>subscription_tests</c> in the "integration" collection, and two classes sharing
+///     one static recorder across collections race.
+/// </summary>
+public class CoordinatorRecordingSubscription : SubscriptionBase
+{
+    private static readonly List<object> _events = new();
+    private static readonly object _lock = new();
+
+    public static IReadOnlyList<object> ProcessedEvents
+    {
+        get
+        {
+            lock (_lock) return _events.ToList();
+        }
+    }
+
+    public static void Reset()
+    {
+        lock (_lock) _events.Clear();
+    }
+
+    public override Task<IChangeListener> ProcessEventsAsync(
+        EventRange page,
+        ISubscriptionController controller,
+        IDocumentOperations operations,
+        CancellationToken cancellationToken)
+    {
+        lock (_lock)
+        {
+            foreach (var @event in page.Events)
+            {
+                _events.Add(@event.Data);
+            }
+        }
+
+        return Task.FromResult<IChangeListener>(NullChangeListener.Instance);
+    }
+}


### PR DESCRIPTION
A two-commit patch release, and **neither half is inert here** — both are upstream fixes for defects Polecat's own #591–#594 work surfaced the same day. So this is not the usual "bump and confirm nothing moved" PR.

## jasperfx#827/#828 — a subscription can now start under `AddProjectionCoordinator`

`JasperFxSubscriptionBase`'s two `BuildExecution` overloads disagreed about what they handed `SubscriptionExecution` as its `storage` argument: the `ILogger` one passed the store, the explicit-interface `ILoggerFactory` one passed the **database**. `SubscriptionExecution` casts that to `ISubscriptionRunner<T>`, which an `IEventDatabase` never implements:

```
System.ArgumentOutOfRangeException: Must implement
  JasperFx.Events.Daemon.ISubscriptionRunner<Polecat.Subscriptions.ISubscription> (Parameter 'storage')
```

`JasperFxAsyncDaemon.buildAgentForShard` calls the second overload, so **a subscription registered in an app using `AddProjectionCoordinator` could never start** — on every store, since the `IEventStorage`→`IEventStore` rename.

**Why nothing caught it, here or upstream:** every subscription compliance suite drives a daemon the fixture built by hand, which takes the *other* overload. Polecat's own `subscription_tests` all go through `WaitForProjectionAsync` — also the working overload. So the coordinator path had no coverage in this repo either, and the bump alone would leave it that way.

`subscription_under_coordinator_tests` closes that. It registers Polecat the documented way, starts a real host, appends, and waits on **the coordinator's own daemon** — asking the fixture for a daemon there would take the overload that always worked and prove nothing.

**Verified in both directions**, which is the part that makes it a pin rather than an exercise:

| Pin | Result |
|---|---|
| 2.69.0 | **fails** — `ArgumentOutOfRangeException`, agent never starts |
| 2.69.1 | passes |

The original failure was *logged*, not thrown, so a test asserting only "no exception" would have passed straight over it. The assertion is on events actually delivered.

## jasperfx#829/#830 — stream lifecycle events leave `ConsumedEvents`

`ProjectionEventModelSource.ToSlice` now filters `Archived` and `Compacted<T>` out of a View slice's consumed events. `determineEventTypes` still appends both to every non-empty apply set — correct about what the projection *handles* — but a canvas asks a narrower question, and they render as stickies for events the application never wrote and no command slice emits, linking to nothing.

Filtered in the source rather than in the reader that fills `AppliedEvents`, deliberately: the same reader feeds `AggregateDescriptor.AppliedEvents`, and a monitoring console asking "what does this projection handle" wants both.

**#594's test asserted the pre-fix set**, so it inverts here — from `ShouldContain` to `ShouldNotContain`, plus an exact-set assertion. Still asserted rather than dropped, and now in the other direction: which of the two questions the slice answers is the entire content of those lines, and a test that simply stopped mentioning the markers would go quiet if the filter were ever lost.

Found upstream independently, while wiring the same source into Fisher.

## Verification

- All compliance suites against 2.69.1: **573 total, 570 passed, 3 skipped, 0 failed**.
- Subscription + event-model tests: 22/22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)