### PR TITLE
gh-602: WaitForNonStaleProjectionDataAsync must cover every configured shard

### DIFF
--- a/src/Polecat.Tests/Daemon/wait_for_non_stale_projection_data_tests.cs
+++ b/src/Polecat.Tests/Daemon/wait_for_non_stale_projection_data_tests.cs
@@ -1,0 +1,294 @@
+using JasperFx;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Projections;
+using Polecat.Internal.Operations;
+using Polecat.Projections;
+using Polecat.Services;
+using Polecat.Subscriptions;
+using Polecat.Tests.Harness;
+
+namespace Polecat.Tests.Daemon;
+
+/// <summary>
+///     polecat#602: <see cref="Polecat.Storage.PolecatDatabase.WaitForNonStaleProjectionDataAsync" />
+///     used to gate on "at least one progression row exists and every row present is caught up".
+///     A shard has no progression row at all until it commits its first batch, so a store with two
+///     async projections spends a window where the first shard has reported at the high-water mark
+///     and the second has written nothing — and that window satisfies the old condition. The wait
+///     returned while a projection had not run, and the caller's next read saw a document that was
+///     never written.
+/// </summary>
+/// <remarks>
+///     <para>
+///         That is exactly the intermittent CI failure in
+///         <c>rebuild_and_catch_up_compliance.rebuilding_one_projection_leaves_another_alone</c>,
+///         whose store registers two async snapshots over the same events. It reproduced 4 runs in 5
+///         under six concurrent worker processes and never once on an idle box, because the window is
+///         only as wide as the gap between the two shards' commits.
+///     </para>
+///     <para>
+///         The tests below plant progression rows directly rather than racing a daemon, so the
+///         condition under test is deterministic: the partial-progress state is constructed, not
+///         waited for.
+///     </para>
+/// </remarks>
+public class wait_for_non_stale_projection_data_tests : OneOffConfigurationsContext
+{
+    private static readonly TimeSpan _shortTimeout = TimeSpan.FromSeconds(3);
+
+    private async Task WithTwoAsyncProjectionsAsync()
+    {
+        ConfigureStore(opts =>
+        {
+            opts.DatabaseSchemaName = "wait_non_stale";
+            opts.AutoCreateSchemaObjects = AutoCreate.All;
+            opts.Projections.Snapshot<WaitTurbine>(SnapshotLifecycle.Async);
+            opts.Projections.Snapshot<WaitTurbineAudit>(SnapshotLifecycle.Async);
+        });
+
+        await theDatabase.ApplyAllConfiguredChangesToDatabaseAsync();
+        await theStore.Advanced.Clean.DeleteAllEventDataAsync();
+        await ClearProgressionAsync();
+    }
+
+    /// <summary>
+    ///     The regression. One of the two shards is fully caught up and the other has never reported;
+    ///     on the old predicate the wait returned immediately.
+    /// </summary>
+    [Fact]
+    public async Task does_not_return_while_a_configured_shard_has_never_reported()
+    {
+        await WithTwoAsyncProjectionsAsync();
+
+        var highWater = await AppendAStreamAsync();
+
+        await SeedAsync(ShardFor<WaitTurbine>(), highWater);
+
+        var ex = await Should.ThrowAsync<TimeoutException>(() =>
+            theDatabase.WaitForNonStaleProjectionDataAsync(_shortTimeout));
+
+        // ...and the message names the shard that never reported, which is the whole point of
+        // reaching the timeout rather than silently returning.
+        ex.Message.ShouldContain(nameof(WaitTurbineAudit));
+        ex.Message.ShouldContain("no progress recorded");
+    }
+
+    [Fact]
+    public async Task returns_once_every_configured_shard_has_reported()
+    {
+        await WithTwoAsyncProjectionsAsync();
+
+        var highWater = await AppendAStreamAsync();
+
+        await SeedAsync(ShardFor<WaitTurbine>(), highWater);
+        await SeedAsync(ShardFor<WaitTurbineAudit>(), highWater);
+
+        await theDatabase.WaitForNonStaleProjectionDataAsync(_shortTimeout);
+    }
+
+    /// <summary>
+    ///     The pre-existing guarantee, unchanged: a row that IS present but behind still blocks.
+    /// </summary>
+    [Fact]
+    public async Task does_not_return_while_a_shard_that_reported_is_behind()
+    {
+        await WithTwoAsyncProjectionsAsync();
+
+        var highWater = await AppendAStreamAsync();
+
+        await SeedAsync(ShardFor<WaitTurbine>(), highWater);
+        await SeedAsync(ShardFor<WaitTurbineAudit>(), highWater - 1);
+
+        await Should.ThrowAsync<TimeoutException>(() =>
+            theDatabase.WaitForNonStaleProjectionDataAsync(_shortTimeout));
+    }
+
+    /// <summary>
+    ///     A per-tenant shard writes its progression under a tenant-qualified identity
+    ///     (<c>Name:All:tenant</c>), which is not the configured shard's identity string. Matching on
+    ///     the identity would hang here; matching structurally on (name, shard key, version) does not.
+    /// </summary>
+    [Fact]
+    public async Task a_tenant_qualified_row_satisfies_its_configured_shard()
+    {
+        await WithTwoAsyncProjectionsAsync();
+
+        var highWater = await AppendAStreamAsync();
+
+        await SeedAsync(ShardFor<WaitTurbine>().ForTenant("acme"), highWater);
+        await SeedAsync(ShardFor<WaitTurbineAudit>().ForTenant("acme"), highWater);
+
+        await theDatabase.WaitForNonStaleProjectionDataAsync(_shortTimeout);
+    }
+
+    /// <summary>
+    ///     A <c>CompositeProjection</c> carries <c>Version = 0</c> on its shard while persisting the
+    ///     unversioned identity <c>Name:All</c>, which parses back as version 1. Comparing the parsed
+    ///     shard's fields therefore never matches a composite's own progression row, and the wait
+    ///     hangs its full timeout over a projection that is caught up.
+    /// </summary>
+    [Fact]
+    public async Task a_composite_projections_own_shard_is_matched_to_its_row()
+    {
+        ConfigureStore(opts =>
+        {
+            opts.DatabaseSchemaName = "wait_non_stale_composite";
+            opts.AutoCreateSchemaObjects = AutoCreate.All;
+            opts.Projections.CompositeProjectionFor("WaitComposite", composite =>
+            {
+                composite.Snapshot<WaitTurbine>();
+            });
+        });
+
+        await theDatabase.ApplyAllConfiguredChangesToDatabaseAsync();
+        await theStore.Advanced.Clean.DeleteAllEventDataAsync();
+        await ClearProgressionAsync();
+
+        var composite = theStore.Options.Projections.AllShards()
+            .Single(x => x.Name.Name == "WaitComposite").Name;
+        composite.Version.ShouldBe(0u, "the trap this test exists for is gone if the version is 1");
+
+        var highWater = await AppendAStreamAsync();
+        await SeedAsync(composite, highWater);
+
+        await theDatabase.WaitForNonStaleProjectionDataAsync(_shortTimeout);
+    }
+
+    /// <summary>
+    ///     Nothing runs asynchronously, so nothing can be stale. The old predicate could never satisfy
+    ///     <c>Count > 0</c> here and timed out instead.
+    /// </summary>
+    [Fact]
+    public async Task returns_immediately_when_no_async_projections_are_registered()
+    {
+        ConfigureStore(opts =>
+        {
+            opts.DatabaseSchemaName = "wait_non_stale_none";
+            opts.AutoCreateSchemaObjects = AutoCreate.All;
+        });
+
+        await theDatabase.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        await AppendAStreamAsync();
+
+        await theDatabase.WaitForNonStaleProjectionDataAsync(_shortTimeout);
+    }
+
+    /// <summary>
+    ///     A subscription writes no queryable document, but it is still part of what this wait
+    ///     covers: callers wait on it to know a subscription has seen a range, and
+    ///     <c>subscription_under_coordinator_tests</c> registers a subscription and nothing else.
+    ///     Dropping subscriptions from the expected set makes the wait return before one has run.
+    /// </summary>
+    [Fact]
+    public async Task a_subscription_is_part_of_what_the_wait_covers()
+    {
+        ConfigureStore(opts =>
+        {
+            opts.DatabaseSchemaName = "wait_non_stale_subscription";
+            opts.AutoCreateSchemaObjects = AutoCreate.All;
+            opts.Projections.Snapshot<WaitTurbine>(SnapshotLifecycle.Async);
+            opts.Projections.Subscribe(new WaitRecordingSubscription());
+        });
+
+        await theDatabase.ApplyAllConfiguredChangesToDatabaseAsync();
+        await theStore.Advanced.Clean.DeleteAllEventDataAsync();
+        await ClearProgressionAsync();
+
+        var highWater = await AppendAStreamAsync();
+
+        // The projection has reported; the subscription has not. That must not be enough.
+        await SeedAsync(ShardFor<WaitTurbine>(), highWater);
+
+        var ex = await Should.ThrowAsync<TimeoutException>(() =>
+            theDatabase.WaitForNonStaleProjectionDataAsync(_shortTimeout));
+        ex.Message.ShouldContain(nameof(WaitRecordingSubscription));
+
+        // ...and once it has, the wait completes.
+        var subscription = theStore.Options.Projections.AllShards()
+            .Single(x => x.Name.Name == nameof(WaitRecordingSubscription)).Name;
+        await SeedAsync(subscription, highWater);
+
+        await theDatabase.WaitForNonStaleProjectionDataAsync(_shortTimeout);
+    }
+
+    private ShardName ShardFor<T>() => theStore.Options.Projections.AllShards()
+        .Single(x => x.Name.Name == typeof(T).Name).Name;
+
+    private async Task<long> AppendAStreamAsync()
+    {
+        await using var session = theStore.LightweightSession();
+        session.Events.StartStream<WaitTurbine>(Guid.NewGuid(),
+            new WaitTurbineInstalled("North Ridge"),
+            new WaitTurbineSpun(10),
+            new WaitTurbineSpun(15));
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        return await theDatabase.FetchHighestEventSequenceNumber(TestContext.Current.CancellationToken);
+    }
+
+    private async Task ClearProgressionAsync()
+    {
+        await using var conn = await OpenConnectionAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"DELETE FROM {theStore.Events.ProgressionTableName};";
+        await cmd.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+    }
+
+    // Seed through the production write path, same as progression_delete_scoping_tests.
+    private async Task SeedAsync(ShardName shardName, long ceiling)
+    {
+        var events = theStore.Database.Events;
+        var op = new RecordProgressionOperation(
+            events.ProgressionTableName,
+            shardName.Identity,
+            ceiling,
+            events.EnableExtendedProgressionTracking,
+            upsert: true);
+
+        await using var conn = await OpenConnectionAsync();
+        await using var batch = new Microsoft.Data.SqlClient.SqlBatch(conn);
+        var builder = new Weasel.SqlServer.BatchBuilder(batch);
+        op.ConfigureCommand(builder);
+        builder.Compile();
+        await using var reader = await batch.ExecuteReaderAsync(TestContext.Current.CancellationToken);
+        await op.PostprocessAsync(reader, new List<Exception>(), TestContext.Current.CancellationToken);
+    }
+}
+
+public record WaitTurbineInstalled(string Site);
+
+public record WaitTurbineSpun(int Revolutions);
+
+public partial class WaitTurbine
+{
+    public Guid Id { get; set; }
+    public string Site { get; set; } = string.Empty;
+    public int TotalRevolutions { get; set; }
+
+    public static WaitTurbine Create(WaitTurbineInstalled e) => new() { Site = e.Site };
+
+    public void Apply(WaitTurbineSpun e) => TotalRevolutions += e.Revolutions;
+}
+
+public partial class WaitTurbineAudit
+{
+    public Guid Id { get; set; }
+    public string Site { get; set; } = string.Empty;
+    public int Revisions { get; set; }
+
+    public static WaitTurbineAudit Create(WaitTurbineInstalled e) => new() { Site = e.Site, Revisions = 1 };
+
+    public void Apply(WaitTurbineSpun _) => Revisions++;
+}
+
+/// <summary>
+///     Registered so the wait has a subscription shard to cover. Its progression rows are planted
+///     directly, so it is never actually run — see <c>a_subscription_is_part_of_what_the_wait_covers</c>.
+/// </summary>
+public class WaitRecordingSubscription : SubscriptionBase
+{
+    public override Task<IChangeListener> ProcessEventsAsync(EventRange page, ISubscriptionController controller,
+        IDocumentOperations operations, CancellationToken cancellationToken)
+        => throw new NotSupportedException("This subscription is never started; its progress is planted.");
+}

