### PR TITLE
5.27.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,7 +15,7 @@
           in the publish path reads it, so a stale value is invisible until someone asks a running
           store what version it is.
         -->
-        <Version>5.26.0</Version>
+        <Version>5.27.0</Version>
         <LangVersion>latest</LangVersion>
         <Authors>Jeremy D. Miller</Authors>
         <PackageIcon>logo.png</PackageIcon>


### PR DESCRIPTION
Version bump for the 5.27.0 release. `Directory.Build.props` only.

Headline is the **Guid optimistic concurrency fix** (#592) — a versioned document loaded in one session could not be stored through another, which is the workflow `IVersioned` exists for.

Contents since 5.26.0:

| PR | |
|---|---|
| #596 | #591 — `ShardStatus.State` reports the real daemon state |
| #597 | #592 — Guid concurrency guard seeded from the document |
| #598 | #593 — tenant dimension on the explorer reads across multiple databases |
| #599 | #594 — store-derived Event Model slices |
| #603 | #602 — `WaitForNonStaleProjectionDataAsync` must cover every configured shard |
| #595, #601 | JasperFx 2.68.0 → 2.69.1 |
| #600 | CLAUDE.md corrections (no user-facing change) |

Creating the `v5.27.0` release after this merges is the publish — the tag triggers `publish.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)