--- a/src/Polecat/Storage/PolecatDatabase.cs
+++ b/src/Polecat/Storage/PolecatDatabase.cs
@@ -763,24 +763,64 @@ public class PolecatDatabase : DatabaseBase<SqlConnection>, IEventDatabase, IPro
         await ApplyAllConfiguredChangesToDatabaseAsync(ct: token);
     }
 
+    /// <summary>
+    ///     Wait until every registered async projection shard and subscription has caught up to the
+    ///     event sequence as of the moment this is called. Intended for test automation.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         #602: the expected shard set comes from the configuration, never from whatever rows
+    ///         happen to be in <c>pc_event_progression</c> at the moment of the poll. A shard only gets
+    ///         a progression row once it commits its first batch, so a store with more than one async
+    ///         projection spends a window — milliseconds on an idle box, far longer under load —
+    ///         where one shard has reported at the high-water mark and the other has written nothing
+    ///         at all. Gating on "some row exists and every row present is caught up" is satisfied by
+    ///         that window, so the wait returned while a projection had not run, and the caller's very
+    ///         next read saw a document that was never written. That is the shape of the flake in
+    ///         <c>rebuilding_one_projection_leaves_another_alone</c>, whose store registers two async
+    ///         snapshots over the same events.
+    ///     </para>
+    ///     <para>
+    ///         A configured shard is matched to its row by <b>store-global identity</b> — the row's
+    ///         key with any tenant suffix stripped. Under per-tenant partitioning one configured
+    ///         shard writes a row per tenant (<c>Name:All:tenant</c>), so comparing the raw keys
+    ///         would never match; and a bare <c>count >= expected</c> comparison (Marten's shape)
+    ///         would let two rows for one tenanted shard stand in for a second shard that never ran,
+    ///         which is the same defect this fixes.
+    ///     </para>
+    /// </remarks>
     public async Task WaitForNonStaleProjectionDataAsync(TimeSpan timeout)
     {
+        // Async projections AND subscriptions — AllShards() is exactly both, and both have to be
+        // caught up before a caller may act on what the daemon has done. A subscription writes no
+        // queryable document, but callers wait on this to know a subscription has seen a range
+        // (subscription_under_coordinator_tests registers a subscription and nothing else), so
+        // dropping them would make the wait return before that subscription ran at all.
+        var expected = _options.Projections.AllShards()
+            .Select(x => x.Name.ForTenant(null).Identity)
+            .Distinct()
+            .ToList();
+
+        // Nothing runs asynchronously, so there is nothing that could be stale.
+        if (expected.Count == 0) return;
+
         var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+        var highWater = 0L;
+        IReadOnlyList<ShardState> projectionProgress = [];
 
         while (stopwatch.Elapsed < timeout)
         {
-            var highWater = await FetchHighestEventSequenceNumber(CancellationToken.None);
+            highWater = await FetchHighestEventSequenceNumber(CancellationToken.None);
             if (highWater == 0) return;
 
             var progress = await AllProjectionProgress(CancellationToken.None);
 
             // Filter out the HighWaterMark entry — only check actual projection shards
-            var projectionProgress = progress
-                .Where(p => p.ShardName != "HighWaterMark")
+            projectionProgress = progress
+                .Where(p => p.ShardName != ShardState.HighWaterMark)
                 .ToList();
 
-            // All projection shards must be caught up to the high water mark
-            if (projectionProgress.Count > 0 && projectionProgress.All(p => p.Sequence >= highWater))
+            if (AllShardsAreCaughtUp(expected, projectionProgress, highWater))
             {
                 return;
             }
@@ -789,7 +829,61 @@ public class PolecatDatabase : DatabaseBase<SqlConnection>, IEventDatabase, IPro
         }
 
         throw new TimeoutException(
-            $"Timed out after {timeout} waiting for projection data to become non-stale.");
+            $"Timed out after {timeout} waiting for projection data to become non-stale. "
+            + $"High water mark is {highWater}. "
+            + $"Shards not caught up: {DescribeLaggingShards(expected, projectionProgress, highWater)}.");
+    }
+
+    private static bool AllShardsAreCaughtUp(
+        IReadOnlyList<string> expected,
+        IReadOnlyList<ShardState> projectionProgress,
+        long highWater)
+    {
+        // Every row that IS present has to be caught up, including rows for shards that are no longer
+        // configured — that was the original check and it stays.
+        if (projectionProgress.Any(p => p.Sequence < highWater)) return false;
+
+        // ...and every CONFIGURED shard has to have a row at all.
+        return expected.All(identity => projectionProgress.Any(p => Matches(p, identity)));
+    }
+
+    /// <summary>
+    ///     Does this progression row belong to the configured shard with <paramref name="identity" />?
+    /// </summary>
+    /// <remarks>
+    ///     The comparison is on the <em>store-global identity string</em> — the row's own key with any
+    ///     tenant suffix stripped — and deliberately not on the parsed shard's fields. A
+    ///     <c>CompositeProjection</c> carries <c>Version = 0</c> on its <see cref="ShardName" /> while
+    ///     persisting the unversioned identity <c>Name:All</c>, which parses back as version 1: a
+    ///     field-by-field comparison therefore never matches a composite's own shard, and the wait
+    ///     hangs for its full timeout on a store whose projection is caught up. Identity is what keys
+    ///     the row, so identity is what to compare.
+    /// </remarks>
+    private static bool Matches(ShardState state, string identity)
+        => ShardName.TryParse(state.ShardName, out var parsed)
+           && parsed?.ForTenant(null).Identity == identity;
+
+    /// <summary>
+    ///     The diagnostic the old timeout message could not give: which shards are behind, and which
+    ///     have never reported at all. A wait that times out is nearly always one shard, and naming it
+    ///     is the difference between a one-line CI failure and a bisect.
+    /// </summary>
+    private static string DescribeLaggingShards(
+        IReadOnlyList<string> expected,
+        IReadOnlyList<ShardState> projectionProgress,
+        long highWater)
+    {
+        var behind = projectionProgress
+            .Where(p => p.Sequence < highWater)
+            .Select(p => $"{p.ShardName}@{p.Sequence}");
+
+        var missing = expected
+            .Where(identity => !projectionProgress.Any(p => Matches(p, identity)))
+            .Select(identity => $"{identity} (no progress recorded)");
+
+        var all = behind.Concat(missing).ToArray();
+
+        return all.Length == 0 ? "none" : string.Join(", ", all);
     }
 
     internal PolecatProjectionDaemon StartProjectionDaemon(DocumentStore store, ILoggerFactory loggerFactory)


### PR DESCRIPTION
Closes #602.

`rebuild_and_catch_up_compliance.rebuilding_one_projection_leaves_another_alone` has been failing intermittently on CI. It is a pre-existing flake, not a regression — it failed on #600, which is a CLAUDE.md edit with no code in it at all.

## Diagnosis

The task came with two hypotheses, and separating them was the point: a wait-condition race, or a rebuild that destroys another projection's storage. **It is the race, and the defect is Polecat's own** — not the suite, not the shared daemon.

`PolecatDatabase.WaitForNonStaleProjectionDataAsync` gated on:

```csharp
if (projectionProgress.Count > 0 && projectionProgress.All(p => p.Sequence >= highWater))
```

A shard has no `pc_event_progression` row **at all** until it commits its first batch. So on a store with two async projections there is a window where the first shard has reported at the high-water mark and the second has written nothing — and `Count > 0 && All(...)` is satisfied by that window. The wait returns while a projection has not run, and the caller's very next read sees a document that was never written.

The window is only as wide as the gap between the two shards' commits. That is why it is CI-only, and why a docs PR can trigger it.

### Hypothesis 2 is ruled out, by evidence rather than by reading

An instrumented probe (two async snapshots, **no rebuild in the loop**), 150 iterations under six concurrent worker processes:

| | pre-fix | post-fix |
|---|---|---|
| wait returned with only 1 of 2 shard rows | 8 | 0 |
| audit document null right after the wait | 6 | 0 |
| audit document null **after** a rebuild | 0 | 0 |
| same, on an idle box | 0 | 0 |

Every early return looked like `EARLY RETURN -- only 1 shard rows: ComplianceTurbine:All@3`. The document is already missing **before any rebuild runs**, which is what kills hypothesis 2 on its own. On top of that, 150 instrumented rebuilds of `ComplianceTurbine` under load left `ComplianceTurbineAudit` intact every time — consistent with the code: `rebuildProjection` stops only agents whose `Name.Name` equals the subscription name, `TeardownProjectionStateAsync` deletes only the projection's published-type tables plus its declared clean-ups, and `ProgressionFilterFor` uses exact identities (the `:`-anchored filter from #436).

### Reproduction

| | result |
|---|---|
| compliance class, six-way parallel, pre-fix | **4 failures in 5 runs** |
| compliance class, six-way parallel, post-fix | **0 failures in 48 runs** (528 executions) |
| single process, either way | always green |

Both CI failures were on the 6-worker runner, which matches.

## The fix

The expected shard set now comes from the configuration — `Projections.AllShards()` — and every shard must have a row at the high-water mark. Every row that *is* present must still be caught up, as before.

This is what Polecat's **other** staleness gate already did: the LINQ `WaitForNonStaleData` in `PolecatLinqQueryProvider` (#148) has always built its expected set from configuration. The database-level helper was the odd one out. Marten's equivalent gates on `projections.Count >= AllShards().Count + 1`.

Two things surfaced while verifying against the full suite. Both were diagnosed in **one run each** by the new timeout message, which names which shards are behind and which never reported — the old message said nothing at all.

**Composites.** `CompositeProjection` sets `Version = 0` on its shard while persisting the unversioned identity `Name:All`, which parses back as version 1. Matching a configured shard to its row on the parsed `(name, shard key, version)` therefore never matches a composite's own row, and the wait hangs its full timeout over a projection that is caught up. Rows are matched on the **tenant-stripped identity string** instead — that is what actually keys the row, and it also survives the per-tenant `Name:All:tenant` form. A bare `count >= expected` comparison would not: it lets two rows for one tenanted shard stand in for a second shard that never ran, which is the same defect this PR fixes.

**Subscriptions are included.** I first excluded them, on the evidence that `ProjectionStatusCompliance` registers one that never records progress. That inference was wrong, and rebasing onto #601 proved it: the reason it never reported was jasperfx#827/#828 — a subscription's agent could not start under `AddProjectionCoordinator` **at all** before 2.69.1. With that fixed, subscriptions do report, and `subscription_under_coordinator_tests` (which registers a subscription and nothing else) depends on this wait covering it. Excluding them made that test deliver 0 events. Included, matching Marten.

## Tests

`src/Polecat.Tests/Daemon/wait_for_non_stale_projection_data_tests.cs` — 7 tests. They **plant progression rows directly** rather than racing a daemon, so the partial-progress state is constructed instead of waited for, and the suite gains no new timing dependency.

Verified in both directions, which is what makes them a pin: **3 of the 7 fail against the pre-fix implementation** on the same 2.69.1 pin — `does_not_return_while_a_configured_shard_has_never_reported`, `a_subscription_is_part_of_what_the_wait_covers`, and `returns_immediately_when_no_async_projections_are_registered` (the old predicate could never satisfy `Count > 0` with no async projections, so it timed out instead of returning).

The composite case is pinned by an assertion on the precondition itself (`composite.Version.ShouldBe(0u)`), so the test goes red rather than quiet if that upstream quirk is ever fixed.

No compliance suite was touched, no assertion weakened, and the flaky test is not disabled.

## Verification

- **Full suite, rebased onto #601 (JasperFx 2.69.1), fresh database: 2670 total, 2664 passed, 6 skipped, 0 failed.**
- 48 consecutive runs of the compliance class under six-way parallel load: 0 failures.
- Affected classes together on 2.69.1 (`wait_for_non_stale_*`, `subscription_under_coordinator_tests`, `polecat_projection_status_compliance`, `composite_projection_compliance`, `rebuild_and_catch_up_compliance`, `subscription_compliance`): 42/42.

All local runs used dedicated catalogs via `POLECAT_TESTING_DATABASE`, never the shared `master`.

## One upstream note

`EventStoreComplianceFixture.WaitForNonStaleProjectionDataAsync` is completely undocumented — there is no stated contract that an implementation must cover every configured shard. A doc comment there would stop the next store repeating this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
